### PR TITLE
feat: DRA DeviceClass definitions for H100_SXM5 and A100_80GB (#68)

### DIFF
--- a/catalog/units/gpu-inference-dra/terragrunt.hcl
+++ b/catalog/units/gpu-inference-dra/terragrunt.hcl
@@ -1,0 +1,66 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference DRA DeviceClass Definitions — Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys Kubernetes DeviceClass and ResourceClaimTemplate resources for
+# DRA-based GPU allocation on the gpu-inference EKS cluster.
+#
+# Resources created:
+#   DeviceClasses:
+#     - nvidia-h100-sxm5     — CEL selector for H100 SXM5 (p5.48xlarge)
+#     - nvidia-a100-80gb     — CEL selector for A100 80GB (p4d.24xlarge)
+#   ResourceClaimTemplates:
+#     - single-gpu-inference     — 1x H100 for inference
+#     - full-node-training       — 8x H100 ExactCount for training (NVLink island)
+#     - prioritized-gpu-inference — H100 preferred, A100 fallback
+#
+# Requires: EKS 1.35+ with DRA feature gate enabled (GA in 1.35).
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/gpu-inference-dra"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  environment = local.account_vars.locals.environment
+  aws_region  = local.region_vars.locals.aws_region
+}
+
+dependency "eks" {
+  config_path = "../gpu-inference-eks"
+
+  mock_outputs = {
+    cluster_name                       = "mock-cluster"
+    cluster_endpoint                   = "https://mock-endpoint.eks.amazonaws.com"
+    cluster_certificate_authority_data = "bW9jay1jZXJ0LWRhdGE="
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+generate "k8s_providers" {
+  path      = "k8s_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "kubernetes" {
+      host                   = "${dependency.eks.outputs.cluster_endpoint}"
+      cluster_ca_certificate = base64decode("${dependency.eks.outputs.cluster_certificate_authority_data}")
+      exec {
+        api_version = "client.authentication.k8s.io/v1beta1"
+        command     = "aws"
+        args        = ["eks", "get-token", "--cluster-name", "${dependency.eks.outputs.cluster_name}"]
+      }
+    }
+  PROVIDERS
+}
+
+inputs = {
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-inference"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/k8s/gpu-inference/dra/deviceclass-a100-80gb.yaml
+++ b/k8s/gpu-inference/dra/deviceclass-a100-80gb.yaml
@@ -1,0 +1,11 @@
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: nvidia-a100-80gb
+  labels:
+    gpu-type: A100-80GB
+    managed-by: gpu-inference
+spec:
+  selectors:
+    - cel:
+        expression: "device.driver == 'gpu.nvidia.com' && device.attributes['gpu.nvidia.com'].productName == 'A100-SXM4-80GB'"

--- a/k8s/gpu-inference/dra/deviceclass-h100-sxm5.yaml
+++ b/k8s/gpu-inference/dra/deviceclass-h100-sxm5.yaml
@@ -1,0 +1,11 @@
+apiVersion: resource.k8s.io/v1
+kind: DeviceClass
+metadata:
+  name: nvidia-h100-sxm5
+  labels:
+    gpu-type: H100-SXM5
+    managed-by: gpu-inference
+spec:
+  selectors:
+    - cel:
+        expression: "device.driver == 'gpu.nvidia.com' && device.attributes['gpu.nvidia.com'].productName == 'H100-SXM5'"

--- a/k8s/gpu-inference/dra/resourceclaimtemplate-full-node.yaml
+++ b/k8s/gpu-inference/dra/resourceclaimtemplate-full-node.yaml
@@ -1,0 +1,15 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: full-node-training
+  labels:
+    workload-type: training
+    managed-by: gpu-inference
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpus
+          deviceClassName: nvidia-h100-sxm5
+          count: 8
+          allocationMode: ExactCount

--- a/k8s/gpu-inference/dra/resourceclaimtemplate-prioritized.yaml
+++ b/k8s/gpu-inference/dra/resourceclaimtemplate-prioritized.yaml
@@ -1,0 +1,15 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: prioritized-gpu-inference
+  labels:
+    workload-type: inference
+    managed-by: gpu-inference
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          firstAvailable:
+            - deviceClassName: nvidia-h100-sxm5
+            - deviceClassName: nvidia-a100-80gb

--- a/k8s/gpu-inference/dra/resourceclaimtemplate-single-gpu.yaml
+++ b/k8s/gpu-inference/dra/resourceclaimtemplate-single-gpu.yaml
@@ -1,0 +1,14 @@
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: single-gpu-inference
+  labels:
+    workload-type: inference
+    managed-by: gpu-inference
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          deviceClassName: nvidia-h100-sxm5
+          count: 1

--- a/terraform/modules/gpu-inference-dra/main.tf
+++ b/terraform/modules/gpu-inference-dra/main.tf
@@ -1,0 +1,156 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference DRA DeviceClass Definitions
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys Kubernetes DeviceClass and ResourceClaimTemplate resources for
+# DRA-based GPU allocation. DeviceClasses define CEL selectors for GPU types
+# using the NVIDIA DRA driver, and ResourceClaimTemplates provide reusable
+# allocation patterns for common workload shapes.
+#
+# DeviceClasses:
+#   - nvidia-h100-sxm5  — H100 SXM5 GPUs (p5.48xlarge)
+#   - nvidia-a100-80gb  — A100 80GB GPUs (p4d.24xlarge)
+#
+# ResourceClaimTemplates:
+#   - single-gpu-inference    — 1x H100 for inference workloads
+#   - full-node-training      — 8x H100 (full NVLink island) for training
+#   - prioritized-gpu-inference — H100 preferred, A100 fallback
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "deviceclass_h100" {
+  manifest = {
+    apiVersion = "resource.k8s.io/v1"
+    kind       = "DeviceClass"
+    metadata = {
+      name = "nvidia-h100-sxm5"
+      labels = {
+        "gpu-type"   = "H100-SXM5"
+        "managed-by" = "gpu-inference"
+      }
+    }
+    spec = {
+      selectors = [
+        {
+          cel = {
+            expression = "device.driver == 'gpu.nvidia.com' && device.attributes['gpu.nvidia.com'].productName == 'H100-SXM5'"
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource "kubernetes_manifest" "deviceclass_a100" {
+  manifest = {
+    apiVersion = "resource.k8s.io/v1"
+    kind       = "DeviceClass"
+    metadata = {
+      name = "nvidia-a100-80gb"
+      labels = {
+        "gpu-type"   = "A100-80GB"
+        "managed-by" = "gpu-inference"
+      }
+    }
+    spec = {
+      selectors = [
+        {
+          cel = {
+            expression = "device.driver == 'gpu.nvidia.com' && device.attributes['gpu.nvidia.com'].productName == 'A100-SXM4-80GB'"
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource "kubernetes_manifest" "claimtemplate_single_gpu" {
+  manifest = {
+    apiVersion = "resource.k8s.io/v1"
+    kind       = "ResourceClaimTemplate"
+    metadata = {
+      name = "single-gpu-inference"
+      labels = {
+        "workload-type" = "inference"
+        "managed-by"    = "gpu-inference"
+      }
+    }
+    spec = {
+      spec = {
+        devices = {
+          requests = [
+            {
+              name            = "gpu"
+              deviceClassName = "nvidia-h100-sxm5"
+              count           = 1
+            }
+          ]
+        }
+      }
+    }
+  }
+
+  depends_on = [kubernetes_manifest.deviceclass_h100]
+}
+
+resource "kubernetes_manifest" "claimtemplate_full_node" {
+  manifest = {
+    apiVersion = "resource.k8s.io/v1"
+    kind       = "ResourceClaimTemplate"
+    metadata = {
+      name = "full-node-training"
+      labels = {
+        "workload-type" = "training"
+        "managed-by"    = "gpu-inference"
+      }
+    }
+    spec = {
+      spec = {
+        devices = {
+          requests = [
+            {
+              name            = "gpus"
+              deviceClassName = "nvidia-h100-sxm5"
+              count           = 8
+              allocationMode  = "ExactCount"
+            }
+          ]
+        }
+      }
+    }
+  }
+
+  depends_on = [kubernetes_manifest.deviceclass_h100]
+}
+
+resource "kubernetes_manifest" "claimtemplate_prioritized" {
+  manifest = {
+    apiVersion = "resource.k8s.io/v1"
+    kind       = "ResourceClaimTemplate"
+    metadata = {
+      name = "prioritized-gpu-inference"
+      labels = {
+        "workload-type" = "inference"
+        "managed-by"    = "gpu-inference"
+      }
+    }
+    spec = {
+      spec = {
+        devices = {
+          requests = [
+            {
+              name = "gpu"
+              firstAvailable = [
+                { deviceClassName = "nvidia-h100-sxm5" },
+                { deviceClassName = "nvidia-a100-80gb" }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    kubernetes_manifest.deviceclass_h100,
+    kubernetes_manifest.deviceclass_a100,
+  ]
+}

--- a/terraform/modules/gpu-inference-dra/outputs.tf
+++ b/terraform/modules/gpu-inference-dra/outputs.tf
@@ -1,0 +1,24 @@
+output "deviceclass_h100_name" {
+  description = "Name of the H100 SXM5 DeviceClass"
+  value       = kubernetes_manifest.deviceclass_h100.manifest.metadata.name
+}
+
+output "deviceclass_a100_name" {
+  description = "Name of the A100 80GB DeviceClass"
+  value       = kubernetes_manifest.deviceclass_a100.manifest.metadata.name
+}
+
+output "claimtemplate_single_gpu_name" {
+  description = "Name of the single-GPU inference ResourceClaimTemplate"
+  value       = kubernetes_manifest.claimtemplate_single_gpu.manifest.metadata.name
+}
+
+output "claimtemplate_full_node_name" {
+  description = "Name of the full-node training ResourceClaimTemplate"
+  value       = kubernetes_manifest.claimtemplate_full_node.manifest.metadata.name
+}
+
+output "claimtemplate_prioritized_name" {
+  description = "Name of the prioritized GPU inference ResourceClaimTemplate"
+  value       = kubernetes_manifest.claimtemplate_prioritized.manifest.metadata.name
+}

--- a/terraform/modules/gpu-inference-dra/variables.tf
+++ b/terraform/modules/gpu-inference-dra/variables.tf
@@ -1,0 +1,5 @@
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/gpu-inference-dra/versions.tf
+++ b/terraform/modules/gpu-inference-dra/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.25"
+    }
+  }
+}

--- a/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
+++ b/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
@@ -46,3 +46,8 @@ unit "gpu-inference-tgw-connect" {
   source = "${get_repo_root()}/catalog/units/gpu-inference-tgw-connect"
   path   = "gpu-inference-tgw-connect"
 }
+
+unit "gpu-inference-dra" {
+  source = "${get_repo_root()}/catalog/units/gpu-inference-dra"
+  path   = "gpu-inference-dra"
+}


### PR DESCRIPTION
## Summary

- Adds `DeviceClass` manifests for `nvidia-h100-sxm5` and `nvidia-a100-80gb` using CEL selectors against the NVIDIA DRA driver (`gpu.nvidia.com`)
- Adds three `ResourceClaimTemplate` manifests: single-GPU inference (1x H100), full-node training (8x H100, `ExactCount`), and prioritized inference (H100 preferred, A100 fallback via `firstAvailable`)
- Adds `terraform/modules/gpu-inference-dra` with inline `kubernetes_manifest` resources, `depends_on` ordering, and outputs for all DeviceClass/template names
- Adds `catalog/units/gpu-inference-dra` with EKS dependency and kubernetes provider generation matching the existing gpu-inference pattern
- Updates `terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl` to include `gpu-inference-dra` as the third unit after VPC and EKS

## Test plan

- [ ] `terragrunt validate` passes in `catalog/units/gpu-inference-dra`
- [ ] `terraform validate` passes in `terraform/modules/gpu-inference-dra`
- [ ] `terragrunt stack plan` in `terragrunt/prod/eu-west-1/gpu-inference` shows DRA resources in plan output
- [ ] Checkov scan passes on new manifests and module
- [ ] After merge + apply: `kubectl get deviceclass` returns `nvidia-h100-sxm5` and `nvidia-a100-80gb`
- [ ] `kubectl get resourceclaimtemplate` returns all three templates