### PR TITLE
feat: Volcano v1.8 scheduler with DRA integration (#73)

### DIFF
--- a/catalog/units/gpu-inference-volcano/terragrunt.hcl
+++ b/catalog/units/gpu-inference-volcano/terragrunt.hcl
@@ -1,0 +1,85 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference Volcano v1.8 — Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys Volcano batch scheduler as a secondary scheduler on the gpu-inference
+# cluster. Includes gang scheduling, bin-packing, fair-share queues,
+# and DRA plugin integration for GPU resource allocation.
+#
+# Key capabilities:
+#   - Gang scheduling for multi-pod GPU jobs (ensures all-or-nothing allocation)
+#   - Bin-packing to maximise GPU node utilisation
+#   - Fair-share queues: training (weight 10), inference (weight 5), batch (weight 2)
+#   - DRA plugin for Kubernetes Dynamic Resource Allocation (GPU device partitioning)
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/gpu-inference-volcano"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  environment          = local.account_vars.locals.environment
+  aws_region           = local.region_vars.locals.aws_region
+  gpu_inference_config = try(local.account_vars.locals.gpu_inference_config, {})
+}
+
+dependency "eks" {
+  config_path = "../gpu-inference-eks"
+
+  mock_outputs = {
+    cluster_name                       = "mock-cluster"
+    cluster_endpoint                   = "https://mock-endpoint.eks.amazonaws.com"
+    cluster_certificate_authority_data = "bW9jay1jZXJ0LWRhdGE="
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+generate "k8s_providers" {
+  path      = "k8s_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "helm" {
+      kubernetes {
+        host                   = "${dependency.eks.outputs.cluster_endpoint}"
+        cluster_ca_certificate = base64decode("${dependency.eks.outputs.cluster_certificate_authority_data}")
+        exec {
+          api_version = "client.authentication.k8s.io/v1beta1"
+          command     = "aws"
+          args        = ["eks", "get-token", "--cluster-name", "${dependency.eks.outputs.cluster_name}"]
+        }
+      }
+    }
+
+    provider "kubernetes" {
+      host                   = "${dependency.eks.outputs.cluster_endpoint}"
+      cluster_ca_certificate = base64decode("${dependency.eks.outputs.cluster_certificate_authority_data}")
+      exec {
+        api_version = "client.authentication.k8s.io/v1beta1"
+        command     = "aws"
+        args        = ["eks", "get-token", "--cluster-name", "${dependency.eks.outputs.cluster_name}"]
+      }
+    }
+  PROVIDERS
+}
+
+inputs = {
+  chart_version = try(local.gpu_inference_config.volcano_chart_version, "1.8.2")
+
+  scheduler_replicas  = 2
+  controller_replicas = 2
+
+  # Queue weights — higher value = proportionally more cluster resources
+  training_queue_weight  = try(local.gpu_inference_config.volcano_training_queue_weight, 10)
+  inference_queue_weight = try(local.gpu_inference_config.volcano_inference_queue_weight, 5)
+  batch_queue_weight     = try(local.gpu_inference_config.volcano_batch_queue_weight, 2)
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-inference"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/terraform/modules/gpu-inference-volcano/main.tf
+++ b/terraform/modules/gpu-inference-volcano/main.tf
@@ -1,0 +1,110 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Volcano v1.8 Batch Scheduler with DRA Integration
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys Volcano batch scheduler as a secondary scheduler on the gpu-inference
+# cluster. Pods opt-in via schedulerName: volcano. Includes gang scheduling,
+# bin-packing, fair-share queues, and DRA plugin integration.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "helm_release" "volcano" {
+  name             = "volcano"
+  repository       = "https://volcano-sh.github.io/helm-charts"
+  chart            = "volcano"
+  version          = var.chart_version
+  namespace        = "volcano-system"
+  create_namespace = true
+  timeout          = 300
+
+  values = [yamlencode({
+    custom = {
+      scheduler_config_override = yamlencode({
+        actions = "enqueue, allocate, backfill"
+        tiers = [
+          {
+            plugins = [
+              { name = "priority" },
+              { name = "gang", enablePreemptable = false },
+              { name = "conformance" }
+            ]
+          },
+          {
+            plugins = [
+              { name = "dra" },
+              { name = "overcommit" },
+              {
+                name = "binpack"
+                arguments = {
+                  "binpack.weight"                   = 10
+                  "binpack.cpu"                      = 1
+                  "binpack.memory"                   = 1
+                  "binpack.resources"                = "nvidia.com/gpu"
+                  "binpack.resources.nvidia.com/gpu" = 10
+                }
+              },
+              { name = "nodeorder" },
+              { name = "predicates" },
+              { name = "proportion" },
+              { name = "topology" }
+            ]
+          }
+        ]
+      })
+    }
+    scheduler = {
+      replicas = var.scheduler_replicas
+    }
+    controller = {
+      replicas = var.controller_replicas
+    }
+  })]
+}
+
+# Queue definitions
+
+resource "kubernetes_manifest" "queue_training" {
+  depends_on = [helm_release.volcano]
+
+  manifest = {
+    apiVersion = "scheduling.volcano.sh/v1beta1"
+    kind       = "Queue"
+    metadata = {
+      name = "training"
+    }
+    spec = {
+      weight     = var.training_queue_weight
+      capability = {}
+    }
+  }
+}
+
+resource "kubernetes_manifest" "queue_inference" {
+  depends_on = [helm_release.volcano]
+
+  manifest = {
+    apiVersion = "scheduling.volcano.sh/v1beta1"
+    kind       = "Queue"
+    metadata = {
+      name = "inference"
+    }
+    spec = {
+      weight     = var.inference_queue_weight
+      capability = {}
+    }
+  }
+}
+
+resource "kubernetes_manifest" "queue_batch" {
+  depends_on = [helm_release.volcano]
+
+  manifest = {
+    apiVersion = "scheduling.volcano.sh/v1beta1"
+    kind       = "Queue"
+    metadata = {
+      name = "batch"
+    }
+    spec = {
+      weight     = var.batch_queue_weight
+      capability = {}
+    }
+  }
+}

--- a/terraform/modules/gpu-inference-volcano/outputs.tf
+++ b/terraform/modules/gpu-inference-volcano/outputs.tf
@@ -1,0 +1,18 @@
+output "volcano_namespace" {
+  description = "Namespace where Volcano is deployed"
+  value       = helm_release.volcano.namespace
+}
+
+output "volcano_version" {
+  description = "Volcano Helm chart version deployed"
+  value       = helm_release.volcano.version
+}
+
+output "queue_names" {
+  description = "List of Volcano queue names created"
+  value = [
+    kubernetes_manifest.queue_training.manifest.metadata.name,
+    kubernetes_manifest.queue_inference.manifest.metadata.name,
+    kubernetes_manifest.queue_batch.manifest.metadata.name,
+  ]
+}

--- a/terraform/modules/gpu-inference-volcano/variables.tf
+++ b/terraform/modules/gpu-inference-volcano/variables.tf
@@ -1,0 +1,41 @@
+variable "chart_version" {
+  description = "Volcano Helm chart version"
+  type        = string
+  default     = "1.8.2"
+}
+
+variable "scheduler_replicas" {
+  description = "Number of Volcano scheduler replicas"
+  type        = number
+  default     = 2
+}
+
+variable "controller_replicas" {
+  description = "Number of Volcano controller replicas"
+  type        = number
+  default     = 2
+}
+
+variable "training_queue_weight" {
+  description = "Weight for training queue (higher = more resources)"
+  type        = number
+  default     = 10
+}
+
+variable "inference_queue_weight" {
+  description = "Weight for inference queue"
+  type        = number
+  default     = 5
+}
+
+variable "batch_queue_weight" {
+  description = "Weight for batch processing queue"
+  type        = number
+  default     = 2
+}
+
+variable "tags" {
+  description = "Resource tags"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/gpu-inference-volcano/versions.tf
+++ b/terraform/modules/gpu-inference-volcano/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.25"
+    }
+  }
+}

--- a/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
+++ b/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
@@ -51,3 +51,8 @@ unit "gpu-inference-dra" {
   source = "${get_repo_root()}/catalog/units/gpu-inference-dra"
   path   = "gpu-inference-dra"
 }
+
+unit "gpu-inference-volcano" {
+  source = "${get_repo_root()}/catalog/units/gpu-inference-volcano"
+  path   = "gpu-inference-volcano"
+}


### PR DESCRIPTION
## Summary

- Add Terraform module `terraform/modules/gpu-inference-volcano` deploying Volcano v1.8 as a secondary batch scheduler on the gpu-inference cluster
- Configure gang scheduling, bin-packing (GPU-weight 10), DRA plugin, and fair-share queues: training (weight 10), inference (weight 5), batch (weight 2)
- Add catalog unit `catalog/units/gpu-inference-volcano` with EKS dependency, helm+kubernetes providers, and queue weights sourced from `gpu_inference_config`
- Register `gpu-inference-volcano` unit in the gpu-inference live stack (`terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl`)

## Technical details

- Volcano chart version `1.8.2` from `https://volcano-sh.github.io/helm-charts`
- Scheduler actions: `enqueue, allocate, backfill`
- Tier 1 plugins: `priority`, `gang` (preemption disabled), `conformance`
- Tier 2 plugins: `dra`, `overcommit`, `binpack`, `nodeorder`, `predicates`, `proportion`, `topology`
- HA configuration: 2 scheduler replicas, 2 controller replicas
- Queue weights configurable via `gpu_inference_config.volcano_*_queue_weight` in `account.hcl`
- Provider requirements: `helm >= 2.12`, `kubernetes >= 2.25`

## Test plan

- [ ] `terragrunt init` in `catalog/units/gpu-inference-volcano` with mock EKS outputs
- [ ] `terragrunt validate` passes with mock outputs
- [ ] `terragrunt plan` shows Helm release + 3 Queue manifests with correct weights
- [ ] Volcano pods start in `volcano-system` namespace
- [ ] Queues `training`, `inference`, `batch` visible via `kubectl get queues`
- [ ] Submit a test `vcjob` with `schedulerName: volcano` and confirm gang scheduling
- [ ] Verify DRA plugin logs in scheduler for GPU resource allocation events