### PR TITLE
feat: Kata Containers v3.22 + GPU Confidential Computing (#69)

### DIFF
--- a/catalog/units/gpu-inference-kata-cc/terragrunt.hcl
+++ b/catalog/units/gpu-inference-kata-cc/terragrunt.hcl
@@ -1,0 +1,74 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference Kata CC — Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys Kata Containers v3.22 RuntimeClass, CiliumNetworkPolicy, and
+# attestation ConfigMap for GPU Confidential Computing workloads on the
+# gpu-inference cluster.
+#
+# Kata CC wraps each pod in a hardware-attested micro-VM (TDX/SEV-SNP),
+# protecting GPU memory (model weights, KV cache, inference data) from
+# host-level access. Requires CC-capable GPU nodes labeled
+# nvidia.com/cc.enabled=true.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/gpu-inference-kata-cc"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  environment          = local.account_vars.locals.environment
+  aws_region           = local.region_vars.locals.aws_region
+  gpu_inference_config = try(local.account_vars.locals.gpu_inference_config, {})
+}
+
+dependency "eks" {
+  config_path = "../gpu-inference-eks"
+
+  mock_outputs = {
+    cluster_name                       = "mock-cluster"
+    cluster_endpoint                   = "https://mock-endpoint.eks.amazonaws.com"
+    cluster_certificate_authority_data = "bW9jay1jZXJ0LWRhdGE="
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+generate "k8s_providers" {
+  path      = "k8s_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "kubernetes" {
+      host                   = "${dependency.eks.outputs.cluster_endpoint}"
+      cluster_ca_certificate = base64decode("${dependency.eks.outputs.cluster_certificate_authority_data}")
+      exec {
+        api_version = "client.authentication.k8s.io/v1beta1"
+        command     = "aws"
+        args        = ["eks", "get-token", "--cluster-name", "${dependency.eks.outputs.cluster_name}"]
+      }
+    }
+  PROVIDERS
+}
+
+inputs = {
+  kata_version = "3.22.0"
+
+  # Attestation service — override per environment
+  attestation_service_url      = try(local.gpu_inference_config.kata_cc_attestation_url, "https://attestation.example.internal:8443")
+  attestation_tee_type         = try(local.gpu_inference_config.kata_cc_tee_type, "tdx")
+  attestation_policy_namespace = "gpu-inference-cc"
+
+  # Namespace where vLLM CC pods run
+  cc_namespace = "gpu-inference"
+  cc_app_label = "vllm-cc"
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-inference"
+    Feature     = "confidential-computing"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/k8s/gpu-inference/kata-cc/runtimeclass.yaml
+++ b/k8s/gpu-inference/kata-cc/runtimeclass.yaml
@@ -1,0 +1,43 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Kata Containers v3.22 — GPU Confidential Computing RuntimeClass
+# ---------------------------------------------------------------------------------------------------------------------
+# RuntimeClass for GPU workloads requiring hardware attestation (TDX / SEV-SNP).
+# Pods using runtimeClassName: kata-cc-gpu are scheduled exclusively onto nodes
+# labelled nvidia.com/cc.enabled=true and isolated inside Kata micro-VMs.
+#
+# Pod overhead accounts for the Kata agent and guest kernel memory, in addition
+# to the workload container's own resource requests.
+#
+# Usage:
+#   spec:
+#     runtimeClassName: kata-cc-gpu
+# ---------------------------------------------------------------------------------------------------------------------
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata-cc-gpu
+  annotations:
+    kata-containers.io/version: "3.22.0"
+    confidential-computing/tee: "tdx"
+    confidential-computing/vendor: "nvidia"
+# kata-cc is the handler registered by the Kata shim (containerd-shim-kata-v2)
+# in /etc/containerd/config.toml on each CC-capable node.
+handler: kata-cc
+# overhead added to every pod using this RuntimeClass on top of container requests/limits
+overhead:
+  podFixed:
+    cpu: 250m
+    memory: 160Mi
+scheduling:
+  # Tolerate GPU and Kata CC node taints so the scheduler allows placement
+  nodeClassification:
+    tolerated:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      - key: kata-cc
+        operator: Exists
+        effect: NoSchedule
+  # Only schedule on CC-capable nodes (labelled by the NVIDIA GPU Operator CC mode)
+  nodeSelector:
+    nvidia.com/cc.enabled: "true"

--- a/terraform/modules/gpu-inference-kata-cc/main.tf
+++ b/terraform/modules/gpu-inference-kata-cc/main.tf
@@ -1,0 +1,252 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference Kata CC — Kata Containers v3.22 + GPU Confidential Computing
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys Kata Containers v3.22 RuntimeClass for GPU Confidential Computing (CC)
+# workloads on the gpu-inference cluster. Kata CC isolates each pod in a
+# hardware-attested micro-VM (TDX or SEV-SNP), preventing host-level access
+# to GPU memory containing model weights and inference data.
+#
+# Resources:
+#   - RuntimeClass: kata-cc-gpu  — schedules pods onto CC-capable GPU nodes
+#   - CiliumNetworkPolicy         — restricts CC workload egress/ingress
+#   - ConfigMap: kata-cc-attestation-config — attestation service settings
+# ---------------------------------------------------------------------------------------------------------------------
+
+# RuntimeClass — kata-cc-gpu handler with pod overhead and CC node scheduling
+resource "kubernetes_manifest" "kata_cc_runtimeclass" {
+  manifest = {
+    apiVersion = "node.k8s.io/v1"
+    kind       = "RuntimeClass"
+    metadata = {
+      name = "kata-cc-gpu"
+      annotations = {
+        "kata-containers.io/version"    = var.kata_version
+        "confidential-computing/tee"    = var.attestation_tee_type
+        "confidential-computing/vendor" = "nvidia"
+      }
+    }
+    handler = "kata-cc"
+    overhead = {
+      podFixed = {
+        cpu    = "250m"
+        memory = "160Mi"
+      }
+    }
+    scheduling = {
+      nodeClassification = {
+        tolerated = [
+          {
+            key      = "nvidia.com/gpu"
+            operator = "Exists"
+            effect   = "NoSchedule"
+          },
+          {
+            key      = "kata-cc"
+            operator = "Exists"
+            effect   = "NoSchedule"
+          }
+        ]
+      }
+      nodeSelector = {
+        "nvidia.com/cc.enabled" = "true"
+      }
+    }
+  }
+}
+
+# CiliumNetworkPolicy — restrict CC workload egress/ingress to attestation and GPU peers
+resource "kubernetes_manifest" "kata_cc_network_policy" {
+  manifest = {
+    apiVersion = "cilium.io/v2"
+    kind       = "CiliumNetworkPolicy"
+    metadata = {
+      name      = "kata-cc-gpu-policy"
+      namespace = var.cc_namespace
+      labels = {
+        "app.kubernetes.io/name"      = "kata-cc-gpu"
+        "app.kubernetes.io/component" = "network-policy"
+      }
+    }
+    spec = {
+      endpointSelector = {
+        matchLabels = {
+          "app"                        = var.cc_app_label
+          "runtime.kata-containers.io" = "kata-cc"
+        }
+      }
+      # Ingress: allow only from within the same namespace and from kube-system monitoring
+      ingress = [
+        {
+          fromEndpoints = [
+            {
+              matchLabels = {
+                "k8s:io.kubernetes.pod.namespace" = var.cc_namespace
+              }
+            },
+            {
+              matchLabels = {
+                "k8s:io.kubernetes.pod.namespace" = "kube-system"
+                "app.kubernetes.io/name"          = "hubble-relay"
+              }
+            }
+          ]
+        }
+      ]
+      # Egress: allow to attestation service (HTTPS), Kubernetes API, and DNS
+      egress = [
+        {
+          # DNS resolution
+          toEndpoints = [
+            {
+              matchLabels = {
+                "k8s:io.kubernetes.pod.namespace" = "kube-system"
+                "k8s-app"                         = "kube-dns"
+              }
+            }
+          ]
+          toPorts = [
+            {
+              ports = [
+                {
+                  port     = "53"
+                  protocol = "UDP"
+                },
+                {
+                  port     = "53"
+                  protocol = "TCP"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          # Attestation service — HTTPS
+          toCIDR = ["0.0.0.0/0"]
+          toPorts = [
+            {
+              ports = [
+                {
+                  port     = "8443"
+                  protocol = "TCP"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          # Kubernetes API for pod metadata
+          toEntities = ["kube-apiserver"]
+          toPorts = [
+            {
+              ports = [
+                {
+                  port     = "443"
+                  protocol = "TCP"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          # Intra-namespace traffic (NCCL, vLLM tensor parallelism)
+          toEndpoints = [
+            {
+              matchLabels = {
+                "k8s:io.kubernetes.pod.namespace" = var.cc_namespace
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  depends_on = [kubernetes_manifest.kata_cc_runtimeclass]
+}
+
+# ConfigMap — attestation service configuration for Kata CC workloads
+resource "kubernetes_config_map_v1" "kata_cc_attestation_config" {
+  metadata {
+    name      = "kata-cc-attestation-config"
+    namespace = var.cc_namespace
+    labels = {
+      "app.kubernetes.io/name"      = "kata-cc-gpu"
+      "app.kubernetes.io/component" = "attestation-config"
+    }
+    annotations = {
+      "kata-containers.io/version" = var.kata_version
+      "confidential-computing/tee" = var.attestation_tee_type
+    }
+  }
+
+  data = {
+    "attestation.toml" = <<-EOT
+      # Kata Containers v${var.kata_version} — Confidential Computing Attestation
+      [agent.policy]
+      policy_namespace = "${var.attestation_policy_namespace}"
+
+      [attestation]
+      # Remote attestation service endpoint
+      service_url = "${var.attestation_service_url}"
+      tee_type    = "${var.attestation_tee_type}"
+
+      # Attestation retry settings
+      retry_max     = 5
+      retry_backoff = "2s"
+
+      # Evidence collection
+      collect_measurements = true
+      collect_eventlog     = true
+
+      [attestation.tls]
+      # Verify attestation service TLS certificate
+      verify_cert        = true
+      system_certs       = true
+      # Optional: pin expected server cert hash for pinning
+      # server_cert_hash = ""
+
+      [gpu]
+      # NVIDIA CC mode — require GPU attestation report in TEE evidence
+      require_gpu_attestation = true
+      driver_version_min      = "525.105"
+
+      [policy]
+      # OPA policy endpoint for attestation result enforcement
+      opa_endpoint       = "${var.attestation_service_url}/opa/v1"
+      opa_policy_path    = "/gpu/cc/allow"
+
+      [logging]
+      level  = "info"
+      format = "json"
+    EOT
+
+    "kata-configuration-cc.toml" = <<-EOT
+      # Kata Containers v${var.kata_version} — GPU CC Runtime Configuration
+      [hypervisor.qemu]
+      # Use QEMU with TDX/SEV-SNP support
+      path   = "/usr/bin/qemu-system-x86_64"
+      kernel = "/usr/share/kata-containers/vmlinuz-cc"
+      image  = "/usr/share/kata-containers/kata-cc.img"
+
+      # Memory encryption — TDX or SEV-SNP
+      confidential_guest = true
+
+      # GPU passthrough via VFIO
+      hotplug_vfio_on_root_bus = true
+      default_max_vcpus        = 192
+
+      # Memory for GPU workloads — model weights + KV cache
+      default_memory = 131072
+
+      [agent]
+      # Use vsock for host-guest communication
+      use_vsock  = true
+      log_level  = "info"
+
+      [runtime]
+      # Enable CC-specific runtime features
+      enable_cpu_memory_hotplug = false
+      sandbox_cgroup_only       = true
+    EOT
+  }
+}

--- a/terraform/modules/gpu-inference-kata-cc/outputs.tf
+++ b/terraform/modules/gpu-inference-kata-cc/outputs.tf
@@ -1,0 +1,29 @@
+output "runtimeclass_name" {
+  description = "Name of the Kata CC RuntimeClass"
+  value       = kubernetes_manifest.kata_cc_runtimeclass.manifest.metadata.name
+}
+
+output "runtimeclass_handler" {
+  description = "Kata CC handler name"
+  value       = kubernetes_manifest.kata_cc_runtimeclass.manifest.handler
+}
+
+output "network_policy_name" {
+  description = "Name of the CiliumNetworkPolicy for CC workloads"
+  value       = kubernetes_manifest.kata_cc_network_policy.manifest.metadata.name
+}
+
+output "attestation_configmap_name" {
+  description = "Name of the attestation configuration ConfigMap"
+  value       = kubernetes_config_map_v1.kata_cc_attestation_config.metadata[0].name
+}
+
+output "attestation_configmap_namespace" {
+  description = "Namespace of the attestation configuration ConfigMap"
+  value       = kubernetes_config_map_v1.kata_cc_attestation_config.metadata[0].namespace
+}
+
+output "kata_version" {
+  description = "Kata Containers version deployed"
+  value       = var.kata_version
+}

--- a/terraform/modules/gpu-inference-kata-cc/variables.tf
+++ b/terraform/modules/gpu-inference-kata-cc/variables.tf
@@ -1,0 +1,41 @@
+variable "kata_version" {
+  description = "Kata Containers version to reference in annotations"
+  type        = string
+  default     = "3.22.0"
+}
+
+variable "attestation_service_url" {
+  description = "URL of the remote attestation service for CC workloads"
+  type        = string
+  default     = "https://attestation.example.internal:8443"
+}
+
+variable "attestation_tee_type" {
+  description = "Trusted Execution Environment type (tdx, sev-snp)"
+  type        = string
+  default     = "tdx"
+}
+
+variable "attestation_policy_namespace" {
+  description = "OPA policy namespace for attestation enforcement"
+  type        = string
+  default     = "gpu-inference-cc"
+}
+
+variable "cc_namespace" {
+  description = "Kubernetes namespace for CC workloads (used for network policy)"
+  type        = string
+  default     = "gpu-inference"
+}
+
+variable "cc_app_label" {
+  description = "Value of app label to match CC workload pods for network policy"
+  type        = string
+  default     = "vllm-cc"
+}
+
+variable "tags" {
+  description = "Tags to apply to resources (stored in ConfigMap annotations)"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/gpu-inference-kata-cc/versions.tf
+++ b/terraform/modules/gpu-inference-kata-cc/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.25"
+    }
+  }
+}

--- a/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
+++ b/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
@@ -36,3 +36,8 @@ unit "gpu-inference-gpu-operator" {
   source = "${get_repo_root()}/catalog/units/gpu-inference-gpu-operator"
   path   = "gpu-inference-gpu-operator"
 }
+
+unit "gpu-inference-kata-cc" {
+  source = "${get_repo_root()}/catalog/units/gpu-inference-kata-cc"
+  path   = "gpu-inference-kata-cc"
+}


### PR DESCRIPTION
## Summary

- Deploys Kata Containers v3.22 RuntimeClass (`kata-cc-gpu`) for the gpu-inference cluster, isolating vLLM pods inside hardware-attested micro-VMs (TDX / SEV-SNP) to protect GPU memory containing model weights and KV cache
- CiliumNetworkPolicy restricts CC workload egress to attestation service (`:8443`), Kubernetes API, and intra-namespace peers only; ingress limited to same namespace and Hubble relay
- Attestation ConfigMap (`kata-cc-attestation-config`) carries runtime configuration for remote attestation service, OPA policy endpoint, and Kata hypervisor settings

## Files

| Path | Purpose |
|------|---------|
| `terraform/modules/gpu-inference-kata-cc/` | Terraform module: RuntimeClass, CiliumNetworkPolicy, ConfigMap |
| `catalog/units/gpu-inference-kata-cc/terragrunt.hcl` | Catalog unit with EKS dependency + kubernetes provider generation |
| `k8s/gpu-inference/kata-cc/runtimeclass.yaml` | Standalone RuntimeClass manifest for GitOps |
| `terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl` | Stack updated with `gpu-inference-kata-cc` unit |

## RuntimeClass spec

```yaml
handler: kata-cc
overhead:
  podFixed:
    cpu: 250m
    memory: 160Mi
scheduling:
  nodeSelector:
    nvidia.com/cc.enabled: "true"
  nodeClassification:
    tolerated:
      - key: nvidia.com/gpu
      - key: kata-cc
```

## Test plan

- [ ] `terraform validate` passes in `terraform/modules/gpu-inference-kata-cc/`
- [ ] `terragrunt plan` with mock EKS outputs produces expected RuntimeClass, CiliumNetworkPolicy, ConfigMap resources
- [ ] RuntimeClass appears in cluster: `kubectl get runtimeclass kata-cc-gpu`
- [ ] CC workload pod with `runtimeClassName: kata-cc-gpu` schedules on `nvidia.com/cc.enabled=true` nodes
- [ ] Network policy denies egress to non-attestation endpoints; allows DNS and intra-namespace NCCL traffic
- [ ] Attestation ConfigMap key `attestation.toml` parses cleanly with `toml` linter