### PR TITLE
feat: NVIDIA GPU Operator v26.3 with DRA driver (#67)

### DIFF
--- a/catalog/units/gpu-inference-gpu-operator/terragrunt.hcl
+++ b/catalog/units/gpu-inference-gpu-operator/terragrunt.hcl
@@ -1,0 +1,70 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# NVIDIA GPU Operator v26.3 — Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys NVIDIA GPU Operator with DRA driver on the gpu-inference cluster.
+# DRA replaces the traditional device-plugin, publishing GPU attributes via
+# ResourceSlice objects for topology-aware scheduling.
+#
+# Components deployed: DRA Driver, Container Toolkit, GPU Feature Discovery,
+# Node Feature Discovery, CDI. NVIDIA driver is pre-installed in Bottlerocket AMI.
+# DCGM Exporter deployed separately (Phase 5, Issue #77).
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/gpu-operator"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  environment = local.account_vars.locals.environment
+  aws_region  = local.region_vars.locals.aws_region
+}
+
+dependency "eks" {
+  config_path = "../gpu-inference-eks"
+
+  mock_outputs = {
+    cluster_name                       = "mock-cluster"
+    cluster_endpoint                   = "https://mock-endpoint.eks.amazonaws.com"
+    cluster_certificate_authority_data = "bW9jay1jZXJ0LWRhdGE="
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+generate "k8s_providers" {
+  path      = "k8s_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "helm" {
+      kubernetes {
+        host                   = "${dependency.eks.outputs.cluster_endpoint}"
+        cluster_ca_certificate = base64decode("${dependency.eks.outputs.cluster_certificate_authority_data}")
+        exec {
+          api_version = "client.authentication.k8s.io/v1beta1"
+          command     = "aws"
+          args        = ["eks", "get-token", "--cluster-name", "${dependency.eks.outputs.cluster_name}"]
+        }
+      }
+    }
+  PROVIDERS
+}
+
+inputs = {
+  chart_version         = "v26.3.0"
+  dra_driver_version    = "v25.3.0"
+  driver_enabled        = false
+  dcgm_exporter_enabled = false
+
+  operator_cpu_limit    = "500m"
+  operator_memory_limit = "512Mi"
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-inference"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/terraform/modules/gpu-operator/main.tf
+++ b/terraform/modules/gpu-operator/main.tf
@@ -1,0 +1,86 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# NVIDIA GPU Operator v26.3 with DRA Driver
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys NVIDIA GPU Operator via Helm with DRA (Dynamic Resource Allocation)
+# enabled, replacing the traditional device-plugin model. The DRA driver
+# publishes GPU attributes via ResourceSlice objects for topology-aware scheduling.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "helm_release" "gpu_operator" {
+  name             = "gpu-operator"
+  repository       = "https://helm.ngc.nvidia.com/nvidia"
+  chart            = "gpu-operator"
+  version          = var.chart_version
+  namespace        = "gpu-operator"
+  create_namespace = true
+  timeout          = 600
+
+  values = [
+    yamlencode({
+      # DRA driver — replaces device-plugin for GPU allocation
+      dra = {
+        enabled = true
+        version = var.dra_driver_version
+      }
+
+      # Disable legacy device plugin (DRA replaces it)
+      devicePlugin = {
+        enabled = false
+      }
+
+      # GPU driver — pre-installed in AMI (Bottlerocket NVIDIA)
+      driver = {
+        enabled = var.driver_enabled
+      }
+
+      # Container toolkit
+      toolkit = {
+        enabled = true
+      }
+
+      # DCGM Exporter (deployed separately in Phase 5)
+      dcgmExporter = {
+        enabled = var.dcgm_exporter_enabled
+      }
+
+      # GPU Feature Discovery
+      gfd = {
+        enabled = true
+      }
+
+      # Node Feature Discovery
+      nfd = {
+        enabled = true
+      }
+
+      # CDI (Container Device Interface) for DRA
+      cdi = {
+        enabled = true
+      }
+
+      operator = {
+        # Node selector — only deploy on GPU nodes
+        nodeSelector = {
+          "node-role" = "gpu"
+        }
+
+        # Tolerations for GPU taint
+        tolerations = [
+          {
+            key      = "nvidia.com/gpu"
+            operator = "Exists"
+            effect   = "NoSchedule"
+          }
+        ]
+
+        # Operator resource limits
+        resources = {
+          limits = {
+            cpu    = var.operator_cpu_limit
+            memory = var.operator_memory_limit
+          }
+        }
+      }
+    })
+  ]
+}

--- a/terraform/modules/gpu-operator/outputs.tf
+++ b/terraform/modules/gpu-operator/outputs.tf
@@ -1,0 +1,14 @@
+output "gpu_operator_namespace" {
+  description = "Namespace where GPU Operator is installed"
+  value       = helm_release.gpu_operator.namespace
+}
+
+output "gpu_operator_version" {
+  description = "Installed GPU Operator version"
+  value       = helm_release.gpu_operator.version
+}
+
+output "dra_enabled" {
+  description = "Whether DRA driver is enabled"
+  value       = true
+}

--- a/terraform/modules/gpu-operator/variables.tf
+++ b/terraform/modules/gpu-operator/variables.tf
@@ -1,0 +1,41 @@
+variable "chart_version" {
+  description = "NVIDIA GPU Operator Helm chart version"
+  type        = string
+  default     = "v26.3.0"
+}
+
+variable "dra_driver_version" {
+  description = "NVIDIA DRA driver version"
+  type        = string
+  default     = "v25.3.0"
+}
+
+variable "driver_enabled" {
+  description = "Enable NVIDIA driver installation (false if pre-installed in AMI)"
+  type        = bool
+  default     = false
+}
+
+variable "dcgm_exporter_enabled" {
+  description = "Enable DCGM Exporter (deployed separately in Phase 5)"
+  type        = bool
+  default     = false
+}
+
+variable "operator_cpu_limit" {
+  description = "CPU limit for GPU Operator"
+  type        = string
+  default     = "500m"
+}
+
+variable "operator_memory_limit" {
+  description = "Memory limit for GPU Operator"
+  type        = string
+  default     = "512Mi"
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/gpu-operator/versions.tf
+++ b/terraform/modules/gpu-operator/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.12"
+    }
+  }
+}

--- a/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
+++ b/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
@@ -32,3 +32,7 @@ unit "gpu-inference-cilium-encryption" {
   source = "${get_repo_root()}/catalog/units/gpu-inference-cilium-encryption"
   path   = "gpu-inference-cilium-encryption"
 }
+unit "gpu-inference-gpu-operator" {
+  source = "${get_repo_root()}/catalog/units/gpu-inference-gpu-operator"
+  path   = "gpu-inference-gpu-operator"
+}


### PR DESCRIPTION
## Summary

- Adds `terraform/modules/gpu-operator/` — Helm module deploying NVIDIA GPU Operator v26.3 from `https://helm.ngc.nvidia.com/nvidia`
- DRA (Dynamic Resource Allocation) enabled; legacy device-plugin disabled — GPUs published via ResourceSlice for topology-aware scheduling
- NVIDIA driver skipped (pre-installed in Bottlerocket NVIDIA AMI); DCGM Exporter deferred to Phase 5 (Issue #77)
- Adds `catalog/units/gpu-inference-gpu-operator/terragrunt.hcl` with EKS dependency and mock outputs for plan-time validation
- Updates `terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl` to include the new unit

## Components deployed

| Component | Enabled |
|-----------|---------|
| DRA Driver v25.3.0 | yes |
| Container Toolkit | yes |
| GPU Feature Discovery (gfd) | yes |
| Node Feature Discovery (nfd) | yes |
| CDI (Container Device Interface) | yes |
| NVIDIA driver | no (pre-installed in AMI) |
| DCGM Exporter | no (Issue #77) |

## Test plan

- [x] `terraform fmt -recursive terraform/modules/gpu-operator/` — clean
- [x] `terraform init -backend=false && terraform validate` — Success
- [x] `terragrunt hclfmt` on catalog unit and stack file — clean
- [ ] `terragrunt plan` with live EKS dependency in dev environment
- [ ] Verify `ResourceSlice` objects appear after GPU Operator rollout
- [ ] Confirm GPU pods schedule via DRA resource claims