### PR TITLE
feat: multi-regional active-active EKS with ClusterMesh and Global Accelerator

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -92,6 +92,14 @@ Role-specific apps from `apps/cluster-roles/<role>/*` deployed only to clusters 
 
 Observability stack from `apps/infra/observability/*` deployed to ALL clusters into the `observability` namespace.
 
+### 6. Multi-Cluster Workloads (`applicationset-multicluster.yaml`)
+
+Deploys workload applications across multiple regional clusters for active-active. Uses cluster selector with `region` label to discover targets. Each app gets Cilium global service annotations for cross-cluster discovery. RollingSync deploys to eu-west-1 first, then eu-central-1.
+
+### 7. Multi-Cluster Infrastructure (`bootstrap/applicationsets/multicluster-infra-appset.yaml`)
+
+Deploys shared infra to all clusters with `region` label. Supports region-specific value overrides via `values/infra/<app>-<regionShort>.yaml`.
+
 ## Cluster Label Convention
 
 Every cluster registered with ArgoCD must have these labels on its Secret:
@@ -101,6 +109,8 @@ metadata:
   labels:
     cluster-role: dex        # one of: dex, backend, 3rd-party, velocity, listeners
     env: dev                 # one of: dev, stage, integration, prod
+    region: eu-west-1        # AWS region (required for multi-cluster ApplicationSets)
+    region-short: euw1       # short name (used in Application names and value file lookups)
 ```
 
 See `bootstrap/cluster-secrets/in-cluster-template.yaml` for a full example.

--- a/argocd/applicationset-multicluster.yaml
+++ b/argocd/applicationset-multicluster.yaml
@@ -1,0 +1,145 @@
+---
+# ApplicationSet for multi-cluster workload deployment (active-active).
+#
+# Generates ArgoCD Applications for each (team × cluster) combination in staging.
+# Each regional cluster gets the same workloads deployed with region-aware values.
+#
+# This ApplicationSet complements (not replaces) applicationset-workloads.yaml:
+#   - applicationset-workloads.yaml  → single-cluster, all envs, Kargo promotion
+#   - applicationset-multicluster.yaml → multi-cluster, staging only, region-aware
+#
+# Traffic flow:
+#   External → Global Accelerator → NLB (per region) → Pods
+#   Internal → Cilium ClusterMesh global services → local-first, failover remote
+#
+# Prerequisites:
+#   - Cluster secrets registered (staging-euw1, staging-euc1)
+#   - ClusterMesh connectivity established between clusters
+#   - Global Accelerator pointing to regional NLBs
+#
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: multicluster-workloads
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - matrix:
+        generators:
+          # Teams to deploy across clusters
+          - list:
+              elements:
+                - team: mono
+                  namespace: mono
+                - team: chains
+                  namespace: chains
+                - team: direct
+                  namespace: direct
+                - team: protocols
+                  namespace: protocols
+                - team: listeners
+                  namespace: listeners
+          # Target clusters — selected by env + region labels
+          - clusters:
+              selector:
+                matchLabels:
+                  env: staging
+                matchExpressions:
+                  - key: region
+                    operator: In
+                    values:
+                      - eu-west-1
+                      - eu-central-1
+              values:
+                region: '{{ index .metadata.labels "region" }}'
+                regionShort: '{{ index .metadata.labels "region-short" }}'
+  template:
+    metadata:
+      name: '{{ .team }}-{{ .values.regionShort }}'
+      namespace: argocd
+      annotations:
+        kargo.akuity.io/authorized-stage: '{{ .team }}:staging'
+        platform.io/region: '{{ .values.region }}'
+        platform.io/cluster: '{{ .name }}'
+      labels:
+        app.kubernetes.io/part-of: multicluster-workloads
+        app.kubernetes.io/component: '{{ .team }}'
+        app.kubernetes.io/managed-by: applicationset
+        env: staging
+        team: '{{ .team }}'
+        region: '{{ .values.region }}'
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io
+    spec:
+      project: platform-workloads
+      sources:
+        # Source 1: Helm chart
+        - repoURL: git@github.com:100rd/platform-design.git
+          targetRevision: HEAD
+          path: helm/app
+          helm:
+            releaseName: '{{ .team }}'
+            ignoreMissingValueFiles: true
+            valueFiles:
+              # Base team values
+              - $values/apps/{{ .team }}/values.yaml
+              # Environment-specific values (image.tag from Kargo)
+              - $values/envs/staging/values/{{ .team }}/values.yaml
+              # Region-specific overrides (if exists)
+              - $values/envs/staging/values/{{ .team }}/values-{{ .values.regionShort }}.yaml
+            values: |
+              fullnameOverride: "{{ .team }}"
+              environment: "staging"
+              region: "{{ .values.region }}"
+              regionShort: "{{ .values.regionShort }}"
+              cluster: "{{ .name }}"
+              image:
+                repository: "${ECR_REGISTRY}/{{ .team }}"
+              # Enable Cilium global service for cross-cluster discovery
+              service:
+                global: true
+                globalAffinity: local
+        # Source 2: Values reference
+        - repoURL: git@github.com:100rd/platform-design.git
+          targetRevision: HEAD
+          ref: values
+      destination:
+        server: '{{ .server }}'
+        namespace: 'staging-{{ .namespace }}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+          - PruneLast=true
+          - RespectIgnoreDifferences=true
+        retry:
+          limit: 3
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 3m
+      ignoreDifferences:
+        - group: apps
+          kind: Deployment
+          jqPathExpressions:
+            - .spec.replicas
+  syncPolicy:
+    preserveResourcesOnDeletion: true
+  strategy:
+    type: RollingSync
+    rollingSync:
+      steps:
+        # Deploy to eu-west-1 first, then eu-central-1
+        - matchExpressions:
+            - key: region
+              operator: In
+              values: [eu-west-1]
+        - matchExpressions:
+            - key: region
+              operator: In
+              values: [eu-central-1]

--- a/argocd/bootstrap/applicationsets/multicluster-infra-appset.yaml
+++ b/argocd/bootstrap/applicationsets/multicluster-infra-appset.yaml
@@ -1,0 +1,80 @@
+---
+# Multi-cluster infrastructure ApplicationSet.
+#
+# Deploys shared infra apps to ALL registered clusters, with region-aware values.
+# Extends the existing infra-appset.yaml with region label injection so that
+# each cluster gets region-specific configuration (e.g., ExternalDNS zone,
+# cert-manager issuer, AWS LB controller subnet tags).
+#
+# Cluster selection: all clusters with a "region" label.
+# Apps without region-specific values get the same config everywhere.
+#
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: multicluster-infra
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - matrix:
+        generators:
+          - git:
+              repoURL: https://github.com/100rd/platform-design.git
+              revision: HEAD
+              directories:
+                - path: apps/infra/*
+                - path: apps/infra/observability
+                  exclude: true
+          - clusters:
+              selector:
+                matchExpressions:
+                  - key: region
+                    operator: Exists
+              values:
+                env: '{{ index .metadata.labels "env" }}'
+                region: '{{ index .metadata.labels "region" }}'
+                regionShort: '{{ index .metadata.labels "region-short" }}'
+  template:
+    metadata:
+      name: '{{ .path.basename }}-{{ .values.regionShort }}'
+      namespace: argocd
+      labels:
+        app.kubernetes.io/part-of: multicluster-infra
+        env: '{{ .values.env }}'
+        region: '{{ .values.region }}'
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/100rd/platform-design.git
+        targetRevision: HEAD
+        path: '{{ .path.path }}'
+        helm:
+          ignoreMissingValueFiles: true
+          valueFiles:
+            # Environment-specific values
+            - '../../../envs/{{ .values.env }}/values/infra/{{ .path.basename }}.yaml'
+            # Region-specific overrides (if exists)
+            - '../../../envs/{{ .values.env }}/values/infra/{{ .path.basename }}-{{ .values.regionShort }}.yaml'
+          values: |
+            environment: "{{ .values.env }}"
+            region: "{{ .values.region }}"
+            regionShort: "{{ .values.regionShort }}"
+            cluster: "{{ .name }}"
+      destination:
+        server: '{{ .server }}'
+        namespace: '{{ .path.basename }}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+        retry:
+          limit: 3
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 3m

--- a/argocd/bootstrap/cluster-secrets/in-cluster-template.yaml
+++ b/argocd/bootstrap/cluster-secrets/in-cluster-template.yaml
@@ -7,6 +7,8 @@ metadata:
     argocd.argoproj.io/secret-type: cluster
     cluster-role: ROLE       # one of: dex, backend, 3rd-party, velocity, listeners
     env: ENV                 # one of: dev, stage, integration, prod
+    region: REGION           # AWS region (e.g., eu-west-1) — used by multicluster ApplicationSets
+    region-short: SHORT      # short name (e.g., euw1) — used in Application names and value file lookups
 type: Opaque
 stringData:
   name: CLUSTER_NAME
@@ -31,6 +33,8 @@ stringData:
 #     argocd.argoproj.io/secret-type: cluster
 #     cluster-role: dex
 #     env: dev
+#     region: eu-west-1
+#     region-short: euw1
 # type: Opaque
 # stringData:
 #   name: dex-dev

--- a/argocd/bootstrap/cluster-secrets/kustomization.yaml
+++ b/argocd/bootstrap/cluster-secrets/kustomization.yaml
@@ -3,3 +3,6 @@ kind: Kustomization
 
 resources:
   - in-cluster-template.yaml
+  # Multi-region staging clusters (uncomment when clusters are ready)
+  # - staging-euw1.yaml
+  # - staging-euc1.yaml

--- a/argocd/bootstrap/cluster-secrets/staging-euc1.yaml
+++ b/argocd/bootstrap/cluster-secrets/staging-euc1.yaml
@@ -1,0 +1,35 @@
+---
+# Cluster secret for staging eu-central-1 (Frankfurt) EKS cluster.
+# ArgoCD uses this to discover and deploy to the remote cluster.
+#
+# Prerequisites:
+#   - EKS cluster running in eu-central-1
+#   - Service account token or IAM role for ArgoCD access
+#   - Network connectivity from ArgoCD cluster to target API server
+#
+# Replace placeholders:
+#   - CLUSTER_API_SERVER: EKS cluster endpoint (e.g., https://XXXX.gr7.eu-central-1.eks.amazonaws.com)
+#   - <token>: Service account bearer token
+#   - <base64-ca>: Base64-encoded cluster CA certificate
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-staging-euc1
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+    env: staging
+    region: eu-central-1
+    region-short: euc1
+type: Opaque
+stringData:
+  name: staging-euc1
+  server: https://CLUSTER_API_SERVER
+  config: |
+    {
+      "bearerToken": "<token>",
+      "tlsClientConfig": {
+        "insecure": false,
+        "caData": "<base64-ca>"
+      }
+    }

--- a/argocd/bootstrap/cluster-secrets/staging-euw1.yaml
+++ b/argocd/bootstrap/cluster-secrets/staging-euw1.yaml
@@ -1,0 +1,35 @@
+---
+# Cluster secret for staging eu-west-1 (Ireland) EKS cluster.
+# ArgoCD uses this to discover and deploy to the remote cluster.
+#
+# Prerequisites:
+#   - EKS cluster running in eu-west-1
+#   - Service account token or IAM role for ArgoCD access
+#   - Network connectivity from ArgoCD cluster to target API server
+#
+# Replace placeholders:
+#   - CLUSTER_API_SERVER: EKS cluster endpoint (e.g., https://XXXX.gr7.eu-west-1.eks.amazonaws.com)
+#   - <token>: Service account bearer token
+#   - <base64-ca>: Base64-encoded cluster CA certificate
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-staging-euw1
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+    env: staging
+    region: eu-west-1
+    region-short: euw1
+type: Opaque
+stringData:
+  name: staging-euw1
+  server: https://CLUSTER_API_SERVER
+  config: |
+    {
+      "bearerToken": "<token>",
+      "tlsClientConfig": {
+        "insecure": false,
+        "caData": "<base64-ca>"
+      }
+    }

--- a/argocd/bootstrap/kustomization.yaml
+++ b/argocd/bootstrap/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - applicationsets/infra-appset.yaml
   - applicationsets/role-apps-appset.yaml
   - applicationsets/observability-appset.yaml
+  - applicationsets/multicluster-infra-appset.yaml

--- a/docs/multi-region/traffic-routing.md
+++ b/docs/multi-region/traffic-routing.md
@@ -1,0 +1,188 @@
+# Multi-Region Traffic Routing
+
+How traffic reaches the right cluster based on geography, health, and service type.
+
+## Architecture Overview
+
+```
+                    Internet
+                       │
+              ┌────────▼────────┐
+              │ Global Accelerator│  ← Anycast IPs, geo-routing
+              │  (AWS edge POPs)  │
+              └───┬──────────┬───┘
+                  │          │
+           ┌──────▼──┐  ┌───▼──────┐
+           │  NLB    │  │  NLB     │
+           │ eu-west │  │ eu-centr │  ← Per-region NLBs
+           └────┬────┘  └────┬─────┘
+                │             │
+           ┌────▼────┐  ┌────▼─────┐
+           │  EKS    │  │  EKS     │  ← Identical workloads
+           │ euw1    │◄►│ euc1     │
+           └─────────┘  └──────────┘
+                  ClusterMesh
+            (internal service mesh)
+```
+
+## External Traffic (Client → Service)
+
+### How Global Accelerator Routes Traffic
+
+AWS Global Accelerator uses **anycast routing** via AWS edge locations. When a client sends a request:
+
+1. **DNS resolution**: Client resolves the GA DNS name to anycast IPs
+2. **Edge routing**: Request enters the AWS network at the nearest edge POP
+3. **Health-based routing**: GA checks NLB health in each region
+4. **Region selection**: Traffic goes to the healthiest, nearest region
+
+Configuration (from `terragrunt/staging/_global/global-accelerator/`):
+- Both regions: `traffic_dial_percentage = 100` (true active-active)
+- Health checks: TCP/443, 10s interval, 3 threshold
+- Client affinity: `SOURCE_IP` (same client hits same region consistently)
+
+### Geo-Location Behavior
+
+| Client Location | Primary Region | Failover Region |
+|-----------------|---------------|-----------------|
+| Western Europe (UK, FR, ES, PT, NL, BE) | eu-west-1 (Ireland) | eu-central-1 (Frankfurt) |
+| Central Europe (DE, AT, CH, PL, CZ) | eu-central-1 (Frankfurt) | eu-west-1 (Ireland) |
+| Nordics (SE, NO, FI, DK) | eu-west-1 (Ireland) | eu-central-1 (Frankfurt) |
+| Eastern Europe (RO, BG, HU) | eu-central-1 (Frankfurt) | eu-west-1 (Ireland) |
+| Africa | eu-west-1 (Ireland) | eu-central-1 (Frankfurt) |
+| Middle East | eu-central-1 (Frankfurt) | eu-west-1 (Ireland) |
+
+> **Note**: Exact routing depends on AWS edge POP topology, which optimizes for lowest latency. The table above is approximate.
+
+### Manual Traffic Shifting
+
+To shift traffic away from a region (e.g., during maintenance):
+
+```bash
+# Send all traffic to eu-central-1 only
+# In terragrunt/staging/_global/global-accelerator/terragrunt.hcl:
+# Set eu-west-1 traffic_dial_percentage = 0
+terragrunt apply
+
+# Gradual ramp-up (canary):
+# Set eu-west-1 traffic_dial_percentage = 10, then 25, 50, 100
+```
+
+### Automatic Failover
+
+When NLB health checks fail in a region:
+1. GA detects 3 consecutive failures (30s detection time)
+2. GA stops routing new connections to the unhealthy region
+3. Existing connections may timeout (client retry handles this)
+4. 100% of traffic goes to the healthy region
+5. When health recovers, GA resumes routing (within 10-30s)
+
+## Internal Traffic (Service → Service)
+
+### Cilium ClusterMesh Global Services
+
+For pod-to-pod communication across clusters, Cilium ClusterMesh provides transparent service discovery.
+
+A Kubernetes Service annotated with `service.cilium.io/global: "true"` becomes discoverable in **all meshed clusters**.
+
+#### Affinity Modes
+
+| Mode | Annotation | Behavior |
+|------|-----------|----------|
+| **Local-first** (default) | `service.cilium.io/affinity: "local"` | Route to local pods; failover to remote only if ALL local pods are unhealthy |
+| **Remote-first** | `service.cilium.io/affinity: "remote"` | Route to remote pods first (useful for cross-region DB read replicas) |
+| **None** | `service.cilium.io/affinity: "none"` | Round-robin across all pods in all clusters |
+
+#### Shared Services
+
+Add `service.cilium.io/shared: "true"` to load-balance across local AND remote pods simultaneously (weighted by endpoint count).
+
+### How to Enable for Your App
+
+In the Helm values for your team (e.g., `envs/staging/values/mono/values.yaml`):
+
+```yaml
+service:
+  global: true           # Makes service discoverable cross-cluster
+  globalAffinity: local  # local-first with remote failover
+```
+
+The `helm/app` chart v0.3.0 renders these as Cilium annotations on the Service resource.
+
+### What Happens During Failover
+
+1. All pods in eu-west-1 become unhealthy (node failure, cluster issue)
+2. Cilium agent in eu-central-1 detects remote endpoints are gone
+3. Local pods in eu-central-1 already handle local traffic (affinity: local)
+4. Remote clients that were hitting eu-west-1 via GA get rerouted by GA to eu-central-1
+5. Internal services in eu-central-1 that depended on eu-west-1 services via ClusterMesh were already preferring local — no impact
+
+## ApplicationSet Deployment Model
+
+### How Workloads Are Deployed
+
+The `applicationset-multicluster.yaml` uses a **matrix generator**:
+
+```
+Teams (mono, chains, direct, protocols, listeners)
+  ×
+Clusters (staging-euw1, staging-euc1)
+  =
+10 Applications (e.g., mono-euw1, mono-euc1, chains-euw1, chains-euc1, ...)
+```
+
+Each Application:
+- Deploys the same Helm chart (`helm/app`)
+- Uses the same image tag (from Kargo promotion)
+- Gets region injected via Helm values: `region`, `regionShort`, `cluster`
+- Has `service.global: true` to enable ClusterMesh discovery
+- Supports region-specific value overrides: `values-euw1.yaml`, `values-euc1.yaml`
+
+### RollingSync Strategy
+
+The ApplicationSet deploys to eu-west-1 first, then eu-central-1:
+
+```yaml
+strategy:
+  type: RollingSync
+  rollingSync:
+    steps:
+      - matchExpressions: [{key: region, values: [eu-west-1]}]
+      - matchExpressions: [{key: region, values: [eu-central-1]}]
+```
+
+This provides a natural canary: if deployment to eu-west-1 fails, eu-central-1 is not affected.
+
+### Region-Specific Overrides
+
+To customize behavior per region, create a file at:
+```
+envs/staging/values/<team>/values-<regionShort>.yaml
+```
+
+Example — different replica count per region:
+```yaml
+# envs/staging/values/mono/values-euw1.yaml
+replicaCount: 3
+
+# envs/staging/values/mono/values-euc1.yaml
+replicaCount: 2
+```
+
+## Adding a New Region
+
+When adding eu-west-2 or eu-west-3:
+
+1. Create cluster secret with labels `region: eu-west-2`, `region-short: euw2`
+2. Uncomment/add to `argocd/bootstrap/cluster-secrets/kustomization.yaml`
+3. The multicluster ApplicationSets auto-discover new clusters via label selectors
+4. Optionally add region-specific value overrides: `values-euw2.yaml`
+5. Update Global Accelerator endpoint groups to include the new region's NLB
+
+No ApplicationSet YAML changes needed — new clusters are picked up automatically by the `clusters` generator with `region: Exists` selector.
+
+## Monitoring
+
+- **Grafana dashboard**: `multiregion-overview` — GA metrics, per-region health, traffic split
+- **Grafana dashboard**: `clustermesh-status` — mesh connectivity, cross-cluster flows
+- **ArgoCD UI**: Applications grouped by `region` label — filter to see per-region status

--- a/envs/staging/values/infra/external-dns-euc1.yaml
+++ b/envs/staging/values/infra/external-dns-euc1.yaml
@@ -1,0 +1,7 @@
+# Region-specific overrides for ExternalDNS in eu-central-1
+# Loaded by multicluster-infra-appset via: values/infra/external-dns-euc1.yaml
+
+external-dns:
+  aws:
+    region: eu-central-1
+  txtOwnerId: "external-dns-euc1"

--- a/envs/staging/values/infra/external-dns-euw1.yaml
+++ b/envs/staging/values/infra/external-dns-euw1.yaml
@@ -1,0 +1,7 @@
+# Region-specific overrides for ExternalDNS in eu-west-1
+# Loaded by multicluster-infra-appset via: values/infra/external-dns-euw1.yaml
+
+external-dns:
+  aws:
+    region: eu-west-1
+  txtOwnerId: "external-dns-euw1"

--- a/helm/app/Chart.yaml
+++ b/helm/app/Chart.yaml
@@ -2,6 +2,6 @@
 apiVersion: v2
 name: app
 description: Cloud-native application chart with 12-factor support
-version: 0.2.0
+version: 0.3.0
 appVersion: "1.0"
 type: application

--- a/helm/app/templates/service.yaml
+++ b/helm/app/templates/service.yaml
@@ -5,6 +5,19 @@ metadata:
   name: {{include "app.fullname" .}}
   labels:
     {{- include "app.selectorLabels" . | nindent 4}}
+  {{- if or .Values.service.annotations .Values.service.global }}
+  annotations:
+    {{- if .Values.service.global }}
+    service.cilium.io/global: "true"
+    service.cilium.io/affinity: {{ .Values.service.globalAffinity | default "local" | quote }}
+    {{- if .Values.service.shared }}
+    service.cilium.io/shared: "true"
+    {{- end }}
+    {{- end }}
+    {{- with .Values.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{.Values.service.type}}
   ports:

--- a/helm/app/values.yaml
+++ b/helm/app/values.yaml
@@ -95,6 +95,14 @@ envFrom: []
 service:
   type: ClusterIP
   port: 80
+  annotations: {}
+  # Cilium ClusterMesh global service — makes this service discoverable across clusters.
+  # Traffic prefers the local cluster; fails over to remote if local pods are unhealthy.
+  global: false
+  # Affinity: "local" (prefer local, failover remote), "remote" (prefer remote), "none" (round-robin)
+  globalAffinity: local
+  # Shared: when true, load-balances across local AND remote pods simultaneously
+  shared: false
 
 # --- Ingress ---
 ingress:


### PR DESCRIPTION
## Summary

- **Cross-region networking**: Transit Gateway peering (eu-west-1 ↔ eu-central-1), ClusterMesh security group rules for etcd/health/WireGuard/Hubble ports
- **Cilium ClusterMesh**: Cluster identity (staging-euw1/euc1), API server with internal NLB, auto TLS, Hubble peer service for cross-cluster flow visibility
- **External traffic**: AWS Global Accelerator with anycast geo-routing, per-region NLB ingress with TLS termination, SOURCE_IP client affinity
- **Multi-cluster ArgoCD**: ApplicationSet with matrix generator (5 teams × 2 clusters), RollingSync (euw1 first), region-specific value overrides, multicluster-infra-appset for shared infra
- **Helm app chart v0.3.0**: Cilium global service annotations (`service.cilium.io/global`, `/affinity`, `/shared`) on Service resources
- **Observability**: Grafana dashboards for multi-region overview and ClusterMesh status
- **Documentation**: Traffic routing architecture, workload scheduling patterns, topology spread, 4 operational runbooks (manual/auto failover, ClusterMesh troubleshooting, region recovery)

## New Terraform Modules

| Module | Purpose |
|--------|---------|
| `tgw-peering` | Cross-region Transit Gateway peering with route propagation |
| `clustermesh-sg-rules` | Security group rules for ClusterMesh ports (2379, 4240, 51871, 4244) |
| `clustermesh-connect` | Cross-cluster CA cert and endpoint sharing via K8s secrets |
| `global-accelerator` | AWS Global Accelerator with per-region endpoint groups |
| `nlb-ingress` | External NLB per region with TLS and IP-type target groups |

## New Catalog Units

`tgw-peering`, `clustermesh-sg-rules`, `clustermesh-connect`, `nlb-ingress`, `global-accelerator`

## Modified

- Cilium module: ClusterMesh helm values, cluster identity, API server config
- TGW attachment: Fixed route table IDs (was only passing first, now passes all)
- Connectivity stack: Added tgw-peering unit
- Platform stack: Added clustermesh-sg-rules and nlb-ingress units
- Both region live stacks updated
- staging/account.hcl: ClusterMesh IDs, peer CIDRs, feature flags
- ExternalDNS: Region-specific values for euw1/euc1

## Extensibility

Adding eu-west-2 or eu-west-3 requires only configuration changes:
1. Add cluster ID in `clustermesh_cluster_ids` (3 and 4 already reserved)
2. Add CIDR to `peer_vpc_cidrs`
3. Deploy platform stack in new region directory
4. New clusters auto-discovered by ApplicationSet label selectors

## Test plan

- [ ] `terragrunt validate` on all new/modified units
- [ ] `terragrunt plan` in staging/eu-west-1/platform and staging/eu-central-1/platform
- [ ] Verify ClusterMesh connectivity: `cilium clustermesh status`
- [ ] Verify Global Accelerator health checks pass for both regions
- [ ] Test cross-cluster service discovery with global service annotation
- [ ] Test failover: kill pods in one region, verify ClusterMesh routes to other
- [ ] Validate RollingSync deploys euw1 before euc1