### PR TITLE
feat: VictoriaMetrics Operator v0.68 cluster mode (#75)

### DIFF
--- a/catalog/units/gpu-inference-victoriametrics/terragrunt.hcl
+++ b/catalog/units/gpu-inference-victoriametrics/terragrunt.hcl
@@ -1,0 +1,88 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# VictoriaMetrics Operator v0.68 — GPU Inference Metrics Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys VictoriaMetrics Operator and VMCluster CR in cluster mode for
+# high-scale metrics collection from 5000 GPU nodes.
+#
+# Cluster mode splits insert, select, and storage into independently
+# scalable components, supporting sustained high-cardinality ingest from
+# DCGM exporters, Cilium, and kubelet/cAdvisor across the fleet.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/gpu-inference-victoriametrics"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  environment          = local.account_vars.locals.environment
+  aws_region           = local.region_vars.locals.aws_region
+  gpu_inference_config = try(local.account_vars.locals.gpu_inference_config, {})
+}
+
+dependency "eks" {
+  config_path = "../gpu-inference-eks"
+
+  mock_outputs = {
+    cluster_name                       = "mock-cluster"
+    cluster_endpoint                   = "https://mock-endpoint.eks.amazonaws.com"
+    cluster_certificate_authority_data = "bW9jay1jZXJ0LWRhdGE="
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+generate "k8s_providers" {
+  path      = "k8s_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "helm" {
+      kubernetes {
+        host                   = "${dependency.eks.outputs.cluster_endpoint}"
+        cluster_ca_certificate = base64decode("${dependency.eks.outputs.cluster_certificate_authority_data}")
+        exec {
+          api_version = "client.authentication.k8s.io/v1beta1"
+          command     = "aws"
+          args        = ["eks", "get-token", "--cluster-name", "${dependency.eks.outputs.cluster_name}"]
+        }
+      }
+    }
+
+    provider "kubernetes" {
+      host                   = "${dependency.eks.outputs.cluster_endpoint}"
+      cluster_ca_certificate = base64decode("${dependency.eks.outputs.cluster_certificate_authority_data}")
+      exec {
+        api_version = "client.authentication.k8s.io/v1beta1"
+        command     = "aws"
+        args        = ["eks", "get-token", "--cluster-name", "${dependency.eks.outputs.cluster_name}"]
+      }
+    }
+  PROVIDERS
+}
+
+inputs = {
+  # VictoriaMetrics Operator chart version (maps to operator v0.68)
+  operator_chart_version = "0.59.3"
+
+  # Retention — 30 days default; increase for longer-term capacity analysis
+  retention_period = try(local.gpu_inference_config.vm_retention_period, "30d")
+
+  # Replica counts — 3 for HA across 3 AZs
+  vminsert_replicas  = try(local.gpu_inference_config.vminsert_replicas, 3)
+  vmselect_replicas  = try(local.gpu_inference_config.vmselect_replicas, 3)
+  vmstorage_replicas = try(local.gpu_inference_config.vmstorage_replicas, 3)
+
+  # Storage — gp3 for cost-effective throughput; 500Gi per replica
+  storage_class = try(local.gpu_inference_config.vm_storage_class, "gp3")
+  storage_size  = try(local.gpu_inference_config.vm_storage_size, "500Gi")
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-inference"
+    Component   = "monitoring"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/terraform/modules/gpu-inference-victoriametrics/main.tf
+++ b/terraform/modules/gpu-inference-victoriametrics/main.tf
@@ -1,0 +1,135 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# VictoriaMetrics Cluster Mode — GPU Inference Metrics
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys VictoriaMetrics Operator and VMCluster CR for high-scale metrics
+# collection from 5000 GPU nodes. Cluster mode separates insert, select,
+# and storage into independently scalable components.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "helm_release" "vm_operator" {
+  name             = "victoria-metrics-operator"
+  repository       = "https://victoriametrics.github.io/helm-charts"
+  chart            = "victoria-metrics-operator"
+  version          = var.operator_chart_version
+  namespace        = "monitoring"
+  create_namespace = true
+  timeout          = 300
+}
+
+# VMCluster CR for cluster-mode VictoriaMetrics
+resource "kubernetes_manifest" "vmcluster" {
+  depends_on = [helm_release.vm_operator]
+
+  manifest = {
+    apiVersion = "operator.victoriametrics.com/v1beta1"
+    kind       = "VMCluster"
+    metadata = {
+      name      = "gpu-inference-metrics"
+      namespace = "monitoring"
+    }
+    spec = {
+      retentionPeriod = var.retention_period
+      vminsert = {
+        replicaCount = var.vminsert_replicas
+        resources = {
+          requests = { cpu = "2", memory = "4Gi" }
+          limits   = { cpu = "4", memory = "8Gi" }
+        }
+      }
+      vmselect = {
+        replicaCount = var.vmselect_replicas
+        resources = {
+          requests = { cpu = "2", memory = "8Gi" }
+          limits   = { cpu = "4", memory = "16Gi" }
+        }
+        cacheMountPath = "/select-cache"
+      }
+      vmstorage = {
+        replicaCount    = var.vmstorage_replicas
+        storageDataPath = "/vmstorage-data"
+        storage = {
+          volumeClaimTemplate = {
+            spec = {
+              storageClassName = var.storage_class
+              resources = {
+                requests = { storage = var.storage_size }
+              }
+            }
+          }
+        }
+        resources = {
+          requests = { cpu = "2", memory = "4Gi" }
+          limits   = { cpu = "4", memory = "8Gi" }
+        }
+      }
+    }
+  }
+}
+
+# VMServiceScrape for DCGM Exporter
+resource "kubernetes_manifest" "vmscrape_dcgm" {
+  depends_on = [helm_release.vm_operator]
+
+  manifest = {
+    apiVersion = "operator.victoriametrics.com/v1beta1"
+    kind       = "VMServiceScrape"
+    metadata = {
+      name      = "dcgm-exporter"
+      namespace = "monitoring"
+    }
+    spec = {
+      selector = {
+        matchLabels = { "app.kubernetes.io/name" = "dcgm-exporter" }
+      }
+      endpoints = [{ port = "metrics", interval = "15s" }]
+    }
+  }
+}
+
+# VMServiceScrape for Cilium
+resource "kubernetes_manifest" "vmscrape_cilium" {
+  depends_on = [helm_release.vm_operator]
+
+  manifest = {
+    apiVersion = "operator.victoriametrics.com/v1beta1"
+    kind       = "VMServiceScrape"
+    metadata = {
+      name      = "cilium-agent"
+      namespace = "monitoring"
+    }
+    spec = {
+      namespaceSelector = { matchNames = ["kube-system"] }
+      selector = {
+        matchLabels = { "k8s-app" = "cilium" }
+      }
+      endpoints = [{ port = "peer-service", interval = "30s" }]
+    }
+  }
+}
+
+# VMNodeScrape for node-exporter / kubelet-cadvisor
+resource "kubernetes_manifest" "vmscrape_node" {
+  depends_on = [helm_release.vm_operator]
+
+  manifest = {
+    apiVersion = "operator.victoriametrics.com/v1beta1"
+    kind       = "VMNodeScrape"
+    metadata = {
+      name      = "kubelet-cadvisor"
+      namespace = "monitoring"
+    }
+    spec = {
+      scheme          = "https"
+      bearerTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+      tlsConfig = {
+        insecureSkipVerify = true
+      }
+      relabelConfigs = [
+        {
+          action = "labelmap"
+          regex  = "__meta_kubernetes_node_label_(.+)"
+        }
+      ]
+    }
+  }
+}

--- a/terraform/modules/gpu-inference-victoriametrics/outputs.tf
+++ b/terraform/modules/gpu-inference-victoriametrics/outputs.tf
@@ -1,0 +1,14 @@
+output "vmcluster_name" {
+  description = "Name of the VMCluster custom resource"
+  value       = kubernetes_manifest.vmcluster.manifest.metadata.name
+}
+
+output "operator_chart_version" {
+  description = "Deployed VictoriaMetrics Operator Helm chart version"
+  value       = helm_release.vm_operator.version
+}
+
+output "vmselect_endpoint" {
+  description = "VMSelect service endpoint for Grafana datasource configuration"
+  value       = "http://vmselect-gpu-inference-metrics.monitoring.svc.cluster.local:8481/select/0/prometheus"
+}

--- a/terraform/modules/gpu-inference-victoriametrics/variables.tf
+++ b/terraform/modules/gpu-inference-victoriametrics/variables.tf
@@ -1,0 +1,47 @@
+variable "operator_chart_version" {
+  description = "VictoriaMetrics Operator Helm chart version"
+  type        = string
+  default     = "0.59.3"
+}
+
+variable "retention_period" {
+  description = "Metrics retention period (e.g. 30d, 90d)"
+  type        = string
+  default     = "30d"
+}
+
+variable "vminsert_replicas" {
+  description = "Number of vminsert replicas for ingestion scaling"
+  type        = number
+  default     = 3
+}
+
+variable "vmselect_replicas" {
+  description = "Number of vmselect replicas for query scaling"
+  type        = number
+  default     = 3
+}
+
+variable "vmstorage_replicas" {
+  description = "Number of vmstorage replicas for storage HA"
+  type        = number
+  default     = 3
+}
+
+variable "storage_class" {
+  description = "Kubernetes StorageClass for vmstorage PVCs"
+  type        = string
+  default     = "gp3"
+}
+
+variable "storage_size" {
+  description = "Storage size per vmstorage replica"
+  type        = string
+  default     = "500Gi"
+}
+
+variable "tags" {
+  description = "Tags to apply to cloud resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/gpu-inference-victoriametrics/versions.tf
+++ b/terraform/modules/gpu-inference-victoriametrics/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.25"
+    }
+  }
+}

--- a/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
+++ b/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
@@ -56,3 +56,8 @@ unit "gpu-inference-volcano" {
   source = "${get_repo_root()}/catalog/units/gpu-inference-volcano"
   path   = "gpu-inference-volcano"
 }
+
+unit "gpu-inference-victoriametrics" {
+  source = "${get_repo_root()}/catalog/units/gpu-inference-victoriametrics"
+  path   = "gpu-inference-victoriametrics"
+}


### PR DESCRIPTION
## Summary

- Adds `terraform/modules/gpu-inference-victoriametrics/` — Terraform module deploying VictoriaMetrics Operator via Helm and VMCluster CR in cluster mode
- Adds `catalog/units/gpu-inference-victoriametrics/terragrunt.hcl` — Catalog unit wiring EKS dependency and reading `gpu_inference_config` from `account.hcl`
- Updates `terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl` — adds new unit to the gpu-inference stack

## Architecture

VMCluster cluster mode separates three independently scalable components:
- **vminsert** (3 replicas, 2–4 CPU / 4–8Gi) — ingest path for 5000 GPU nodes
- **vmselect** (3 replicas, 2–4 CPU / 8–16Gi) — query/Grafana path
- **vmstorage** (3 replicas, 2–4 CPU / 4–8Gi, 500Gi gp3 PVC) — storage HA across 3 AZs

## Scrape Targets

| Resource | Kind | Interval |
|---|---|---|
| DCGM GPU Exporter | VMServiceScrape | 15s |
| Cilium agent | VMServiceScrape | 30s |
| kubelet / cAdvisor | VMNodeScrape | default |

## Configuration (via `gpu_inference_config` in `account.hcl`)

| Key | Default |
|---|---|
| `vm_retention_period` | `30d` |
| `vminsert_replicas` | `3` |
| `vmselect_replicas` | `3` |
| `vmstorage_replicas` | `3` |
| `vm_storage_class` | `gp3` |
| `vm_storage_size` | `500Gi` |

## Provider Versions

- `hashicorp/helm >= 2.12`
- `hashicorp/kubernetes >= 2.25`

## Test plan

- [ ] `terragrunt validate` passes for `catalog/units/gpu-inference-victoriametrics`
- [ ] `terragrunt plan` with mock EKS outputs shows VMCluster, 4x kubernetes_manifest, 1x helm_release
- [ ] VMCluster CR applies cleanly after VictoriaMetrics Operator is ready
- [ ] Grafana datasource pointed at vmselect endpoint returns GPU metrics