### PR TITLE
Add basic well-architected compliance check

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -1,0 +1,2 @@
+external_checks_dir:
+  - checkov-policies

--- a/.github/workflows/well-architected.yml
+++ b/.github/workflows/well-architected.yml
@@ -1,0 +1,19 @@
+name: Well-Architected Compliance
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  checkov:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Checkov
+        uses: bridgecrewio/checkov-action@v12
+        with:
+          directory: ./terraform
+          config_file: .checkov.yaml
+          quiet: true
+          framework: terraform

--- a/README.md
+++ b/README.md
@@ -52,3 +52,8 @@ docker run -p 8080:8080 example-api
 
 See `docs/platform-overview.md` for an architectural overview of the system.
 See `docs/02-terragrunt-strategy.md` for the Terragrunt proposal.
+
+## Compliance Checks
+
+A GitHub Actions workflow (`well-architected.yml`) runs [Checkov](https://github.com/bridgecrewio/checkov) against the Terraform code. Custom policies located in the `checkov-policies/` directory map to AWS Well-Architected Framework best practices.
+

--- a/checkov-policies/aws_well_architected_s3_encryption.json
+++ b/checkov-policies/aws_well_architected_s3_encryption.json
@@ -1,0 +1,16 @@
+{
+  "metadata": {
+    "id": "WA_AWS_1",
+    "name": "Ensure S3 buckets use server-side encryption",
+    "category": "AWS Well-Architected",
+    "severity": "MEDIUM",
+    "description": "AWS Well-Architected Framework: Encrypt data at rest"
+  },
+  "scope": "resource",
+  "definition": {
+    "cond_type": "attribute",
+    "resource_types": ["aws_s3_bucket"],
+    "attribute": "server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.sse_algorithm",
+    "operator": "exists"
+  }
+}


### PR DESCRIPTION
## Summary
- add Checkov GitHub Action to scan Terraform for AWS Well-Architected best practices
- load custom policies from `checkov-policies` directory
- document compliance scan in README
- include an example policy checking for S3 bucket encryption

## Testing
- `apt-get update` *(fails: 403 Forbidden)*
- `pip install yamllint` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687f4c7376f483239416b32d302851bb