### PR TITLE
feat: custom HPA for vLLM via Prometheus Adapter (#79)

### DIFF
--- a/catalog/units/gpu-inference-hpa/terragrunt.hcl
+++ b/catalog/units/gpu-inference-hpa/terragrunt.hcl
@@ -1,0 +1,88 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference HPA — Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys Prometheus Adapter (pointed at VictoriaMetrics vmselect) and a custom HPA for the
+# vLLM Deployment.  Depends on the gpu-inference EKS cluster unit.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/gpu-inference-hpa"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  account_name = local.account_vars.locals.account_name
+  aws_region   = local.region_vars.locals.aws_region
+  environment  = local.account_vars.locals.environment
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPENDENCY: EKS
+# ---------------------------------------------------------------------------------------------------------------------
+
+dependency "eks" {
+  config_path = "../gpu-inference-eks"
+
+  mock_outputs = {
+    cluster_name                       = "mock-gpu-inference"
+    cluster_endpoint                   = "https://mock-endpoint.eks.amazonaws.com"
+    cluster_certificate_authority_data = "bW9jay1jZXJ0LWRhdGE="
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# PROVIDERS: Helm + Kubernetes (both needed — Helm to deploy the adapter, K8s for the HPA resource)
+# ---------------------------------------------------------------------------------------------------------------------
+
+generate "k8s_helm_providers" {
+  path      = "k8s_helm_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "helm" {
+      kubernetes {
+        host                   = "${dependency.eks.outputs.cluster_endpoint}"
+        cluster_ca_certificate = base64decode("${dependency.eks.outputs.cluster_certificate_authority_data}")
+        exec {
+          api_version = "client.authentication.k8s.io/v1beta1"
+          command     = "aws"
+          args        = ["eks", "get-token", "--cluster-name", "${dependency.eks.outputs.cluster_name}"]
+        }
+      }
+    }
+
+    provider "kubernetes" {
+      host                   = "${dependency.eks.outputs.cluster_endpoint}"
+      cluster_ca_certificate = base64decode("${dependency.eks.outputs.cluster_certificate_authority_data}")
+      exec {
+        api_version = "client.authentication.k8s.io/v1beta1"
+        command     = "aws"
+        args        = ["eks", "get-token", "--cluster-name", "${dependency.eks.outputs.cluster_name}"]
+      }
+    }
+  PROVIDERS
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE INPUTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  cluster_name = dependency.eks.outputs.cluster_name
+
+  # VictoriaMetrics vmselect endpoint.  Override per-environment in account.hcl via:
+  #   vmselect_url = "http://vmselect.monitoring.svc.cluster.local:8481/select/0/prometheus"
+  vmselect_url = try(
+    local.account_vars.locals.vmselect_url,
+    "http://vmselect.monitoring.svc.cluster.local:8481/select/0/prometheus"
+  )
+
+  min_replicas       = try(local.account_vars.locals.vllm_min_replicas, 2)
+  max_replicas       = try(local.account_vars.locals.vllm_max_replicas, 50)
+  queue_depth_target = try(local.account_vars.locals.vllm_queue_depth_target, 5)
+  cache_usage_target = try(local.account_vars.locals.vllm_cache_usage_target, 80)
+}

--- a/k8s/gpu-inference/hpa/prometheus-adapter-rules.yaml
+++ b/k8s/gpu-inference/hpa/prometheus-adapter-rules.yaml
@@ -1,0 +1,32 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Prometheus Adapter Custom Metric Rules — vLLM
+# ---------------------------------------------------------------------------------------------------------------------
+# Documents the three vLLM metric rules configured in the Prometheus Adapter Helm release.
+# The adapter queries VictoriaMetrics vmselect and exposes these metrics on
+# the custom.metrics.k8s.io API for consumption by the HPA.
+#
+# Verify with:
+#   kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta1" | jq '.resources[].name'
+#   kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta1/namespaces/gpu-inference/pods/*/vllm_requests_waiting"
+# ---------------------------------------------------------------------------------------------------------------------
+#
+# Rules are managed via the Helm release (terraform/modules/gpu-inference-hpa/main.tf).
+# This file serves as the human-readable reference.
+#
+# Metric: vllm_requests_waiting
+#   seriesQuery : vllm:num_requests_waiting{namespace!="",pod!=""}
+#   metricsQuery: sum(vllm:num_requests_waiting{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+#   description : Total queued inference requests per pod.  High values indicate the model
+#                 cannot keep up with demand — primary scale-out signal.
+#
+# Metric: vllm_avg_generation_throughput
+#   seriesQuery : vllm:avg_generation_throughput_toks_per_s{namespace!="",pod!=""}
+#   metricsQuery: avg(vllm:avg_generation_throughput_toks_per_s{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+#   description : Average token generation rate (tokens/second) per pod.  Useful for
+#                 capacity planning dashboards; not directly used by the HPA.
+#
+# Metric: vllm_gpu_cache_usage_perc
+#   seriesQuery : vllm:gpu_cache_usage_perc{namespace!="",pod!=""}
+#   metricsQuery: avg(vllm:gpu_cache_usage_perc{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+#   description : KV-cache utilisation percentage (0-100) per pod.  When this approaches
+#                 100 % new requests are rejected.  HPA scales out at 80 %.

--- a/k8s/gpu-inference/hpa/vllm-hpa.yaml
+++ b/k8s/gpu-inference/hpa/vllm-hpa.yaml
@@ -1,0 +1,67 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# vLLM HorizontalPodAutoscaler — Custom Metrics via Prometheus Adapter
+# ---------------------------------------------------------------------------------------------------------------------
+# Scales the vLLM Deployment on two custom metrics exposed by the Prometheus Adapter:
+#
+#   vllm_requests_waiting    — average number of queued requests per pod (target: 5)
+#   vllm_gpu_cache_usage_perc — average KV-cache utilisation per pod (target: 80 %)
+#
+# The Prometheus Adapter fetches these from the VictoriaMetrics vmselect endpoint and
+# re-exposes them via the Kubernetes custom.metrics.k8s.io API.
+#
+# NOTE: This manifest is the declarative reference.  The live object is managed by the
+#       gpu-inference-hpa Terraform module (terraform/modules/gpu-inference-hpa/main.tf).
+# ---------------------------------------------------------------------------------------------------------------------
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: vllm-hpa
+  namespace: gpu-inference
+  labels:
+    app.kubernetes.io/managed-by: terraform
+    platform.sh/component: gpu-inference-hpa
+  annotations:
+    platform.sh/issue: "79"
+    platform.sh/scaler-type: prometheus-adapter
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: vllm
+  minReplicas: 2
+  maxReplicas: 50
+  metrics:
+    # Primary: request queue depth — scale up when requests pile up faster than pods can drain them.
+    - type: Pods
+      pods:
+        metric:
+          name: vllm_requests_waiting
+        target:
+          type: AverageValue
+          averageValue: "5"
+    # Secondary: GPU KV-cache pressure — scale up before cache fills and new requests are rejected.
+    - type: Pods
+      pods:
+        metric:
+          name: vllm_gpu_cache_usage_perc
+        target:
+          type: AverageValue
+          averageValue: "80"
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      selectPolicy: Max
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 30
+        - type: Pods
+          value: 4
+          periodSeconds: 30
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      selectPolicy: Min
+      policies:
+        - type: Percent
+          value: 20
+          periodSeconds: 60

--- a/terraform/modules/gpu-inference-hpa/main.tf
+++ b/terraform/modules/gpu-inference-hpa/main.tf
@@ -1,0 +1,243 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference HPA — Custom Autoscaling for vLLM via Prometheus Adapter + VictoriaMetrics
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys:
+#   1. Prometheus Adapter (prometheus-community/prometheus-adapter) pointed at VictoriaMetrics vmselect.
+#   2. Custom metric rules exposing vLLM-specific metrics to the Kubernetes custom-metrics API.
+#   3. HorizontalPodAutoscaler for the vLLM Deployment scaling on queue depth and GPU cache pressure.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------------------------------------------------
+# PROMETHEUS ADAPTER
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "helm_release" "prometheus_adapter" {
+  name             = "prometheus-adapter"
+  namespace        = var.adapter_namespace
+  create_namespace = true
+  repository       = "https://prometheus-community.github.io/helm-charts"
+  chart            = "prometheus-adapter"
+  version          = var.prometheus_adapter_version
+
+  wait          = true
+  wait_for_jobs = true
+  timeout       = 300
+
+  values = [
+    yamlencode({
+      replicaCount = var.adapter_replicas
+
+      prometheus = {
+        # Point at VictoriaMetrics vmselect; it exposes a Prometheus-compatible HTTP API.
+        url  = var.vmselect_url
+        port = 0 # port is embedded in the URL
+      }
+
+      # Resource requests/limits — sized for a large (5000-node) cluster metric volume.
+      resources = {
+        requests = {
+          cpu    = "100m"
+          memory = "128Mi"
+        }
+        limits = {
+          cpu    = "500m"
+          memory = "512Mi"
+        }
+      }
+
+      # Affinity — prefer non-GPU nodes so we don't waste GPU capacity on the adapter.
+      affinity = {
+        nodeAffinity = {
+          preferredDuringSchedulingIgnoredDuringExecution = [
+            {
+              weight = 100
+              preference = {
+                matchExpressions = [
+                  {
+                    key      = "node.kubernetes.io/instance-type"
+                    operator = "NotIn"
+                    values   = ["p4d.24xlarge", "p3.16xlarge", "g5.48xlarge", "g6.48xlarge"]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+
+      # Custom metric rules — expose three vLLM metrics to the custom-metrics API.
+      rules = {
+        custom = [
+          # vllm:num_requests_waiting — queue depth per vLLM pod.
+          {
+            seriesQuery = "vllm:num_requests_waiting{namespace!=\"\",pod!=\"\"}"
+            resources = {
+              overrides = {
+                namespace = { resource = "namespace" }
+                pod       = { resource = "pod" }
+              }
+            }
+            name = {
+              matches = "vllm:num_requests_waiting"
+              as      = "vllm_requests_waiting"
+            }
+            metricsQuery = "sum(vllm:num_requests_waiting{<<.LabelMatchers>>}) by (<<.GroupBy>>)"
+          },
+
+          # vllm:avg_generation_throughput — tokens/s throughput per pod.
+          {
+            seriesQuery = "vllm:avg_generation_throughput_toks_per_s{namespace!=\"\",pod!=\"\"}"
+            resources = {
+              overrides = {
+                namespace = { resource = "namespace" }
+                pod       = { resource = "pod" }
+              }
+            }
+            name = {
+              matches = "vllm:avg_generation_throughput_toks_per_s"
+              as      = "vllm_avg_generation_throughput"
+            }
+            metricsQuery = "avg(vllm:avg_generation_throughput_toks_per_s{<<.LabelMatchers>>}) by (<<.GroupBy>>)"
+          },
+
+          # vllm:gpu_cache_usage_perc — KV-cache fill percentage per pod (0-100).
+          {
+            seriesQuery = "vllm:gpu_cache_usage_perc{namespace!=\"\",pod!=\"\"}"
+            resources = {
+              overrides = {
+                namespace = { resource = "namespace" }
+                pod       = { resource = "pod" }
+              }
+            }
+            name = {
+              matches = "vllm:gpu_cache_usage_perc"
+              as      = "vllm_gpu_cache_usage_perc"
+            }
+            metricsQuery = "avg(vllm:gpu_cache_usage_perc{<<.LabelMatchers>>}) by (<<.GroupBy>>)"
+          }
+        ]
+
+        # Expose standard resource metrics (CPU/memory) unchanged — required for kubectl top.
+        resource = {
+          cpu = {
+            containerQuery = "sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>,container!=\"\",pod!=\"\"}[3m])) by (<<.GroupBy>>)"
+            nodeQuery      = "sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>,id=\"/\"}[3m])) by (<<.GroupBy>>)"
+            resources = {
+              overrides = {
+                node      = { resource = "node" }
+                namespace = { resource = "namespace" }
+                pod       = { resource = "pod" }
+              }
+            }
+            containerLabel = "container"
+          }
+          memory = {
+            containerQuery = "sum(container_memory_working_set_bytes{<<.LabelMatchers>>,container!=\"\",pod!=\"\"}) by (<<.GroupBy>>)"
+            nodeQuery      = "sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id=\"/\"}) by (<<.GroupBy>>)"
+            resources = {
+              overrides = {
+                node      = { resource = "node" }
+                namespace = { resource = "namespace" }
+                pod       = { resource = "pod" }
+              }
+            }
+            containerLabel = "container"
+          }
+          window = "3m"
+        }
+      }
+    })
+  ]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# HPA — vLLM Custom Autoscaler
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_horizontal_pod_autoscaler_v2" "vllm" {
+  depends_on = [helm_release.prometheus_adapter]
+
+  metadata {
+    name      = "vllm-hpa"
+    namespace = var.vllm_namespace
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "platform.sh/component"        = "gpu-inference-hpa"
+      "platform.sh/cluster"          = var.cluster_name
+    }
+    annotations = {
+      "platform.sh/issue"       = "79"
+      "platform.sh/scaler-type" = "prometheus-adapter"
+    }
+  }
+
+  spec {
+    min_replicas = var.min_replicas
+    max_replicas = var.max_replicas
+
+    scale_target_ref {
+      api_version = "apps/v1"
+      kind        = "Deployment"
+      name        = var.vllm_deployment_name
+    }
+
+    # Primary metric: request queue depth — scale up fast when requests queue up.
+    metric {
+      type = "Pods"
+      pods {
+        metric {
+          name = "vllm_requests_waiting"
+        }
+        target {
+          type          = "AverageValue"
+          average_value = var.queue_depth_target
+        }
+      }
+    }
+
+    # Secondary metric: GPU KV-cache pressure — scale up before OOM evictions occur.
+    metric {
+      type = "Pods"
+      pods {
+        metric {
+          name = "vllm_gpu_cache_usage_perc"
+        }
+        target {
+          type          = "AverageValue"
+          average_value = var.cache_usage_target
+        }
+      }
+    }
+
+    behavior {
+      # Scale-up: react quickly to inference spikes.
+      scale_up {
+        stabilization_window_seconds = 0
+        select_policy                = "Max"
+
+        policy {
+          type           = "Percent"
+          value          = 100
+          period_seconds = 30
+        }
+        policy {
+          type           = "Pods"
+          value          = 4
+          period_seconds = 30
+        }
+      }
+
+      # Scale-down: wait 5 minutes before removing pods to avoid flapping.
+      scale_down {
+        stabilization_window_seconds = 300
+        select_policy                = "Min"
+
+        policy {
+          type           = "Percent"
+          value          = 20
+          period_seconds = 60
+        }
+      }
+    }
+  }
+}

--- a/terraform/modules/gpu-inference-hpa/outputs.tf
+++ b/terraform/modules/gpu-inference-hpa/outputs.tf
@@ -1,0 +1,19 @@
+output "hpa_name" {
+  description = "Name of the vLLM HorizontalPodAutoscaler"
+  value       = kubernetes_horizontal_pod_autoscaler_v2.vllm.metadata[0].name
+}
+
+output "prometheus_adapter_namespace" {
+  description = "Namespace where Prometheus Adapter is installed"
+  value       = helm_release.prometheus_adapter.namespace
+}
+
+output "prometheus_adapter_release_name" {
+  description = "Helm release name of Prometheus Adapter"
+  value       = helm_release.prometheus_adapter.name
+}
+
+output "prometheus_adapter_version" {
+  description = "Installed version of the prometheus-adapter Helm chart"
+  value       = helm_release.prometheus_adapter.version
+}

--- a/terraform/modules/gpu-inference-hpa/variables.tf
+++ b/terraform/modules/gpu-inference-hpa/variables.tf
@@ -1,0 +1,63 @@
+variable "cluster_name" {
+  description = "EKS cluster name"
+  type        = string
+}
+
+variable "vmselect_url" {
+  description = "VictoriaMetrics vmselect HTTP URL (e.g. http://vmselect.monitoring.svc:8481/select/0/prometheus)"
+  type        = string
+}
+
+variable "prometheus_adapter_version" {
+  description = "Helm chart version for prometheus-community/prometheus-adapter"
+  type        = string
+  default     = "4.11.0"
+}
+
+variable "adapter_namespace" {
+  description = "Kubernetes namespace where Prometheus Adapter is installed"
+  type        = string
+  default     = "monitoring"
+}
+
+variable "adapter_replicas" {
+  description = "Number of Prometheus Adapter replicas"
+  type        = number
+  default     = 2
+}
+
+variable "vllm_namespace" {
+  description = "Kubernetes namespace where the vLLM deployment runs"
+  type        = string
+  default     = "gpu-inference"
+}
+
+variable "vllm_deployment_name" {
+  description = "Name of the vLLM Deployment to scale"
+  type        = string
+  default     = "vllm"
+}
+
+variable "min_replicas" {
+  description = "Minimum number of vLLM replicas"
+  type        = number
+  default     = 2
+}
+
+variable "max_replicas" {
+  description = "Maximum number of vLLM replicas"
+  type        = number
+  default     = 50
+}
+
+variable "queue_depth_target" {
+  description = "Target value for vllm_requests_waiting metric (avg per pod)"
+  type        = number
+  default     = 5
+}
+
+variable "cache_usage_target" {
+  description = "Target gpu_cache_usage_perc (percentage, e.g. 80)"
+  type        = number
+  default     = 80
+}

--- a/terraform/modules/gpu-inference-hpa/versions.tf
+++ b/terraform/modules/gpu-inference-hpa/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.25"
+    }
+  }
+}

--- a/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
+++ b/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
@@ -81,3 +81,8 @@ unit "gpu-inference-vllm" {
   source = "${get_repo_root()}/catalog/units/gpu-inference-vllm"
   path   = "gpu-inference-vllm"
 }
+
+unit "gpu-inference-hpa" {
+  source = "${get_repo_root()}/catalog/units/gpu-inference-hpa"
+  path   = "gpu-inference-hpa"
+}


### PR DESCRIPTION
## Summary

- Adds `terraform/modules/gpu-inference-hpa/` — Terraform module deploying Prometheus Adapter (prometheus-community/prometheus-adapter v4.11.0) pointed at VictoriaMetrics vmselect, with custom metric rules for three vLLM metrics and an HPA for the vLLM Deployment.
- Adds `catalog/units/gpu-inference-hpa/terragrunt.hcl` — Catalog unit with EKS dependency and both Helm + Kubernetes provider generation.
- Adds `k8s/gpu-inference/hpa/` — Declarative HPA manifest (`vllm-hpa.yaml`) and metric rules reference (`prometheus-adapter-rules.yaml`).
- Updates `terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl` to include the `gpu-inference-hpa` unit.

## Variables

| Variable | Default | Description |
|---|---|---|
| `vmselect_url` | `http://vmselect.monitoring.svc.cluster.local:8481/select/0/prometheus` | VictoriaMetrics vmselect HTTP URL |
| `min_replicas` | `2` | Minimum vLLM replicas |
| `max_replicas` | `50` | Maximum vLLM replicas |
| `queue_depth_target` | `5` | Target avg `vllm_requests_waiting` per pod |
| `cache_usage_target` | `80` | Target avg `vllm_gpu_cache_usage_perc` (%) |

## Outputs

- `hpa_name` — name of the created HPA object
- `prometheus_adapter_namespace` — namespace where Prometheus Adapter is installed

## Custom Metrics Exposed

| Kubernetes metric name | Source PromQL | Use |
|---|---|---|
| `vllm_requests_waiting` | `sum(vllm:num_requests_waiting{…})` | Primary HPA signal |
| `vllm_gpu_cache_usage_perc` | `avg(vllm:gpu_cache_usage_perc{…})` | Secondary HPA signal |
| `vllm_avg_generation_throughput` | `avg(vllm:avg_generation_throughput_toks_per_s{…})` | Dashboards / alerting |

## Test plan

- [ ] `terragrunt init` succeeds for `gpu-inference-hpa` unit
- [ ] `terragrunt validate` passes with no errors
- [ ] `terragrunt plan` shows Prometheus Adapter Helm release + vllm-hpa HPA resource
- [ ] After apply: `kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta1" | jq '.resources[].name'` returns the three vLLM metrics
- [ ] `kubectl get hpa -n gpu-inference vllm-hpa` shows min=2 max=50 with both custom metrics
- [ ] Scale-up test: inject synthetic load raising `vllm:num_requests_waiting` above 5; verify HPA triggers within 30 s
- [ ] Scale-down test: drain requests; verify HPA holds for 5 min stabilisation window before removing pods