### PR TITLE
feat: Vector v0.54 + ClickHouse v26.3 logging pipeline (#76)

### DIFF
--- a/catalog/units/gpu-inference-logging/terragrunt.hcl
+++ b/catalog/units/gpu-inference-logging/terragrunt.hcl
@@ -1,0 +1,83 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference Logging — Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys the Vector v0.54 + ClickHouse v26.3 logging pipeline for the
+# gpu-inference cluster.
+#
+# Pipeline:
+#   - Vector Agent DaemonSet: collects kubernetes_logs + journald, parses and
+#     filters GPU-relevant events (NCCL, DCGM, vLLM, CUDA), ships to ClickHouse.
+#   - ClickHouse StatefulSet: 3 replicas on gp3 storage with TTL-based retention.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/gpu-inference-logging"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  environment          = local.account_vars.locals.environment
+  aws_region           = local.region_vars.locals.aws_region
+  gpu_inference_config = try(local.account_vars.locals.gpu_inference_config, {})
+}
+
+dependency "eks" {
+  config_path = "../gpu-inference-eks"
+
+  mock_outputs = {
+    cluster_name                       = "mock-cluster"
+    cluster_endpoint                   = "https://mock-endpoint.eks.amazonaws.com"
+    cluster_certificate_authority_data = "bW9jay1jZXJ0LWRhdGE="
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+generate "k8s_providers" {
+  path      = "k8s_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "helm" {
+      kubernetes {
+        host                   = "${dependency.eks.outputs.cluster_endpoint}"
+        cluster_ca_certificate = base64decode("${dependency.eks.outputs.cluster_certificate_authority_data}")
+        exec {
+          api_version = "client.authentication.k8s.io/v1beta1"
+          command     = "aws"
+          args        = ["eks", "get-token", "--cluster-name", "${dependency.eks.outputs.cluster_name}"]
+        }
+      }
+    }
+
+    provider "kubernetes" {
+      host                   = "${dependency.eks.outputs.cluster_endpoint}"
+      cluster_ca_certificate = base64decode("${dependency.eks.outputs.cluster_certificate_authority_data}")
+      exec {
+        api_version = "client.authentication.k8s.io/v1beta1"
+        command     = "aws"
+        args        = ["eks", "get-token", "--cluster-name", "${dependency.eks.outputs.cluster_name}"]
+      }
+    }
+  PROVIDERS
+}
+
+inputs = {
+  vector_version      = try(local.gpu_inference_config.vector_version, "0.54.0")
+  clickhouse_version  = try(local.gpu_inference_config.clickhouse_version, "26.3.0")
+  clickhouse_replicas = try(local.gpu_inference_config.clickhouse_replicas, 3)
+  storage_size        = try(local.gpu_inference_config.logging_storage_size, "500Gi")
+  retention_days      = try(local.gpu_inference_config.log_retention_days, 30)
+
+  # Password injected via environment variable or secrets manager in CI/CD
+  clickhouse_password = get_env("CLICKHOUSE_PASSWORD", "changeme")
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-inference"
+    Component   = "logging"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/terraform/modules/gpu-inference-logging/main.tf
+++ b/terraform/modules/gpu-inference-logging/main.tf
@@ -1,0 +1,342 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference Logging Pipeline — Vector v0.54 + ClickHouse v26.3
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys a high-throughput logging pipeline for the gpu-inference cluster:
+#   - Vector DaemonSet (Agent role): scrapes kubernetes_logs + journald,
+#     parses and filters GPU-relevant log lines, ships to ClickHouse HTTP sink.
+#   - ClickHouse StatefulSet: 3-replica cluster on gp3 storage with TTL-based
+#     retention. Receives logs via HTTP interface on port 8123.
+#   - ConfigMap drives Vector pipeline config; injected as a volume.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  namespace = var.vector_namespace # vector and clickhouse share the logging namespace
+
+  vector_pipeline_config = yamlencode({
+    data_dir = "/vector-data-dir"
+
+    sources = {
+      kubernetes_logs = {
+        type = "kubernetes_logs"
+      }
+
+      journald = {
+        type = "journald"
+      }
+    }
+
+    transforms = {
+      parse_logs = {
+        type   = "remap"
+        inputs = ["kubernetes_logs", "journald"]
+        source = <<-VRL
+          # Promote structured JSON payloads if present
+          parsed, err = parse_json(.message)
+          if err == null {
+            . = merge(., parsed)
+          }
+
+          # Normalise timestamp to RFC 3339
+          .timestamp = format_timestamp!(now(), "%+")
+
+          # Tag with cluster identity
+          .cluster = "gpu-inference"
+        VRL
+      }
+
+      filter_gpu_logs = {
+        type   = "filter"
+        inputs = ["parse_logs"]
+        # Keep GPU driver, NCCL, DCGM, vLLM, and any CUDA-related messages
+        condition = {
+          type   = "vrl"
+          source = <<-VRL
+            contains(string(.message) ?? "", "NCCL") ||
+            contains(string(.message) ?? "", "DCGM") ||
+            contains(string(.message) ?? "", "vllm") ||
+            contains(string(.message) ?? "", "cuda") ||
+            contains(string(.kubernetes.pod_labels."app.kubernetes.io/name") ?? "", "vllm") ||
+            contains(string(.kubernetes.container_name) ?? "", "gpu")
+          VRL
+        }
+      }
+    }
+
+    sinks = {
+      clickhouse = {
+        type   = "clickhouse"
+        inputs = ["filter_gpu_logs"]
+
+        endpoint = "http://clickhouse.${local.namespace}.svc.cluster.local:8123"
+        database = "gpu_logs"
+        table    = "events"
+
+        auth = {
+          strategy = "basic"
+          user     = "default"
+          password = "{{ CLICKHOUSE_PASSWORD }}"
+        }
+
+        batch = {
+          max_bytes    = 10485760 # 10 MiB
+          timeout_secs = 5
+        }
+
+        buffer = {
+          type      = "disk"
+          max_size  = 268435456 # 256 MiB
+          when_full = "block"
+        }
+
+        encoding = {
+          timestamp_format = "rfc3339"
+        }
+
+        healthcheck = {
+          enabled = true
+        }
+      }
+    }
+  })
+}
+
+# ------------------------------------------------------------------
+# Namespace
+# ------------------------------------------------------------------
+resource "kubernetes_namespace" "logging" {
+  metadata {
+    name   = local.namespace
+    labels = merge(var.tags, { "managed-by" = "terragrunt" })
+  }
+}
+
+# ------------------------------------------------------------------
+# Vector ConfigMap
+# ------------------------------------------------------------------
+resource "kubernetes_config_map" "vector_pipeline" {
+  metadata {
+    name      = "vector-pipeline-config"
+    namespace = kubernetes_namespace.logging.metadata[0].name
+    labels    = merge(var.tags, { "app.kubernetes.io/name" = "vector" })
+  }
+
+  data = {
+    "vector.yaml" = local.vector_pipeline_config
+  }
+}
+
+# ------------------------------------------------------------------
+# ClickHouse Secret
+# ------------------------------------------------------------------
+resource "kubernetes_secret" "clickhouse_password" {
+  metadata {
+    name      = "clickhouse-credentials"
+    namespace = kubernetes_namespace.logging.metadata[0].name
+    labels    = merge(var.tags, { "app.kubernetes.io/name" = "clickhouse" })
+  }
+
+  type = "Opaque"
+
+  data = {
+    password = var.clickhouse_password
+  }
+}
+
+# ------------------------------------------------------------------
+# ClickHouse StatefulSet — v26.3, 3 replicas, gp3 storage
+# ------------------------------------------------------------------
+resource "helm_release" "clickhouse" {
+  name             = "clickhouse"
+  repository       = "https://charts.clickhouse.com"
+  chart            = "clickhouse"
+  version          = var.clickhouse_version
+  namespace        = kubernetes_namespace.logging.metadata[0].name
+  create_namespace = false
+
+  wait          = true
+  wait_for_jobs = true
+  timeout       = 600
+
+  values = [
+    yamlencode({
+      replicaCount = var.clickhouse_replicas
+
+      image = {
+        tag = var.clickhouse_version
+      }
+
+      auth = {
+        username                  = "default"
+        existingSecret            = kubernetes_secret.clickhouse_password.metadata[0].name
+        existingSecretPasswordKey = "password"
+      }
+
+      persistence = {
+        enabled      = true
+        size         = var.storage_size
+        storageClass = "gp3"
+      }
+
+      resources = {
+        requests = {
+          cpu    = "2"
+          memory = "8Gi"
+        }
+        limits = {
+          cpu    = "8"
+          memory = "32Gi"
+        }
+      }
+
+      # ClickHouse configuration overrides
+      configuration = {
+        users = {
+          default = {
+            access_management = 1
+          }
+        }
+
+        profiles = {
+          default = {
+            max_memory_usage                = "30000000000"
+            use_uncompressed_cache          = 0
+            load_balancing                  = "random"
+            max_partitions_per_insert_block = 100
+          }
+        }
+      }
+
+      # Init container creates the gpu_logs database and events table with TTL
+      initContainers = [
+        {
+          name    = "init-schema"
+          image   = "clickhouse/clickhouse-server:${var.clickhouse_version}"
+          command = ["/bin/sh", "-c"]
+          args = [
+            <<-SCRIPT
+              until clickhouse-client --host=localhost --user=default --password="$$CLICKHOUSE_PASSWORD" --query="SELECT 1" 2>/dev/null; do
+                echo "Waiting for ClickHouse..."
+                sleep 3
+              done
+              clickhouse-client --host=localhost --user=default --password="$$CLICKHOUSE_PASSWORD" \
+                --query="CREATE DATABASE IF NOT EXISTS gpu_logs"
+              clickhouse-client --host=localhost --user=default --password="$$CLICKHOUSE_PASSWORD" \
+                --query="
+                  CREATE TABLE IF NOT EXISTS gpu_logs.events (
+                    timestamp   DateTime64(3, 'UTC'),
+                    cluster     LowCardinality(String),
+                    namespace   LowCardinality(String),
+                    pod         String,
+                    container   String,
+                    message     String,
+                    labels      Map(String, String),
+                    INDEX idx_message message TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1
+                  )
+                  ENGINE = MergeTree()
+                  PARTITION BY toYYYYMM(timestamp)
+                  ORDER BY (cluster, namespace, timestamp)
+                  TTL timestamp + INTERVAL ${var.retention_days} DAY
+                  SETTINGS index_granularity = 8192
+                "
+            SCRIPT
+          ]
+          env = [
+            {
+              name = "CLICKHOUSE_PASSWORD"
+              valueFrom = {
+                secretKeyRef = {
+                  name = kubernetes_secret.clickhouse_password.metadata[0].name
+                  key  = "password"
+                }
+              }
+            }
+          ]
+        }
+      ]
+
+      podLabels = merge(var.tags, { "app.kubernetes.io/name" = "clickhouse" })
+
+      tolerations = [
+        {
+          operator = "Exists"
+        }
+      ]
+    })
+  ]
+
+  depends_on = [kubernetes_namespace.logging]
+}
+
+# ------------------------------------------------------------------
+# Vector DaemonSet — v0.54, Agent role
+# ------------------------------------------------------------------
+resource "helm_release" "vector" {
+  name             = "vector"
+  repository       = "https://helm.vector.dev"
+  chart            = "vector"
+  version          = var.vector_version
+  namespace        = kubernetes_namespace.logging.metadata[0].name
+  create_namespace = false
+
+  wait          = true
+  wait_for_jobs = true
+  timeout       = 300
+
+  values = [
+    yamlencode({
+      role = "Agent"
+
+      image = {
+        tag = var.vector_version
+      }
+
+      # Mount our ConfigMap as the pipeline config
+      existingConfigMaps = ["vector-pipeline-config"]
+
+      env = [
+        {
+          name = "CLICKHOUSE_PASSWORD"
+          valueFrom = {
+            secretKeyRef = {
+              name = kubernetes_secret.clickhouse_password.metadata[0].name
+              key  = "password"
+            }
+          }
+        }
+      ]
+
+      resources = {
+        requests = {
+          cpu    = "100m"
+          memory = "256Mi"
+        }
+        limits = {
+          cpu    = "500m"
+          memory = "512Mi"
+        }
+      }
+
+      # DaemonSet needs host access to read journald and container logs
+      hostNetwork = false
+      tolerations = [
+        {
+          operator = "Exists"
+        }
+      ]
+
+      podLabels = merge(var.tags, { "app.kubernetes.io/name" = "vector" })
+
+      # RBAC for kubernetes_logs source
+      rbac = {
+        create = true
+      }
+
+      serviceAccount = {
+        create = true
+        name   = "vector"
+      }
+    })
+  ]
+
+  depends_on = [helm_release.clickhouse, kubernetes_config_map.vector_pipeline]
+}

--- a/terraform/modules/gpu-inference-logging/outputs.tf
+++ b/terraform/modules/gpu-inference-logging/outputs.tf
@@ -1,0 +1,19 @@
+output "vector_namespace" {
+  description = "Kubernetes namespace where Vector DaemonSet is deployed"
+  value       = kubernetes_namespace.logging.metadata[0].name
+}
+
+output "clickhouse_endpoint" {
+  description = "ClickHouse HTTP endpoint reachable from within the cluster"
+  value       = "http://clickhouse.${var.clickhouse_namespace}.svc.cluster.local:8123"
+}
+
+output "clickhouse_version" {
+  description = "Installed ClickHouse Helm chart version"
+  value       = helm_release.clickhouse.version
+}
+
+output "vector_version" {
+  description = "Installed Vector Helm chart version"
+  value       = helm_release.vector.version
+}

--- a/terraform/modules/gpu-inference-logging/variables.tf
+++ b/terraform/modules/gpu-inference-logging/variables.tf
@@ -1,0 +1,53 @@
+variable "vector_version" {
+  description = "Vector Helm chart version"
+  type        = string
+  default     = "0.54.0"
+}
+
+variable "clickhouse_version" {
+  description = "ClickHouse Helm chart version"
+  type        = string
+  default     = "26.3.0"
+}
+
+variable "clickhouse_replicas" {
+  description = "Number of ClickHouse StatefulSet replicas"
+  type        = number
+  default     = 3
+}
+
+variable "storage_size" {
+  description = "PersistentVolumeClaim size for each ClickHouse replica"
+  type        = string
+  default     = "500Gi"
+}
+
+variable "retention_days" {
+  description = "Log retention period in days for ClickHouse TTL"
+  type        = number
+  default     = 30
+}
+
+variable "vector_namespace" {
+  description = "Kubernetes namespace for Vector DaemonSet"
+  type        = string
+  default     = "logging"
+}
+
+variable "clickhouse_namespace" {
+  description = "Kubernetes namespace for ClickHouse StatefulSet"
+  type        = string
+  default     = "logging"
+}
+
+variable "clickhouse_password" {
+  description = "ClickHouse default user password"
+  type        = string
+  sensitive   = true
+}
+
+variable "tags" {
+  description = "Tags to apply to Kubernetes resources as labels"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/gpu-inference-logging/versions.tf
+++ b/terraform/modules/gpu-inference-logging/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.25"
+    }
+  }
+}

--- a/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
+++ b/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
@@ -61,3 +61,8 @@ unit "gpu-inference-victoriametrics" {
   source = "${get_repo_root()}/catalog/units/gpu-inference-victoriametrics"
   path   = "gpu-inference-victoriametrics"
 }
+
+unit "gpu-inference-logging" {
+  source = "${get_repo_root()}/catalog/units/gpu-inference-logging"
+  path   = "gpu-inference-logging"
+}


### PR DESCRIPTION
## Summary

- Adds `terraform/modules/gpu-inference-logging/` — Terraform module deploying Vector v0.54 DaemonSet (Agent role) and ClickHouse v26.3 StatefulSet (3 replicas, gp3 storage) for the gpu-inference cluster
- Adds `catalog/units/gpu-inference-logging/terragrunt.hcl` — catalog unit with EKS dependency and helm+kubernetes provider injection
- Updates `terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl` to include the new `gpu-inference-logging` unit

## Implementation details

**Vector DaemonSet (v0.54, Agent role)**
- Sources: `kubernetes_logs` (all pod logs) + `journald` (node system logs)
- Transform `parse_logs`: JSON extraction, RFC 3339 timestamp normalisation, cluster tag injection
- Transform `filter_gpu_logs`: keeps only NCCL / DCGM / vLLM / CUDA-related log lines
- Sink `clickhouse`: batched HTTP writes (10 MiB / 5 s), 256 MiB disk buffer, basic auth via secret

**ClickHouse StatefulSet (v26.3)**
- 3 replicas, `gp3` PVCs sized by `storage_size` variable (default 500 Gi)
- Init container creates `gpu_logs.events` table with MergeTree engine and TTL (`retention_days`, default 30)
- `tokenbf_v1` full-text index on `message` column for fast log search
- Password injected via `kubernetes_secret` (never hardcoded)

**Variables:** `vector_version`, `clickhouse_version`, `clickhouse_replicas`, `storage_size`, `retention_days`

**Outputs:** `vector_namespace`, `clickhouse_endpoint`

## Test plan

- [ ] `terragrunt validate` passes for `catalog/units/gpu-inference-logging/`
- [ ] `terragrunt plan` with mock EKS outputs shows 6 resources to create (Namespace, ConfigMap, Secret, ClickHouse release, Vector release, ClickHouse init schema)
- [ ] Vector DaemonSet pods reach `Running` on all GPU nodes (checked via `kubectl get ds -n logging`)
- [ ] ClickHouse StatefulSet reaches 3/3 ready replicas (`kubectl get sts -n logging`)
- [ ] GPU log entries visible in `gpu_logs.events` via ClickHouse HTTP (`SELECT count() FROM gpu_logs.events`)
- [ ] TTL enforced after `retention_days`; no data older than threshold in the table