### PR TITLE
feat: add Bitcoin full node setup to blockchain cluster

### DIFF
--- a/apps/chains/bitcoin/configmap.yaml
+++ b/apps/chains/bitcoin/configmap.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bitcoin-config
+  namespace: bitcoin
+data:
+  bitcoin.conf: |
+    # Network
+    listen=1
+    maxconnections=125
+    port=8333
+
+    # RPC
+    server=1
+    rpcport=8332
+    rpcbind=0.0.0.0
+    rpcallowip=10.0.0.0/8
+
+    # Performance
+    dbcache=8192
+    maxmempool=1024
+    par=8
+
+    # Full archive node
+    prune=0
+    txindex=1
+
+    # Logging
+    printtoconsole=1
+    debug=net
+    debug=mempool

--- a/apps/chains/bitcoin/namespace.yaml
+++ b/apps/chains/bitcoin/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bitcoin
+  labels:
+    app.kubernetes.io/name: bitcoin
+    app.kubernetes.io/component: blockchain
+    pod-security.kubernetes.io/enforce: restricted

--- a/apps/chains/bitcoin/networkpolicy.yaml
+++ b/apps/chains/bitcoin/networkpolicy.yaml
@@ -1,0 +1,52 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: bitcoin-node-policy
+  namespace: bitcoin
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: bitcoin
+  ingress:
+    # P2P from anywhere (Bitcoin network)
+    - fromEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "8333"
+              protocol: TCP
+    # RPC from within the cluster only
+    - fromEndpoints:
+        - {}
+      toPorts:
+        - ports:
+            - port: "8332"
+              protocol: TCP
+  egress:
+    # P2P to Bitcoin network
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "8333"
+              protocol: TCP
+    # DNS resolution
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # HTTPS for seed nodes DNS resolution
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "53"
+              protocol: UDP

--- a/apps/chains/bitcoin/pdb.yaml
+++ b/apps/chains/bitcoin/pdb.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: bitcoin
+  namespace: bitcoin
+  labels:
+    app.kubernetes.io/name: bitcoin
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bitcoin

--- a/apps/chains/bitcoin/secret.yaml
+++ b/apps/chains/bitcoin/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bitcoin-rpc-credentials
+  namespace: bitcoin
+  labels:
+    app.kubernetes.io/name: bitcoin
+type: Opaque
+stringData:
+  rpcuser: "bitcoinrpc"
+  rpcpassword: "CHANGE_ME_USE_EXTERNAL_SECRETS_IN_PRODUCTION"

--- a/apps/chains/bitcoin/service-headless.yaml
+++ b/apps/chains/bitcoin/service-headless.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bitcoin-headless
+  namespace: bitcoin
+  labels:
+    app.kubernetes.io/name: bitcoin
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: bitcoin
+  ports:
+    - name: rpc
+      port: 8332
+      targetPort: rpc
+    - name: p2p
+      port: 8333
+      targetPort: p2p

--- a/apps/chains/bitcoin/service-p2p.yaml
+++ b/apps/chains/bitcoin/service-p2p.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bitcoin-p2p
+  namespace: bitcoin
+  labels:
+    app.kubernetes.io/name: bitcoin
+    app.kubernetes.io/component: p2p
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  selector:
+    app.kubernetes.io/name: bitcoin
+  ports:
+    - name: p2p
+      port: 8333
+      targetPort: p2p
+      protocol: TCP

--- a/apps/chains/bitcoin/service-rpc.yaml
+++ b/apps/chains/bitcoin/service-rpc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bitcoin-rpc
+  namespace: bitcoin
+  labels:
+    app.kubernetes.io/name: bitcoin
+    app.kubernetes.io/component: rpc
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: bitcoin
+  ports:
+    - name: rpc
+      port: 8332
+      targetPort: rpc
+      protocol: TCP

--- a/apps/chains/bitcoin/serviceaccount.yaml
+++ b/apps/chains/bitcoin/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bitcoin
+  namespace: bitcoin
+  labels:
+    app.kubernetes.io/name: bitcoin
+automountServiceAccountToken: false

--- a/apps/chains/bitcoin/statefulset.yaml
+++ b/apps/chains/bitcoin/statefulset.yaml
@@ -1,0 +1,141 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: bitcoin
+  namespace: bitcoin
+  labels:
+    app.kubernetes.io/name: bitcoin
+    app.kubernetes.io/component: full-node
+spec:
+  serviceName: bitcoin-headless
+  replicas: 2
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bitcoin
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bitcoin
+        app.kubernetes.io/component: full-node
+        blockchain.io/role: bitcoin-full-node
+        blockchain.io/network: bitcoin
+    spec:
+      serviceAccountName: bitcoin
+      automountServiceAccountToken: false
+
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+
+      # Schedule on bitcoin-full-nodes Karpenter nodepool
+      tolerations:
+        - key: blockchain.io/role
+          value: bitcoin-full-node
+          effect: NoSchedule
+      nodeSelector:
+        blockchain.io/role: bitcoin-full-node
+
+      # Spread replicas across nodes
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: bitcoin
+
+      containers:
+        - name: bitcoind
+          image: lncm/bitcoind:v27.1
+          args:
+            - -conf=/etc/bitcoin/bitcoin.conf
+            - -datadir=/bitcoin/data
+          ports:
+            - name: p2p
+              containerPort: 8333
+              protocol: TCP
+            - name: rpc
+              containerPort: 8332
+              protocol: TCP
+          env:
+            - name: BITCOIN_RPC_USER
+              valueFrom:
+                secretKeyRef:
+                  name: bitcoin-rpc-credentials
+                  key: rpcuser
+            - name: BITCOIN_RPC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: bitcoin-rpc-credentials
+                  key: rpcpassword
+          resources:
+            requests:
+              cpu: "4"
+              memory: 16Gi
+            limits:
+              cpu: "8"
+              memory: 64Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: bitcoin-data
+              mountPath: /bitcoin/data
+            - name: bitcoin-config
+              mountPath: /etc/bitcoin
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          livenessProbe:
+            exec:
+              command:
+                - bitcoin-cli
+                - -datadir=/bitcoin/data
+                - getblockchaininfo
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - bitcoin-cli
+                - -datadir=/bitcoin/data
+                - getblockchaininfo
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            exec:
+              command:
+                - bitcoin-cli
+                - -datadir=/bitcoin/data
+                - getblockchaininfo
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 30
+
+      volumes:
+        - name: bitcoin-config
+          configMap:
+            name: bitcoin-config
+        - name: tmp
+          emptyDir: {}
+
+  volumeClaimTemplates:
+    - metadata:
+        name: bitcoin-data
+      spec:
+        storageClassName: gp3-bitcoin
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 2Ti

--- a/apps/chains/bitcoin/storageclass.yaml
+++ b/apps/chains/bitcoin/storageclass.yaml
@@ -1,0 +1,13 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3-bitcoin
+provisioner: ebs.csi.aws.com
+parameters:
+  type: gp3
+  iops: "16000"
+  throughput: "1000"
+  encrypted: "true"
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: Retain


### PR DESCRIPTION
Add bitcoin-full-nodes Karpenter NodePool to the existing blockchain cluster (r6i/r7i, 2TB gp3 @ 16K IOPS, on-demand, zero disruption). Add K8s manifests: StatefulSet with 2 replicas, RPC load balancing, P2P LoadBalancer, CiliumNetworkPolicy, PDB, and gp3-bitcoin StorageClass.