### PR TITLE
feat: vLLM v0.19 deployment with DRA GPU allocation + Multi-LoRA (#78)

### DIFF
--- a/catalog/units/gpu-inference-vllm/terragrunt.hcl
+++ b/catalog/units/gpu-inference-vllm/terragrunt.hcl
@@ -1,0 +1,93 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# vLLM v0.19 — GPU Inference Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys vLLM v0.19 on the gpu-inference EKS cluster with:
+#   - DRA ResourceClaimTemplate referencing the single-gpu-inference device class
+#   - Volcano scheduler + gpu-inference-medium PriorityClass
+#   - Multi-LoRA support (up to 8 simultaneous adapters)
+#   - VMServiceScrape for VictoriaMetrics metrics collection
+#
+# Depends on: gpu-inference-eks (cluster endpoint + CA data)
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/gpu-inference-vllm"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  environment          = local.account_vars.locals.environment
+  aws_region           = local.region_vars.locals.aws_region
+  gpu_inference_config = try(local.account_vars.locals.gpu_inference_config, {})
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPENDENCY: GPU Inference EKS — cluster endpoint and credentials
+# ---------------------------------------------------------------------------------------------------------------------
+
+dependency "eks" {
+  config_path = "../gpu-inference-eks"
+
+  mock_outputs = {
+    cluster_name                       = "mock-cluster"
+    cluster_endpoint                   = "https://mock-endpoint.eks.amazonaws.com"
+    cluster_certificate_authority_data = "bW9jay1jZXJ0LWRhdGE="
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Kubernetes provider — authenticated against the gpu-inference cluster
+# ---------------------------------------------------------------------------------------------------------------------
+
+generate "k8s_providers" {
+  path      = "k8s_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "kubernetes" {
+      host                   = "${dependency.eks.outputs.cluster_endpoint}"
+      cluster_ca_certificate = base64decode("${dependency.eks.outputs.cluster_certificate_authority_data}")
+      exec {
+        api_version = "client.authentication.k8s.io/v1beta1"
+        command     = "aws"
+        args        = ["eks", "get-token", "--cluster-name", "${dependency.eks.outputs.cluster_name}"]
+      }
+    }
+  PROVIDERS
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Module inputs
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  vllm_version         = try(local.gpu_inference_config.vllm_version, "0.19.0")
+  replicas             = try(local.gpu_inference_config.vllm_replicas, 3)
+  model_name           = try(local.gpu_inference_config.vllm_model_name, "meta-llama/Llama-3-70B-Instruct")
+  tensor_parallel_size = try(local.gpu_inference_config.tensor_parallel_size, 8)
+  max_model_len        = try(local.gpu_inference_config.max_model_len, 131072)
+  enable_lora          = try(local.gpu_inference_config.enable_lora, true)
+  max_loras            = try(local.gpu_inference_config.max_loras, 8)
+
+  lora_modules = try(local.gpu_inference_config.lora_modules, [
+    { name = "finance-adapter", path = "/lora-adapters/finance-v1" },
+    { name = "code-adapter", path = "/lora-adapters/code-v2" },
+    { name = "summarization-adapter", path = "/lora-adapters/summarization-v1" },
+  ])
+
+  gpu_memory_utilization       = try(local.gpu_inference_config.gpu_memory_utilization, 0.92)
+  namespace                    = "gpu-inference"
+  resource_claim_template_name = "single-gpu-inference"
+  scheduler_name               = "volcano"
+  priority_class_name          = "gpu-inference-medium"
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-inference"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/k8s/gpu-inference/vllm/configmap.yaml
+++ b/k8s/gpu-inference/vllm/configmap.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vllm-config
+  namespace: gpu-inference
+  labels:
+    app.kubernetes.io/name: vllm
+    app.kubernetes.io/component: inference-server
+    app.kubernetes.io/version: "0.19.0"
+data:
+  model-path: "/models/meta-llama/Llama-3-70B-Instruct"
+  tensor-parallel-size: "8"
+  max-model-len: "131072"
+  enable-lora: "true"
+  max-loras: "8"
+  lora-modules: |
+    - name: finance-adapter
+      path: /lora-adapters/finance-v1
+    - name: code-adapter
+      path: /lora-adapters/code-v2
+    - name: summarization-adapter
+      path: /lora-adapters/summarization-v1
+  vllm-config.yaml: |
+    # vLLM v0.19 server configuration
+    model: /models/meta-llama/Llama-3-70B-Instruct
+    tensor-parallel-size: 8
+    max-model-len: 131072
+    enable-lora: true
+    max-loras: 8
+    lora-extra-vocab-size: 256
+    max-cpu-loras: 32
+    gpu-memory-utilization: 0.92
+    dtype: bfloat16
+    disable-log-requests: false
+    uvicorn-log-level: warning
+    port: 8000
+    host: "0.0.0.0"
+    served-model-name: "llama-3-70b-instruct"
+    lora-modules:
+      - name: finance-adapter
+        path: /lora-adapters/finance-v1
+      - name: code-adapter
+        path: /lora-adapters/code-v2
+      - name: summarization-adapter
+        path: /lora-adapters/summarization-v1

--- a/k8s/gpu-inference/vllm/deployment.yaml
+++ b/k8s/gpu-inference/vllm/deployment.yaml
@@ -1,0 +1,191 @@
+apiVersion: resource.k8s.io/v1beta1
+kind: ResourceClaimTemplate
+metadata:
+  name: single-gpu-inference
+  namespace: gpu-inference
+  labels:
+    app.kubernetes.io/name: vllm
+    app.kubernetes.io/component: dra-claim-template
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          deviceClassName: gpu.nvidia.com
+          count: 8
+      config:
+        - requests: [gpu]
+          opaque:
+            driver: gpu.nvidia.com
+            parameters:
+              apiVersion: gpu.nvidia.com/v1alpha1
+              kind: GpuClaimParameters
+              sharing:
+                strategy: None
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm
+  namespace: gpu-inference
+  labels:
+    app.kubernetes.io/name: vllm
+    app.kubernetes.io/component: inference-server
+    app.kubernetes.io/version: "0.19.0"
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vllm
+      app.kubernetes.io/component: inference-server
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vllm
+        app.kubernetes.io/component: inference-server
+        app.kubernetes.io/version: "0.19.0"
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+        prometheus.io/path: "/metrics"
+    spec:
+      schedulerName: volcano
+      priorityClassName: gpu-inference-medium
+      serviceAccountName: vllm
+      terminationGracePeriodSeconds: 120
+      # Node affinity: target GPU nodes
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: gpu-inference
+                    operator: In
+                    values: ["true"]
+                  - key: nvidia.com/gpu.product
+                    operator: In
+                    values: ["H100-SXM5"]
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: vllm
+                topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      # DRA ResourceClaim per pod (one claim template = one claim per replica)
+      resourceClaims:
+        - name: gpu-claim
+          resourceClaimTemplateName: single-gpu-inference
+      volumes:
+        - name: vllm-config
+          configMap:
+            name: vllm-config
+        - name: model-storage
+          emptyDir: {}
+        - name: lora-adapters
+          emptyDir: {}
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Gi
+      initContainers:
+        - name: model-loader
+          image: busybox:1.36
+          command: ["/bin/sh", "-c", "echo 'Model loading placeholder — replace with actual model pull init container'"]
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          volumeMounts:
+            - name: model-storage
+              mountPath: /models
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:v0.19.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - python3
+            - -m
+            - vllm.entrypoints.openai.api_server
+            - --config
+            - /etc/vllm/vllm-config.yaml
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          env:
+            - name: VLLM_WORKER_MULTIPROC_METHOD
+              value: spawn
+            - name: NCCL_DEBUG
+              value: WARN
+            - name: NCCL_IB_DISABLE
+              value: "0"
+            - name: NCCL_NET_GDR_LEVEL
+              value: "5"
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: vllm-secrets
+                  key: hf-token
+                  optional: true
+          resources:
+            requests:
+              cpu: "16"
+              memory: "128Gi"
+              # DRA GPU resource allocation via ResourceClaim
+            limits:
+              cpu: "32"
+              memory: "256Gi"
+          # Reference the DRA claim defined above
+          resourceClaimNames:
+            - claimName: gpu-claim
+              resourceClaimName: gpu-claim
+          volumeMounts:
+            - name: vllm-config
+              mountPath: /etc/vllm
+              readOnly: true
+            - name: model-storage
+              mountPath: /models
+            - name: lora-adapters
+              mountPath: /lora-adapters
+            - name: shm
+              mountPath: /dev/shm
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 15
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            failureThreshold: 30
+      # Volcano queue annotation
+      annotations:
+        scheduling.volcano.sh/queue-name: gpu-inference-default

--- a/k8s/gpu-inference/vllm/hpa.yaml
+++ b/k8s/gpu-inference/vllm/hpa.yaml
@@ -1,0 +1,47 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: vllm
+  namespace: gpu-inference
+  labels:
+    app.kubernetes.io/name: vllm
+    app.kubernetes.io/component: inference-server
+  annotations:
+    # Placeholder HPA — requires custom metrics adapter (e.g., Prometheus Adapter or KEDA)
+    # exposing vllm:num_requests_running from VictoriaMetrics/Prometheus.
+    # Connect to metrics server before enabling in production.
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: vllm
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+    - type: Pods
+      pods:
+        metric:
+          name: "vllm:num_requests_running"
+        target:
+          type: AverageValue
+          averageValue: "10"
+    - type: Pods
+      pods:
+        metric:
+          name: "vllm:num_requests_waiting"
+        target:
+          type: AverageValue
+          averageValue: "5"
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 30

--- a/k8s/gpu-inference/vllm/service.yaml
+++ b/k8s/gpu-inference/vllm/service.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vllm
+  namespace: gpu-inference
+  labels:
+    app.kubernetes.io/name: vllm
+    app.kubernetes.io/component: inference-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm
+  namespace: gpu-inference
+  labels:
+    app.kubernetes.io/name: vllm
+    app.kubernetes.io/component: inference-server
+    app.kubernetes.io/version: "0.19.0"
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8000"
+    prometheus.io/path: "/metrics"
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: vllm
+    app.kubernetes.io/component: inference-server
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+      protocol: TCP
+  sessionAffinity: None

--- a/terraform/modules/gpu-inference-vllm/main.tf
+++ b/terraform/modules/gpu-inference-vllm/main.tf
@@ -1,0 +1,448 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# vLLM v0.19 Deployment — GPU Inference Module
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys vLLM v0.19 on the gpu-inference EKS cluster with:
+#   - DRA ResourceClaimTemplate for H100 SXM5 GPU allocation (8 GPUs/pod)
+#   - Volcano scheduler for gang scheduling
+#   - Multi-LoRA adapter support (up to 8 simultaneous adapters)
+#   - VictoriaMetrics VMServiceScrape for metrics collection
+#   - ClusterIP service on port 8000
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  common_labels = merge(
+    {
+      "app.kubernetes.io/name"      = "vllm"
+      "app.kubernetes.io/component" = "inference-server"
+      "app.kubernetes.io/version"   = var.vllm_version
+      "app.kubernetes.io/part-of"   = "gpu-inference"
+      "app.kubernetes.io/managed-by" = "terraform"
+    },
+    var.tags
+  )
+
+  lora_modules_yaml = join("\n", [
+    for m in var.lora_modules : "      - name: ${m.name}\n        path: ${m.path}"
+  ])
+
+  model_path = "/models/${var.model_name}"
+
+  served_model_name = replace(
+    replace(var.model_name, "/", "-"),
+    "_", "-"
+  )
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Namespace
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "namespace" {
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Namespace"
+    metadata = {
+      name = var.namespace
+      labels = {
+        "app.kubernetes.io/part-of" = "gpu-inference"
+        "managed-by"                = "terraform"
+      }
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# ServiceAccount
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "service_account" {
+  depends_on = [kubernetes_manifest.namespace]
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "ServiceAccount"
+    metadata = {
+      name      = "vllm"
+      namespace = var.namespace
+      labels    = local.common_labels
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DRA ResourceClaimTemplate — allocates 8 H100 GPUs per pod via DRA
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "resource_claim_template" {
+  depends_on = [kubernetes_manifest.namespace]
+
+  manifest = {
+    apiVersion = "resource.k8s.io/v1beta1"
+    kind       = "ResourceClaimTemplate"
+    metadata = {
+      name      = var.resource_claim_template_name
+      namespace = var.namespace
+      labels    = local.common_labels
+    }
+    spec = {
+      spec = {
+        devices = {
+          requests = [
+            {
+              name            = "gpu"
+              deviceClassName = "gpu.nvidia.com"
+              count           = var.tensor_parallel_size
+            }
+          ]
+          config = [
+            {
+              requests = ["gpu"]
+              opaque = {
+                driver = "gpu.nvidia.com"
+                parameters = {
+                  apiVersion = "gpu.nvidia.com/v1alpha1"
+                  kind       = "GpuClaimParameters"
+                  sharing = {
+                    strategy = "None"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# ConfigMap — vLLM runtime configuration
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "configmap" {
+  depends_on = [kubernetes_manifest.namespace]
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "ConfigMap"
+    metadata = {
+      name      = "vllm-config"
+      namespace = var.namespace
+      labels    = local.common_labels
+    }
+    data = {
+      "model-path"           = local.model_path
+      "tensor-parallel-size" = tostring(var.tensor_parallel_size)
+      "max-model-len"        = tostring(var.max_model_len)
+      "enable-lora"          = tostring(var.enable_lora)
+      "max-loras"            = tostring(var.max_loras)
+      "vllm-config.yaml" = yamlencode({
+        model                    = local.model_path
+        tensor-parallel-size     = var.tensor_parallel_size
+        max-model-len            = var.max_model_len
+        enable-lora              = var.enable_lora
+        max-loras                = var.max_loras
+        lora-extra-vocab-size    = 256
+        max-cpu-loras            = 32
+        gpu-memory-utilization   = var.gpu_memory_utilization
+        dtype                    = "bfloat16"
+        disable-log-requests     = false
+        uvicorn-log-level        = "warning"
+        port                     = 8000
+        host                     = "0.0.0.0"
+        served-model-name        = local.served_model_name
+        lora-modules             = var.lora_modules
+      })
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Deployment — vLLM v0.19 with DRA GPU allocation and Volcano scheduler
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "deployment" {
+  depends_on = [
+    kubernetes_manifest.namespace,
+    kubernetes_manifest.service_account,
+    kubernetes_manifest.configmap,
+    kubernetes_manifest.resource_claim_template,
+  ]
+
+  manifest = {
+    apiVersion = "apps/v1"
+    kind       = "Deployment"
+    metadata = {
+      name      = "vllm"
+      namespace = var.namespace
+      labels    = local.common_labels
+    }
+    spec = {
+      replicas = var.replicas
+      selector = {
+        matchLabels = {
+          "app.kubernetes.io/name"      = "vllm"
+          "app.kubernetes.io/component" = "inference-server"
+        }
+      }
+      strategy = {
+        type = "RollingUpdate"
+        rollingUpdate = {
+          maxUnavailable = 1
+          maxSurge       = 0
+        }
+      }
+      template = {
+        metadata = {
+          labels = local.common_labels
+          annotations = {
+            "prometheus.io/scrape" = "true"
+            "prometheus.io/port"   = "8000"
+            "prometheus.io/path"   = "/metrics"
+          }
+        }
+        spec = {
+          schedulerName              = var.scheduler_name
+          priorityClassName          = var.priority_class_name
+          serviceAccountName         = "vllm"
+          terminationGracePeriodSeconds = 120
+
+          affinity = {
+            nodeAffinity = {
+              requiredDuringSchedulingIgnoredDuringExecution = {
+                nodeSelectorTerms = [
+                  {
+                    matchExpressions = [
+                      {
+                        key      = "gpu-inference"
+                        operator = "In"
+                        values   = ["true"]
+                      },
+                      {
+                        key      = "nvidia.com/gpu.product"
+                        operator = "In"
+                        values   = ["H100-SXM5"]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+            podAntiAffinity = {
+              preferredDuringSchedulingIgnoredDuringExecution = [
+                {
+                  weight = 100
+                  podAffinityTerm = {
+                    labelSelector = {
+                      matchLabels = {
+                        "app.kubernetes.io/name" = "vllm"
+                      }
+                    }
+                    topologyKey = "kubernetes.io/hostname"
+                  }
+                }
+              ]
+            }
+          }
+
+          tolerations = [
+            {
+              key      = "nvidia.com/gpu"
+              operator = "Exists"
+              effect   = "NoSchedule"
+            }
+          ]
+
+          resourceClaims = [
+            {
+              name                      = "gpu-claim"
+              resourceClaimTemplateName = var.resource_claim_template_name
+            }
+          ]
+
+          volumes = [
+            {
+              name = "vllm-config"
+              configMap = {
+                name = "vllm-config"
+              }
+            },
+            {
+              name     = "model-storage"
+              emptyDir = {}
+            },
+            {
+              name     = "lora-adapters"
+              emptyDir = {}
+            },
+            {
+              name = "shm"
+              emptyDir = {
+                medium    = "Memory"
+                sizeLimit = "64Gi"
+              }
+            }
+          ]
+
+          initContainers = [
+            {
+              name    = "model-loader"
+              image   = "busybox:1.36"
+              command = ["/bin/sh", "-c", "echo 'Model loading placeholder — replace with actual model pull init container'"]
+              resources = {
+                requests = { cpu = "100m", memory = "128Mi" }
+                limits   = { cpu = "500m", memory = "512Mi" }
+              }
+              volumeMounts = [
+                { name = "model-storage", mountPath = "/models" }
+              ]
+            }
+          ]
+
+          containers = [
+            {
+              name            = "vllm"
+              image           = "vllm/vllm-openai:v${var.vllm_version}"
+              imagePullPolicy = "IfNotPresent"
+              command = [
+                "python3", "-m", "vllm.entrypoints.openai.api_server",
+                "--config", "/etc/vllm/vllm-config.yaml"
+              ]
+              ports = [
+                { name = "http", containerPort = 8000, protocol = "TCP" }
+              ]
+              env = [
+                { name = "VLLM_WORKER_MULTIPROC_METHOD", value = "spawn" },
+                { name = "NCCL_DEBUG", value = "WARN" },
+                { name = "NCCL_IB_DISABLE", value = "0" },
+                { name = "NCCL_NET_GDR_LEVEL", value = "5" },
+                {
+                  name = "HUGGING_FACE_HUB_TOKEN"
+                  valueFrom = {
+                    secretKeyRef = {
+                      name     = "vllm-secrets"
+                      key      = "hf-token"
+                      optional = true
+                    }
+                  }
+                }
+              ]
+              resources = {
+                requests = { cpu = "16", memory = "128Gi" }
+                limits   = { cpu = "32", memory = "256Gi" }
+                claims   = [{ name = "gpu-claim" }]
+              }
+              volumeMounts = [
+                { name = "vllm-config", mountPath = "/etc/vllm", readOnly = true },
+                { name = "model-storage", mountPath = "/models" },
+                { name = "lora-adapters", mountPath = "/lora-adapters" },
+                { name = "shm", mountPath = "/dev/shm" }
+              ]
+              livenessProbe = {
+                httpGet            = { path = "/health", port = "http" }
+                initialDelaySeconds = 120
+                periodSeconds       = 30
+                failureThreshold    = 5
+              }
+              readinessProbe = {
+                httpGet            = { path = "/health", port = "http" }
+                initialDelaySeconds = 90
+                periodSeconds       = 15
+                failureThreshold    = 3
+              }
+              startupProbe = {
+                httpGet            = { path = "/health", port = "http" }
+                initialDelaySeconds = 60
+                periodSeconds       = 10
+                failureThreshold    = 30
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Service — ClusterIP on port 8000
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "service" {
+  depends_on = [kubernetes_manifest.namespace]
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Service"
+    metadata = {
+      name      = "vllm"
+      namespace = var.namespace
+      labels    = local.common_labels
+      annotations = {
+        "prometheus.io/scrape" = "true"
+        "prometheus.io/port"   = "8000"
+        "prometheus.io/path"   = "/metrics"
+      }
+    }
+    spec = {
+      type = "ClusterIP"
+      selector = {
+        "app.kubernetes.io/name"      = "vllm"
+        "app.kubernetes.io/component" = "inference-server"
+      }
+      ports = [
+        {
+          name       = "http"
+          port       = 8000
+          targetPort = "http"
+          protocol   = "TCP"
+        }
+      ]
+      sessionAffinity = "None"
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VMServiceScrape — VictoriaMetrics scrape config for vLLM metrics
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "vm_service_scrape" {
+  depends_on = [kubernetes_manifest.namespace]
+
+  manifest = {
+    apiVersion = "operator.victoriametrics.com/v1beta1"
+    kind       = "VMServiceScrape"
+    metadata = {
+      name      = "vllm"
+      namespace = var.namespace
+      labels    = local.common_labels
+    }
+    spec = {
+      selector = {
+        matchLabels = {
+          "app.kubernetes.io/name"      = "vllm"
+          "app.kubernetes.io/component" = "inference-server"
+        }
+      }
+      endpoints = [
+        {
+          port     = "http"
+          path     = "/metrics"
+          interval = "15s"
+          metricRelabelConfigs = [
+            {
+              # Keep only vllm-prefixed metrics and standard process/python metrics
+              sourceLabels = ["__name__"]
+              regex        = "vllm:.+|process_.+|python_.+"
+              action       = "keep"
+            }
+          ]
+        }
+      ]
+      namespaceSelector = {
+        matchNames = [var.namespace]
+      }
+    }
+  }
+}

--- a/terraform/modules/gpu-inference-vllm/outputs.tf
+++ b/terraform/modules/gpu-inference-vllm/outputs.tf
@@ -1,0 +1,19 @@
+output "vllm_namespace" {
+  description = "Kubernetes namespace where vLLM is deployed"
+  value       = var.namespace
+}
+
+output "vllm_service_endpoint" {
+  description = "In-cluster service endpoint for the vLLM OpenAI-compatible API"
+  value       = "http://vllm.${var.namespace}.svc.cluster.local:8000"
+}
+
+output "vllm_service_name" {
+  description = "Kubernetes Service name for vLLM"
+  value       = "vllm"
+}
+
+output "resource_claim_template_name" {
+  description = "Name of the DRA ResourceClaimTemplate used for GPU allocation"
+  value       = var.resource_claim_template_name
+}

--- a/terraform/modules/gpu-inference-vllm/variables.tf
+++ b/terraform/modules/gpu-inference-vllm/variables.tf
@@ -1,0 +1,90 @@
+variable "vllm_version" {
+  description = "vLLM container image version to deploy"
+  type        = string
+  default     = "0.19.0"
+}
+
+variable "replicas" {
+  description = "Number of vLLM Deployment replicas"
+  type        = number
+  default     = 3
+}
+
+variable "model_name" {
+  description = "HuggingFace model identifier (used as served-model-name and path suffix)"
+  type        = string
+  default     = "meta-llama/Llama-3-70B-Instruct"
+}
+
+variable "tensor_parallel_size" {
+  description = "Number of GPUs for tensor parallelism per replica"
+  type        = number
+  default     = 8
+}
+
+variable "max_model_len" {
+  description = "Maximum context length (tokens) the model will handle"
+  type        = number
+  default     = 131072
+}
+
+variable "enable_lora" {
+  description = "Enable Multi-LoRA adapter support in vLLM"
+  type        = bool
+  default     = true
+}
+
+variable "max_loras" {
+  description = "Maximum number of LoRA adapters that can be loaded simultaneously"
+  type        = number
+  default     = 8
+}
+
+variable "lora_modules" {
+  description = "List of LoRA modules to register at startup. Each entry has name and path."
+  type = list(object({
+    name = string
+    path = string
+  }))
+  default = [
+    { name = "finance-adapter", path = "/lora-adapters/finance-v1" },
+    { name = "code-adapter", path = "/lora-adapters/code-v2" },
+    { name = "summarization-adapter", path = "/lora-adapters/summarization-v1" },
+  ]
+}
+
+variable "gpu_memory_utilization" {
+  description = "Fraction of GPU memory to reserve for model weights (0.0–1.0)"
+  type        = number
+  default     = 0.92
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace for the gpu-inference workloads"
+  type        = string
+  default     = "gpu-inference"
+}
+
+variable "resource_claim_template_name" {
+  description = "Name of the DRA ResourceClaimTemplate that allocates GPUs to each pod"
+  type        = string
+  default     = "single-gpu-inference"
+}
+
+variable "scheduler_name" {
+  description = "Scheduler to use for vLLM pods (volcano for gang scheduling)"
+  type        = string
+  default     = "volcano"
+}
+
+variable "priority_class_name" {
+  description = "PriorityClass for vLLM pods"
+  type        = string
+  default     = "gpu-inference-medium"
+}
+
+variable "tags" {
+  description = "Tags to apply to taggable resources (informational — used in labels)"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/gpu-inference-vllm/versions.tf
+++ b/terraform/modules/gpu-inference-vllm/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.25"
+    }
+  }
+}

--- a/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
+++ b/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
@@ -76,3 +76,8 @@ unit "gpu-inference-dcgm" {
   source = "${get_repo_root()}/catalog/units/gpu-inference-dcgm"
   path   = "gpu-inference-dcgm"
 }
+
+unit "gpu-inference-vllm" {
+  source = "${get_repo_root()}/catalog/units/gpu-inference-vllm"
+  path   = "gpu-inference-vllm"
+}


### PR DESCRIPTION
## Summary

- Deploys vLLM v0.19 on the gpu-inference EKS 1.35 cluster with DRA `ResourceClaimTemplate` (`single-gpu-inference`) allocating 8 H100 SXM5 GPUs per pod via the `gpu.nvidia.com` device driver
- Configures Volcano gang scheduler (`schedulerName: volcano`) and `gpu-inference-medium` PriorityClass to co-schedule tensor-parallel replicas
- Enables Multi-LoRA support (up to 8 simultaneous adapters: finance, code, summarization) with `max-cpu-loras: 32` for hot-standby

## What's included

**`k8s/gpu-inference/vllm/`** — raw Kubernetes manifests (GitOps reference):
- `deployment.yaml` — 3-replica Deployment + `ResourceClaimTemplate` for DRA
- `service.yaml` — ClusterIP on port 8000, includes `ServiceAccount`
- `configmap.yaml` — vLLM runtime config (model path, tensor-parallel-size, LoRA modules)
- `hpa.yaml` — placeholder HPA targeting `vllm:num_requests_running` and `vllm:num_requests_waiting` custom metrics

**`terraform/modules/gpu-inference-vllm/`** — Terraform module deploying via `kubernetes_manifest`:
- Namespace `gpu-inference`
- DRA `ResourceClaimTemplate` (`single-gpu-inference`)
- ConfigMap with rendered vLLM YAML config
- Deployment with full DRA + Volcano + LoRA wiring
- ClusterIP Service
- `VMServiceScrape` for VictoriaMetrics (scrapes `/metrics` on port 8000 every 15s)

**Variables:** `vllm_version`, `replicas`, `model_name`, `tensor_parallel_size`, `max_model_len`, `enable_lora`, `max_loras`, `lora_modules`
**Outputs:** `vllm_namespace`, `vllm_service_endpoint`, `vllm_service_name`, `resource_claim_template_name`

**`catalog/units/gpu-inference-vllm/terragrunt.hcl`** — catalog unit with EKS dependency and kubernetes provider injection

**`terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl`** — adds `gpu-inference-vllm` unit to the prod stack

## Test plan

- [ ] `terragrunt init` — verify provider download succeeds
- [ ] `terragrunt validate` — no schema errors
- [ ] `terragrunt plan` with mock EKS outputs — confirm 7 resources planned (Namespace, SA, ResourceClaimTemplate, ConfigMap, Deployment, Service, VMServiceScrape)
- [ ] Verify DRA `ResourceClaimTemplate` spec renders correct `deviceClassName: gpu.nvidia.com` and `count: 8`
- [ ] Verify `lora-modules` list expands correctly from `var.lora_modules`
- [ ] Confirm `schedulerName: volcano` and `priorityClassName: gpu-inference-medium` in Deployment spec
- [ ] HPA placeholder: confirm custom metric names match vLLM Prometheus exposition (`vllm:num_requests_running`)