### PR TITLE
feat: Cilium WireGuard encryption + high-scale tuning (#71)

### DIFF
--- a/catalog/units/gpu-inference-cilium-encryption/terragrunt.hcl
+++ b/catalog/units/gpu-inference-cilium-encryption/terragrunt.hcl
@@ -1,0 +1,72 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Cilium WireGuard Encryption + High-Scale Tuning — Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# Enables WireGuard transparent encryption on Cilium and applies high-scale
+# tuning for 5000-node gpu-inference cluster operation.
+#
+# Depends on gpu-inference-cilium (Issue #70) for base Cilium deployment.
+# Creates encryption config, optional NCCL traffic exemption, and
+# Prometheus alerting rules for BGP session and WireGuard monitoring.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/gpu-inference-cilium-encryption"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  environment          = local.account_vars.locals.environment
+  aws_region           = local.region_vars.locals.aws_region
+  gpu_inference_config = try(local.account_vars.locals.gpu_inference_config, {})
+}
+
+dependency "eks" {
+  config_path = "../gpu-inference-eks"
+
+  mock_outputs = {
+    cluster_name                       = "mock-cluster"
+    cluster_endpoint                   = "https://mock-endpoint.eks.amazonaws.com"
+    cluster_certificate_authority_data = "bW9jay1jZXJ0LWRhdGE="
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+generate "k8s_providers" {
+  path      = "k8s_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "kubernetes" {
+      host                   = "${dependency.eks.outputs.cluster_endpoint}"
+      cluster_ca_certificate = base64decode("${dependency.eks.outputs.cluster_certificate_authority_data}")
+      exec {
+        api_version = "client.authentication.k8s.io/v1beta1"
+        command     = "aws"
+        args        = ["eks", "get-token", "--cluster-name", "${dependency.eks.outputs.cluster_name}"]
+      }
+    }
+  PROVIDERS
+}
+
+inputs = {
+  operator_replicas = 3
+  k8s_api_qps       = 50
+  k8s_api_burst     = 100
+
+  agent_cpu_limit      = "2"
+  agent_memory_limit   = "2Gi"
+  agent_cpu_request    = "500m"
+  agent_memory_request = "512Mi"
+
+  exclude_nccl_from_encryption = try(local.gpu_inference_config.exclude_nccl_encryption, false)
+  enable_prometheus_alerts     = true
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-inference"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/terraform/modules/gpu-inference-cilium-encryption/main.tf
+++ b/terraform/modules/gpu-inference-cilium-encryption/main.tf
@@ -1,0 +1,157 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Cilium WireGuard Encryption + High-Scale Tuning
+# ---------------------------------------------------------------------------------------------------------------------
+# Enables WireGuard transparent encryption on Cilium for gpu-inference cluster
+# and applies high-scale tuning for 5000-node operation.
+#
+# Deployed as a separate ConfigMap + patch to the existing Cilium installation
+# (from gpu-inference-cilium module, Issue #70).
+# ---------------------------------------------------------------------------------------------------------------------
+
+# ConfigMap with Cilium encryption configuration
+resource "kubernetes_config_map_v1" "cilium_encryption_config" {
+  metadata {
+    name      = "cilium-encryption-config"
+    namespace = "kube-system"
+    labels = {
+      "app.kubernetes.io/name"      = "cilium-encryption"
+      "app.kubernetes.io/component" = "config"
+    }
+  }
+
+  data = {
+    "encryption-config.yaml" = yamlencode({
+      encryption = {
+        enabled = true
+        type    = "wireguard"
+        wireguard = {
+          userspaceFallback = false
+        }
+      }
+    })
+
+    "high-scale-config.yaml" = yamlencode({
+      operator = {
+        replicas  = var.operator_replicas
+        extraArgs = ["--k8s-api-qps=${var.k8s_api_qps}", "--k8s-api-burst=${var.k8s_api_burst}"]
+      }
+      identityAllocationMode = "crd"
+      agent = {
+        resources = {
+          limits = {
+            cpu    = var.agent_cpu_limit
+            memory = var.agent_memory_limit
+          }
+          requests = {
+            cpu    = var.agent_cpu_request
+            memory = var.agent_memory_request
+          }
+        }
+      }
+    })
+  }
+}
+
+# CiliumNetworkPolicy to optionally exclude NCCL traffic from encryption
+resource "kubernetes_manifest" "nccl_no_encrypt_policy" {
+  count = var.exclude_nccl_from_encryption ? 1 : 0
+
+  manifest = {
+    apiVersion = "cilium.io/v2"
+    kind       = "CiliumNetworkPolicy"
+    metadata = {
+      name      = "gpu-nccl-no-encrypt"
+      namespace = "gpu-inference"
+    }
+    spec = {
+      endpointSelector = {
+        matchLabels = {
+          "app.kubernetes.io/component" = "gpu-worker"
+        }
+      }
+      egress = [
+        {
+          toEndpoints = [
+            {
+              matchLabels = {
+                "app.kubernetes.io/component" = "gpu-worker"
+              }
+            }
+          ]
+          toPorts = [
+            {
+              ports = [
+                for port in var.nccl_port_range : {
+                  port     = tostring(port)
+                  protocol = "TCP"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+
+# PrometheusRule for Cilium monitoring alerts
+resource "kubernetes_manifest" "cilium_alerts" {
+  count = var.enable_prometheus_alerts ? 1 : 0
+
+  manifest = {
+    apiVersion = "monitoring.coreos.com/v1"
+    kind       = "PrometheusRule"
+    metadata = {
+      name      = "cilium-gpu-inference-alerts"
+      namespace = "kube-system"
+      labels = {
+        "prometheus" = "kube-prometheus"
+      }
+    }
+    spec = {
+      groups = [
+        {
+          name = "cilium-gpu-inference"
+          rules = [
+            {
+              alert = "CiliumBGPSessionDown"
+              expr  = "cilium_bgp_session_status != 1"
+              for   = "5m"
+              labels = {
+                severity = "critical"
+              }
+              annotations = {
+                summary     = "Cilium BGP session is down on {{ $labels.node }}"
+                description = "BGP peering with TGW Connect has been down for more than 5 minutes. Pod routing may be affected."
+              }
+            },
+            {
+              alert = "CiliumWireGuardErrors"
+              expr  = "rate(cilium_wireguard_error_total[5m]) > 0"
+              for   = "10m"
+              labels = {
+                severity = "warning"
+              }
+              annotations = {
+                summary     = "Cilium WireGuard errors on {{ $labels.node }}"
+                description = "WireGuard encryption errors detected. Check kernel module and key rotation."
+              }
+            },
+            {
+              alert = "CiliumEndpointCountHigh"
+              expr  = "cilium_endpoint_count > 50000"
+              for   = "15m"
+              labels = {
+                severity = "warning"
+              }
+              annotations = {
+                summary     = "High endpoint count on {{ $labels.node }}"
+                description = "Cilium endpoint count exceeds 50k. Consider scaling operator or increasing BPF map sizes."
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/terraform/modules/gpu-inference-cilium-encryption/outputs.tf
+++ b/terraform/modules/gpu-inference-cilium-encryption/outputs.tf
@@ -1,0 +1,14 @@
+output "encryption_config_name" {
+  description = "Name of the encryption configuration ConfigMap"
+  value       = kubernetes_config_map_v1.cilium_encryption_config.metadata[0].name
+}
+
+output "encryption_type" {
+  description = "Type of encryption configured"
+  value       = "wireguard"
+}
+
+output "operator_replicas" {
+  description = "Number of Cilium operator replicas"
+  value       = var.operator_replicas
+}

--- a/terraform/modules/gpu-inference-cilium-encryption/variables.tf
+++ b/terraform/modules/gpu-inference-cilium-encryption/variables.tf
@@ -1,0 +1,65 @@
+variable "operator_replicas" {
+  description = "Number of Cilium operator replicas for HA"
+  type        = number
+  default     = 3
+}
+
+variable "k8s_api_qps" {
+  description = "Kubernetes API QPS for Cilium operator"
+  type        = number
+  default     = 50
+}
+
+variable "k8s_api_burst" {
+  description = "Kubernetes API burst for Cilium operator"
+  type        = number
+  default     = 100
+}
+
+variable "agent_cpu_limit" {
+  description = "CPU limit for Cilium agent"
+  type        = string
+  default     = "2"
+}
+
+variable "agent_memory_limit" {
+  description = "Memory limit for Cilium agent"
+  type        = string
+  default     = "2Gi"
+}
+
+variable "agent_cpu_request" {
+  description = "CPU request for Cilium agent"
+  type        = string
+  default     = "500m"
+}
+
+variable "agent_memory_request" {
+  description = "Memory request for Cilium agent"
+  type        = string
+  default     = "512Mi"
+}
+
+variable "exclude_nccl_from_encryption" {
+  description = "Exclude NCCL traffic from WireGuard encryption for max training performance"
+  type        = bool
+  default     = false
+}
+
+variable "nccl_port_range" {
+  description = "NCCL port range to exclude from encryption"
+  type        = list(number)
+  default     = [5000, 5001, 5002, 5003, 5004, 5005]
+}
+
+variable "enable_prometheus_alerts" {
+  description = "Enable Prometheus alerting rules for Cilium"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/gpu-inference-cilium-encryption/versions.tf
+++ b/terraform/modules/gpu-inference-cilium-encryption/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.25"
+    }
+  }
+}

--- a/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
+++ b/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
@@ -4,6 +4,7 @@
 # Deploys the gpu-inference cluster infrastructure for prod eu-west-1.
 # Phase 1: VPC + EKS cluster foundation.
 # Phase 2: Cilium v1.19 native routing + BGP Control Plane peering via TGW Connect.
+# Phase 3: Cilium WireGuard transparent encryption + high-scale tuning for 5000 nodes.
 # Additional units will be added as subsequent issues are implemented.
 # ---------------------------------------------------------------------------------------------------------------------
 
@@ -25,4 +26,9 @@ unit "gpu-inference-node-tuning" {
 unit "gpu-inference-cilium" {
   source = "${get_repo_root()}/catalog/units/gpu-inference-cilium"
   path   = "gpu-inference-cilium"
+}
+
+unit "gpu-inference-cilium-encryption" {
+  source = "${get_repo_root()}/catalog/units/gpu-inference-cilium-encryption"
+  path   = "gpu-inference-cilium-encryption"
 }


### PR DESCRIPTION
## Summary

- Adds `terraform/modules/gpu-inference-cilium-encryption` — Terraform module that provisions a `kubernetes_config_map_v1` with WireGuard encryption config and high-scale operator tuning, an optional `CiliumNetworkPolicy` to exempt NCCL traffic from encryption, and a `PrometheusRule` with alerts for BGP session down, WireGuard errors, and high endpoint counts
- Adds `catalog/units/gpu-inference-cilium-encryption/terragrunt.hcl` — catalog unit with EKS dependency, generated kubernetes provider, and prod-tuned inputs (3 operator replicas, 50 QPS / 100 burst, 2 CPU / 2Gi memory agent limits)
- Updates `terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl` — adds the new `gpu-inference-cilium-encryption` unit to the prod gpu-inference stack

Depends on `gpu-inference-cilium` (Issue #70) for base Cilium deployment.

## Test plan

- [ ] `terraform fmt -recursive terraform/modules/gpu-inference-cilium-encryption/` — no changes (already clean)
- [ ] `terragrunt hclfmt` on catalog unit and stack — clean
- [ ] `terraform init -backend=false && terraform validate` in module — passes with no warnings
- [ ] `terragrunt plan` with mock EKS outputs returns expected ConfigMap, optional CiliumNetworkPolicy, and PrometheusRule resources
- [ ] Verify `exclude_nccl_from_encryption = true` creates the `gpu-nccl-no-encrypt` CiliumNetworkPolicy in the `gpu-inference` namespace
- [ ] Verify `enable_prometheus_alerts = false` suppresses the PrometheusRule resource