### PR TITLE
feat: add external-dns and kyverno Helm charts

### DIFF
--- a/apps/infra/external-dns/Chart.yaml
+++ b/apps/infra/external-dns/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+name: external-dns
+description: ExternalDNS - Synchronize Kubernetes resources with DNS providers
+version: 1.0.0
+appVersion: "0.15.1"
+type: application
+
+dependencies:
+  # ExternalDNS - Automatic DNS record management
+  # https://github.com/kubernetes-sigs/external-dns
+  - name: external-dns
+    version: "1.15.2"
+    repository: https://kubernetes-sigs.github.io/external-dns
+    condition: external-dns.enabled
+
+maintainers:
+  - name: Platform Team
+    email: platform@example.com
+
+keywords:
+  - dns
+  - route53
+  - cloudflare
+  - ingress
+  - service
+  - kubernetes
+
+annotations:
+  category: Networking
+  platform: Kubernetes

--- a/apps/infra/external-dns/README.md
+++ b/apps/infra/external-dns/README.md
@@ -1,0 +1,160 @@
+# ExternalDNS
+
+Automatically synchronize Kubernetes Ingress/Service resources with DNS providers.
+
+## Overview
+
+ExternalDNS watches Kubernetes resources (Services, Ingresses, etc.) and automatically creates/updates/deletes DNS records in your DNS provider (Route53, CloudFlare, etc.).
+
+## Status
+
+**Disabled by default.** Enable by setting `external-dns.enabled: true` in values.yaml.
+
+## Prerequisites
+
+1. **DNS Hosted Zone**: A hosted zone in Route53 (or other provider)
+2. **IAM Permissions**: IAM role with Route53 access (via IRSA or Pod Identity)
+3. **Domain Filters**: Configure which domains ExternalDNS should manage
+
+## Quick Start
+
+### 1. Create IAM Role (Terraform)
+
+```hcl
+module "external_dns_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.0"
+
+  role_name = "${var.cluster_name}-external-dns"
+
+  attach_external_dns_policy    = true
+  external_dns_hosted_zone_arns = ["arn:aws:route53:::hostedzone/Z1234567890ABC"]
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["external-dns:external-dns"]
+    }
+  }
+}
+```
+
+### 2. Enable and Configure
+
+```yaml
+# values.yaml
+external-dns:
+  enabled: true
+
+  domainFilters:
+    - example.com
+    - api.example.com
+
+  aws:
+    region: eu-central-1
+
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/my-cluster-external-dns
+```
+
+### 3. Annotate Your Services/Ingresses
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: my-app
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: app.example.com
+    external-dns.alpha.kubernetes.io/ttl: "300"
+spec:
+  rules:
+    - host: app.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: my-app
+                port:
+                  number: 80
+```
+
+## How It Works
+
+```
++-------------+     +---------------+     +-----------+
+|  Ingress/   | --> | ExternalDNS   | --> |  Route53  |
+|  Service    |     | Controller    |     |  (DNS)    |
++-------------+     +---------------+     +-----------+
+      |                    |
+      |  Watches for       |  Creates/updates
+      |  annotations       |  DNS records
+      v                    v
+  hostname: app.example.com  ->  A/ALIAS record
+```
+
+## Supported Sources
+
+| Source | Description |
+|--------|-------------|
+| `service` | LoadBalancer services |
+| `ingress` | Ingress resources |
+| `istio-gateway` | Istio Gateway resources |
+| `contour-httpproxy` | Contour HTTPProxy |
+| `crd` | Custom DNSEndpoint resources |
+
+## Common Annotations
+
+| Annotation | Description |
+|------------|-------------|
+| `external-dns.alpha.kubernetes.io/hostname` | DNS hostname to create |
+| `external-dns.alpha.kubernetes.io/ttl` | TTL in seconds |
+| `external-dns.alpha.kubernetes.io/target` | Override target (IP or hostname) |
+| `external-dns.alpha.kubernetes.io/alias` | Create ALIAS record (AWS only) |
+
+## Sync Policies
+
+| Policy | Behavior |
+|--------|----------|
+| `sync` | Full sync - creates, updates, and deletes records |
+| `upsert-only` | Only creates and updates, never deletes (safer) |
+
+**Default: `upsert-only`** - safer for initial deployment.
+
+## Ownership & TXT Records
+
+ExternalDNS uses TXT records to track ownership:
+- Prefix: `_externaldns.` (configurable)
+- Owner ID: Identifies which cluster owns the record
+
+This prevents conflicts when multiple clusters manage the same zone.
+
+## Monitoring
+
+ExternalDNS exposes Prometheus metrics:
+
+- `external_dns_source_endpoints` - Number of endpoints from sources
+- `external_dns_registry_endpoints` - Number of endpoints in registry
+- `external_dns_controller_last_sync_timestamp` - Last successful sync
+
+## Troubleshooting
+
+```bash
+# Check logs
+kubectl logs -n external-dns -l app.kubernetes.io/name=external-dns
+
+# Check current endpoints
+kubectl get endpoints -A
+
+# Verify DNS records in Route53
+aws route53 list-resource-record-sets --hosted-zone-id Z1234567890ABC
+```
+
+## Resources
+
+- [Documentation](https://kubernetes-sigs.github.io/external-dns/)
+- [Helm Chart](https://github.com/kubernetes-sigs/external-dns/tree/master/charts/external-dns)
+- [Tutorials](https://kubernetes-sigs.github.io/external-dns/latest/tutorials/)

--- a/apps/infra/external-dns/values.yaml
+++ b/apps/infra/external-dns/values.yaml
@@ -1,0 +1,163 @@
+# ExternalDNS Configuration
+# https://github.com/kubernetes-sigs/external-dns
+#
+# DISABLED BY DEFAULT - Set external-dns.enabled to true to deploy
+#
+# Prerequisites:
+# - IAM role with Route53 permissions (via IRSA or Pod Identity)
+# - Hosted zone in Route53 (or other supported provider)
+
+external-dns:
+  # Disabled by default - enable when ready to use
+  enabled: false
+
+  # DNS provider configuration
+  # Supported: aws, azure, cloudflare, google, etc.
+  provider:
+    name: aws
+
+  # AWS-specific configuration (Route53)
+  aws:
+    # AWS region
+    region: eu-central-1
+
+    # Zone type: public, private, or empty for both
+    zoneType: ""
+
+    # Prefer CNAME over ALIAS records (ALIAS is AWS-specific but recommended)
+    preferCNAME: false
+
+    # Evaluate target health for ALIAS records
+    evaluateTargetHealth: true
+
+    # Batch size for Route53 changes (max 1000)
+    batchChangeSize: 1000
+
+    # Batch change interval
+    batchChangeInterval: 1s
+
+  # Domain filters - only manage records for these domains
+  domainFilters: []
+  # - example.com
+  # - subdomain.example.net
+
+  # Exclude domains
+  excludeDomains: []
+  # - internal.example.com
+
+  # Zone ID filter - limit to specific hosted zones
+  zoneIdFilters: []
+  # - Z1234567890ABC
+
+  # Sources to watch for DNS records
+  sources:
+    - service
+    - ingress
+    # - istio-gateway
+    # - istio-virtualservice
+    # - contour-httpproxy
+    # - gloo-proxy
+    # - crd  # For DNSEndpoint CRD
+
+  # Sync policy: sync (create/update/delete) or upsert-only (no deletes)
+  policy: upsert-only  # Safer default - won't delete records
+
+  # Registry for ownership tracking
+  registry: txt
+  txtOwnerId: "external-dns"
+  txtPrefix: "_externaldns."
+
+  # Sync interval
+  interval: 1m
+
+  # Trigger resync on source changes
+  triggerLoopOnEvent: true
+
+  # Resource configuration
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
+  # Replica count (1 is usually sufficient, leader election enabled)
+  replicaCount: 1
+
+  # Security context
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    fsGroup: 65534
+    seccompProfile:
+      type: RuntimeDefault
+
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+
+  # Pod annotations for IRSA (AWS IAM Roles for Service Accounts)
+  # Uncomment and set your IAM role ARN
+  serviceAccount:
+    create: true
+    annotations: {}
+    # eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/external-dns-role
+
+  # Tolerations
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+
+  # Priority class
+  priorityClassName: system-cluster-critical
+
+  # Log level (panic, debug, info, warning, error, fatal)
+  logLevel: info
+
+  # Log format (text or json)
+  logFormat: json
+
+  # Prometheus metrics
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      namespace: monitoring
+      interval: 30s
+      labels:
+        prometheus: kube-prometheus
+
+  # Pod disruption budget
+  podDisruptionBudget:
+    minAvailable: 0  # Only 1 replica, so allow disruption
+
+# IAM policy reference (for documentation)
+# Create this IAM policy and attach to the IRSA role:
+#
+# {
+#   "Version": "2012-10-17",
+#   "Statement": [
+#     {
+#       "Effect": "Allow",
+#       "Action": [
+#         "route53:ChangeResourceRecordSets"
+#       ],
+#       "Resource": [
+#         "arn:aws:route53:::hostedzone/*"
+#       ]
+#     },
+#     {
+#       "Effect": "Allow",
+#       "Action": [
+#         "route53:ListHostedZones",
+#         "route53:ListResourceRecordSets",
+#         "route53:ListTagsForResource"
+#       ],
+#       "Resource": ["*"]
+#     }
+#   ]
+# }

--- a/apps/infra/kyverno/Chart.yaml
+++ b/apps/infra/kyverno/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+name: kyverno
+description: Kyverno - Kubernetes Native Policy Management
+version: 1.0.0
+appVersion: "1.13.4"
+type: application
+
+dependencies:
+  # Kyverno - Kubernetes native policy engine
+  # https://kyverno.io/docs/
+  - name: kyverno
+    version: "3.3.7"
+    repository: https://kyverno.github.io/kyverno
+    condition: kyverno.enabled
+
+maintainers:
+  - name: Platform Team
+    email: platform@example.com
+
+keywords:
+  - policy
+  - security
+  - validation
+  - mutation
+  - generation
+  - kubernetes
+
+annotations:
+  category: Security
+  platform: Kubernetes

--- a/apps/infra/kyverno/README.md
+++ b/apps/infra/kyverno/README.md
@@ -1,0 +1,101 @@
+# Kyverno
+
+Kubernetes Native Policy Management engine for validating, mutating, and generating resources.
+
+## Overview
+
+Kyverno is a policy engine designed specifically for Kubernetes. Unlike OPA Gatekeeper, policies are written as Kubernetes resources (no Rego required).
+
+## Features
+
+- **Validate**: Block non-compliant resources
+- **Mutate**: Modify resources on creation/update
+- **Generate**: Create resources automatically
+- **Verify Images**: Validate container image signatures
+- **Cleanup**: Automatically delete resources based on policies
+
+## Status
+
+**Disabled by default.** Enable by setting `kyverno.enabled: true` in values.yaml.
+
+## Comparison with OPA Gatekeeper
+
+| Feature | Kyverno | Gatekeeper |
+|---------|---------|------------|
+| Policy Language | YAML (native K8s) | Rego |
+| Learning Curve | Lower | Higher |
+| Mutation Support | Native | Experimental |
+| Generation | Yes | No |
+| Image Verification | Built-in | External |
+| Policy Reports | Native | Requires add-on |
+
+**Recommendation**: Choose one policy engine. If already using Gatekeeper, evaluate migration vs running both.
+
+## Quick Start
+
+1. Enable Kyverno:
+   ```yaml
+   # values.yaml
+   kyverno:
+     enabled: true
+   ```
+
+2. Deploy a sample policy:
+   ```yaml
+   apiVersion: kyverno.io/v1
+   kind: ClusterPolicy
+   metadata:
+     name: require-labels
+   spec:
+     validationFailureAction: Audit
+     rules:
+       - name: check-team-label
+         match:
+           any:
+             - resources:
+                 kinds:
+                   - Pod
+         validate:
+           message: "Label 'team' is required"
+           pattern:
+             metadata:
+               labels:
+                 team: "?*"
+   ```
+
+3. Check policy reports:
+   ```bash
+   kubectl get policyreport -A
+   kubectl get clusterpolicyreport
+   ```
+
+## Architecture
+
+```
+                    +-----------------------+
+                    |   Admission Webhook   |
+                    |   (Validate/Mutate)   |
+                    +-----------+-----------+
+                                |
+        +-----------------------+-----------------------+
+        |                       |                       |
++-------v-------+       +-------v-------+       +-------v-------+
+|  Background   |       |   Cleanup     |       |   Reports     |
+|  Controller   |       |  Controller   |       |  Controller   |
+| (Generate)    |       | (TTL cleanup) |       | (PolicyReport)|
++---------------+       +---------------+       +---------------+
+```
+
+## Monitoring
+
+Kyverno exposes Prometheus metrics:
+
+- `kyverno_policy_results_total` - Policy evaluation results
+- `kyverno_admission_review_duration_seconds` - Webhook latency
+- `kyverno_controller_reconcile_total` - Controller reconciliation
+
+## Resources
+
+- [Documentation](https://kyverno.io/docs/)
+- [Policy Library](https://kyverno.io/policies/)
+- [Helm Chart](https://github.com/kyverno/kyverno/tree/main/charts/kyverno)

--- a/apps/infra/kyverno/values.yaml
+++ b/apps/infra/kyverno/values.yaml
@@ -1,0 +1,154 @@
+# Kyverno Configuration
+# https://kyverno.io/docs/
+#
+# DISABLED BY DEFAULT - Set kyverno.enabled to true to deploy
+#
+# Note: If you have OPA Gatekeeper deployed, consider which policy engine
+# to use. Running both is possible but may add complexity.
+
+kyverno:
+  # Disabled by default - enable when ready to use
+  enabled: false
+
+  # CRDs are managed by the Kyverno Helm chart (installCRDs: true)
+  # Unlike other tools, Kyverno CRDs are tightly coupled with the controller version
+  crds:
+    install: true
+
+  # Admission controller configuration
+  admissionController:
+    replicas: 3
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+    # Security context
+    container:
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
+
+    # Anti-affinity for HA
+    antiAffinity:
+      enabled: true
+
+    # Tolerate system node taints
+    tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+
+    # Priority class
+    priorityClassName: system-cluster-critical
+
+  # Background controller for generate/mutate existing resources
+  backgroundController:
+    replicas: 2
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  # Cleanup controller for policy cleanup jobs
+  cleanupController:
+    replicas: 2
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+
+  # Reports controller for policy reports
+  reportsController:
+    replicas: 2
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  # Webhook configuration
+  webhooksCleanup:
+    enabled: true
+
+  # Fail-open mode: don't block resources if Kyverno is unavailable
+  # Set to Fail in production for stricter enforcement
+  config:
+    webhooks:
+      - failurePolicy: Ignore
+        namespaceSelector:
+          matchExpressions:
+            - key: kubernetes.io/metadata.name
+              operator: NotIn
+              values:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+                - kyverno
+                - cert-manager
+                - external-secrets
+                - argocd
+
+  # Enable policy reports
+  features:
+    policyReports:
+      enabled: true
+    logging:
+      format: json
+
+  # Metrics for Prometheus
+  metricsConfig:
+    metricsExposure:
+      enabled: true
+
+# Example ClusterPolicy templates (disabled by default)
+# Uncomment and customize as needed
+policies:
+  enabled: false
+
+  # Require resource limits on all containers
+  requireResourceLimits:
+    enabled: false
+    validationFailureAction: Audit  # Audit or Enforce
+
+  # Require labels on namespaces
+  requireNamespaceLabels:
+    enabled: false
+    requiredLabels:
+      - team
+      - environment
+
+  # Restrict image registries
+  restrictImageRegistries:
+    enabled: false
+    allowedRegistries:
+      - docker.io
+      - gcr.io
+      - ghcr.io
+      - "*.dkr.ecr.*.amazonaws.com"
+
+  # Require pod security standards
+  podSecurityStandards:
+    enabled: false
+    level: baseline  # privileged, baseline, or restricted


### PR DESCRIPTION
Add ExternalDNS v1.15.2 wrapper chart for automated Route53 DNS record management from Kubernetes Ingress/Service resources.

Add Kyverno v3.3.7 wrapper chart for Kubernetes-native policy management (validate, mutate, generate, image verification).

Both are disabled by default and follow the existing apps/infra wrapper chart pattern with hardened security contexts.