### PR TITLE
feat: add video pipeline data infrastructure for GPU analysis cluster

### DIFF
--- a/catalog/stacks/gpu-analysis/terragrunt.stack.hcl
+++ b/catalog/stacks/gpu-analysis/terragrunt.stack.hcl
@@ -1,13 +1,22 @@
 # ---------------------------------------------------------------------------------------------------------------------
 # GPU Video Analysis Stack Template
 # ---------------------------------------------------------------------------------------------------------------------
-# Composable stack that deploys the GPU video analysis EKS infrastructure:
-#   gpu-vpc → gpu-placement-group → gpu-eks → gpu-cilium
-#                                            → gpu-karpenter-iam → gpu-karpenter-controller
-#                                                                 → gpu-karpenter-nodepools
+# Composable stack that deploys the GPU video analysis infrastructure:
+#
+#   Compute Layer:
+#     gpu-vpc → gpu-placement-group → gpu-eks → gpu-cilium
+#                                              → gpu-karpenter-iam → gpu-karpenter-controller
+#                                                                   → gpu-karpenter-nodepools
+#   Data Layer:
+#     gpu-s3-raw-video ──→ gpu-eventbridge-video (requires gpu-sqs-video-jobs)
+#     gpu-s3-processing
+#     gpu-s3-results ────→ gpu-cloudfront
+#     gpu-sqs-video-jobs
+#     gpu-dynamodb-jobs
+#     gpu-elasticache (requires gpu-vpc + gpu-eks)
 #
 # Optimized for real-time video analysis: GPU instances (A10G/T4), placement groups
-# for low-latency networking, single-AZ pinning, mixed on-demand/spot capacity.
+# for low-latency networking, S3 storage tiers, SQS job queue, CloudFront delivery.
 #
 # CNI: Cilium with ENI IPAM mode
 # AMI: Bottlerocket (native Cilium support)
@@ -17,6 +26,10 @@
 #   terragrunt stack plan
 #   terragrunt stack apply
 # ---------------------------------------------------------------------------------------------------------------------
+
+# =============================================================================
+# Compute Layer
+# =============================================================================
 
 unit "gpu-vpc" {
   source = "${get_repo_root()}/catalog/units/gpu-vpc"
@@ -51,4 +64,60 @@ unit "gpu-karpenter-controller" {
 unit "gpu-karpenter-nodepools" {
   source = "${get_repo_root()}/catalog/units/gpu-karpenter-nodepools"
   path   = "gpu-karpenter-nodepools"
+}
+
+# =============================================================================
+# Data Layer — Storage
+# =============================================================================
+
+unit "gpu-s3-raw-video" {
+  source = "${get_repo_root()}/catalog/units/gpu-s3-raw-video"
+  path   = "gpu-s3-raw-video"
+}
+
+unit "gpu-s3-processing" {
+  source = "${get_repo_root()}/catalog/units/gpu-s3-processing"
+  path   = "gpu-s3-processing"
+}
+
+unit "gpu-s3-results" {
+  source = "${get_repo_root()}/catalog/units/gpu-s3-results"
+  path   = "gpu-s3-results"
+}
+
+# =============================================================================
+# Data Layer — Queue & Events
+# =============================================================================
+
+unit "gpu-sqs-video-jobs" {
+  source = "${get_repo_root()}/catalog/units/gpu-sqs-video-jobs"
+  path   = "gpu-sqs-video-jobs"
+}
+
+unit "gpu-eventbridge-video" {
+  source = "${get_repo_root()}/catalog/units/gpu-eventbridge-video"
+  path   = "gpu-eventbridge-video"
+}
+
+# =============================================================================
+# Data Layer — Metadata & Cache
+# =============================================================================
+
+unit "gpu-dynamodb-jobs" {
+  source = "${get_repo_root()}/catalog/units/gpu-dynamodb-jobs"
+  path   = "gpu-dynamodb-jobs"
+}
+
+unit "gpu-elasticache" {
+  source = "${get_repo_root()}/catalog/units/gpu-elasticache"
+  path   = "gpu-elasticache"
+}
+
+# =============================================================================
+# Data Layer — Delivery
+# =============================================================================
+
+unit "gpu-cloudfront" {
+  source = "${get_repo_root()}/catalog/units/gpu-cloudfront"
+  path   = "gpu-cloudfront"
 }

--- a/catalog/units/gpu-cloudfront/terragrunt.hcl
+++ b/catalog/units/gpu-cloudfront/terragrunt.hcl
@@ -1,0 +1,63 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Video Analysis CloudFront CDN -- Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# Provisions a CloudFront distribution with S3 origin for delivering heat map results
+# to end users. Uses Origin Access Control (OAC) for secure S3 access and geo-restricts
+# delivery to European countries.
+#
+# The distribution fronts the gpu-s3-results bucket and enforces HTTPS with the managed
+# CachingOptimized cache policy. A 403-to-404 error mapping prevents bucket enumeration.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/cloudfront-s3"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  account_name = local.account_vars.locals.account_name
+  aws_region   = local.region_vars.locals.aws_region
+  environment  = local.account_vars.locals.environment
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPENDENCY: GPU S3 Results Bucket
+# ---------------------------------------------------------------------------------------------------------------------
+
+dependency "s3_results" {
+  config_path = "../gpu-s3-results"
+
+  mock_outputs = {
+    bucket_id          = "mock-gpu-results-bucket"
+    bucket_arn         = "arn:aws:s3:::mock-gpu-results-bucket"
+    bucket_domain_name = "mock-gpu-results-bucket.s3.eu-west-3.amazonaws.com"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE INPUTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  name                           = "${local.environment}-${local.aws_region}-gpu-results-cdn"
+  s3_bucket_id                   = dependency.s3_results.outputs.bucket_id
+  s3_bucket_arn                  = dependency.s3_results.outputs.bucket_arn
+  s3_bucket_regional_domain_name = dependency.s3_results.outputs.bucket_domain_name
+
+  price_class = "PriceClass_100"
+
+  # EU country whitelist for geo-restriction
+  allowed_countries = ["FR", "DE", "GB", "ES", "IT", "NL", "BE", "AT", "CH", "PT"]
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-analysis"
+    DataTier    = "delivery"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/catalog/units/gpu-dynamodb-jobs/terragrunt.hcl
+++ b/catalog/units/gpu-dynamodb-jobs/terragrunt.hcl
@@ -1,0 +1,70 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Video Analysis DynamoDB Jobs Table -- Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# Provisions a DynamoDB table for tracking GPU video analysis job metadata. Stores job
+# state, video information, and result URLs with GSIs for querying by game ID and status.
+#
+# Schema:
+#   Partition key: job_id (S)    -- Unique job identifier
+#   Sort key:      timestamp (S) -- ISO-8601 job creation/update timestamp
+#   GSI:           game-id-index (game_id + timestamp) -- Query jobs by game
+#   GSI:           status-index  (status + timestamp)  -- Query jobs by processing status
+#   TTL:           ttl           -- Auto-expire completed jobs after retention period
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/dynamodb"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  account_name = local.account_vars.locals.account_name
+  aws_region   = local.region_vars.locals.aws_region
+  environment  = local.account_vars.locals.environment
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE INPUTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  name         = "${local.environment}-${local.aws_region}-gpu-video-jobs"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "job_id"
+  range_key    = "timestamp"
+
+  attributes = [
+    { name = "job_id", type = "S" },
+    { name = "timestamp", type = "S" },
+    { name = "game_id", type = "S" },
+    { name = "status", type = "S" },
+  ]
+
+  global_secondary_indexes = [
+    {
+      name            = "game-id-index"
+      hash_key        = "game_id"
+      range_key       = "timestamp"
+      projection_type = "ALL"
+    },
+    {
+      name            = "status-index"
+      hash_key        = "status"
+      range_key       = "timestamp"
+      projection_type = "ALL"
+    },
+  ]
+
+  point_in_time_recovery = true
+  ttl_attribute          = "ttl"
+  create_iam_policies    = true
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-analysis"
+    DataTier    = "metadata"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/catalog/units/gpu-elasticache/terragrunt.hcl
+++ b/catalog/units/gpu-elasticache/terragrunt.hcl
@@ -1,0 +1,88 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Analysis ElastiCache Redis — Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# Redis cache for the video analysis pipeline. Provides:
+#   - API response caching (heat map queries)
+#   - Job metadata hot cache (reduces DynamoDB reads)
+#   - Rate limiting counters
+#   - WebSocket session state (future real-time features)
+#
+# Deployed in the GPU Analysis VPC database subnets with access restricted to
+# the EKS cluster node security group.
+#
+# PCI-DSS: slow-log and engine-log shipped to CloudWatch (Req 10.1).
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/elasticache"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  account_name          = local.account_vars.locals.account_name
+  aws_region            = local.region_vars.locals.aws_region
+  environment           = local.account_vars.locals.environment
+  video_pipeline_config = local.account_vars.locals.video_pipeline_config
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPENDENCIES: GPU VPC (subnets, SG) and GPU EKS (node SG for access)
+# ---------------------------------------------------------------------------------------------------------------------
+
+dependency "vpc" {
+  config_path = "../gpu-vpc"
+
+  mock_outputs = {
+    vpc_id           = "vpc-00000000000000000"
+    database_subnets = ["subnet-00000000000000000", "subnet-11111111111111111", "subnet-22222222222222222"]
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+dependency "eks" {
+  config_path = "../gpu-eks"
+
+  mock_outputs = {
+    node_security_group_id = "sg-00000000000000000"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE INPUTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  name        = "${local.environment}-${local.aws_region}-gpu-video-cache"
+  description = "Redis cache for GPU video analysis pipeline"
+
+  vpc_id     = dependency.vpc.outputs.vpc_id
+  subnet_ids = dependency.vpc.outputs.database_subnets
+
+  allowed_security_group_ids = [dependency.eks.outputs.node_security_group_id]
+
+  engine_version = try(local.video_pipeline_config.redis_engine_version, "7.1")
+  node_type      = try(local.video_pipeline_config.redis_node_type, "cache.t4g.micro")
+  num_cache_clusters = try(local.video_pipeline_config.redis_num_nodes, 2)
+
+  transit_encryption_enabled = true
+  snapshot_retention_limit   = 7
+
+  # PCI-DSS logging
+  slow_log_enabled   = true
+  engine_log_enabled = true
+  log_retention_days = 365
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-analysis"
+    DataTier    = "cache"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/catalog/units/gpu-eventbridge-video/terragrunt.hcl
+++ b/catalog/units/gpu-eventbridge-video/terragrunt.hcl
@@ -1,0 +1,70 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Video Upload EventBridge Rule — Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# Connects the raw video S3 bucket to the video jobs SQS queue via EventBridge.
+# When a video file (.mp4, .avi, .mov, .mkv) is uploaded to the raw video bucket,
+# EventBridge routes the event to the SQS queue for GPU pod consumption.
+#
+# Dependencies:
+#   - gpu-s3-raw-video: provides the source bucket name and ARN
+#   - gpu-sqs-video-jobs: provides the target queue ARN and URL
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/eventbridge-s3-sqs"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  account_name = local.account_vars.locals.account_name
+  aws_region   = local.region_vars.locals.aws_region
+  environment  = local.account_vars.locals.environment
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPENDENCIES
+# ---------------------------------------------------------------------------------------------------------------------
+
+dependency "s3_raw_video" {
+  config_path = "../gpu-s3-raw-video"
+
+  mock_outputs = {
+    bucket_id  = "mock-staging-eu-west-3-gpu-raw-video"
+    bucket_arn = "arn:aws:s3:::mock-staging-eu-west-3-gpu-raw-video"
+  }
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+dependency "sqs_video_jobs" {
+  config_path = "../gpu-sqs-video-jobs"
+
+  mock_outputs = {
+    queue_arn = "arn:aws:sqs:eu-west-3:123456789012:mock-staging-eu-west-3-gpu-video-jobs"
+    queue_url = "https://sqs.eu-west-3.amazonaws.com/123456789012/mock-staging-eu-west-3-gpu-video-jobs"
+  }
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE INPUTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  name               = "${local.environment}-${local.aws_region}-gpu-video-upload"
+  source_bucket_name = dependency.s3_raw_video.outputs.bucket_id
+  source_bucket_arn  = dependency.s3_raw_video.outputs.bucket_arn
+  target_queue_arn   = dependency.sqs_video_jobs.outputs.queue_arn
+  target_queue_url   = dependency.sqs_video_jobs.outputs.queue_url
+
+  event_pattern_suffix = [".mp4", ".avi", ".mov", ".mkv"]
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-analysis"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/catalog/units/gpu-s3-processing/terragrunt.hcl
+++ b/catalog/units/gpu-s3-processing/terragrunt.hcl
@@ -1,0 +1,49 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Processing Bucket — Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# Ephemeral S3 bucket for intermediate GPU processing artifacts (frames, tensors, partial results).
+# Data expires after 7 days — this is scratch space, not long-term storage.
+#
+# Versioning is disabled because intermediate data is disposable and regenerable.
+# force_destroy is enabled in non-production environments for easy teardown.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/s3-app"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  account_name = local.account_vars.locals.account_name
+  aws_region   = local.region_vars.locals.aws_region
+  environment  = local.account_vars.locals.environment
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE INPUTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  bucket_name        = "${local.environment}-${local.aws_region}-gpu-processing"
+  versioning_enabled = false
+  force_destroy      = local.environment != "prod"
+
+  lifecycle_rules = [
+    {
+      id              = "expire-ephemeral"
+      prefix          = ""
+      expiration_days = 7
+    },
+  ]
+
+  create_iam_policies = true
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-analysis"
+    DataTier    = "processing"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/catalog/units/gpu-s3-raw-video/terragrunt.hcl
+++ b/catalog/units/gpu-s3-raw-video/terragrunt.hcl
@@ -1,0 +1,61 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Raw Video Upload Bucket — Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# S3 bucket for raw sport video uploads before GPU processing.
+# Lifecycle tiering: INTELLIGENT_TIERING (1 day) -> GLACIER (90 days) -> DEEP_ARCHIVE (180 days).
+#
+# EventBridge notifications on this bucket trigger the video processing pipeline via SQS.
+# IAM policies are created for IRSA-based pod access.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/s3-app"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  account_name = local.account_vars.locals.account_name
+  aws_region   = local.region_vars.locals.aws_region
+  environment  = local.account_vars.locals.environment
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE INPUTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  bucket_name        = "${local.environment}-${local.aws_region}-gpu-raw-video"
+  versioning_enabled = true
+
+  lifecycle_rules = [
+    {
+      id     = "tiering"
+      prefix = ""
+      transitions = [
+        {
+          days          = 1
+          storage_class = "INTELLIGENT_TIERING"
+        },
+        {
+          days          = 90
+          storage_class = "GLACIER"
+        },
+        {
+          days          = 180
+          storage_class = "DEEP_ARCHIVE"
+        },
+      ]
+    },
+  ]
+
+  create_iam_policies = true
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-analysis"
+    DataTier    = "raw"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/catalog/units/gpu-s3-results/terragrunt.hcl
+++ b/catalog/units/gpu-s3-results/terragrunt.hcl
@@ -1,0 +1,57 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Analysis Results Bucket — Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# S3 bucket for final video analysis results (heat maps, player tracking data, statistics).
+# Versioning is enabled to protect completed analysis outputs.
+#
+# Lifecycle tiering: INTELLIGENT_TIERING (30 days) -> GLACIER (365 days) for cost optimization
+# on older results that are infrequently accessed but must be retained.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/s3-app"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  account_name = local.account_vars.locals.account_name
+  aws_region   = local.region_vars.locals.aws_region
+  environment  = local.account_vars.locals.environment
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE INPUTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  bucket_name        = "${local.environment}-${local.aws_region}-gpu-results"
+  versioning_enabled = true
+
+  lifecycle_rules = [
+    {
+      id     = "tiering"
+      prefix = ""
+      transitions = [
+        {
+          days          = 30
+          storage_class = "INTELLIGENT_TIERING"
+        },
+        {
+          days          = 365
+          storage_class = "GLACIER"
+        },
+      ]
+    },
+  ]
+
+  create_iam_policies = true
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-analysis"
+    DataTier    = "results"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/catalog/units/gpu-sqs-video-jobs/terragrunt.hcl
+++ b/catalog/units/gpu-sqs-video-jobs/terragrunt.hcl
@@ -1,0 +1,42 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Video Processing Job Queue — Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# SQS queue for GPU video analysis jobs. EventBridge routes S3 upload events from the
+# raw video bucket into this queue. GPU pods consume messages via long polling.
+#
+# visibility_timeout is set to 1 hour to accommodate long-running GPU video analysis.
+# Messages are retained for 14 days and moved to DLQ after 3 failed processing attempts.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/sqs"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  account_name = local.account_vars.locals.account_name
+  aws_region   = local.region_vars.locals.aws_region
+  environment  = local.account_vars.locals.environment
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE INPUTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  name                       = "${local.environment}-${local.aws_region}-gpu-video-jobs"
+  visibility_timeout_seconds = 3600
+  message_retention_seconds  = 1209600
+  receive_wait_time_seconds  = 20
+  create_dlq                 = true
+  max_receive_count          = 3
+  create_iam_policies        = true
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-analysis"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/terraform/modules/cloudfront-s3/main.tf
+++ b/terraform/modules/cloudfront-s3/main.tf
@@ -1,0 +1,112 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# CloudFront Distribution with S3 Origin
+# ---------------------------------------------------------------------------------------------------------------------
+# Provisions a CloudFront distribution using Origin Access Control (OAC) for private
+# S3 bucket access. Includes geo-restriction, HTTPS enforcement, and an S3 bucket policy
+# granting CloudFront read access to the origin bucket.
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_caller_identity" "current" {}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Origin Access Control (modern replacement for OAI)
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_cloudfront_origin_access_control" "this" {
+  name                              = var.name
+  description                       = "OAC for ${var.name} S3 origin"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CloudFront Distribution
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_cloudfront_distribution" "this" {
+  comment             = var.name
+  enabled             = true
+  default_root_object = ""
+  price_class         = var.price_class
+  aliases             = var.aliases
+  web_acl_id          = var.web_acl_id
+
+  # S3 Origin with OAC
+  origin {
+    domain_name              = var.s3_bucket_regional_domain_name
+    origin_id                = "s3-${var.s3_bucket_id}"
+    origin_access_control_id = aws_cloudfront_origin_access_control.this.id
+  }
+
+  # Default cache behavior
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "s3-${var.s3_bucket_id}"
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+
+    # Use AWS managed CachingOptimized policy
+    cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+
+    default_ttl = var.default_ttl
+    max_ttl     = var.max_ttl
+  }
+
+  # Geo restriction
+  restrictions {
+    geo_restriction {
+      restriction_type = length(var.allowed_countries) > 0 ? "whitelist" : "none"
+      locations        = var.allowed_countries
+    }
+  }
+
+  # TLS certificate
+  viewer_certificate {
+    cloudfront_default_certificate = var.acm_certificate_arn == null
+    acm_certificate_arn            = var.acm_certificate_arn
+    ssl_support_method             = var.acm_certificate_arn != null ? "sni-only" : null
+    minimum_protocol_version       = var.acm_certificate_arn != null ? "TLSv1.2_2021" : null
+  }
+
+  # Custom error response: map 403 (S3 access denied) to 404
+  custom_error_response {
+    error_code            = 403
+    response_code         = 404
+    response_page_path    = ""
+    error_caching_min_ttl = 300
+  }
+
+  tags = var.tags
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# S3 Bucket Policy — Allow CloudFront OAC to read from the origin bucket
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "s3_cloudfront" {
+  statement {
+    sid    = "AllowCloudFrontServicePrincipalReadOnly"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    actions   = ["s3:GetObject"]
+    resources = ["${var.s3_bucket_arn}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.this.arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "cloudfront" {
+  bucket = var.s3_bucket_id
+  policy = data.aws_iam_policy_document.s3_cloudfront.json
+}

--- a/terraform/modules/cloudfront-s3/outputs.tf
+++ b/terraform/modules/cloudfront-s3/outputs.tf
@@ -1,0 +1,19 @@
+output "distribution_id" {
+  description = "CloudFront distribution ID"
+  value       = aws_cloudfront_distribution.this.id
+}
+
+output "distribution_arn" {
+  description = "CloudFront distribution ARN"
+  value       = aws_cloudfront_distribution.this.arn
+}
+
+output "distribution_domain_name" {
+  description = "CloudFront distribution domain name (e.g. d123456.cloudfront.net)"
+  value       = aws_cloudfront_distribution.this.domain_name
+}
+
+output "oac_id" {
+  description = "CloudFront Origin Access Control ID"
+  value       = aws_cloudfront_origin_access_control.this.id
+}

--- a/terraform/modules/cloudfront-s3/variables.tf
+++ b/terraform/modules/cloudfront-s3/variables.tf
@@ -1,0 +1,72 @@
+variable "name" {
+  description = "Name used for the distribution comment and OAC identifier"
+  type        = string
+}
+
+variable "s3_bucket_id" {
+  description = "ID of the S3 bucket used as the CloudFront origin"
+  type        = string
+}
+
+variable "s3_bucket_arn" {
+  description = "ARN of the S3 bucket used for the bucket policy"
+  type        = string
+}
+
+variable "s3_bucket_regional_domain_name" {
+  description = "Regional domain name of the S3 bucket for the CloudFront origin"
+  type        = string
+}
+
+variable "price_class" {
+  description = "CloudFront price class (PriceClass_100 = EU/NA, PriceClass_200 = EU/NA/Asia, PriceClass_All = all edge locations)"
+  type        = string
+  default     = "PriceClass_100"
+
+  validation {
+    condition     = contains(["PriceClass_100", "PriceClass_200", "PriceClass_All"], var.price_class)
+    error_message = "price_class must be PriceClass_100, PriceClass_200, or PriceClass_All."
+  }
+}
+
+variable "allowed_countries" {
+  description = "ISO 3166-1 alpha-2 country codes for geo-restriction whitelist. Empty list disables geo-restriction."
+  type        = list(string)
+  default     = ["FR", "DE", "GB", "ES", "IT", "NL", "BE", "AT", "CH", "PT"]
+}
+
+variable "default_ttl" {
+  description = "Default TTL in seconds for cached objects"
+  type        = number
+  default     = 86400
+}
+
+variable "max_ttl" {
+  description = "Maximum TTL in seconds for cached objects"
+  type        = number
+  default     = 31536000
+}
+
+variable "web_acl_id" {
+  description = "ARN of a WAF WebACL to associate with the distribution (optional)"
+  type        = string
+  default     = null
+}
+
+variable "aliases" {
+  description = "Custom domain names (CNAMEs) for the distribution"
+  type        = list(string)
+  default     = []
+}
+
+variable "acm_certificate_arn" {
+  description = "ARN of the ACM certificate for custom domain HTTPS. Required when aliases is non-empty."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/cloudfront-s3/versions.tf
+++ b/terraform/modules/cloudfront-s3/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/modules/dynamodb/main.tf
+++ b/terraform/modules/dynamodb/main.tf
@@ -1,0 +1,102 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# DynamoDB Table
+# ---------------------------------------------------------------------------------------------------------------------
+# Provisions a DynamoDB table with optional GSIs, PITR, TTL, server-side encryption,
+# and IRSA IAM policies (readwrite + readonly) for EKS workloads.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_dynamodb_table" "this" {
+  name         = var.name
+  billing_mode = var.billing_mode
+  hash_key     = var.hash_key
+  range_key    = var.range_key
+
+  dynamic "attribute" {
+    for_each = var.attributes
+    content {
+      name = attribute.value.name
+      type = attribute.value.type
+    }
+  }
+
+  dynamic "global_secondary_index" {
+    for_each = var.global_secondary_indexes
+    content {
+      name            = global_secondary_index.value.name
+      hash_key        = global_secondary_index.value.hash_key
+      range_key       = lookup(global_secondary_index.value, "range_key", null)
+      projection_type = lookup(global_secondary_index.value, "projection_type", "ALL")
+    }
+  }
+
+  point_in_time_recovery {
+    enabled = var.point_in_time_recovery
+  }
+
+  server_side_encryption {
+    enabled = true
+  }
+
+  ttl {
+    attribute_name = var.ttl_attribute
+    enabled        = var.ttl_attribute != ""
+  }
+
+  tags = var.tags
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# IAM Policies for IRSA access
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "readwrite" {
+  statement {
+    actions = [
+      "dynamodb:PutItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:GetItem",
+      "dynamodb:DeleteItem",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "dynamodb:BatchWriteItem",
+      "dynamodb:BatchGetItem",
+    ]
+    resources = [
+      aws_dynamodb_table.this.arn,
+      "${aws_dynamodb_table.this.arn}/index/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "readonly" {
+  statement {
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "dynamodb:BatchGetItem",
+    ]
+    resources = [
+      aws_dynamodb_table.this.arn,
+      "${aws_dynamodb_table.this.arn}/index/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "readwrite" {
+  count = var.create_iam_policies ? 1 : 0
+
+  name   = "${var.name}-dynamodb-readwrite"
+  policy = data.aws_iam_policy_document.readwrite.json
+
+  tags = var.tags
+}
+
+resource "aws_iam_policy" "readonly" {
+  count = var.create_iam_policies ? 1 : 0
+
+  name   = "${var.name}-dynamodb-readonly"
+  policy = data.aws_iam_policy_document.readonly.json
+
+  tags = var.tags
+}

--- a/terraform/modules/dynamodb/outputs.tf
+++ b/terraform/modules/dynamodb/outputs.tf
@@ -1,0 +1,24 @@
+output "table_arn" {
+  description = "ARN of the DynamoDB table"
+  value       = aws_dynamodb_table.this.arn
+}
+
+output "table_name" {
+  description = "Name of the DynamoDB table"
+  value       = aws_dynamodb_table.this.name
+}
+
+output "table_id" {
+  description = "ID of the DynamoDB table"
+  value       = aws_dynamodb_table.this.id
+}
+
+output "readwrite_policy_arn" {
+  description = "IAM policy ARN for DynamoDB read-write access via IRSA"
+  value       = var.create_iam_policies ? aws_iam_policy.readwrite[0].arn : null
+}
+
+output "readonly_policy_arn" {
+  description = "IAM policy ARN for DynamoDB read-only access via IRSA"
+  value       = var.create_iam_policies ? aws_iam_policy.readonly[0].arn : null
+}

--- a/terraform/modules/dynamodb/variables.tf
+++ b/terraform/modules/dynamodb/variables.tf
@@ -1,0 +1,74 @@
+variable "name" {
+  description = "Name of the DynamoDB table"
+  type        = string
+}
+
+variable "billing_mode" {
+  description = "DynamoDB billing mode (PAY_PER_REQUEST or PROVISIONED)"
+  type        = string
+  default     = "PAY_PER_REQUEST"
+
+  validation {
+    condition     = contains(["PAY_PER_REQUEST", "PROVISIONED"], var.billing_mode)
+    error_message = "billing_mode must be PAY_PER_REQUEST or PROVISIONED."
+  }
+}
+
+variable "hash_key" {
+  description = "Partition key attribute name"
+  type        = string
+}
+
+variable "range_key" {
+  description = "Sort key attribute name (optional)"
+  type        = string
+  default     = null
+}
+
+variable "attributes" {
+  description = "List of attribute definitions for all key attributes (hash, range, and GSI keys)"
+  type = list(object({
+    name = string
+    type = string
+  }))
+
+  validation {
+    condition     = alltrue([for a in var.attributes : contains(["S", "N", "B"], a.type)])
+    error_message = "Attribute type must be S (string), N (number), or B (binary)."
+  }
+}
+
+variable "global_secondary_indexes" {
+  description = "List of global secondary index definitions"
+  type = list(object({
+    name            = string
+    hash_key        = string
+    range_key       = optional(string)
+    projection_type = optional(string, "ALL")
+  }))
+  default = []
+}
+
+variable "point_in_time_recovery" {
+  description = "Enable point-in-time recovery for the table"
+  type        = bool
+  default     = true
+}
+
+variable "ttl_attribute" {
+  description = "Name of the TTL attribute. Empty string disables TTL."
+  type        = string
+  default     = ""
+}
+
+variable "create_iam_policies" {
+  description = "Create IAM policies for readwrite and readonly IRSA access"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/dynamodb/versions.tf
+++ b/terraform/modules/dynamodb/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/modules/eventbridge-s3-sqs/main.tf
+++ b/terraform/modules/eventbridge-s3-sqs/main.tf
@@ -1,0 +1,93 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# EventBridge S3-to-SQS Rule
+# ---------------------------------------------------------------------------------------------------------------------
+# Routes S3 ObjectCreated events for specific file suffixes to an SQS queue.
+# Requires EventBridge notifications to be enabled on the source S3 bucket.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Enable EventBridge notifications on the source S3 bucket
+# ---------------------------------------------------------------------------
+resource "aws_s3_bucket_notification" "this" {
+  bucket      = var.source_bucket_name
+  eventbridge = true
+}
+
+# ---------------------------------------------------------------------------
+# EventBridge rule — match S3 Object Created events for video files
+# ---------------------------------------------------------------------------
+resource "aws_cloudwatch_event_rule" "this" {
+  name        = var.name
+  description = "Route S3 ObjectCreated events from ${var.source_bucket_name} to SQS"
+
+  event_pattern = jsonencode({
+    source      = ["aws.s3"]
+    detail-type = ["Object Created"]
+    detail = {
+      bucket = {
+        name = [var.source_bucket_name]
+      }
+      object = {
+        key = [for suffix in var.event_pattern_suffix : { suffix = suffix }]
+      }
+    }
+  })
+
+  tags = var.tags
+}
+
+# ---------------------------------------------------------------------------
+# EventBridge target — send matching events to SQS
+# ---------------------------------------------------------------------------
+resource "aws_cloudwatch_event_target" "this" {
+  rule = aws_cloudwatch_event_rule.this.name
+  arn  = var.target_queue_arn
+
+  # Use the full event detail as the SQS message body
+  input_transformer {
+    input_paths = {
+      bucket = "$.detail.bucket.name"
+      key    = "$.detail.object.key"
+      size   = "$.detail.object.size"
+      etag   = "$.detail.object.etag"
+    }
+    input_template = <<-TEMPLATE
+      {
+        "bucket": <bucket>,
+        "key": <key>,
+        "size": <size>,
+        "etag": <etag>,
+        "source": "eventbridge"
+      }
+    TEMPLATE
+  }
+}
+
+# ---------------------------------------------------------------------------
+# SQS queue policy — allow EventBridge to send messages
+# ---------------------------------------------------------------------------
+data "aws_iam_policy_document" "sqs_allow_eventbridge" {
+  statement {
+    sid    = "AllowEventBridgeSendMessage"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    actions   = ["sqs:SendMessage"]
+    resources = [var.target_queue_arn]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [aws_cloudwatch_event_rule.this.arn]
+    }
+  }
+}
+
+resource "aws_sqs_queue_policy" "this" {
+  queue_url = var.target_queue_url
+  policy    = data.aws_iam_policy_document.sqs_allow_eventbridge.json
+}

--- a/terraform/modules/eventbridge-s3-sqs/outputs.tf
+++ b/terraform/modules/eventbridge-s3-sqs/outputs.tf
@@ -1,0 +1,9 @@
+output "rule_arn" {
+  description = "ARN of the EventBridge rule"
+  value       = aws_cloudwatch_event_rule.this.arn
+}
+
+output "rule_name" {
+  description = "Name of the EventBridge rule"
+  value       = aws_cloudwatch_event_rule.this.name
+}

--- a/terraform/modules/eventbridge-s3-sqs/variables.tf
+++ b/terraform/modules/eventbridge-s3-sqs/variables.tf
@@ -1,0 +1,36 @@
+variable "name" {
+  description = "Name for the EventBridge rule"
+  type        = string
+}
+
+variable "source_bucket_name" {
+  description = "Name of the S3 bucket to watch for ObjectCreated events"
+  type        = string
+}
+
+variable "source_bucket_arn" {
+  description = "ARN of the source S3 bucket (used for documentation and potential future IAM policies)"
+  type        = string
+}
+
+variable "target_queue_arn" {
+  description = "ARN of the SQS queue to receive event messages"
+  type        = string
+}
+
+variable "target_queue_url" {
+  description = "URL of the SQS queue (required for the queue policy resource)"
+  type        = string
+}
+
+variable "event_pattern_suffix" {
+  description = "List of file suffixes to match in S3 ObjectCreated events"
+  type        = list(string)
+  default     = [".mp4", ".avi", ".mov", ".mkv"]
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/eventbridge-s3-sqs/versions.tf
+++ b/terraform/modules/eventbridge-s3-sqs/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terragrunt/staging/account.hcl
+++ b/terragrunt/staging/account.hcl
@@ -360,6 +360,23 @@ locals {
   }
 
   # ===========================================================================
+  # GPU Video Pipeline Configuration
+  # ===========================================================================
+  # Data infrastructure for the video analysis pipeline: storage, queuing,
+  # metadata, caching, and delivery.
+  # ===========================================================================
+  video_pipeline_config = {
+    # --- ElastiCache Redis ---
+    redis_engine_version = "7.1"
+    redis_node_type      = "cache.t4g.micro"   # Small for staging
+    redis_num_nodes      = 2                     # Multi-AZ
+
+    # --- CloudFront ---
+    cloudfront_price_class    = "PriceClass_100"  # EU + NA only
+    cloudfront_allowed_countries = ["FR", "DE", "GB", "ES", "IT", "NL", "BE", "AT", "CH", "PT"]
+  }
+
+  # ===========================================================================
   # Platform Karpenter NodePools (existing — unchanged)
   # ===========================================================================
   karpenter_nodepools = {

--- a/terragrunt/staging/eu-west-3/gpu-analysis/terragrunt.stack.hcl
+++ b/terragrunt/staging/eu-west-3/gpu-analysis/terragrunt.stack.hcl
@@ -1,13 +1,20 @@
 # ---------------------------------------------------------------------------------------------------------------------
 # GPU Video Analysis Stack — Live Deployment (staging/eu-west-3)
 # ---------------------------------------------------------------------------------------------------------------------
-# Deploys the GPU video analysis EKS infrastructure for this environment and region.
+# Deploys the complete GPU video analysis infrastructure for this environment and region.
+# Includes compute (EKS + GPU), storage (S3), queuing (SQS + EventBridge),
+# metadata (DynamoDB), caching (ElastiCache), and delivery (CloudFront).
+#
 # Environment-specific values come from account.hcl; region-specific from region.hcl.
 #
 # Usage:
 #   terragrunt stack plan
 #   terragrunt stack apply
 # ---------------------------------------------------------------------------------------------------------------------
+
+# =============================================================================
+# Compute Layer
+# =============================================================================
 
 unit "gpu-vpc" {
   source = "${get_repo_root()}/catalog/units/gpu-vpc"
@@ -42,4 +49,60 @@ unit "gpu-karpenter-controller" {
 unit "gpu-karpenter-nodepools" {
   source = "${get_repo_root()}/catalog/units/gpu-karpenter-nodepools"
   path   = "gpu-karpenter-nodepools"
+}
+
+# =============================================================================
+# Data Layer — Storage
+# =============================================================================
+
+unit "gpu-s3-raw-video" {
+  source = "${get_repo_root()}/catalog/units/gpu-s3-raw-video"
+  path   = "gpu-s3-raw-video"
+}
+
+unit "gpu-s3-processing" {
+  source = "${get_repo_root()}/catalog/units/gpu-s3-processing"
+  path   = "gpu-s3-processing"
+}
+
+unit "gpu-s3-results" {
+  source = "${get_repo_root()}/catalog/units/gpu-s3-results"
+  path   = "gpu-s3-results"
+}
+
+# =============================================================================
+# Data Layer — Queue & Events
+# =============================================================================
+
+unit "gpu-sqs-video-jobs" {
+  source = "${get_repo_root()}/catalog/units/gpu-sqs-video-jobs"
+  path   = "gpu-sqs-video-jobs"
+}
+
+unit "gpu-eventbridge-video" {
+  source = "${get_repo_root()}/catalog/units/gpu-eventbridge-video"
+  path   = "gpu-eventbridge-video"
+}
+
+# =============================================================================
+# Data Layer — Metadata & Cache
+# =============================================================================
+
+unit "gpu-dynamodb-jobs" {
+  source = "${get_repo_root()}/catalog/units/gpu-dynamodb-jobs"
+  path   = "gpu-dynamodb-jobs"
+}
+
+unit "gpu-elasticache" {
+  source = "${get_repo_root()}/catalog/units/gpu-elasticache"
+  path   = "gpu-elasticache"
+}
+
+# =============================================================================
+# Data Layer — Delivery
+# =============================================================================
+
+unit "gpu-cloudfront" {
+  source = "${get_repo_root()}/catalog/units/gpu-cloudfront"
+  path   = "gpu-cloudfront"
 }


### PR DESCRIPTION
Add S3 storage (raw/processing/results), SQS job queue with EventBridge routing, DynamoDB job metadata, ElastiCache Redis cache, and CloudFront CDN delivery. Three new Terraform modules (eventbridge-s3-sqs, dynamodb, cloudfront-s3) and eight new catalog units. Stack grows from 7 to 16 units.