### PR TITLE
feat: gang scheduling policies + binpack optimization (#74)

### DIFF
--- a/catalog/units/gpu-inference-scheduling-policies/terragrunt.hcl
+++ b/catalog/units/gpu-inference-scheduling-policies/terragrunt.hcl
@@ -1,0 +1,68 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference Scheduling Policies — Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys Kubernetes scheduling primitives for the gpu-inference cluster:
+#   - Four PriorityClasses (system-critical / training-high / inference-medium / batch-low)
+#   - Volcano PodGroup example for 8-pod gang scheduling
+#   - Per-namespace ResourceQuotas for GPU/CPU/memory limits
+#
+# Depends on: gpu-inference-eks (provides cluster endpoint + CA data)
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/gpu-inference-scheduling-policies"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  environment          = local.account_vars.locals.environment
+  aws_region           = local.region_vars.locals.aws_region
+  gpu_inference_config = try(local.account_vars.locals.gpu_inference_config, {})
+}
+
+dependency "eks" {
+  config_path = "../gpu-inference-eks"
+
+  mock_outputs = {
+    cluster_name                       = "mock-cluster"
+    cluster_endpoint                   = "https://mock-endpoint.eks.amazonaws.com"
+    cluster_certificate_authority_data = "bW9jay1jZXJ0LWRhdGE="
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+generate "k8s_providers" {
+  path      = "k8s_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "kubernetes" {
+      host                   = "${dependency.eks.outputs.cluster_endpoint}"
+      cluster_ca_certificate = base64decode("${dependency.eks.outputs.cluster_certificate_authority_data}")
+      exec {
+        api_version = "client.authentication.k8s.io/v1beta1"
+        command     = "aws"
+        args        = ["eks", "get-token", "--cluster-name", "${dependency.eks.outputs.cluster_name}"]
+      }
+    }
+  PROVIDERS
+}
+
+inputs = {
+  # Priority values — override in account.hcl gpu_inference_config if needed
+  training_priority  = try(local.gpu_inference_config.training_priority, 100000)
+  inference_priority = try(local.gpu_inference_config.inference_priority, 50000)
+  batch_priority     = try(local.gpu_inference_config.batch_priority, 10000)
+
+  # ResourceQuotas enabled by default; disable in dev via gpu_inference_config
+  enable_resource_quotas = try(local.gpu_inference_config.enable_resource_quotas, true)
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-inference"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/k8s/gpu-inference/scheduling/podgroup-distributed-training-example.yaml
+++ b/k8s/gpu-inference/scheduling/podgroup-distributed-training-example.yaml
@@ -1,0 +1,44 @@
+# Volcano PodGroup — distributed-training-example
+#
+# Gang scheduling guarantee: all 8 pods must be simultaneously schedulable before
+# any pod is allowed to start. This prevents partial allocation where some workers
+# start but others cannot be placed, wasting GPU resources on idle processes.
+#
+# Usage:
+#   Add `scheduling.volcano.sh/group-name: distributed-training-example` to
+#   your training pod annotations. Volcano will hold all pods until the full
+#   gang (minMember=8) can be co-scheduled.
+#
+# Binpack optimization:
+#   The `gpu-training-queue` Volcano Queue should be configured with
+#   `binpack` action to pack pods onto the fewest nodes, maximising NVLink
+#   bandwidth utilisation and minimising cross-node NCCL traffic.
+#
+# Prerequisites:
+#   - Volcano scheduler installed in the cluster
+#   - Namespace `gpu-training` exists
+#   - PriorityClass `gpu-training-high` exists
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: PodGroup
+metadata:
+  name: distributed-training-example
+  namespace: gpu-training
+  annotations:
+    gpu-inference/managed-by: terraform
+    gpu-inference/description: "Example 8-pod gang-scheduled PodGroup for distributed training"
+spec:
+  # Hard gang constraint — no pod starts until all 8 can be placed
+  minMember: 8
+
+  # Volcano queue with binpack scheduling policy
+  queue: gpu-training-queue
+
+  # Inherit training high-priority to preempt inference/batch under pressure
+  priorityClassName: gpu-training-high
+
+  # Minimum aggregate resources the scheduler must reserve before gang starts.
+  # 8x p5.48xlarge = 8x 8 H100 = 64 GPUs; 8x 192 vCPU; 8x 768Gi RAM (headroom).
+  minResources:
+    nvidia.com/gpu: "8"
+    cpu: "64"
+    memory: "512Gi"

--- a/k8s/gpu-inference/scheduling/priority-class-batch-low.yaml
+++ b/k8s/gpu-inference/scheduling/priority-class-batch-low.yaml
@@ -1,0 +1,17 @@
+# PriorityClass: gpu-batch-low
+# Value: 10,000 — for offline / batch scoring jobs.
+# These workloads are preemptible by all higher-priority classes.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: gpu-batch-low
+  annotations:
+    gpu-inference/managed-by: terraform
+    gpu-inference/tier: batch
+value: 10000
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: >
+  Low-priority class for offline batch scoring and evaluation jobs.
+  Preemptible by training-high, inference-medium, and system-critical.
+  Best-effort scheduling; may be evicted under resource pressure.

--- a/k8s/gpu-inference/scheduling/priority-class-inference-medium.yaml
+++ b/k8s/gpu-inference/scheduling/priority-class-inference-medium.yaml
@@ -1,0 +1,17 @@
+# PriorityClass: gpu-inference-medium
+# Value: 50,000 — default for real-time inference workloads (vLLM, Triton).
+# Set as globalDefault so inference pods automatically inherit this class.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: gpu-inference-medium
+  annotations:
+    gpu-inference/managed-by: terraform
+    gpu-inference/tier: inference
+value: 50000
+globalDefault: true
+preemptionPolicy: PreemptLowerPriority
+description: >
+  Default priority for real-time GPU inference workloads (vLLM, Triton Inference Server).
+  globalDefault=true ensures pods without an explicit priorityClassName inherit this class.
+  Preempts batch workloads; preempted by training-high and system-critical.

--- a/k8s/gpu-inference/scheduling/priority-class-system-critical.yaml
+++ b/k8s/gpu-inference/scheduling/priority-class-system-critical.yaml
@@ -1,0 +1,16 @@
+# PriorityClass: gpu-system-critical
+# Value: 1,000,000 — reserved for GPU operators, device plugins, and drivers.
+# Do NOT assign to user workloads; preempts everything else.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: gpu-system-critical
+  annotations:
+    gpu-inference/managed-by: terraform
+    gpu-inference/tier: system
+value: 1000000
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: >
+  Reserved for GPU system components (operators, device plugins, NVIDIA drivers).
+  Preempts all lower-priority workloads. Do not assign to user workloads.

--- a/k8s/gpu-inference/scheduling/priority-class-training-high.yaml
+++ b/k8s/gpu-inference/scheduling/priority-class-training-high.yaml
@@ -1,0 +1,16 @@
+# PriorityClass: gpu-training-high
+# Value: 100,000 — for distributed training jobs (Volcano PodGroups, PyTorch DDP, DeepSpeed).
+# Preempts inference and batch workloads when cluster resources are constrained.
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: gpu-training-high
+  annotations:
+    gpu-inference/managed-by: terraform
+    gpu-inference/tier: training
+value: 100000
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+description: >
+  High-priority class for distributed GPU training jobs managed by Volcano.
+  Assigns to PodGroups in the gpu-training namespace. Preempts inference and batch.

--- a/terraform/modules/gpu-inference-scheduling-policies/main.tf
+++ b/terraform/modules/gpu-inference-scheduling-policies/main.tf
@@ -1,0 +1,147 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference Scheduling Policies
+# ---------------------------------------------------------------------------------------------------------------------
+# Establishes Kubernetes scheduling primitives for the gpu-inference cluster:
+#
+#   PriorityClasses (4 tiers):
+#     - gpu-system-critical   (1000000) — system-level GPU controllers / operators
+#     - gpu-training-high     (var)     — distributed training jobs (Volcano / PyTorch DDP)
+#     - gpu-inference-medium  (var)     — real-time inference workloads (vLLM, Triton)
+#     - gpu-batch-low         (var)     — offline / batch scoring jobs
+#
+#   Gang scheduling:
+#     - Volcano PodGroup "distributed-training-example" — 8-pod gang for training demos
+#
+#   ResourceQuotas:
+#     - Per-namespace GPU/CPU/memory quotas (optional, toggled by var.enable_resource_quotas)
+#
+# The module uses kubernetes_manifest for CRDs (PodGroup) and native kubernetes provider
+# resources for PriorityClass and ResourceQuota.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# ── PriorityClass: gpu-system-critical ──────────────────────────────────────
+resource "kubernetes_priority_class_v1" "gpu_system_critical" {
+  metadata {
+    name = "gpu-system-critical"
+    annotations = {
+      "gpu-inference/managed-by" = "terraform"
+      "gpu-inference/tier"       = "system"
+    }
+  }
+
+  value             = 1000000
+  global_default    = false
+  preemption_policy = "PreemptLowerPriority"
+  description       = "Reserved for GPU system components (operators, device plugins, drivers). Do not assign to workloads."
+}
+
+# ── PriorityClass: gpu-training-high ────────────────────────────────────────
+resource "kubernetes_priority_class_v1" "gpu_training_high" {
+  metadata {
+    name = "gpu-training-high"
+    annotations = {
+      "gpu-inference/managed-by" = "terraform"
+      "gpu-inference/tier"       = "training"
+    }
+  }
+
+  value             = var.training_priority
+  global_default    = false
+  preemption_policy = "PreemptLowerPriority"
+  description       = "High-priority class for distributed GPU training jobs (Volcano PodGroups, PyTorch DDP, DeepSpeed)."
+}
+
+# ── PriorityClass: gpu-inference-medium ─────────────────────────────────────
+resource "kubernetes_priority_class_v1" "gpu_inference_medium" {
+  metadata {
+    name = "gpu-inference-medium"
+    annotations = {
+      "gpu-inference/managed-by" = "terraform"
+      "gpu-inference/tier"       = "inference"
+    }
+  }
+
+  value             = var.inference_priority
+  global_default    = true
+  preemption_policy = "PreemptLowerPriority"
+  description       = "Default priority for real-time GPU inference workloads (vLLM, Triton Inference Server)."
+}
+
+# ── PriorityClass: gpu-batch-low ────────────────────────────────────────────
+resource "kubernetes_priority_class_v1" "gpu_batch_low" {
+  metadata {
+    name = "gpu-batch-low"
+    annotations = {
+      "gpu-inference/managed-by" = "terraform"
+      "gpu-inference/tier"       = "batch"
+    }
+  }
+
+  value             = var.batch_priority
+  global_default    = false
+  preemption_policy = "PreemptLowerPriority"
+  description       = "Low-priority class for batch/offline GPU scoring jobs. Preemptible by training and inference."
+}
+
+# ── Gang scheduling — Volcano PodGroup example ──────────────────────────────
+# Volcano PodGroup enforces gang scheduling: all `minMember` pods must be
+# schedulable simultaneously before any are allowed to start. This prevents
+# partial allocation dead-locks in multi-node distributed training.
+resource "kubernetes_manifest" "distributed_training_podgroup" {
+  manifest = {
+    apiVersion = "scheduling.volcano.sh/v1beta1"
+    kind       = "PodGroup"
+    metadata = {
+      name      = "distributed-training-example"
+      namespace = "gpu-training"
+      annotations = {
+        "gpu-inference/managed-by"  = "terraform"
+        "gpu-inference/description" = "Example 8-pod gang-scheduled PodGroup for distributed training"
+      }
+    }
+    spec = {
+      # All 8 pods must be schedulable simultaneously (gang guarantee)
+      minMember = var.example_podgroup_min_member
+
+      # Queue ties this group to a Volcano queue with binpack policy
+      queue = "gpu-training-queue"
+
+      # Priority class applied to the whole gang
+      priorityClassName = kubernetes_priority_class_v1.gpu_training_high.metadata[0].name
+
+      # Minimum aggregate resources the scheduler must reserve before starting any pod
+      minResources = {
+        "nvidia.com/gpu" = var.example_podgroup_min_resources_gpu
+        cpu              = "64"
+        memory           = "512Gi"
+      }
+    }
+  }
+
+  depends_on = [kubernetes_priority_class_v1.gpu_training_high]
+}
+
+# ── ResourceQuotas per namespace ─────────────────────────────────────────────
+resource "kubernetes_resource_quota_v1" "gpu_namespace_quota" {
+  for_each = var.enable_resource_quotas ? var.gpu_quota_namespaces : {}
+
+  metadata {
+    name      = "gpu-resource-quota"
+    namespace = each.key
+    annotations = {
+      "gpu-inference/managed-by" = "terraform"
+      "gpu-inference/tier"       = "quota"
+    }
+  }
+
+  spec {
+    hard = {
+      "requests.nvidia.com/gpu" = each.value.requests_gpu
+      "limits.nvidia.com/gpu"   = each.value.limits_gpu
+      "requests.cpu"            = each.value.requests_cpu
+      "limits.cpu"              = each.value.limits_cpu
+      "requests.memory"         = each.value.requests_mem
+      "limits.memory"           = each.value.limits_mem
+    }
+  }
+}

--- a/terraform/modules/gpu-inference-scheduling-policies/outputs.tf
+++ b/terraform/modules/gpu-inference-scheduling-policies/outputs.tf
@@ -1,0 +1,43 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference Scheduling Policies — Outputs
+# ---------------------------------------------------------------------------------------------------------------------
+
+output "priorityclass_system_critical" {
+  description = "Name of the gpu-system-critical PriorityClass"
+  value       = kubernetes_priority_class_v1.gpu_system_critical.metadata[0].name
+}
+
+output "priorityclass_training_high" {
+  description = "Name of the gpu-training-high PriorityClass"
+  value       = kubernetes_priority_class_v1.gpu_training_high.metadata[0].name
+}
+
+output "priorityclass_inference_medium" {
+  description = "Name of the gpu-inference-medium PriorityClass"
+  value       = kubernetes_priority_class_v1.gpu_inference_medium.metadata[0].name
+}
+
+output "priorityclass_batch_low" {
+  description = "Name of the gpu-batch-low PriorityClass"
+  value       = kubernetes_priority_class_v1.gpu_batch_low.metadata[0].name
+}
+
+output "priorityclass_names" {
+  description = "Map of all PriorityClass names keyed by tier"
+  value = {
+    system_critical  = kubernetes_priority_class_v1.gpu_system_critical.metadata[0].name
+    training_high    = kubernetes_priority_class_v1.gpu_training_high.metadata[0].name
+    inference_medium = kubernetes_priority_class_v1.gpu_inference_medium.metadata[0].name
+    batch_low        = kubernetes_priority_class_v1.gpu_batch_low.metadata[0].name
+  }
+}
+
+output "example_podgroup_name" {
+  description = "Name of the example gang-scheduled PodGroup"
+  value       = "distributed-training-example"
+}
+
+output "resource_quota_namespaces" {
+  description = "List of namespaces with GPU ResourceQuotas applied"
+  value       = var.enable_resource_quotas ? keys(var.gpu_quota_namespaces) : []
+}

--- a/terraform/modules/gpu-inference-scheduling-policies/variables.tf
+++ b/terraform/modules/gpu-inference-scheduling-policies/variables.tf
@@ -1,0 +1,83 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference Scheduling Policies — Variables
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "training_priority" {
+  description = "PriorityClass value for gpu-training-high workloads (distributed training jobs)"
+  type        = number
+  default     = 100000
+}
+
+variable "inference_priority" {
+  description = "PriorityClass value for gpu-inference-medium workloads (real-time inference)"
+  type        = number
+  default     = 50000
+}
+
+variable "batch_priority" {
+  description = "PriorityClass value for gpu-batch-low workloads (batch/offline jobs)"
+  type        = number
+  default     = 10000
+}
+
+variable "enable_resource_quotas" {
+  description = "Whether to create ResourceQuota objects per namespace limiting GPU allocation"
+  type        = bool
+  default     = true
+}
+
+variable "gpu_quota_namespaces" {
+  description = "Map of namespace => GPU resource quota settings"
+  type = map(object({
+    requests_gpu = string
+    limits_gpu   = string
+    requests_cpu = string
+    limits_cpu   = string
+    requests_mem = string
+    limits_mem   = string
+  }))
+  default = {
+    "gpu-training" = {
+      requests_gpu = "64"
+      limits_gpu   = "64"
+      requests_cpu = "2048"
+      limits_cpu   = "2048"
+      requests_mem = "8192Gi"
+      limits_mem   = "8192Gi"
+    }
+    "gpu-inference" = {
+      requests_gpu = "32"
+      limits_gpu   = "32"
+      requests_cpu = "1024"
+      limits_cpu   = "1024"
+      requests_mem = "4096Gi"
+      limits_mem   = "4096Gi"
+    }
+    "gpu-batch" = {
+      requests_gpu = "16"
+      limits_gpu   = "16"
+      requests_cpu = "512"
+      limits_cpu   = "512"
+      requests_mem = "2048Gi"
+      limits_mem   = "2048Gi"
+    }
+  }
+}
+
+variable "example_podgroup_min_member" {
+  description = "Minimum number of members for the example gang-scheduled PodGroup"
+  type        = number
+  default     = 8
+}
+
+variable "example_podgroup_min_resources_gpu" {
+  description = "Minimum GPU resources for the example training PodGroup"
+  type        = string
+  default     = "8"
+}
+
+variable "tags" {
+  description = "Common tags applied to all resources (passed to annotations)"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/gpu-inference-scheduling-policies/versions.tf
+++ b/terraform/modules/gpu-inference-scheduling-policies/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.25"
+    }
+  }
+}

--- a/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
+++ b/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
@@ -66,3 +66,8 @@ unit "gpu-inference-logging" {
   source = "${get_repo_root()}/catalog/units/gpu-inference-logging"
   path   = "gpu-inference-logging"
 }
+
+unit "gpu-inference-scheduling-policies" {
+  source = "${get_repo_root()}/catalog/units/gpu-inference-scheduling-policies"
+  path   = "gpu-inference-scheduling-policies"
+}


### PR DESCRIPTION
## Summary

- Adds four `PriorityClass` objects tiering GPU workloads: `gpu-system-critical` (1 000 000), `gpu-training-high` (100 000), `gpu-inference-medium` (50 000, globalDefault), `gpu-batch-low` (10 000)
- Adds a Volcano `PodGroup` example enforcing 8-pod gang scheduling for distributed training, with `gpu-training-queue` binpack policy to maximise NVLink bandwidth
- Adds per-namespace `ResourceQuota` objects capping GPU/CPU/memory for `gpu-training`, `gpu-inference`, and `gpu-batch` namespaces
- Wires everything through a new `gpu-inference-scheduling-policies` Terraform module + catalog unit, and registers the unit in the prod eu-west-1 gpu-inference stack

## Files changed

| Path | Description |
|------|-------------|
| `terraform/modules/gpu-inference-scheduling-policies/` | New module: PriorityClasses, PodGroup (kubernetes_manifest), ResourceQuotas |
| `catalog/units/gpu-inference-scheduling-policies/terragrunt.hcl` | Catalog unit — EKS dependency, k8s provider injection |
| `k8s/gpu-inference/scheduling/` | Raw YAML manifests for all four PriorityClasses + example PodGroup |
| `terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl` | Added `gpu-inference-scheduling-policies` unit to stack |

## Variables

| Variable | Default | Purpose |
|----------|---------|---------|
| `training_priority` | 100000 | PriorityClass value for training-high |
| `inference_priority` | 50000 | PriorityClass value for inference-medium |
| `batch_priority` | 10000 | PriorityClass value for batch-low |
| `enable_resource_quotas` | true | Toggle per-namespace GPU quotas |

## Test plan

- [ ] `terraform init && terraform validate` passes in `terraform/modules/gpu-inference-scheduling-policies/`
- [ ] `terraform fmt -check -recursive` clean
- [ ] `terragrunt hclfmt --check` clean on catalog unit and stack file
- [ ] `checkov` scan passes (soft-fail on Phase 1.1 checks)
- [ ] On a live cluster: confirm four PriorityClasses created, `globalDefault` set only on `gpu-inference-medium`
- [ ] Verify Volcano `PodGroup` gang constraint: partial pod set does not start until all 8 are schedulable
- [ ] Confirm `ResourceQuota` blocks GPU allocations exceeding per-namespace limits