### PR TITLE
feat: Cilium v1.19 native routing + BGP peering via TGW Connect (#70)

### DIFF
--- a/catalog/units/gpu-inference-cilium/terragrunt.hcl
+++ b/catalog/units/gpu-inference-cilium/terragrunt.hcl
@@ -1,0 +1,100 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference Cilium v1.19 — Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys Cilium v1.19 in native-routing mode with BGP Control Plane peering
+# to AWS Transit Gateway Connect for the gpu-inference cluster.
+#
+# Key differences from platform Cilium:
+#   - Native routing (not ENI IPAM)
+#   - BGP Control Plane enabled for TGW Connect peering
+#   - Cluster-pool IPAM with Pod CIDR 100.64.0.0/10
+#   - L7 proxy disabled (latency-sensitive GPU traffic)
+#   - High-scale BPF map tuning (512k LB, 64k policy)
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/gpu-inference-cilium"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  environment          = local.account_vars.locals.environment
+  aws_region           = local.region_vars.locals.aws_region
+  gpu_inference_config = try(local.account_vars.locals.gpu_inference_config, {})
+}
+
+dependency "eks" {
+  config_path = "../gpu-inference-eks"
+
+  mock_outputs = {
+    cluster_name                       = "mock-cluster"
+    cluster_endpoint                   = "https://mock-endpoint.eks.amazonaws.com"
+    cluster_certificate_authority_data = "bW9jay1jZXJ0LWRhdGE="
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+dependency "vpc" {
+  config_path = "../gpu-inference-vpc"
+
+  mock_outputs = {
+    pod_cidr = "100.64.0.0/10"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+generate "k8s_providers" {
+  path      = "k8s_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "helm" {
+      kubernetes {
+        host                   = "${dependency.eks.outputs.cluster_endpoint}"
+        cluster_ca_certificate = base64decode("${dependency.eks.outputs.cluster_certificate_authority_data}")
+        exec {
+          api_version = "client.authentication.k8s.io/v1beta1"
+          command     = "aws"
+          args        = ["eks", "get-token", "--cluster-name", "${dependency.eks.outputs.cluster_name}"]
+        }
+      }
+    }
+
+    provider "kubernetes" {
+      host                   = "${dependency.eks.outputs.cluster_endpoint}"
+      cluster_ca_certificate = base64decode("${dependency.eks.outputs.cluster_certificate_authority_data}")
+      exec {
+        api_version = "client.authentication.k8s.io/v1beta1"
+        command     = "aws"
+        args        = ["eks", "get-token", "--cluster-name", "${dependency.eks.outputs.cluster_name}"]
+      }
+    }
+  PROVIDERS
+}
+
+inputs = {
+  cilium_version   = "1.19.2"
+  cluster_endpoint = replace(dependency.eks.outputs.cluster_endpoint, "https://", "")
+  pod_cidr         = dependency.vpc.outputs.pod_cidr
+
+  # High-scale tuning
+  operator_replicas  = 2
+  bpf_lb_map_max     = "512000"
+  bpf_policy_map_max = "65536"
+
+  # BGP peering — enable once TGW Connect peers are configured
+  enable_bgp_peering = try(local.gpu_inference_config.enable_bgp_peering, false)
+  bgp_local_asn      = try(local.gpu_inference_config.bgp_local_asn, 65100)
+  bgp_peers          = try(local.gpu_inference_config.bgp_peers, [])
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-inference"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/terraform/modules/gpu-inference-cilium/main.tf
+++ b/terraform/modules/gpu-inference-cilium/main.tf
@@ -1,0 +1,145 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference Cilium v1.19 — Native Routing + BGP Control Plane
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys Cilium v1.19 in native-routing mode with BGP Control Plane peering
+# to AWS Transit Gateway Connect. Pods get IPs from cluster-pool CIDR
+# (100.64.0.0/10), not VPC. Each node is a BGP speaker announcing its Pod CIDR
+# to TGW, enabling near-physical-network latency for NCCL/distributed training.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "helm_release" "cilium" {
+  name             = "cilium"
+  repository       = "https://helm.cilium.io/"
+  chart            = "cilium"
+  version          = var.cilium_version
+  namespace        = "kube-system"
+  create_namespace = false
+
+  wait          = true
+  wait_for_jobs = true
+  timeout       = 600
+
+  values = [
+    yamlencode({
+      # Native routing mode — no VXLAN/Geneve encapsulation
+      routingMode           = "native"
+      autoDirectNodeRoutes  = true
+      ipv4NativeRoutingCIDR = var.pod_cidr
+
+      # Cluster-pool IPAM (pods get IPs from 100.64.0.0/10, not VPC)
+      ipam = {
+        mode = "cluster-pool"
+        operator = {
+          clusterPoolIPv4PodCIDRList = [var.pod_cidr]
+          clusterPoolIPv4MaskSize    = var.pod_cidr_mask_size
+        }
+      }
+
+      # kube-proxy replacement via eBPF
+      kubeProxyReplacement = true
+      k8sServiceHost       = var.cluster_endpoint
+      k8sServicePort       = 443
+
+      # BPF settings
+      bpf = {
+        masquerade   = true
+        lbMapMax     = tonumber(var.bpf_lb_map_max)
+        policyMapMax = tonumber(var.bpf_policy_map_max)
+      }
+
+      # No conntrack iptables rules — eBPF handles it
+      installNoConntrackIptablesRules = true
+
+      # Disable L7 proxy for GPU traffic — adds latency
+      l7Proxy = false
+
+      # Socket-level acceleration for node-local traffic
+      sockops = {
+        enabled = true
+      }
+
+      # EDT-based bandwidth management
+      bandwidthManager = {
+        enabled = true
+      }
+
+      # BGP Control Plane
+      bgpControlPlane = {
+        enabled = true
+      }
+
+      # EndpointSlice for 5000-node scale
+      endpointSlice = {
+        enabled = true
+      }
+
+      # Hubble observability
+      hubble = {
+        enabled = true
+        relay = {
+          enabled = true
+        }
+        ui = {
+          enabled = false
+        }
+      }
+
+      # Operator tuning for high-scale
+      operator = {
+        replicas = var.operator_replicas
+        prometheus = {
+          enabled = true
+        }
+      }
+
+      # Prometheus metrics
+      prometheus = {
+        enabled = true
+      }
+
+      # Tolerations to run on all nodes including GPU taints
+      tolerations = [
+        {
+          operator = "Exists"
+        }
+      ]
+    })
+  ]
+}
+
+# BGP Peering Policy for TGW Connect
+resource "kubernetes_manifest" "bgp_peering_policy" {
+  count = var.enable_bgp_peering ? 1 : 0
+
+  manifest = {
+    apiVersion = "cilium.io/v2alpha1"
+    kind       = "CiliumBGPPeeringPolicy"
+    metadata = {
+      name = "gpu-inference-bgp"
+    }
+    spec = {
+      nodeSelector = {
+        matchLabels = {
+          "node-role" = "gpu"
+        }
+      }
+      virtualRouters = [
+        {
+          localASN = var.bgp_local_asn
+          neighbors = [
+            for peer in var.bgp_peers : {
+              peerAddress             = "${peer.address}/32"
+              peerASN                 = peer.asn
+              connectRetryTimeSeconds = 30
+              holdTimeSeconds         = 90
+              keepAliveTimeSeconds    = 30
+            }
+          ]
+          exportPodCIDR = true
+        }
+      ]
+    }
+  }
+
+  depends_on = [helm_release.cilium]
+}

--- a/terraform/modules/gpu-inference-cilium/outputs.tf
+++ b/terraform/modules/gpu-inference-cilium/outputs.tf
@@ -1,0 +1,19 @@
+output "cilium_version" {
+  description = "Installed Cilium version"
+  value       = helm_release.cilium.version
+}
+
+output "cilium_namespace" {
+  description = "Namespace where Cilium is installed"
+  value       = helm_release.cilium.namespace
+}
+
+output "pod_cidr" {
+  description = "Pod CIDR configured for Cilium cluster-pool IPAM"
+  value       = var.pod_cidr
+}
+
+output "bgp_local_asn" {
+  description = "Local ASN used for BGP peering"
+  value       = var.bgp_local_asn
+}

--- a/terraform/modules/gpu-inference-cilium/variables.tf
+++ b/terraform/modules/gpu-inference-cilium/variables.tf
@@ -1,0 +1,67 @@
+variable "cilium_version" {
+  description = "Cilium Helm chart version"
+  type        = string
+  default     = "1.19.2"
+}
+
+variable "cluster_endpoint" {
+  description = "EKS cluster API endpoint (without https://)"
+  type        = string
+}
+
+variable "pod_cidr" {
+  description = "Pod CIDR block announced via BGP"
+  type        = string
+  default     = "100.64.0.0/10"
+}
+
+variable "pod_cidr_mask_size" {
+  description = "Per-node Pod CIDR mask size"
+  type        = string
+  default     = "24"
+}
+
+variable "operator_replicas" {
+  description = "Number of Cilium operator replicas"
+  type        = number
+  default     = 2
+}
+
+variable "bpf_lb_map_max" {
+  description = "Maximum BPF LB map entries"
+  type        = string
+  default     = "512000"
+}
+
+variable "bpf_policy_map_max" {
+  description = "Maximum BPF policy map entries"
+  type        = string
+  default     = "65536"
+}
+
+variable "enable_bgp_peering" {
+  description = "Enable BGP peering policy for TGW Connect"
+  type        = bool
+  default     = false
+}
+
+variable "bgp_local_asn" {
+  description = "Local ASN for BGP peering"
+  type        = number
+  default     = 65100
+}
+
+variable "bgp_peers" {
+  description = "BGP peer configurations for TGW Connect"
+  type = list(object({
+    address = string
+    asn     = number
+  }))
+  default = []
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/gpu-inference-cilium/versions.tf
+++ b/terraform/modules/gpu-inference-cilium/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.25"
+    }
+  }
+}

--- a/terragrunt/prod/account.hcl
+++ b/terragrunt/prod/account.hcl
@@ -133,5 +133,9 @@ locals {
     reserved_system_cpus = "0-3"
     isolated_cpus        = "4-191"
     hugepages_count      = 1536
+    # Cilium BGP peering
+    enable_bgp_peering = false # Enable after TGW Connect peers configured
+    bgp_local_asn      = 65100
+    bgp_peers          = [] # Populate with TGW Connect peer IPs after deployment
   }
 }

--- a/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
+++ b/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
@@ -3,6 +3,7 @@
 # ---------------------------------------------------------------------------------------------------------------------
 # Deploys the gpu-inference cluster infrastructure for prod eu-west-1.
 # Phase 1: VPC + EKS cluster foundation.
+# Phase 2: Cilium v1.19 native routing + BGP Control Plane peering via TGW Connect.
 # Additional units will be added as subsequent issues are implemented.
 # ---------------------------------------------------------------------------------------------------------------------
 
@@ -19,4 +20,9 @@ unit "gpu-inference-eks" {
 unit "gpu-inference-node-tuning" {
   source = "${get_repo_root()}/catalog/units/gpu-inference-node-tuning"
   path   = "gpu-inference-node-tuning"
+}
+
+unit "gpu-inference-cilium" {
+  source = "${get_repo_root()}/catalog/units/gpu-inference-cilium"
+  path   = "gpu-inference-cilium"
 }


### PR DESCRIPTION
## Summary

- Adds `terraform/modules/gpu-inference-cilium/` — new Terraform module deploying Cilium v1.19 in native-routing mode with BGP Control Plane for the gpu-inference cluster
- Adds `catalog/units/gpu-inference-cilium/terragrunt.hcl` — catalog unit wiring the module to the gpu-inference EKS and VPC dependencies
- Updates `terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl` to include the `gpu-inference-cilium` unit (Phase 2)
- Updates `terragrunt/prod/account.hcl` to add `enable_bgp_peering`, `bgp_local_asn`, and `bgp_peers` fields to `gpu_inference_config`

## Key design decisions

- **Native routing** (no VXLAN/Geneve) — zero encapsulation overhead for NCCL traffic
- **Cluster-pool IPAM** — pods use `100.64.0.0/10`, not VPC space; each node gets a `/24`, announced via BGP
- **BGP ASN 65100** → TGW Connect peers; disabled by default until TGW Connect endpoints are provisioned
- **kube-proxy fully replaced** by eBPF — conntrack iptables rules disabled
- **L7 proxy disabled** — eliminates proxy latency for latency-sensitive GPU inference paths
- **BPF map tuning** — 512k LB entries, 64k policy entries for 5000-node scale
- **sockops + bandwidth manager** enabled for socket-level acceleration and EDT-based QoS

## Test plan

- [ ] `terraform init -backend=false && terraform validate` in `terraform/modules/gpu-inference-cilium/` — passes
- [ ] `terraform fmt -recursive` — no changes
- [ ] `terragrunt hclfmt` on catalog unit and stack file — no changes
- [ ] `terragrunt plan` with mock outputs for EKS/VPC dependencies
- [ ] BGP peering enabled and peers populated after TGW Connect deployment