### PR TITLE
feat: implement centralized app versioning system

### DIFF
--- a/.github/workflows/version-manifest-validate.yml
+++ b/.github/workflows/version-manifest-validate.yml
@@ -1,0 +1,137 @@
+name: Version Manifest Validation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "versions/**"
+      - ".github/workflows/version-manifest-validate.yml"
+  pull_request:
+    paths:
+      - "versions/**"
+  workflow_dispatch:
+
+jobs:
+  validate-schema:
+    name: Validate Version Manifests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          npm install -g ajv-cli ajv-formats
+
+      - name: Validate version manifest schema
+        run: |
+          for env in dev integration staging prod; do
+            echo "Validating versions/${env}/versions.yaml..."
+            # Convert YAML to JSON for ajv validation
+            python3 -c "
+          import yaml, json, sys
+          with open('versions/${env}/versions.yaml') as f:
+              data = yaml.safe_load(f)
+          json.dump(data, sys.stdout)
+          " | ajv validate -s versions/schema.json -d /dev/stdin --strict=false
+          done
+
+      - name: Check required applications exist
+        run: |
+          REQUIRED_APPS="mono chains direct protocols listeners"
+          for env in dev integration staging prod; do
+            echo "Checking versions/${env}/versions.yaml..."
+            for app in $REQUIRED_APPS; do
+              if ! grep -q "^    ${app}:" "versions/${env}/versions.yaml"; then
+                echo "ERROR: Missing required application '${app}' in versions/${env}/versions.yaml"
+                exit 1
+              fi
+            done
+          done
+          echo "All required applications present in all environments"
+
+      - name: Validate image tags are valid
+        run: |
+          for env in dev integration staging prod; do
+            echo "Checking image tags in versions/${env}/versions.yaml..."
+            # Extract all image tags and validate format
+            python3 -c "
+          import yaml, re, sys
+          with open('versions/${env}/versions.yaml') as f:
+              data = yaml.safe_load(f)
+
+          tag_pattern = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9._-]*$')
+          errors = []
+
+          for app, config in data.get('spec', {}).get('applications', {}).items():
+              tag = config.get('image', {}).get('tag', '')
+              if tag and not tag_pattern.match(tag):
+                  errors.append(f'{app}: invalid tag format \"{tag}\"')
+
+          if errors:
+              print('\\n'.join(errors))
+              sys.exit(1)
+          print(f'All image tags valid in ${env}')
+          "
+          done
+
+  diff-environments:
+    name: Generate Environment Diff
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate version diff report
+        run: |
+          echo "## Version Changes" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          for env in dev integration staging prod; do
+            if git diff --quiet origin/main -- "versions/${env}/versions.yaml" 2>/dev/null; then
+              continue
+            fi
+
+            echo "### ${env}" >> $GITHUB_STEP_SUMMARY
+            echo '```diff' >> $GITHUB_STEP_SUMMARY
+            git diff origin/main -- "versions/${env}/versions.yaml" >> $GITHUB_STEP_SUMMARY || true
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          done
+
+      - name: Compare environments
+        run: |
+          echo "## Environment Comparison" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Application | dev | integration | staging | prod |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------------|-----|-------------|---------|------|" >> $GITHUB_STEP_SUMMARY
+
+          python3 << 'EOF' >> $GITHUB_STEP_SUMMARY
+          import yaml
+
+          envs = ['dev', 'integration', 'staging', 'prod']
+          versions = {}
+
+          for env in envs:
+              try:
+                  with open(f'versions/{env}/versions.yaml') as f:
+                      data = yaml.safe_load(f)
+                      versions[env] = {
+                          app: config.get('image', {}).get('tag', 'N/A')
+                          for app, config in data.get('spec', {}).get('applications', {}).items()
+                      }
+              except:
+                  versions[env] = {}
+
+          all_apps = set()
+          for env in envs:
+              all_apps.update(versions.get(env, {}).keys())
+
+          for app in sorted(all_apps):
+              row = f"| {app} |"
+              for env in envs:
+                  tag = versions.get(env, {}).get(app, 'N/A')
+                  row += f" {tag} |"
+              print(row)
+          EOF

--- a/argocd/applicationset-workloads.yaml
+++ b/argocd/applicationset-workloads.yaml
@@ -1,0 +1,139 @@
+---
+# ApplicationSet for workload applications.
+# Generates ArgoCD Applications for each (team × environment) combination.
+# Replaces individual Application files in argocd/workloads/{team}/{env}.yaml
+#
+# Version information flows:
+#   1. Kargo Warehouse detects new image in ECR
+#   2. Kargo Stage promotion updates versions/{env}/versions.yaml
+#   3. Kargo Stage also updates envs/{env}/values/{team}/values.yaml (for ArgoCD)
+#   4. ArgoCD syncs the Application with new image tag
+#
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: platform-workloads
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - matrix:
+        generators:
+          # Teams/applications to deploy
+          - list:
+              elements:
+                - team: mono
+                  namespace: mono
+                - team: chains
+                  namespace: chains
+                - team: direct
+                  namespace: direct
+                - team: protocols
+                  namespace: protocols
+                - team: listeners
+                  namespace: listeners
+          # Environments to deploy to
+          - list:
+              elements:
+                - env: dev
+                  cluster: https://kubernetes.default.svc
+                  autoSync: true
+                - env: integration
+                  cluster: https://kubernetes.default.svc
+                  autoSync: true
+                - env: staging
+                  cluster: https://kubernetes.default.svc
+                  autoSync: true
+                - env: prod
+                  cluster: https://kubernetes.default.svc
+                  autoSync: false
+  template:
+    metadata:
+      name: '{{ .team }}-{{ .env }}'
+      namespace: argocd
+      annotations:
+        # Kargo authorization for promotion
+        kargo.akuity.io/authorized-stage: '{{ .team }}:{{ .env }}'
+        # Link to version manifest for visibility
+        platform.io/version-manifest: 'versions/{{ .env }}/versions.yaml'
+      labels:
+        app.kubernetes.io/part-of: platform-workloads
+        app.kubernetes.io/component: '{{ .team }}'
+        app.kubernetes.io/managed-by: applicationset
+        env: '{{ .env }}'
+        team: '{{ .team }}'
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io
+    spec:
+      project: platform-workloads
+      sources:
+        # Source 1: Helm chart
+        - repoURL: git@github.com:IgorGerasimow/platform-design.git
+          targetRevision: HEAD
+          path: helm/app
+          helm:
+            releaseName: '{{ .team }}'
+            ignoreMissingValueFiles: true
+            valueFiles:
+              # Environment-specific values (contains image.tag from Kargo)
+              - $values/envs/{{ .env }}/values/{{ .team }}/values.yaml
+              # Team-specific base values (if exists)
+              - $values/apps/{{ .team }}/values.yaml
+            values: |
+              fullnameOverride: "{{ .team }}"
+              environment: "{{ .env }}"
+              # Default image repository - override in values if needed
+              image:
+                repository: "${ECR_REGISTRY}/{{ .team }}"
+        # Source 2: Values reference
+        - repoURL: git@github.com:IgorGerasimow/platform-design.git
+          targetRevision: HEAD
+          ref: values
+      destination:
+        server: '{{ .cluster }}'
+        namespace: '{{ .env }}-{{ .namespace }}'
+      syncPolicy:
+        {{- if eq .autoSync true }}
+        automated:
+          prune: true
+          selfHeal: true
+        {{- end }}
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+          - PruneLast=true
+          - RespectIgnoreDifferences=true
+        retry:
+          limit: 3
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 3m
+      ignoreDifferences:
+        - group: apps
+          kind: Deployment
+          jqPathExpressions:
+            - .spec.replicas
+  syncPolicy:
+    preserveResourcesOnDeletion: true
+  strategy:
+    type: RollingSync
+    rollingSync:
+      steps:
+        - matchExpressions:
+            - key: env
+              operator: In
+              values: [dev]
+        - matchExpressions:
+            - key: env
+              operator: In
+              values: [integration]
+        - matchExpressions:
+            - key: env
+              operator: In
+              values: [staging]
+        - matchExpressions:
+            - key: env
+              operator: In
+              values: [prod]

--- a/kargo/stages/chains/dev.yaml
+++ b/kargo/stages/chains/dev.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -20,6 +21,16 @@ spec:
               - branch: main
                 path: ./src
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/dev/versions.yaml
+            updates:
+              - key: spec.applications.chains.image.tag
+                value: ${{ imageFrom("chains").Tag }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/dev/values/chains/values.yaml
             updates:
@@ -28,8 +39,10 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(chains): promote to dev v${{ imageFrom("chains").Tag }}
+
+              Image: ${{ imageFrom("chains").RepoURL }}:${{ imageFrom("chains").Tag }}
         - uses: git-push
           config:
             path: ./src

--- a/kargo/stages/chains/integration.yaml
+++ b/kargo/stages/chains/integration.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -21,6 +22,16 @@ spec:
               - branch: main
                 path: ./src
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/integration/versions.yaml
+            updates:
+              - key: spec.applications.chains.image.tag
+                value: ${{ imageFrom("chains").Tag }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/integration/values/chains/values.yaml
             updates:
@@ -29,8 +40,10 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(chains): promote to integration v${{ imageFrom("chains").Tag }}
+
+              Image: ${{ imageFrom("chains").RepoURL }}:${{ imageFrom("chains").Tag }}
         - uses: git-push
           config:
             path: ./src
@@ -40,4 +53,5 @@ spec:
               - name: chains-integration
   verification:
     analysisTemplates:
-      - name: smoke-test
+      - name: health-check
+      - name: integration-test

--- a/kargo/stages/chains/prod.yaml
+++ b/kargo/stages/chains/prod.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -21,6 +22,18 @@ spec:
               - branch: main
                 path: ./src
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/prod/versions.yaml
+            updates:
+              - key: spec.applications.chains.image.tag
+                value: ${{ imageFrom("chains").Tag }}
+              - key: spec.applications.chains.image.digest
+                value: ${{ imageFrom("chains").Digest }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/prod/values/chains/values.yaml
             updates:
@@ -29,8 +42,10 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(chains): promote to prod v${{ imageFrom("chains").Tag }}
+
+              Image: ${{ imageFrom("chains").RepoURL }}:${{ imageFrom("chains").Tag }}
         - uses: git-push
           config:
             path: ./src
@@ -41,3 +56,5 @@ spec:
   verification:
     analysisTemplates:
       - name: health-check
+      - name: smoke-test
+      - name: integration-test

--- a/kargo/stages/chains/staging.yaml
+++ b/kargo/stages/chains/staging.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -21,6 +22,16 @@ spec:
               - branch: main
                 path: ./src
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/staging/versions.yaml
+            updates:
+              - key: spec.applications.chains.image.tag
+                value: ${{ imageFrom("chains").Tag }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/staging/values/chains/values.yaml
             updates:
@@ -29,8 +40,10 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(chains): promote to staging v${{ imageFrom("chains").Tag }}
+
+              Image: ${{ imageFrom("chains").RepoURL }}:${{ imageFrom("chains").Tag }}
         - uses: git-push
           config:
             path: ./src
@@ -40,4 +53,5 @@ spec:
               - name: chains-staging
   verification:
     analysisTemplates:
-      - name: integration-test
+      - name: health-check
+      - name: smoke-test

--- a/kargo/stages/direct/dev.yaml
+++ b/kargo/stages/direct/dev.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -20,6 +21,16 @@ spec:
               - branch: main
                 path: ./src
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/dev/versions.yaml
+            updates:
+              - key: spec.applications.direct.image.tag
+                value: ${{ imageFrom("direct").Tag }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/dev/values/direct/values.yaml
             updates:
@@ -28,8 +39,10 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(direct): promote to dev v${{ imageFrom("direct").Tag }}
+
+              Image: ${{ imageFrom("direct").RepoURL }}:${{ imageFrom("direct").Tag }}
         - uses: git-push
           config:
             path: ./src

--- a/kargo/stages/direct/integration.yaml
+++ b/kargo/stages/direct/integration.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -21,6 +22,16 @@ spec:
               - branch: main
                 path: ./src
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/integration/versions.yaml
+            updates:
+              - key: spec.applications.direct.image.tag
+                value: ${{ imageFrom("direct").Tag }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/integration/values/direct/values.yaml
             updates:
@@ -29,8 +40,10 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(direct): promote to integration v${{ imageFrom("direct").Tag }}
+
+              Image: ${{ imageFrom("direct").RepoURL }}:${{ imageFrom("direct").Tag }}
         - uses: git-push
           config:
             path: ./src
@@ -40,4 +53,5 @@ spec:
               - name: direct-integration
   verification:
     analysisTemplates:
-      - name: smoke-test
+      - name: health-check
+      - name: integration-test

--- a/kargo/stages/direct/prod.yaml
+++ b/kargo/stages/direct/prod.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -21,6 +22,18 @@ spec:
               - branch: main
                 path: ./src
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/prod/versions.yaml
+            updates:
+              - key: spec.applications.direct.image.tag
+                value: ${{ imageFrom("direct").Tag }}
+              - key: spec.applications.direct.image.digest
+                value: ${{ imageFrom("direct").Digest }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/prod/values/direct/values.yaml
             updates:
@@ -29,8 +42,10 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(direct): promote to prod v${{ imageFrom("direct").Tag }}
+
+              Image: ${{ imageFrom("direct").RepoURL }}:${{ imageFrom("direct").Tag }}
         - uses: git-push
           config:
             path: ./src
@@ -41,3 +56,5 @@ spec:
   verification:
     analysisTemplates:
       - name: health-check
+      - name: smoke-test
+      - name: integration-test

--- a/kargo/stages/direct/staging.yaml
+++ b/kargo/stages/direct/staging.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -21,6 +22,16 @@ spec:
               - branch: main
                 path: ./src
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/staging/versions.yaml
+            updates:
+              - key: spec.applications.direct.image.tag
+                value: ${{ imageFrom("direct").Tag }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/staging/values/direct/values.yaml
             updates:
@@ -29,8 +40,10 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(direct): promote to staging v${{ imageFrom("direct").Tag }}
+
+              Image: ${{ imageFrom("direct").RepoURL }}:${{ imageFrom("direct").Tag }}
         - uses: git-push
           config:
             path: ./src
@@ -40,4 +53,5 @@ spec:
               - name: direct-staging
   verification:
     analysisTemplates:
-      - name: integration-test
+      - name: health-check
+      - name: smoke-test

--- a/kargo/stages/listeners/dev.yaml
+++ b/kargo/stages/listeners/dev.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -20,6 +21,16 @@ spec:
               - branch: main
                 path: ./src
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/dev/versions.yaml
+            updates:
+              - key: spec.applications.listeners.image.tag
+                value: ${{ imageFrom("listeners").Tag }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/dev/values/listeners/values.yaml
             updates:
@@ -28,8 +39,10 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(listeners): promote to dev v${{ imageFrom("listeners").Tag }}
+
+              Image: ${{ imageFrom("listeners").RepoURL }}:${{ imageFrom("listeners").Tag }}
         - uses: git-push
           config:
             path: ./src

--- a/kargo/stages/listeners/integration.yaml
+++ b/kargo/stages/listeners/integration.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -21,6 +22,16 @@ spec:
               - branch: main
                 path: ./src
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/integration/versions.yaml
+            updates:
+              - key: spec.applications.listeners.image.tag
+                value: ${{ imageFrom("listeners").Tag }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/integration/values/listeners/values.yaml
             updates:
@@ -29,8 +40,10 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(listeners): promote to integration v${{ imageFrom("listeners").Tag }}
+
+              Image: ${{ imageFrom("listeners").RepoURL }}:${{ imageFrom("listeners").Tag }}
         - uses: git-push
           config:
             path: ./src
@@ -40,4 +53,5 @@ spec:
               - name: listeners-integration
   verification:
     analysisTemplates:
-      - name: smoke-test
+      - name: health-check
+      - name: integration-test

--- a/kargo/stages/listeners/prod.yaml
+++ b/kargo/stages/listeners/prod.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -21,6 +22,18 @@ spec:
               - branch: main
                 path: ./src
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/prod/versions.yaml
+            updates:
+              - key: spec.applications.listeners.image.tag
+                value: ${{ imageFrom("listeners").Tag }}
+              - key: spec.applications.listeners.image.digest
+                value: ${{ imageFrom("listeners").Digest }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/prod/values/listeners/values.yaml
             updates:
@@ -29,8 +42,10 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(listeners): promote to prod v${{ imageFrom("listeners").Tag }}
+
+              Image: ${{ imageFrom("listeners").RepoURL }}:${{ imageFrom("listeners").Tag }}
         - uses: git-push
           config:
             path: ./src
@@ -41,3 +56,5 @@ spec:
   verification:
     analysisTemplates:
       - name: health-check
+      - name: smoke-test
+      - name: integration-test

--- a/kargo/stages/listeners/staging.yaml
+++ b/kargo/stages/listeners/staging.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -21,6 +22,16 @@ spec:
               - branch: main
                 path: ./src
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/staging/versions.yaml
+            updates:
+              - key: spec.applications.listeners.image.tag
+                value: ${{ imageFrom("listeners").Tag }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/staging/values/listeners/values.yaml
             updates:
@@ -29,8 +40,10 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(listeners): promote to staging v${{ imageFrom("listeners").Tag }}
+
+              Image: ${{ imageFrom("listeners").RepoURL }}:${{ imageFrom("listeners").Tag }}
         - uses: git-push
           config:
             path: ./src
@@ -40,4 +53,5 @@ spec:
               - name: listeners-staging
   verification:
     analysisTemplates:
-      - name: integration-test
+      - name: health-check
+      - name: smoke-test

--- a/kargo/stages/mono/dev.yaml
+++ b/kargo/stages/mono/dev.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -19,7 +20,19 @@ spec:
             checkout:
               - branch: main
                 path: ./src
+        # Update version manifest (source of truth)
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/dev/versions.yaml
+            updates:
+              - key: spec.applications.mono.image.tag
+                value: ${{ imageFrom("mono").Tag }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        # Update values file (for ArgoCD consumption)
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/dev/values/mono/values.yaml
             updates:
@@ -28,8 +41,11 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(mono): promote to dev v${{ imageFrom("mono").Tag }}
+
+              Image: ${{ imageFrom("mono").RepoURL }}:${{ imageFrom("mono").Tag }}
+              Digest: ${{ imageFrom("mono").Digest }}
         - uses: git-push
           config:
             path: ./src

--- a/kargo/stages/mono/integration.yaml
+++ b/kargo/stages/mono/integration.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -21,6 +22,16 @@ spec:
               - branch: main
                 path: ./src
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/integration/versions.yaml
+            updates:
+              - key: spec.applications.mono.image.tag
+                value: ${{ imageFrom("mono").Tag }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/integration/values/mono/values.yaml
             updates:
@@ -29,8 +40,11 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(mono): promote to integration v${{ imageFrom("mono").Tag }}
+
+              Image: ${{ imageFrom("mono").RepoURL }}:${{ imageFrom("mono").Tag }}
+              Promoted from: dev
         - uses: git-push
           config:
             path: ./src
@@ -40,4 +54,5 @@ spec:
               - name: mono-integration
   verification:
     analysisTemplates:
-      - name: smoke-test
+      - name: health-check
+      - name: integration-test

--- a/kargo/stages/mono/prod.yaml
+++ b/kargo/stages/mono/prod.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -21,6 +22,18 @@ spec:
               - branch: main
                 path: ./src
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/prod/versions.yaml
+            updates:
+              - key: spec.applications.mono.image.tag
+                value: ${{ imageFrom("mono").Tag }}
+              - key: spec.applications.mono.image.digest
+                value: ${{ imageFrom("mono").Digest }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/prod/values/mono/values.yaml
             updates:
@@ -29,8 +42,12 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(mono): promote to prod v${{ imageFrom("mono").Tag }}
+
+              Image: ${{ imageFrom("mono").RepoURL }}:${{ imageFrom("mono").Tag }}
+              Digest: ${{ imageFrom("mono").Digest }}
+              Promoted from: staging
         - uses: git-push
           config:
             path: ./src
@@ -41,3 +58,5 @@ spec:
   verification:
     analysisTemplates:
       - name: health-check
+      - name: smoke-test
+      - name: integration-test

--- a/kargo/stages/mono/staging.yaml
+++ b/kargo/stages/mono/staging.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -21,6 +22,16 @@ spec:
               - branch: main
                 path: ./src
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/staging/versions.yaml
+            updates:
+              - key: spec.applications.mono.image.tag
+                value: ${{ imageFrom("mono").Tag }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/staging/values/mono/values.yaml
             updates:
@@ -29,8 +40,11 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(mono): promote to staging v${{ imageFrom("mono").Tag }}
+
+              Image: ${{ imageFrom("mono").RepoURL }}:${{ imageFrom("mono").Tag }}
+              Promoted from: integration
         - uses: git-push
           config:
             path: ./src
@@ -40,4 +54,5 @@ spec:
               - name: mono-staging
   verification:
     analysisTemplates:
-      - name: integration-test
+      - name: health-check
+      - name: smoke-test

--- a/kargo/stages/protocols/dev.yaml
+++ b/kargo/stages/protocols/dev.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -20,6 +21,16 @@ spec:
               - branch: main
                 path: ./src
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/dev/versions.yaml
+            updates:
+              - key: spec.applications.protocols.image.tag
+                value: ${{ imageFrom("protocols").Tag }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/dev/values/protocols/values.yaml
             updates:
@@ -28,8 +39,10 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(protocols): promote to dev v${{ imageFrom("protocols").Tag }}
+
+              Image: ${{ imageFrom("protocols").RepoURL }}:${{ imageFrom("protocols").Tag }}
         - uses: git-push
           config:
             path: ./src

--- a/kargo/stages/protocols/integration.yaml
+++ b/kargo/stages/protocols/integration.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -21,6 +22,16 @@ spec:
               - branch: main
                 path: ./src
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/integration/versions.yaml
+            updates:
+              - key: spec.applications.protocols.image.tag
+                value: ${{ imageFrom("protocols").Tag }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/integration/values/protocols/values.yaml
             updates:
@@ -29,8 +40,10 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(protocols): promote to integration v${{ imageFrom("protocols").Tag }}
+
+              Image: ${{ imageFrom("protocols").RepoURL }}:${{ imageFrom("protocols").Tag }}
         - uses: git-push
           config:
             path: ./src
@@ -40,4 +53,5 @@ spec:
               - name: protocols-integration
   verification:
     analysisTemplates:
-      - name: smoke-test
+      - name: health-check
+      - name: integration-test

--- a/kargo/stages/protocols/prod.yaml
+++ b/kargo/stages/protocols/prod.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -21,6 +22,18 @@ spec:
               - branch: main
                 path: ./src
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/prod/versions.yaml
+            updates:
+              - key: spec.applications.protocols.image.tag
+                value: ${{ imageFrom("protocols").Tag }}
+              - key: spec.applications.protocols.image.digest
+                value: ${{ imageFrom("protocols").Digest }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/prod/values/protocols/values.yaml
             updates:
@@ -29,8 +42,10 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(protocols): promote to prod v${{ imageFrom("protocols").Tag }}
+
+              Image: ${{ imageFrom("protocols").RepoURL }}:${{ imageFrom("protocols").Tag }}
         - uses: git-push
           config:
             path: ./src
@@ -41,3 +56,5 @@ spec:
   verification:
     analysisTemplates:
       - name: health-check
+      - name: smoke-test
+      - name: integration-test

--- a/kargo/stages/protocols/staging.yaml
+++ b/kargo/stages/protocols/staging.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
@@ -21,6 +22,16 @@ spec:
               - branch: main
                 path: ./src
         - uses: yaml-update
+          as: update-version-manifest
+          config:
+            path: ./src/versions/staging/versions.yaml
+            updates:
+              - key: spec.applications.protocols.image.tag
+                value: ${{ imageFrom("protocols").Tag }}
+              - key: metadata.lastUpdated
+                value: ${{ now | date "2006-01-02T15:04:05Z" }}
+        - uses: yaml-update
+          as: update-values
           config:
             path: ./src/envs/staging/values/protocols/values.yaml
             updates:
@@ -29,8 +40,10 @@ spec:
         - uses: git-commit
           config:
             path: ./src
-            messageFromSteps:
-              - yaml-update
+            message: |
+              chore(protocols): promote to staging v${{ imageFrom("protocols").Tag }}
+
+              Image: ${{ imageFrom("protocols").RepoURL }}:${{ imageFrom("protocols").Tag }}
         - uses: git-push
           config:
             path: ./src
@@ -40,4 +53,5 @@ spec:
               - name: protocols-staging
   verification:
     analysisTemplates:
-      - name: integration-test
+      - name: health-check
+      - name: smoke-test

--- a/scripts/version-diff.sh
+++ b/scripts/version-diff.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# version-diff.sh - Compare application versions across environments
+#
+# Usage:
+#   ./scripts/version-diff.sh              # Compare all environments
+#   ./scripts/version-diff.sh dev prod     # Compare specific environments
+#   ./scripts/version-diff.sh -a mono      # Show specific app across all envs
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+VERSIONS_DIR="$REPO_ROOT/versions"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+usage() {
+    echo "Usage: $0 [options] [env1] [env2]"
+    echo ""
+    echo "Options:"
+    echo "  -a, --app APP    Show versions for specific application"
+    echo "  -h, --help       Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  $0                    # Compare all apps across all environments"
+    echo "  $0 dev prod           # Compare dev and prod"
+    echo "  $0 -a mono            # Show mono versions across all environments"
+    exit 0
+}
+
+get_version() {
+    local env=$1
+    local app=$2
+    local file="$VERSIONS_DIR/$env/versions.yaml"
+
+    if [[ ! -f "$file" ]]; then
+        echo "N/A"
+        return
+    fi
+
+    python3 -c "
+import yaml
+with open('$file') as f:
+    data = yaml.safe_load(f)
+apps = data.get('spec', {}).get('applications', {})
+app_config = apps.get('$app', {})
+print(app_config.get('image', {}).get('tag', 'N/A'))
+" 2>/dev/null || echo "N/A"
+}
+
+get_all_apps() {
+    local apps=()
+    for env in dev integration staging prod; do
+        local file="$VERSIONS_DIR/$env/versions.yaml"
+        if [[ -f "$file" ]]; then
+            while IFS= read -r app; do
+                apps+=("$app")
+            done < <(python3 -c "
+import yaml
+with open('$file') as f:
+    data = yaml.safe_load(f)
+for app in data.get('spec', {}).get('applications', {}).keys():
+    print(app)
+" 2>/dev/null)
+        fi
+    done
+    printf '%s\n' "${apps[@]}" | sort -u
+}
+
+compare_all() {
+    local envs=("dev" "integration" "staging" "prod")
+
+    # Header
+    printf "%-15s" "Application"
+    for env in "${envs[@]}"; do
+        printf "%-15s" "$env"
+    done
+    echo ""
+
+    # Separator
+    printf "%-15s" "---------------"
+    for _ in "${envs[@]}"; do
+        printf "%-15s" "---------------"
+    done
+    echo ""
+
+    # Data
+    while IFS= read -r app; do
+        printf "%-15s" "$app"
+        local prev_version=""
+        for env in "${envs[@]}"; do
+            local version
+            version=$(get_version "$env" "$app")
+            if [[ "$prev_version" != "" && "$version" != "$prev_version" ]]; then
+                printf "${YELLOW}%-15s${NC}" "$version"
+            else
+                printf "%-15s" "$version"
+            fi
+            prev_version="$version"
+        done
+        echo ""
+    done < <(get_all_apps)
+}
+
+compare_two() {
+    local env1=$1
+    local env2=$2
+
+    echo -e "${BLUE}Comparing $env1 vs $env2${NC}"
+    echo ""
+
+    printf "%-15s %-15s %-15s %s\n" "Application" "$env1" "$env2" "Status"
+    printf "%-15s %-15s %-15s %s\n" "---------------" "---------------" "---------------" "------"
+
+    while IFS= read -r app; do
+        local v1 v2
+        v1=$(get_version "$env1" "$app")
+        v2=$(get_version "$env2" "$app")
+
+        local status=""
+        if [[ "$v1" == "$v2" ]]; then
+            status="${GREEN}==${NC}"
+        else
+            status="${RED}!=${NC}"
+        fi
+
+        printf "%-15s %-15s %-15s " "$app" "$v1" "$v2"
+        echo -e "$status"
+    done < <(get_all_apps)
+}
+
+show_app() {
+    local app=$1
+    local envs=("dev" "integration" "staging" "prod")
+
+    echo -e "${BLUE}Versions for: $app${NC}"
+    echo ""
+
+    for env in "${envs[@]}"; do
+        local version
+        version=$(get_version "$env" "$app")
+        printf "%-15s %s\n" "$env:" "$version"
+    done
+}
+
+# Parse arguments
+APP=""
+ENVS=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -a|--app)
+            APP="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            ENVS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# Execute
+if [[ -n "$APP" ]]; then
+    show_app "$APP"
+elif [[ ${#ENVS[@]} -eq 2 ]]; then
+    compare_two "${ENVS[0]}" "${ENVS[1]}"
+else
+    compare_all
+fi

--- a/versions/README.md
+++ b/versions/README.md
@@ -1,0 +1,178 @@
+# Application Version Management
+
+Centralized version control for all platform applications across environments.
+
+## Overview
+
+This directory contains **version manifests** - the single source of truth for
+what version of each application is deployed in each environment.
+
+```
+versions/
+├── schema.json              # JSON Schema for validation
+├── dev/
+│   └── versions.yaml        # All app versions for dev environment
+├── integration/
+│   └── versions.yaml
+├── staging/
+│   └── versions.yaml
+└── prod/
+    └── versions.yaml
+```
+
+## Version Manifest Structure
+
+```yaml
+apiVersion: platform.io/v1
+kind: VersionManifest
+metadata:
+  environment: dev
+  lastUpdated: "2026-02-03T15:00:00Z"
+  updatedBy: kargo
+spec:
+  defaults:
+    helm:
+      chart: helm/app
+      version: "0.2.0"
+    image:
+      repository: "${ECR_REGISTRY}"
+
+  applications:
+    mono:
+      image:
+        tag: "1.2.3"
+        digest: "sha256:..."  # Optional, recommended for prod
+      replicas: 2
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+```
+
+## How Version Updates Flow
+
+```
+┌─────────────┐     ┌───────────┐     ┌──────────────────┐     ┌────────┐
+│ ECR Image   │────▶│  Kargo    │────▶│ Version Manifest │────▶│ ArgoCD │
+│ Published   │     │ Warehouse │     │ + Values File    │     │  Sync  │
+└─────────────┘     └───────────┘     └──────────────────┘     └────────┘
+```
+
+1. **New image pushed to ECR** - CI/CD builds and pushes image with semver tag
+2. **Kargo Warehouse detects** - Watches ECR for new images matching constraints
+3. **Kargo Stage promotes** - Updates BOTH:
+   - `versions/{env}/versions.yaml` (source of truth)
+   - `envs/{env}/values/{app}/values.yaml` (for ArgoCD)
+4. **ArgoCD syncs** - Detects values file change, deploys new version
+
+## Promotion Pipeline
+
+```
+dev ──▶ integration ──▶ staging ──▶ prod
+         (auto)          (auto)     (manual)
+```
+
+- **dev**: Auto-promoted when new image detected
+- **integration**: Auto-promoted after dev verification passes
+- **staging**: Auto-promoted after integration tests pass
+- **prod**: Manual approval required
+
+## CLI Tools
+
+### Compare versions across environments
+
+```bash
+# All apps, all environments
+./scripts/version-diff.sh
+
+# Output:
+# Application     dev             integration     staging         prod
+# -------------------------------------------------------------------------------
+# mono            1.2.3           1.2.3           1.2.2           1.2.0
+# chains          2.0.0           2.0.0           2.0.0           1.9.5
+
+# Compare specific environments
+./scripts/version-diff.sh dev prod
+
+# Show specific app
+./scripts/version-diff.sh -a mono
+```
+
+## Adding a New Application
+
+1. **Add to version manifests** for each environment:
+
+```yaml
+# versions/dev/versions.yaml
+spec:
+  applications:
+    my-new-app:
+      image:
+        tag: "0.1.0"
+      replicas: 1
+```
+
+2. **Create values file**:
+
+```yaml
+# envs/dev/values/my-new-app/values.yaml
+image:
+  tag: "0.1.0"
+```
+
+3. **Create Kargo resources**:
+   - Warehouse (subscribes to ECR)
+   - Stages (dev, integration, staging, prod)
+   - Project (promotion policies)
+
+4. **Add to ApplicationSet** (if not using dynamic generation):
+
+```yaml
+# argocd/applicationset-workloads.yaml
+generators:
+  - list:
+      elements:
+        - team: my-new-app
+          namespace: my-new-app
+```
+
+## Validation
+
+Version manifests are validated on every PR:
+
+- **Schema validation** - Ensures correct structure
+- **Required apps check** - All core apps must be present
+- **Tag format validation** - Must match `^[a-zA-Z0-9][a-zA-Z0-9._-]*$`
+- **Environment diff** - Shows what versions will change
+
+## Best Practices
+
+1. **Never edit version manifests manually** - Let Kargo handle updates
+2. **Use semver tags** - Enables proper version ordering
+3. **Pin digests in prod** - For immutable, reproducible deployments
+4. **Review version diffs** - Before merging PRs that change versions
+
+## Rollback
+
+To rollback an application:
+
+1. **Find previous version** in git history:
+   ```bash
+   git log -p versions/prod/versions.yaml
+   ```
+
+2. **Revert the version** manually or re-promote from Kargo UI
+
+3. **Commit and push** - ArgoCD will sync the rollback
+
+## Schema Reference
+
+See `schema.json` for the full JSON Schema definition. Key fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `spec.applications.{app}.image.tag` | string | Image tag (required) |
+| `spec.applications.{app}.image.digest` | string | SHA256 digest |
+| `spec.applications.{app}.helm.version` | string | Helm chart version |
+| `spec.applications.{app}.replicas` | integer | Override replica count |
+| `spec.applications.{app}.enabled` | boolean | Enable/disable app |

--- a/versions/dev/versions.yaml
+++ b/versions/dev/versions.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: platform.io/v1
+kind: VersionManifest
+metadata:
+  environment: dev
+  lastUpdated: "2026-02-03T00:00:00Z"
+  updatedBy: platform-team
+spec:
+  # Default values inherited by all applications
+  defaults:
+    helm:
+      chart: helm/app
+      version: "0.2.0"
+    image:
+      repository: "${ECR_REGISTRY}"  # Substituted at deploy time
+
+  applications:
+    # --- Mono team applications ---
+    mono:
+      image:
+        tag: "0.1.0"
+      replicas: 1
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 256Mi
+
+    # --- Chains team applications ---
+    chains:
+      image:
+        tag: "0.1.0"
+      replicas: 1
+
+    # --- Direct team applications ---
+    direct:
+      image:
+        tag: "0.1.0"
+      replicas: 1
+
+    # --- Protocols team applications ---
+    protocols:
+      image:
+        tag: "0.1.0"
+      replicas: 1
+
+    # --- Listeners team applications ---
+    listeners:
+      image:
+        tag: "0.1.0"
+      replicas: 1

--- a/versions/integration/versions.yaml
+++ b/versions/integration/versions.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: platform.io/v1
+kind: VersionManifest
+metadata:
+  environment: integration
+  lastUpdated: "2026-02-03T00:00:00Z"
+  updatedBy: platform-team
+spec:
+  defaults:
+    helm:
+      chart: helm/app
+      version: "0.2.0"
+    image:
+      repository: "${ECR_REGISTRY}"
+
+  applications:
+    mono:
+      image:
+        tag: "0.1.0"
+      replicas: 2
+
+    chains:
+      image:
+        tag: "0.1.0"
+      replicas: 2
+
+    direct:
+      image:
+        tag: "0.1.0"
+      replicas: 2
+
+    protocols:
+      image:
+        tag: "0.1.0"
+      replicas: 2
+
+    listeners:
+      image:
+        tag: "0.1.0"
+      replicas: 2

--- a/versions/prod/versions.yaml
+++ b/versions/prod/versions.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: platform.io/v1
+kind: VersionManifest
+metadata:
+  environment: prod
+  lastUpdated: "2026-02-03T00:00:00Z"
+  updatedBy: platform-team
+spec:
+  defaults:
+    helm:
+      chart: helm/app
+      version: "0.2.0"
+    image:
+      repository: "${ECR_REGISTRY}"
+
+  applications:
+    mono:
+      image:
+        tag: "0.1.0"
+        # digest: sha256:...  # Uncomment and set for immutable prod deploys
+      replicas: 3
+      resources:
+        requests:
+          cpu: 500m
+          memory: 512Mi
+        limits:
+          cpu: 2000m
+          memory: 1Gi
+
+    chains:
+      image:
+        tag: "0.1.0"
+      replicas: 3
+
+    direct:
+      image:
+        tag: "0.1.0"
+      replicas: 3
+
+    protocols:
+      image:
+        tag: "0.1.0"
+      replicas: 3
+
+    listeners:
+      image:
+        tag: "0.1.0"
+      replicas: 3

--- a/versions/schema.json
+++ b/versions/schema.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://platform.io/schemas/version-manifest.json",
+  "title": "Version Manifest",
+  "description": "Centralized version control for platform applications",
+  "type": "object",
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "const": "platform.io/v1"
+    },
+    "kind": {
+      "type": "string",
+      "const": "VersionManifest"
+    },
+    "metadata": {
+      "type": "object",
+      "required": ["environment"],
+      "properties": {
+        "environment": {
+          "type": "string",
+          "enum": ["dev", "integration", "staging", "prod"]
+        },
+        "lastUpdated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updatedBy": {
+          "type": "string",
+          "description": "User or system that last updated the manifest"
+        }
+      }
+    },
+    "spec": {
+      "type": "object",
+      "required": ["applications"],
+      "properties": {
+        "defaults": {
+          "type": "object",
+          "description": "Default values inherited by all applications",
+          "properties": {
+            "helm": {
+              "$ref": "#/$defs/helmSpec"
+            },
+            "image": {
+              "$ref": "#/$defs/imageSpec"
+            }
+          }
+        },
+        "applications": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/applicationSpec"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "applicationSpec": {
+      "type": "object",
+      "required": ["image"],
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether this application is deployed in this environment"
+        },
+        "image": {
+          "$ref": "#/$defs/imageSpec"
+        },
+        "helm": {
+          "$ref": "#/$defs/helmSpec"
+        },
+        "config": {
+          "$ref": "#/$defs/configSpec"
+        },
+        "replicas": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Override replica count for this environment"
+        },
+        "resources": {
+          "$ref": "#/$defs/resourcesSpec"
+        }
+      }
+    },
+    "imageSpec": {
+      "type": "object",
+      "required": ["tag"],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "Container image repository (overrides default)"
+        },
+        "tag": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$",
+          "description": "Image tag (semver recommended)"
+        },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$",
+          "description": "Image digest for immutable deployments"
+        }
+      }
+    },
+    "helmSpec": {
+      "type": "object",
+      "properties": {
+        "chart": {
+          "type": "string",
+          "description": "Path to Helm chart in repo"
+        },
+        "version": {
+          "type": "string",
+          "description": "Chart version (from Chart.yaml)"
+        },
+        "valuesFile": {
+          "type": "string",
+          "description": "Additional values file path"
+        }
+      }
+    },
+    "configSpec": {
+      "type": "object",
+      "properties": {
+        "revision": {
+          "type": "string",
+          "description": "Git commit SHA for config values"
+        },
+        "valuesChecksum": {
+          "type": "string",
+          "description": "SHA256 checksum of merged values"
+        }
+      }
+    },
+    "resourcesSpec": {
+      "type": "object",
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        },
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/versions/staging/versions.yaml
+++ b/versions/staging/versions.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: platform.io/v1
+kind: VersionManifest
+metadata:
+  environment: staging
+  lastUpdated: "2026-02-03T00:00:00Z"
+  updatedBy: platform-team
+spec:
+  defaults:
+    helm:
+      chart: helm/app
+      version: "0.2.0"
+    image:
+      repository: "${ECR_REGISTRY}"
+
+  applications:
+    mono:
+      image:
+        tag: "0.1.0"
+      replicas: 2
+      resources:
+        requests:
+          cpu: 200m
+          memory: 256Mi
+        limits:
+          cpu: 1000m
+          memory: 512Mi
+
+    chains:
+      image:
+        tag: "0.1.0"
+      replicas: 2
+
+    direct:
+      image:
+        tag: "0.1.0"
+      replicas: 2
+
+    protocols:
+      image:
+        tag: "0.1.0"
+      replicas: 2
+
+    listeners:
+      image:
+        tag: "0.1.0"
+      replicas: 2


### PR DESCRIPTION
Add centralized version manifests as single source of truth for application versions across all environments.

Version manifests (versions/{env}/versions.yaml):
- Define image tags, replicas, resources per app/env
- JSON Schema validation (versions/schema.json)
- Defaults inheritance for helm chart and image repo
- Digest pinning support for prod immutability

ArgoCD workloads ApplicationSet:
- Generates Applications dynamically from team×env matrix
- Replaces 20 individual Application files
- Rolling sync strategy (dev→integration→staging→prod)
- Kargo authorization annotations

Kargo stage updates (all 20 stages):
- Update version manifest as source of truth
- Continue updating values files for ArgoCD
- Improved commit messages with image/digest info
- Verification templates per environment tier

CI/CD:
- version-manifest-validate.yml workflow
- Schema validation, required apps check, tag format
- PR diff report showing version changes
- Environment comparison table

CLI tools:
- scripts/version-diff.sh - Compare versions across envs

