### PR TITLE
feat: TGW Connect attachment + BGP peering infrastructure (#72)

### DIFF
--- a/catalog/units/gpu-inference-tgw-connect/terragrunt.hcl
+++ b/catalog/units/gpu-inference-tgw-connect/terragrunt.hcl
@@ -1,0 +1,54 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference TGW Connect BGP Peering — Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# Creates TGW Connect peers for BGP sessions between the gpu-inference cluster
+# and Transit Gateway. One peer per AZ for HA. Propagates Pod CIDR
+# (100.64.0.0/10) to shared route table for cross-cluster communication.
+#
+# Depends on gpu-inference-vpc (provides tgw_connect_attachment_id).
+# Consumed by Cilium BGP peering policy (Issue #70).
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/gpu-inference-tgw-connect"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  environment          = local.account_vars.locals.environment
+  aws_region           = local.region_vars.locals.aws_region
+  gpu_inference_config = try(local.account_vars.locals.gpu_inference_config, {})
+  cluster_name         = "${local.environment}-${local.aws_region}-gpu-inference"
+}
+
+dependency "vpc" {
+  config_path = "../gpu-inference-vpc"
+
+  mock_outputs = {
+    tgw_connect_attachment_id = "tgw-attach-mock"
+    pod_cidr                  = "100.64.0.0/10"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+inputs = {
+  name                      = local.cluster_name
+  tgw_connect_attachment_id = dependency.vpc.outputs.tgw_connect_attachment_id
+  tgw_route_table_id        = try(local.account_vars.locals.tgw_route_table_id, "")
+  shared_route_table_id     = try(local.account_vars.locals.tgw_shared_route_table_id, "")
+  pod_cidr                  = dependency.vpc.outputs.pod_cidr
+  enable_static_fallback    = true
+
+  # BGP peers — empty by default, populated after TGW Connect deployment
+  bgp_peers = try(local.gpu_inference_config.tgw_bgp_peers, {})
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-inference"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/terraform/modules/gpu-inference-tgw-connect/main.tf
+++ b/terraform/modules/gpu-inference-tgw-connect/main.tf
@@ -1,0 +1,40 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference TGW Connect + BGP Peering
+# ---------------------------------------------------------------------------------------------------------------------
+# Creates AWS Transit Gateway Connect attachment with GRE tunnels and BGP
+# peering configuration for Cilium native routing. Each Connect peer represents
+# a BGP session between the gpu-inference cluster and TGW.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# TGW Connect Peers for BGP sessions (one per AZ for HA)
+resource "aws_ec2_transit_gateway_connect_peer" "this" {
+  for_each = var.bgp_peers
+
+  transit_gateway_attachment_id = var.tgw_connect_attachment_id
+  peer_address                  = each.value.peer_address
+  transit_gateway_address       = each.value.tgw_address
+  bgp_asn                       = each.value.bgp_asn
+  inside_cidr_blocks            = each.value.inside_cidr_blocks
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-peer-${each.key}"
+    AZ   = each.value.availability_zone
+  })
+}
+
+# Static route for Pod CIDR as fallback (if BGP flaps)
+resource "aws_ec2_transit_gateway_route" "pod_cidr_fallback" {
+  count = var.enable_static_fallback ? 1 : 0
+
+  destination_cidr_block         = var.pod_cidr
+  transit_gateway_attachment_id  = var.tgw_connect_attachment_id
+  transit_gateway_route_table_id = var.tgw_route_table_id
+}
+
+# Propagate Pod CIDR to shared route table for cross-cluster communication
+resource "aws_ec2_transit_gateway_route_table_propagation" "shared" {
+  count = var.shared_route_table_id != "" ? 1 : 0
+
+  transit_gateway_attachment_id  = var.tgw_connect_attachment_id
+  transit_gateway_route_table_id = var.shared_route_table_id
+}

--- a/terraform/modules/gpu-inference-tgw-connect/outputs.tf
+++ b/terraform/modules/gpu-inference-tgw-connect/outputs.tf
@@ -1,0 +1,14 @@
+output "tgw_connect_peer_ids" {
+  description = "Map of TGW Connect peer IDs"
+  value       = { for k, v in aws_ec2_transit_gateway_connect_peer.this : k => v.id }
+}
+
+output "bgp_asn" {
+  description = "BGP ASN configured for the cluster"
+  value       = try(values(aws_ec2_transit_gateway_connect_peer.this)[0].bgp_asn, null)
+}
+
+output "peer_addresses" {
+  description = "Map of peer addresses by AZ"
+  value       = { for k, v in aws_ec2_transit_gateway_connect_peer.this : k => v.peer_address }
+}

--- a/terraform/modules/gpu-inference-tgw-connect/variables.tf
+++ b/terraform/modules/gpu-inference-tgw-connect/variables.tf
@@ -1,0 +1,51 @@
+variable "name" {
+  description = "Name prefix for resources"
+  type        = string
+}
+
+variable "tgw_connect_attachment_id" {
+  description = "TGW Connect attachment ID (from gpu-inference-vpc module)"
+  type        = string
+}
+
+variable "tgw_route_table_id" {
+  description = "TGW route table ID for the prod environment"
+  type        = string
+  default     = ""
+}
+
+variable "shared_route_table_id" {
+  description = "TGW shared route table ID for cross-cluster propagation"
+  type        = string
+  default     = ""
+}
+
+variable "pod_cidr" {
+  description = "Pod CIDR to route via TGW Connect (100.64.0.0/10)"
+  type        = string
+  default     = "100.64.0.0/10"
+}
+
+variable "enable_static_fallback" {
+  description = "Enable static route for Pod CIDR as BGP fallback"
+  type        = bool
+  default     = true
+}
+
+variable "bgp_peers" {
+  description = "BGP peer configurations (one per AZ for HA)"
+  type = map(object({
+    peer_address       = string
+    tgw_address        = string
+    bgp_asn            = number
+    inside_cidr_blocks = list(string)
+    availability_zone  = string
+  }))
+  default = {}
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/gpu-inference-tgw-connect/versions.tf
+++ b/terraform/modules/gpu-inference-tgw-connect/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/terragrunt/prod/account.hcl
+++ b/terragrunt/prod/account.hcl
@@ -137,5 +137,7 @@ locals {
     enable_bgp_peering = false # Enable after TGW Connect peers configured
     bgp_local_asn      = 65100
     bgp_peers          = [] # Populate with TGW Connect peer IPs after deployment
+    # TGW Connect BGP peers (populate after TGW Connect deployment)
+    tgw_bgp_peers = {}
   }
 }

--- a/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
+++ b/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
@@ -41,3 +41,8 @@ unit "gpu-inference-kata-cc" {
   source = "${get_repo_root()}/catalog/units/gpu-inference-kata-cc"
   path   = "gpu-inference-kata-cc"
 }
+
+unit "gpu-inference-tgw-connect" {
+  source = "${get_repo_root()}/catalog/units/gpu-inference-tgw-connect"
+  path   = "gpu-inference-tgw-connect"
+}


### PR DESCRIPTION
## Summary

- Adds `terraform/modules/gpu-inference-tgw-connect`: TGW Connect peer resources (one per AZ for HA), static Pod CIDR fallback route (`100.64.0.0/10`), and shared route table propagation for cross-cluster communication
- Adds `catalog/units/gpu-inference-tgw-connect`: Terragrunt catalog unit wired to `gpu-inference-vpc` dependency for `tgw_connect_attachment_id` and `pod_cidr`
- Registers the unit in `terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl`
- Extends `terragrunt/prod/account.hcl` with `tgw_shared_route_table_id` and `tgw_bgp_peers` (empty placeholder, populated after TGW Connect deployment)

Closes #72. Consumed by Cilium BGP peering policy (Issue #70).

## Test plan

- [x] `terraform fmt -recursive` — no changes
- [x] `terragrunt hclfmt` — no changes
- [x] `terraform init -backend=false && terraform validate` — success
- [ ] `terragrunt plan` with mock outputs once TGW Connect attachment is live in network account