### PR TITLE
feat: gpu-inference VPC with BGP-ready subnets and TGW Connect (#63)

### DIFF
--- a/catalog/units/argocd/terragrunt.hcl
+++ b/catalog/units/argocd/terragrunt.hcl
@@ -92,7 +92,7 @@ inputs = {
   ha_enabled    = try(local.account_vars.locals.argocd_ha_enabled, local.environment == "prod")
   enable_dex    = try(local.account_vars.locals.argocd_enable_dex, false)
 
-  controller_resources = try(local.account_vars.locals.argocd_controller_resources, null)
+  controller_resources  = try(local.account_vars.locals.argocd_controller_resources, null)
   repo_server_resources = try(local.account_vars.locals.argocd_repo_server_resources, null)
 
   tags = {

--- a/catalog/units/aws-config/terragrunt.hcl
+++ b/catalog/units/aws-config/terragrunt.hcl
@@ -25,10 +25,10 @@ locals {
 }
 
 inputs = {
-  recorder_name               = "default"
-  s3_bucket_name              = "aws-config-snapshots-${local.account_id}"
-  snapshot_delivery_frequency = "TwentyFour_Hours"
-  recording_all_resources     = true
+  recorder_name                 = "default"
+  s3_bucket_name                = "aws-config-snapshots-${local.account_id}"
+  snapshot_delivery_frequency   = "TwentyFour_Hours"
+  recording_all_resources       = true
   include_global_resource_types = true
 
   # Lifecycle: 1yr Glacier -> 7yr expire

--- a/catalog/units/blockchain-vpc/terragrunt.hcl
+++ b/catalog/units/blockchain-vpc/terragrunt.hcl
@@ -25,22 +25,22 @@ locals {
   # Separate /16 blocks in the 10.100+ range to avoid overlap with platform VPCs.
   # ---------------------------------------------------------------------------
   cidr_map = {
-    dev-eu-west-1           = "10.100.0.0/16"
-    dev-eu-west-2           = "10.101.0.0/16"
-    dev-eu-west-3           = "10.102.0.0/16"
-    dev-eu-central-1        = "10.103.0.0/16"
-    staging-eu-west-1       = "10.110.0.0/16"
-    staging-eu-west-2       = "10.111.0.0/16"
-    staging-eu-west-3       = "10.112.0.0/16"
-    staging-eu-central-1    = "10.113.0.0/16"
-    prod-eu-west-1          = "10.120.0.0/16"
-    prod-eu-west-2          = "10.121.0.0/16"
-    prod-eu-west-3          = "10.122.0.0/16"
-    prod-eu-central-1       = "10.123.0.0/16"
-    dr-eu-west-1            = "10.130.0.0/16"
-    dr-eu-west-2            = "10.131.0.0/16"
-    dr-eu-west-3            = "10.132.0.0/16"
-    dr-eu-central-1         = "10.133.0.0/16"
+    dev-eu-west-1        = "10.100.0.0/16"
+    dev-eu-west-2        = "10.101.0.0/16"
+    dev-eu-west-3        = "10.102.0.0/16"
+    dev-eu-central-1     = "10.103.0.0/16"
+    staging-eu-west-1    = "10.110.0.0/16"
+    staging-eu-west-2    = "10.111.0.0/16"
+    staging-eu-west-3    = "10.112.0.0/16"
+    staging-eu-central-1 = "10.113.0.0/16"
+    prod-eu-west-1       = "10.120.0.0/16"
+    prod-eu-west-2       = "10.121.0.0/16"
+    prod-eu-west-3       = "10.122.0.0/16"
+    prod-eu-central-1    = "10.123.0.0/16"
+    dr-eu-west-1         = "10.130.0.0/16"
+    dr-eu-west-2         = "10.131.0.0/16"
+    dr-eu-west-3         = "10.132.0.0/16"
+    dr-eu-central-1      = "10.133.0.0/16"
   }
 
   vpc_cidr     = local.cidr_map["${local.environment}-${local.aws_region}"]

--- a/catalog/units/cilium/terragrunt.hcl
+++ b/catalog/units/cilium/terragrunt.hcl
@@ -74,8 +74,8 @@ inputs = {
   operator_replicas = local.environment == "prod" ? 2 : 1
 
   # ClusterMesh for multi-region service discovery
-  enable_clustermesh            = try(local.account_vars.locals.enable_clustermesh, false)
-  cluster_mesh_name             = try(local.account_vars.locals.enable_clustermesh, false) ? "${local.environment}-${local.region_vars.locals.region_short}" : ""
-  cluster_mesh_id               = try(local.account_vars.locals.enable_clustermesh, false) ? local.account_vars.locals.clustermesh_cluster_ids[local.aws_region] : 0
+  enable_clustermesh             = try(local.account_vars.locals.enable_clustermesh, false)
+  cluster_mesh_name              = try(local.account_vars.locals.enable_clustermesh, false) ? "${local.environment}-${local.region_vars.locals.region_short}" : ""
+  cluster_mesh_id                = try(local.account_vars.locals.enable_clustermesh, false) ? local.account_vars.locals.clustermesh_cluster_ids[local.aws_region] : 0
   clustermesh_apiserver_replicas = try(local.account_vars.locals.clustermesh_apiserver_replicas, 2)
 }

--- a/catalog/units/gpu-eks/terragrunt.hcl
+++ b/catalog/units/gpu-eks/terragrunt.hcl
@@ -18,10 +18,10 @@ locals {
   account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
   region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
 
-  account_name         = local.account_vars.locals.account_name
-  aws_region           = local.region_vars.locals.aws_region
-  environment          = local.account_vars.locals.environment
-  gpu_analysis_config  = local.account_vars.locals.gpu_analysis_config
+  account_name        = local.account_vars.locals.account_name
+  aws_region          = local.region_vars.locals.aws_region
+  environment         = local.account_vars.locals.environment
+  gpu_analysis_config = local.account_vars.locals.gpu_analysis_config
 
   cluster_name = "${local.environment}-${local.aws_region}-gpu-analysis"
 }

--- a/catalog/units/gpu-elasticache/terragrunt.hcl
+++ b/catalog/units/gpu-elasticache/terragrunt.hcl
@@ -67,8 +67,8 @@ inputs = {
 
   allowed_security_group_ids = [dependency.eks.outputs.node_security_group_id]
 
-  engine_version = try(local.video_pipeline_config.redis_engine_version, "7.1")
-  node_type      = try(local.video_pipeline_config.redis_node_type, "cache.t4g.micro")
+  engine_version     = try(local.video_pipeline_config.redis_engine_version, "7.1")
+  node_type          = try(local.video_pipeline_config.redis_node_type, "cache.t4g.micro")
   num_cache_clusters = try(local.video_pipeline_config.redis_num_nodes, 2)
 
   transit_encryption_enabled = true

--- a/catalog/units/gpu-inference-vpc/terragrunt.hcl
+++ b/catalog/units/gpu-inference-vpc/terragrunt.hcl
@@ -1,0 +1,75 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference VPC Configuration — Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# Dedicated VPC for the gpu-inference EKS cluster with BGP-native routing
+# via AWS Transit Gateway Connect. Uses a separate Pod CIDR (100.64.0.0/10)
+# announced via BGP to avoid ENI IP limits at scale (up to 5000 nodes).
+#
+# Prod-only deployment. CIDR range 10.180+ to avoid overlap with platform
+# (10.0-53), blockchain (10.100-133), and gpu-analysis (10.140-173) VPCs.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/gpu-inference-vpc"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  account_name = local.account_vars.locals.account_name
+  aws_region   = local.region_vars.locals.aws_region
+  environment  = local.account_vars.locals.environment
+
+  # ---------------------------------------------------------------------------
+  # GPU Inference CIDR allocation map (prod only)
+  # Separate /16 blocks in the 10.180+ range to avoid overlap with:
+  #   platform:    10.0-53
+  #   blockchain:  10.100-133
+  #   gpu-analysis: 10.140-173
+  # ---------------------------------------------------------------------------
+  cidr_map = {
+    prod-eu-west-1    = "10.180.0.0/16"
+    prod-eu-west-2    = "10.181.0.0/16"
+    prod-eu-west-3    = "10.182.0.0/16"
+    prod-eu-central-1 = "10.183.0.0/16"
+  }
+
+  vpc_cidr     = local.cidr_map["${local.environment}-${local.aws_region}"]
+  cluster_name = "${local.environment}-${local.aws_region}-gpu-inference"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE INPUTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  name     = local.cluster_name
+  vpc_cidr = local.vpc_cidr
+  azs      = local.region_vars.locals.azs
+
+  cluster_name = local.cluster_name
+
+  # Private subnets: /20 blocks for GPU node groups (3 AZs)
+  private_subnets = [for i, az in local.region_vars.locals.azs : cidrsubnet(local.vpc_cidr, 4, i)]
+
+  # Intra subnets: /20 blocks for GPU node-to-node traffic (no NAT route)
+  intra_subnets = [for i, az in local.region_vars.locals.azs : cidrsubnet(local.vpc_cidr, 4, i + 4)]
+
+  # Pod CIDR announced via BGP (not part of VPC CIDR)
+  pod_cidr = "100.64.0.0/10"
+
+  # NAT Gateway — one per AZ in prod for HA
+  single_nat_gateway = local.account_vars.locals.single_nat_gateway
+
+  # Transit Gateway connectivity
+  transit_gateway_id   = try(local.account_vars.locals.transit_gateway_id, "")
+  tgw_route_table_id   = try(local.account_vars.locals.tgw_route_table_id, "")
+  tgw_destination_cidr = "10.0.0.0/8"
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-inference"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/catalog/units/gpu-karpenter-controller/terragrunt.hcl
+++ b/catalog/units/gpu-karpenter-controller/terragrunt.hcl
@@ -13,10 +13,10 @@ locals {
   account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
   region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
 
-  account_name         = local.account_vars.locals.account_name
-  aws_region           = local.region_vars.locals.aws_region
-  environment          = local.account_vars.locals.environment
-  gpu_analysis_config  = local.account_vars.locals.gpu_analysis_config
+  account_name        = local.account_vars.locals.account_name
+  aws_region          = local.region_vars.locals.aws_region
+  environment         = local.account_vars.locals.environment
+  gpu_analysis_config = local.account_vars.locals.gpu_analysis_config
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/catalog/units/gpu-karpenter-nodepools/terragrunt.hcl
+++ b/catalog/units/gpu-karpenter-nodepools/terragrunt.hcl
@@ -17,10 +17,10 @@ locals {
   account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
   region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
 
-  account_name         = local.account_vars.locals.account_name
-  aws_region           = local.region_vars.locals.aws_region
-  environment          = local.account_vars.locals.environment
-  gpu_analysis_config  = local.account_vars.locals.gpu_analysis_config
+  account_name        = local.account_vars.locals.account_name
+  aws_region          = local.region_vars.locals.aws_region
+  environment         = local.account_vars.locals.environment
+  gpu_analysis_config = local.account_vars.locals.gpu_analysis_config
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/catalog/units/guardduty-org/terragrunt.hcl
+++ b/catalog/units/guardduty-org/terragrunt.hcl
@@ -18,13 +18,13 @@ terraform {
 }
 
 inputs = {
-  enable_s3_protection           = true
+  enable_s3_protection            = true
   enable_eks_audit_log_monitoring = true
-  enable_eks_runtime_monitoring  = true
-  enable_malware_protection      = true
-  enable_rds_protection          = true
-  enable_lambda_protection       = true
-  auto_enable_org_members        = true
+  enable_eks_runtime_monitoring   = true
+  enable_malware_protection       = true
+  enable_rds_protection           = true
+  enable_lambda_protection        = true
+  auto_enable_org_members         = true
 
   tags = {
     Environment = "management"

--- a/catalog/units/platform-crds/terragrunt.hcl
+++ b/catalog/units/platform-crds/terragrunt.hcl
@@ -87,13 +87,13 @@ generate "k8s_providers" {
 
 inputs = {
   # CRD versions — override from account.hcl or use module defaults
-  argocd_version                  = try(local.account_vars.locals.argocd_version, null)
-  cert_manager_version            = try(local.account_vars.locals.cert_manager_version, null)
-  external_secrets_version        = try(local.account_vars.locals.external_secrets_version, null)
+  argocd_version                   = try(local.account_vars.locals.argocd_version, null)
+  cert_manager_version             = try(local.account_vars.locals.cert_manager_version, null)
+  external_secrets_version         = try(local.account_vars.locals.external_secrets_version, null)
   prometheus_operator_crds_version = try(local.account_vars.locals.prometheus_operator_crds_version, null)
-  gatekeeper_version              = try(local.account_vars.locals.gatekeeper_version, null)
-  velero_version                  = try(local.account_vars.locals.velero_version, null)
-  kargo_version                   = try(local.account_vars.locals.kargo_version, null)
+  gatekeeper_version               = try(local.account_vars.locals.gatekeeper_version, null)
+  velero_version                   = try(local.account_vars.locals.velero_version, null)
+  kargo_version                    = try(local.account_vars.locals.kargo_version, null)
 
   tags = {
     Environment = local.environment

--- a/terraform/modules/gpu-inference-vpc/main.tf
+++ b/terraform/modules/gpu-inference-vpc/main.tf
@@ -1,0 +1,265 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference VPC — Terraform Module
+# ---------------------------------------------------------------------------------------------------------------------
+# Dedicated VPC for the gpu-inference EKS cluster with BGP-native routing
+# via AWS Transit Gateway Connect. Designed for up to 5000 GPU nodes using
+# a separate Pod CIDR (100.64.0.0/10) announced via BGP, avoiding ENI IP
+# limits and VPC route table constraints.
+# ---------------------------------------------------------------------------------------------------------------------
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 6.6"
+
+  name = var.name
+  cidr = var.vpc_cidr
+
+  azs             = var.azs
+  private_subnets = var.private_subnets
+  intra_subnets   = var.intra_subnets
+
+  # No public subnets — all traffic via TGW or NAT
+  public_subnets = []
+
+  # NAT Gateway for outbound internet (image pulls, API calls)
+  enable_nat_gateway     = true
+  single_nat_gateway     = var.single_nat_gateway
+  one_nat_gateway_per_az = !var.single_nat_gateway
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  # VPC Flow Logs — audit and forensics
+  enable_flow_log                                 = true
+  flow_log_destination_type                       = "cloud-watch-logs"
+  create_flow_log_cloudwatch_log_group            = true
+  flow_log_cloudwatch_log_group_retention_in_days = 365
+  flow_log_max_aggregation_interval               = 60
+  flow_log_traffic_type                           = "ALL"
+
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb"           = "1"
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "karpenter.sh/discovery"                    = var.cluster_name
+  }
+
+  intra_subnet_tags = {
+    "Role" = "gpu-node-interconnect"
+  }
+
+  tags = var.tags
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Transit Gateway Connect Attachment
+# ---------------------------------------------------------------------------------------------------------------------
+# TGW Connect provides BGP peering over GRE tunnels, enabling Cilium nodes
+# to advertise the Pod CIDR (100.64.0.0/10) directly to the transit gateway.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
+  count = var.transit_gateway_id != "" ? 1 : 0
+
+  transit_gateway_id = var.transit_gateway_id
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.vpc.private_subnets
+
+  transit_gateway_default_route_table_association = false
+  transit_gateway_default_route_table_propagation = false
+
+  dns_support = "enable"
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-tgw-attachment"
+  })
+}
+
+resource "aws_ec2_transit_gateway_connect" "this" {
+  count = var.transit_gateway_id != "" ? 1 : 0
+
+  transport_attachment_id = aws_ec2_transit_gateway_vpc_attachment.this[0].id
+  transit_gateway_id      = var.transit_gateway_id
+  protocol                = "gre"
+
+  transit_gateway_default_route_table_association = false
+  transit_gateway_default_route_table_propagation = false
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-tgw-connect"
+  })
+}
+
+# Route table association for the TGW Connect attachment
+resource "aws_ec2_transit_gateway_route_table_association" "this" {
+  count = var.transit_gateway_id != "" && var.tgw_route_table_id != "" ? 1 : 0
+
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_connect.this[0].id
+  transit_gateway_route_table_id = var.tgw_route_table_id
+}
+
+# Route table propagation for the TGW Connect attachment
+resource "aws_ec2_transit_gateway_route_table_propagation" "this" {
+  count = var.transit_gateway_id != "" && var.tgw_route_table_id != "" ? 1 : 0
+
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_connect.this[0].id
+  transit_gateway_route_table_id = var.tgw_route_table_id
+}
+
+# VPC routes pointing to TGW for cross-account traffic
+resource "aws_route" "tgw_routes" {
+  for_each = var.transit_gateway_id != "" ? { for i, rt in module.vpc.private_route_table_ids : "private-${i}" => rt } : {}
+
+  route_table_id         = each.value
+  destination_cidr_block = var.tgw_destination_cidr
+  transit_gateway_id     = var.transit_gateway_id
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Security Groups
+# ---------------------------------------------------------------------------------------------------------------------
+
+# GPU node-to-node communication (NCCL, RDMA, all-reduce)
+resource "aws_security_group" "gpu_interconnect" {
+  name_prefix = "${var.name}-gpu-interconnect-"
+  description = "GPU node-to-node communication for NCCL and RDMA"
+  vpc_id      = module.vpc.vpc_id
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-gpu-interconnect"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Allow all traffic within the GPU interconnect security group
+resource "aws_vpc_security_group_ingress_rule" "gpu_self" {
+  security_group_id            = aws_security_group.gpu_interconnect.id
+  referenced_security_group_id = aws_security_group.gpu_interconnect.id
+  ip_protocol                  = "-1"
+  description                  = "All traffic between GPU nodes (NCCL/RDMA)"
+}
+
+resource "aws_vpc_security_group_egress_rule" "gpu_self" {
+  security_group_id            = aws_security_group.gpu_interconnect.id
+  referenced_security_group_id = aws_security_group.gpu_interconnect.id
+  ip_protocol                  = "-1"
+  description                  = "All traffic between GPU nodes (NCCL/RDMA)"
+}
+
+# Allow outbound to all (NAT gateway for image pulls, API calls)
+resource "aws_vpc_security_group_egress_rule" "gpu_egress_all" {
+  security_group_id = aws_security_group.gpu_interconnect.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+  description       = "Outbound internet access via NAT"
+}
+
+# BGP and GRE security group for TGW Connect peering
+resource "aws_security_group" "bgp_gre" {
+  name_prefix = "${var.name}-bgp-gre-"
+  description = "BGP and GRE for TGW Connect peering"
+  vpc_id      = module.vpc.vpc_id
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-bgp-gre"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# BGP (TCP/179) ingress from VPC CIDR
+resource "aws_vpc_security_group_ingress_rule" "bgp_ingress" {
+  security_group_id = aws_security_group.bgp_gre.id
+  cidr_ipv4         = var.vpc_cidr
+  from_port         = 179
+  to_port           = 179
+  ip_protocol       = "tcp"
+  description       = "BGP peering"
+}
+
+# GRE (protocol 47) ingress from VPC CIDR
+resource "aws_vpc_security_group_ingress_rule" "gre_ingress" {
+  security_group_id = aws_security_group.bgp_gre.id
+  cidr_ipv4         = var.vpc_cidr
+  ip_protocol       = "47"
+  description       = "GRE tunnels for TGW Connect"
+}
+
+# BGP + GRE egress
+resource "aws_vpc_security_group_egress_rule" "bgp_egress" {
+  security_group_id = aws_security_group.bgp_gre.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+  description       = "Outbound for BGP and GRE"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Network ACLs for BGP and GRE
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_network_acl" "gpu_private" {
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-gpu-private"
+  })
+}
+
+# Allow all inbound from VPC CIDR
+resource "aws_network_acl_rule" "private_inbound_vpc" {
+  network_acl_id = aws_network_acl.gpu_private.id
+  rule_number    = 100
+  egress         = false
+  protocol       = "-1"
+  rule_action    = "allow"
+  cidr_block     = var.vpc_cidr
+}
+
+# Allow BGP (TCP/179) from any (TGW endpoints)
+resource "aws_network_acl_rule" "private_inbound_bgp" {
+  network_acl_id = aws_network_acl.gpu_private.id
+  rule_number    = 110
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 179
+  to_port        = 179
+}
+
+# Allow GRE (protocol 47) from any (TGW endpoints)
+resource "aws_network_acl_rule" "private_inbound_gre" {
+  network_acl_id = aws_network_acl.gpu_private.id
+  rule_number    = 120
+  egress         = false
+  protocol       = "47"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+}
+
+# Allow return traffic (ephemeral ports)
+resource "aws_network_acl_rule" "private_inbound_ephemeral" {
+  network_acl_id = aws_network_acl.gpu_private.id
+  rule_number    = 200
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 1024
+  to_port        = 65535
+}
+
+# Allow all outbound
+resource "aws_network_acl_rule" "private_outbound_all" {
+  network_acl_id = aws_network_acl.gpu_private.id
+  rule_number    = 100
+  egress         = true
+  protocol       = "-1"
+  rule_action    = "allow"
+  cidr_block     = "0.0.0.0/0"
+}

--- a/terraform/modules/gpu-inference-vpc/outputs.tf
+++ b/terraform/modules/gpu-inference-vpc/outputs.tf
@@ -1,0 +1,63 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference VPC — Outputs
+# ---------------------------------------------------------------------------------------------------------------------
+
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = module.vpc.vpc_id
+}
+
+output "vpc_cidr_block" {
+  description = "CIDR block of the VPC"
+  value       = module.vpc.vpc_cidr_block
+}
+
+output "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  value       = module.vpc.private_subnets
+}
+
+output "private_route_table_ids" {
+  description = "List of private route table IDs"
+  value       = module.vpc.private_route_table_ids
+}
+
+output "intra_subnet_ids" {
+  description = "List of intra subnet IDs (GPU interconnect)"
+  value       = module.vpc.intra_subnets
+}
+
+output "intra_route_table_ids" {
+  description = "List of intra route table IDs"
+  value       = module.vpc.intra_route_table_ids
+}
+
+output "nat_gateway_ids" {
+  description = "List of NAT gateway IDs"
+  value       = module.vpc.natgw_ids
+}
+
+output "tgw_connect_attachment_id" {
+  description = "Transit Gateway Connect attachment ID"
+  value       = try(aws_ec2_transit_gateway_connect.this[0].id, "")
+}
+
+output "tgw_vpc_attachment_id" {
+  description = "Transit Gateway VPC attachment ID"
+  value       = try(aws_ec2_transit_gateway_vpc_attachment.this[0].id, "")
+}
+
+output "pod_cidr" {
+  description = "Pod CIDR block (announced via BGP, not part of VPC CIDR)"
+  value       = var.pod_cidr
+}
+
+output "gpu_interconnect_security_group_id" {
+  description = "Security group ID for GPU node-to-node communication"
+  value       = aws_security_group.gpu_interconnect.id
+}
+
+output "bgp_gre_security_group_id" {
+  description = "Security group ID for BGP and GRE (TGW Connect peering)"
+  value       = aws_security_group.bgp_gre.id
+}

--- a/terraform/modules/gpu-inference-vpc/variables.tf
+++ b/terraform/modules/gpu-inference-vpc/variables.tf
@@ -1,0 +1,69 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference VPC — Variables
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "name" {
+  description = "Name prefix for all resources"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+}
+
+variable "azs" {
+  description = "List of availability zones"
+  type        = list(string)
+}
+
+variable "private_subnets" {
+  description = "List of private subnet CIDR blocks"
+  type        = list(string)
+}
+
+variable "intra_subnets" {
+  description = "List of intra subnet CIDR blocks (GPU node-to-node, no NAT route)"
+  type        = list(string)
+}
+
+variable "cluster_name" {
+  description = "Name of the EKS cluster for subnet tagging"
+  type        = string
+}
+
+variable "pod_cidr" {
+  description = "Pod CIDR block announced via BGP (not part of VPC CIDR)"
+  type        = string
+  default     = "100.64.0.0/10"
+}
+
+variable "single_nat_gateway" {
+  description = "Use a single NAT gateway (true) or one per AZ (false)"
+  type        = bool
+  default     = false
+}
+
+variable "transit_gateway_id" {
+  description = "Transit Gateway ID for TGW Connect attachment"
+  type        = string
+  default     = ""
+}
+
+variable "tgw_route_table_id" {
+  description = "Transit Gateway route table ID for association and propagation"
+  type        = string
+  default     = ""
+}
+
+variable "tgw_destination_cidr" {
+  description = "Destination CIDR for TGW routes in VPC route tables"
+  type        = string
+  default     = "10.0.0.0/8"
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/gpu-inference-vpc/versions.tf
+++ b/terraform/modules/gpu-inference-vpc/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/terragrunt/gcp-staging/project.hcl
+++ b/terragrunt/gcp-staging/project.hcl
@@ -1,26 +1,26 @@
 locals {
-  project_id   = "my-gcp-project-staging"  # TODO: Replace with actual GCP project ID
+  project_id   = "my-gcp-project-staging" # TODO: Replace with actual GCP project ID
   project_name = "gcp-staging"
   environment  = "staging"
 
   # GPU Video Analysis Cluster Configuration
   gpu_analysis_config = {
     # GKE system node pool sizing
-    gke_machine_type    = "e2-standard-4"
-    gke_min_node_count  = 1
-    gke_max_node_count  = 3
+    gke_machine_type   = "e2-standard-4"
+    gke_min_node_count = 1
+    gke_max_node_count = 3
 
     # GPU Node Pools
     gpu_node_pools = {
       gpu-inference = {
-        machine_type = "g2-standard-8"
-        accelerator_type  = "nvidia-l4"
-        accelerator_count = 1
-        disk_size_gb      = 200
-        disk_type         = "pd-ssd"
-        spot              = false  # On-demand for SLA
-        min_node_count    = 0
-        max_node_count    = 4
+        machine_type       = "g2-standard-8"
+        accelerator_type   = "nvidia-l4"
+        accelerator_count  = 1
+        disk_size_gb       = 200
+        disk_type          = "pd-ssd"
+        spot               = false # On-demand for SLA
+        min_node_count     = 0
+        max_node_count     = 4
         initial_node_count = 1
         labels = {
           "gpu-type"      = "l4"
@@ -32,14 +32,14 @@ locals {
       }
 
       gpu-preprocessing = {
-        machine_type = "n1-standard-8"
-        accelerator_type  = "nvidia-tesla-t4"
-        accelerator_count = 1
-        disk_size_gb      = 200
-        disk_type         = "pd-ssd"
-        spot              = true  # Spot for cost optimization
-        min_node_count    = 0
-        max_node_count    = 4
+        machine_type       = "n1-standard-8"
+        accelerator_type   = "nvidia-tesla-t4"
+        accelerator_count  = 1
+        disk_size_gb       = 200
+        disk_type          = "pd-ssd"
+        spot               = true # Spot for cost optimization
+        min_node_count     = 0
+        max_node_count     = 4
         initial_node_count = 0
         labels = {
           "gpu-type"      = "t4"
@@ -51,14 +51,14 @@ locals {
       }
 
       cpu-coordination = {
-        machine_type = "n2-standard-4"
-        accelerator_type  = null
-        accelerator_count = 0
-        disk_size_gb      = 100
-        disk_type         = "pd-ssd"
-        spot              = true
-        min_node_count    = 0
-        max_node_count    = 3
+        machine_type       = "n2-standard-4"
+        accelerator_type   = null
+        accelerator_count  = 0
+        disk_size_gb       = 100
+        disk_type          = "pd-ssd"
+        spot               = true
+        min_node_count     = 0
+        max_node_count     = 3
         initial_node_count = 1
         labels = {
           "workload-type" = "coordination"

--- a/terragrunt/prod/account.hcl
+++ b/terragrunt/prod/account.hcl
@@ -100,8 +100,8 @@ locals {
       consolidate_after    = "Never"
       weight               = 5
       labels = {
-        "node-type"      = "cde"
-        "pci-dss-scope"  = "true"
+        "node-type"     = "cde"
+        "pci-dss-scope" = "true"
       }
       taints = [
         { key = "pci-dss", value = "cde", effect = "NoSchedule" }

--- a/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
+++ b/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
@@ -1,0 +1,12 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference Stack — Live Deployment (Prod)
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys the gpu-inference cluster infrastructure for prod eu-west-1.
+# Phase 1: VPC with BGP-ready subnets and TGW Connect.
+# Additional units will be added as subsequent issues are implemented.
+# ---------------------------------------------------------------------------------------------------------------------
+
+unit "gpu-inference-vpc" {
+  source = "${get_repo_root()}/catalog/units/gpu-inference-vpc"
+  path   = "gpu-inference-vpc"
+}

--- a/terragrunt/staging/_global/clustermesh-connect/terragrunt.hcl
+++ b/terragrunt/staging/_global/clustermesh-connect/terragrunt.hcl
@@ -33,8 +33,8 @@ dependency "cilium_euw1" {
   config_path = "../../eu-west-1/platform/cilium"
 
   mock_outputs = {
-    cluster_mesh_name  = "staging-euw1"
-    cluster_mesh_id    = 1
+    cluster_mesh_name   = "staging-euw1"
+    cluster_mesh_id     = 1
     clustermesh_enabled = true
   }
 
@@ -46,8 +46,8 @@ dependency "cilium_euc1" {
   config_path = "../../eu-central-1/platform/cilium"
 
   mock_outputs = {
-    cluster_mesh_name  = "staging-euc1"
-    cluster_mesh_id    = 2
+    cluster_mesh_name   = "staging-euc1"
+    cluster_mesh_id     = 2
     clustermesh_enabled = true
   }
 

--- a/terragrunt/staging/account.hcl
+++ b/terragrunt/staging/account.hcl
@@ -11,9 +11,9 @@ locals {
   network_account    = "555555555555"
 
   # Transit Gateway connectivity (shared via RAM from network account)
-  enable_tgw_attachment = true  # Enabled for multi-region connectivity
-  transit_gateway_id    = ""    # Populate after network account deployment
-  tgw_route_table_id    = ""    # nonprod route table ID from network account
+  enable_tgw_attachment = true # Enabled for multi-region connectivity
+  transit_gateway_id    = ""   # Populate after network account deployment
+  tgw_route_table_id    = ""   # nonprod route table ID from network account
 
   single_nat_gateway    = false
   eks_public_access     = false
@@ -43,8 +43,8 @@ locals {
   clustermesh_cluster_ids = {
     "eu-west-1"    = 1
     "eu-central-1" = 2
-    "eu-west-2"    = 3  # Reserved for future
-    "eu-west-3"    = 4  # Reserved for future
+    "eu-west-2"    = 3 # Reserved for future
+    "eu-west-3"    = 4 # Reserved for future
   }
   clustermesh_apiserver_replicas = 2
   peer_vpc_cidrs = {
@@ -61,9 +61,9 @@ locals {
   # Each replica is encrypted with the region-specific KMS CMK for secrets-manager.
   # replica_kms_key_arns: populate with actual KMS key ARNs after deploying KMS in each region.
   secrets_config = {
-    primary_region = "eu-central-1"
+    primary_region  = "eu-central-1"
     replica_regions = ["eu-west-1", "eu-west-2", "eu-west-3"]
-    rotation_days  = 90
+    rotation_days   = 90
     replica_kms_key_arns = {
       "eu-west-1" = "" # TODO: Set to KMS secrets-manager key ARN from eu-west-1 after deployment
       "eu-west-2" = "" # TODO: Set to KMS secrets-manager key ARN from eu-west-2 after deployment
@@ -250,9 +250,9 @@ locals {
         enabled           = true
         cpu_limit         = 32
         memory_limit      = 128
-        spot_percentage   = 0          # On-demand — chain sync takes 5-7 days
+        spot_percentage   = 0                      # On-demand — chain sync takes 5-7 days
         instance_families = ["r6i", "r7i", "r6a"]  # Memory-optimized for UTXO set
-        instance_sizes    = ["2xlarge", "4xlarge"]  # 8-16 vCPU, 64-128GB RAM
+        instance_sizes    = ["2xlarge", "4xlarge"] # 8-16 vCPU, 64-128GB RAM
         architectures     = ["amd64"]
 
         # No placement group — Bitcoin P2P is global, no latency benefit
@@ -271,7 +271,7 @@ locals {
         consolidation_policy = "WhenEmpty"
         consolidate_after    = "Never"
         disruption_budgets = [
-          { nodes = "0" }  # Zero disruption
+          { nodes = "0" } # Zero disruption
         ]
 
         labels = {
@@ -329,8 +329,8 @@ locals {
         enabled           = true
         cpu_limit         = 100
         memory_limit      = 400
-        spot_percentage   = 0          # On-demand — real-time SLA
-        instance_families = ["g5"]     # NVIDIA A10G (24GB VRAM)
+        spot_percentage   = 0      # On-demand — real-time SLA
+        instance_families = ["g5"] # NVIDIA A10G (24GB VRAM)
         instance_sizes    = ["xlarge", "2xlarge", "4xlarge"]
         architectures     = ["amd64"]
 
@@ -364,7 +364,7 @@ locals {
           { key = "nvidia.com/gpu", value = "true", effect = "NoSchedule" }
         ]
 
-        expire_after = "1440h"  # 60 days
+        expire_after = "1440h" # 60 days
         weight       = 10
       }
 
@@ -376,8 +376,8 @@ locals {
         enabled           = true
         cpu_limit         = 100
         memory_limit      = 400
-        spot_percentage   = 70         # Cost optimization for batch work
-        instance_families = ["g4dn"]   # NVIDIA T4 (16GB VRAM)
+        spot_percentage   = 70       # Cost optimization for batch work
+        instance_families = ["g4dn"] # NVIDIA T4 (16GB VRAM)
         instance_sizes    = ["xlarge", "2xlarge", "4xlarge"]
         architectures     = ["amd64"]
 
@@ -407,7 +407,7 @@ locals {
           { key = "nvidia.com/gpu", value = "true", effect = "NoSchedule" }
         ]
 
-        expire_after = "720h"   # 30 days
+        expire_after = "720h" # 30 days
         weight       = 20
       }
 
@@ -432,7 +432,7 @@ locals {
           "workload.io/type" = "coordination"
         }
 
-        expire_after = "720h"   # 30 days
+        expire_after = "720h" # 30 days
         weight       = 30
       }
     }
@@ -447,11 +447,11 @@ locals {
   video_pipeline_config = {
     # --- ElastiCache Redis ---
     redis_engine_version = "7.1"
-    redis_node_type      = "cache.t4g.micro"   # Small for staging
-    redis_num_nodes      = 2                     # Multi-AZ
+    redis_node_type      = "cache.t4g.micro" # Small for staging
+    redis_num_nodes      = 2                 # Multi-AZ
 
     # --- CloudFront ---
-    cloudfront_price_class    = "PriceClass_100"  # EU + NA only
+    cloudfront_price_class       = "PriceClass_100" # EU + NA only
     cloudfront_allowed_countries = ["FR", "DE", "GB", "ES", "IT", "NL", "BE", "AT", "CH", "PT"]
   }
 


### PR DESCRIPTION
## Summary

Implements Issue #63 — GPU Inference VPC with BGP-ready subnets and TGW Connect.

- **New Terraform module** `terraform/modules/gpu-inference-vpc/`: Dedicated VPC module for the gpu-inference EKS cluster with:
  - Private subnets (`/20` per AZ) tagged for Karpenter discovery and internal ELB
  - Intra subnets (`/20` per AZ) for GPU node-to-node traffic (NCCL/RDMA) with no NAT route
  - VPC Flow Logs to CloudWatch (365-day retention, ALL traffic)
  - `aws_ec2_transit_gateway_vpc_attachment` + `aws_ec2_transit_gateway_connect` (GRE protocol) for BGP peering via TGW Connect
  - TGW route table association and propagation
  - VPC routes pointing to TGW for `10.0.0.0/8` cross-account traffic
  - Security groups for GPU interconnect (NCCL/RDMA self-referencing) and BGP/GRE (TCP/179 + proto 47)
  - Network ACLs permitting BGP, GRE, and ephemeral return traffic on private subnets
  - No public subnets — all traffic via TGW or NAT Gateway

- **New catalog unit** `catalog/units/gpu-inference-vpc/terragrunt.hcl`: Prod-only deployment using CIDR range `10.180.0.0/16–10.183.0.0/16` (avoids overlap with platform 10.0–53, blockchain 10.100–133, gpu-analysis 10.140–173). Pod CIDR `100.64.0.0/10` announced via BGP, not part of VPC CIDR.

- **New live stack** `terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl`: Phase 1 stack for prod eu-west-1. Additional units (EKS, Karpenter, Cilium, etc.) will be added in subsequent issues (#64–#80).

- **hclfmt fixes**: Reformatted existing catalog units and live configs for consistent HCL formatting.

## Test plan

- [ ] `terraform validate` passes (confirmed locally)
- [ ] `terraform fmt` is clean (confirmed locally)
- [ ] `terragrunt hclfmt` is clean (confirmed locally)
- [ ] CI checkov scan passes
- [ ] `terragrunt stack plan` in prod eu-west-1 with a real TGW ID produces a clean plan