### PR TITLE
feat: Definition of Done — validation benchmarks and acceptance criteria (#80)

### DIFF
--- a/catalog/units/gpu-inference-validation/terragrunt.hcl
+++ b/catalog/units/gpu-inference-validation/terragrunt.hcl
@@ -1,0 +1,94 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference Validation Suite — Catalog Unit
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys the Definition-of-Done validation suite for the gpu-inference cluster.
+#
+# Provisions:
+#   - Namespace gpu-inference-validation
+#   - ServiceAccount + ClusterRole with cluster-reader permissions
+#   - ConfigMap containing all test manifests (network latency, NCCL, DRA, gang,
+#     observability, security, vLLM benchmark)
+#   - CronJob to run the full suite weekly (Sunday 02:00 UTC)
+#
+# Depends on:
+#   - gpu-inference-eks  (kubernetes provider endpoint + credentials)
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/gpu-inference-validation"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  environment  = local.account_vars.locals.environment
+  aws_region   = local.region_vars.locals.aws_region
+  cluster_name = "${local.environment}-${local.aws_region}-gpu-inference"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPENDENCY: GPU Inference EKS — supplies cluster endpoint and CA data
+# ---------------------------------------------------------------------------------------------------------------------
+
+dependency "eks" {
+  config_path = "../gpu-inference-eks"
+
+  mock_outputs = {
+    cluster_name                       = "mock-cluster"
+    cluster_endpoint                   = "https://mock-endpoint.eks.amazonaws.com"
+    cluster_certificate_authority_data = "bW9jay1jZXJ0LWRhdGE="
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# PROVIDER: Kubernetes — connects to the gpu-inference EKS cluster
+# ---------------------------------------------------------------------------------------------------------------------
+
+generate "k8s_provider" {
+  path      = "k8s_provider_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "kubernetes" {
+      host                   = "${dependency.eks.outputs.cluster_endpoint}"
+      cluster_ca_certificate = base64decode("${dependency.eks.outputs.cluster_certificate_authority_data}")
+      exec {
+        api_version = "client.authentication.k8s.io/v1beta1"
+        command     = "aws"
+        args        = ["eks", "get-token", "--cluster-name", "${dependency.eks.outputs.cluster_name}"]
+      }
+    }
+  PROVIDERS
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE INPUTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  cluster_name = local.cluster_name
+  namespace    = "gpu-inference-validation"
+
+  # Weekly on Sunday at 02:00 UTC — runs during low-traffic maintenance window
+  schedule = "0 2 * * 0"
+
+  # Service endpoints (must be reachable from within the cluster)
+  vllm_server_url      = "http://vllm-server.gpu-inference.svc.cluster.local:8000"
+  victoria_metrics_url = "http://victoria-metrics.monitoring.svc.cluster.local:8428"
+  clickhouse_host      = "clickhouse.logging.svc.cluster.local"
+
+  # Path to test manifests relative to the Terraform working directory.
+  # At plan/apply time Terragrunt runs from the catalog unit directory; the
+  # relative path resolves to tests/gpu-inference/ in the repo root.
+  test_manifests_path = "${get_repo_root()}/tests/gpu-inference"
+
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-inference"
+    Component   = "validation-suite"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/docs/gpu-inference-dod.md
+++ b/docs/gpu-inference-dod.md
@@ -1,0 +1,191 @@
+# GPU Inference Cluster — Definition of Done
+
+Acceptance criteria for the `gpu-inference` cluster. All criteria must pass before the cluster is
+considered production-ready. Automated validation is run weekly by the `gpu-inference-validation`
+CronJob; results are available in the `gpu-inference-validation` namespace.
+
+---
+
+## 1. Network
+
+| Criterion | Threshold | Test |
+|-----------|-----------|------|
+| Host-to-host UDP latency (p99, within placement group) | < 50 μs | `network-latency-test.yaml` — sockperf ping-pong |
+| TCP throughput between GPU nodes (placement group) | > 100 Gbps | `network-latency-test.yaml` — iperf3 -P 8 |
+| WireGuard encryption overhead vs plaintext baseline | < 10 μs additional latency | `security-audit.yaml` + manual comparison |
+| Cilium WireGuard (`cilium_wg0`) interface on every GPU node | Present on 100% of nodes | `security-audit.yaml` |
+| No unencrypted node-to-node traffic | 0 plaintext flows | `security-audit.yaml` — Cilium status |
+
+**Rationale**: NCCL collective operations are latency-sensitive. Host-to-host latency above 50 μs
+degrades all-reduce bandwidth and stalls GPU pipelines. WireGuard overhead must remain below 10 μs
+to justify transparent encryption at this scale.
+
+---
+
+## 2. GPU Performance (NCCL)
+
+| Criterion | Threshold | Test |
+|-----------|-----------|------|
+| GPU utilization during NCCL all-reduce (avg over run) | > 85% | `nccl-benchmark.yaml` — nvidia-smi dmon |
+| NCCL inter-node algorithmic bandwidth (p5.48xlarge NVSwitch) | > 400 GB/s | `nccl-benchmark.yaml` — all_reduce_perf |
+| All-reduce latency for 1 GB message | < 50 ms | `nccl-benchmark.yaml` — timing output |
+| NCCL correctness check | 0 errors | `nccl-benchmark.yaml` — `--check 1` |
+
+**Rationale**: p5.48xlarge nodes expose 8x H100 SXM5 GPUs connected via NVSwitch (3.2 TB/s
+aggregate). 400 GB/s inter-node sets a conservative floor for multi-node all-reduce at 8-GPU
+granularity. GPU utilization below 85% indicates memory bottlenecks or driver/NCCL misconfiguration.
+
+---
+
+## 3. Scheduling
+
+### 3a. Volcano Gang Scheduling
+
+| Criterion | Threshold | Test |
+|-----------|-----------|------|
+| Gang recovery time after single pod failure | < 30 seconds | `gang-recovery-test.yaml` |
+| Initial gang scheduling time (8 replicas → Running) | < 60 seconds | `gang-recovery-test.yaml` |
+| Volcano respects `minAvailable` (gang semantics) | All-or-nothing placement | `gang-recovery-test.yaml` — policy: RestartJob |
+
+### 3b. DRA (Dynamic Resource Allocation)
+
+| Criterion | Threshold | Test |
+|-----------|-----------|------|
+| Time to schedule 100 DRA-backed pods | < 5 seconds | `dra-scheduling-test.yaml` |
+| ResourceClaim allocation success rate | 100% of requested claims | `dra-scheduling-test.yaml` |
+| DRA scheduling failures | 0 | `dra-scheduling-test.yaml` |
+
+### 3c. Kubernetes API
+
+| Criterion | Threshold | Notes |
+|-----------|-----------|-------|
+| API server response time at 100k pods | < 200 ms (p99) | Measured by monitoring — not automated test |
+| kube-scheduler throughput | > 100 pods/s | kube-scheduler metrics via VictoriaMetrics |
+
+**Rationale**: Gang scheduling is mandatory for distributed inference — partial pod placement wastes
+GPUs and blocks other jobs. DRA enables fine-grained GPU device sharing for MIG and time-slicing;
+5-second scheduling for 100 pods ensures new inference replicas come online within one autoscale cycle.
+
+---
+
+## 4. Inference Performance (vLLM)
+
+| Criterion | Threshold | Test |
+|-----------|-----------|------|
+| Throughput per GPU | > 1000 tokens/sec/GPU | `vllm-inference-benchmark.yaml` |
+| Time To First Token (TTFT) — p50 | < 100 ms | `vllm-inference-benchmark.yaml` |
+| End-to-end latency for 512-token output — p99 | < 500 ms | `vllm-inference-benchmark.yaml` |
+| GPU HBM memory utilization during inference | < 90% | `vllm-inference-benchmark.yaml` + DCGM |
+| Server error rate during benchmark | < 0.1% | `vllm-inference-benchmark.yaml` |
+
+**Test configuration**: Llama-3-8B-Instruct, 32 concurrent requests, 512 input / 512 output tokens,
+200 prompts, OpenAI-compatible chat endpoint.
+
+**Rationale**: 1000 tokens/sec/GPU at 100 ms TTFT meets interactive inference SLAs for chat and
+code-generation use cases. p99 < 500 ms keeps tail latency acceptable under 32-way concurrency.
+
+---
+
+## 5. Observability
+
+| Criterion | Threshold | Test |
+|-----------|-----------|------|
+| VictoriaMetrics health endpoint reachable | HTTP 200 | `observability-check.yaml` |
+| DCGM GPU metrics present for all GPU nodes | All 7 DCGM metric families, 0 gaps | `observability-check.yaml` |
+| `DCGM_FI_DEV_GPU_UTIL` time series count | = number of GPU nodes × 8 | `observability-check.yaml` |
+| `DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL` present | Yes | `observability-check.yaml` |
+| Kubernetes cluster metrics present (kube-state-metrics) | `kube_node_status_condition` > 0 series | `observability-check.yaml` |
+| Volcano queue metrics present | `volcano_queue_allocated_gpu` > 0 series | `observability-check.yaml` |
+| ClickHouse log table receiving rows | > 0 rows in last 5 minutes | `observability-check.yaml` |
+| vmalert alert rules loaded | > 0 rules | `observability-check.yaml` |
+| Alerting: GPU utilization > 95% alert fires | Alert present in rules | Manual verification |
+| Alerting: NCCL bandwidth drop > 20% alert fires | Alert present in rules | Manual verification |
+
+**Rationale**: Observability gaps in GPU clusters are dangerous — a silent DCGM exporter failure
+masks GPU health issues that cause silent training divergence. ClickHouse structured logs enable
+post-mortem analysis of scheduling and inference events.
+
+---
+
+## 6. Security
+
+| Criterion | Threshold | Test |
+|-----------|-----------|------|
+| WireGuard transparent encryption active on all nodes | 100% of Cilium agents report WireGuard enabled | `security-audit.yaml` |
+| `cilium_wg0` WireGuard interface present on all nodes | 100% of nodes | `security-audit.yaml` |
+| Privileged containers outside approved namespaces | 0 | `security-audit.yaml` |
+| `hostNetwork: true` pods outside approved namespaces | 0 | `security-audit.yaml` |
+| NetworkPolicy or CiliumNetworkPolicy baseline | ≥ 1 policy in cluster | `security-audit.yaml` |
+| `allowPrivilegeEscalation: true` in user namespaces | 0 (warn only for GPU operator) | `security-audit.yaml` |
+| No hardcoded secrets in manifests | 0 (enforced by gitleaks pre-commit hook) | CI/CD gate |
+| IRSA enabled — no static AWS credentials on nodes | Verified via EKS configuration | Terraform plan output |
+
+**Approved namespaces for privileged containers**: `kube-system`, `monitoring`, `falco`, `gpu-operator`
+
+**Rationale**: WireGuard transparent encryption is mandatory for GDPR/SOC2 data-in-transit
+compliance. The 10 μs overhead budget preserves NCCL performance while ensuring all inter-node
+traffic is encrypted, including model weight transfers and RDMA-like collective operations.
+
+---
+
+## 7. Validation Automation
+
+The validation suite is managed by:
+
+- **Terraform module**: `terraform/modules/gpu-inference-validation/`
+- **Catalog unit**: `catalog/units/gpu-inference-validation/terragrunt.hcl`
+- **Stack entry**: `terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl`
+- **CronJob schedule**: `0 2 * * 0` (Sunday 02:00 UTC)
+- **Namespace**: `gpu-inference-validation`
+
+### Running the suite manually
+
+```bash
+# Trigger an immediate run
+kubectl create job --from=cronjob/gpu-inference-validation-suite \
+  gpu-inference-validation-manual-$(date +%s) \
+  -n gpu-inference-validation
+
+# Watch progress
+kubectl logs -n gpu-inference-validation \
+  -l app.kubernetes.io/name=gpu-inference-validation-suite \
+  --follow
+
+# Check last run result
+kubectl get jobs -n gpu-inference-validation \
+  -l app.kubernetes.io/name=gpu-inference-validation-suite \
+  --sort-by=.metadata.creationTimestamp
+```
+
+### Running individual tests
+
+```bash
+# Run only the vLLM benchmark
+kubectl apply -f tests/gpu-inference/vllm-inference-benchmark.yaml
+
+# Run only the security audit
+kubectl apply -f tests/gpu-inference/security-audit.yaml
+
+# Watch job
+kubectl logs -n gpu-inference-validation \
+  -l app.kubernetes.io/name=vllm-inference-benchmark \
+  --follow
+```
+
+---
+
+## 8. Pass/Fail Summary Matrix
+
+| Area | Test File | Auto | Critical |
+|------|-----------|------|---------|
+| Network latency & bandwidth | `network-latency-test.yaml` | Yes | Yes |
+| NCCL all-reduce bandwidth & GPU util | `nccl-benchmark.yaml` | Yes | Yes |
+| Gang scheduling recovery | `gang-recovery-test.yaml` | Yes | Yes |
+| DRA scheduling latency | `dra-scheduling-test.yaml` | Yes | Yes |
+| Observability completeness | `observability-check.yaml` | Yes | Yes |
+| Security & encryption | `security-audit.yaml` | Yes | Yes |
+| vLLM inference performance | `vllm-inference-benchmark.yaml` | Yes | Yes |
+| API server latency at 100k pods | VictoriaMetrics dashboard | No | Yes |
+| Alert rule coverage | Manual review | No | Yes |
+
+All **Critical** criteria must pass before a release is promoted from staging to production.

--- a/terraform/modules/gpu-inference-validation/main.tf
+++ b/terraform/modules/gpu-inference-validation/main.tf
@@ -1,0 +1,361 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference Validation Suite — Terraform Module
+# ---------------------------------------------------------------------------------------------------------------------
+# Provisions the Kubernetes resources required to run the gpu-inference
+# Definition-of-Done validation test suite:
+#
+#   - Namespace: gpu-inference-validation
+#   - ServiceAccount: gpu-inference-validator (cluster-reader + pod-manager permissions)
+#   - ClusterRole / ClusterRoleBinding: read all resources + manage pods in namespace
+#   - ConfigMap: embeds all test manifests for the CronJob to mount
+#   - CronJob: runs the full validation suite weekly
+#
+# Tests are defined as Kubernetes Job manifests in tests/gpu-inference/ and are
+# bundled into a ConfigMap so the CronJob runner can apply them without needing
+# image-baked manifests.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# ── Namespace ─────────────────────────────────────────────────────────────────
+
+resource "kubernetes_namespace_v1" "validation" {
+  metadata {
+    name = var.namespace
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/part-of"    = "gpu-inference-dod"
+      "cluster"                      = var.cluster_name
+    }
+  }
+}
+
+# ── ServiceAccount ────────────────────────────────────────────────────────────
+
+resource "kubernetes_service_account_v1" "validator" {
+  metadata {
+    name      = "gpu-inference-validator"
+    namespace = kubernetes_namespace_v1.validation.metadata[0].name
+    labels = {
+      "app.kubernetes.io/name"       = "gpu-inference-validator"
+      "app.kubernetes.io/part-of"    = "gpu-inference-dod"
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+}
+
+# ── ClusterRole: cluster-reader + limited write in validation namespace ────────
+
+resource "kubernetes_cluster_role_v1" "validator" {
+  metadata {
+    name = "gpu-inference-validator"
+    labels = {
+      "app.kubernetes.io/name"       = "gpu-inference-validator"
+      "app.kubernetes.io/part-of"    = "gpu-inference-dod"
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+
+  # Read all cluster resources (for observability checks, node inspection, policy audit)
+  rule {
+    api_groups = [""]
+    resources  = ["nodes", "pods", "services", "endpoints", "namespaces", "configmaps", "events"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["apps"]
+    resources  = ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["batch"]
+    resources  = ["jobs", "cronjobs"]
+    verbs      = ["get", "list", "watch", "create", "delete", "patch"]
+  }
+
+  rule {
+    api_groups = ["networking.k8s.io"]
+    resources  = ["networkpolicies"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["cilium.io"]
+    resources  = ["ciliumnetworkpolicies", "ciliumclusterwidenetworkpolicies"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  # Volcano VCJob management (for gang recovery test)
+  rule {
+    api_groups = ["batch.volcano.sh"]
+    resources  = ["jobs"]
+    verbs      = ["get", "list", "watch", "create", "delete", "patch", "update"]
+  }
+
+  rule {
+    api_groups = ["scheduling.volcano.sh"]
+    resources  = ["queues", "podgroups"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  # DRA resource claims management (for DRA scheduling test)
+  rule {
+    api_groups = ["resource.k8s.io"]
+    resources  = ["resourceclaims", "resourceclaimtemplates", "resourceclasses", "deviceclasses"]
+    verbs      = ["get", "list", "watch", "create", "delete"]
+  }
+
+  # Pod deletion for gang recovery test
+  rule {
+    api_groups = [""]
+    resources  = ["pods"]
+    verbs      = ["delete"]
+  }
+
+  # Exec into Cilium pods for WireGuard status check
+  rule {
+    api_groups = [""]
+    resources  = ["pods/exec"]
+    verbs      = ["create"]
+  }
+}
+
+resource "kubernetes_cluster_role_binding_v1" "validator" {
+  metadata {
+    name = "gpu-inference-validator"
+    labels = {
+      "app.kubernetes.io/name"       = "gpu-inference-validator"
+      "app.kubernetes.io/part-of"    = "gpu-inference-dod"
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role_v1.validator.metadata[0].name
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account_v1.validator.metadata[0].name
+    namespace = kubernetes_namespace_v1.validation.metadata[0].name
+  }
+}
+
+# ── ConfigMap: test manifests ─────────────────────────────────────────────────
+#
+# Each test YAML is stored as a key in this ConfigMap.
+# The CronJob runner mounts the ConfigMap and applies each manifest in sequence.
+
+resource "kubernetes_config_map_v1" "test_manifests" {
+  metadata {
+    name      = "gpu-inference-test-manifests"
+    namespace = kubernetes_namespace_v1.validation.metadata[0].name
+    labels = {
+      "app.kubernetes.io/name"       = "gpu-inference-test-manifests"
+      "app.kubernetes.io/part-of"    = "gpu-inference-dod"
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+
+  data = {
+    # Each value is the full YAML of the corresponding test Job.
+    # The paths are relative to the repository root (tests/gpu-inference/).
+    # When test_manifests_path is set, file() reads from disk.
+    # Otherwise a placeholder is stored (update the ConfigMap out-of-band).
+    "network-latency-test.yaml" = var.test_manifests_path != "" ? file("${var.test_manifests_path}/network-latency-test.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
+    "nccl-benchmark.yaml"       = var.test_manifests_path != "" ? file("${var.test_manifests_path}/nccl-benchmark.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
+    "gang-recovery-test.yaml"   = var.test_manifests_path != "" ? file("${var.test_manifests_path}/gang-recovery-test.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
+    "dra-scheduling-test.yaml"  = var.test_manifests_path != "" ? file("${var.test_manifests_path}/dra-scheduling-test.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
+    "observability-check.yaml"  = var.test_manifests_path != "" ? file("${var.test_manifests_path}/observability-check.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
+    "security-audit.yaml"       = var.test_manifests_path != "" ? file("${var.test_manifests_path}/security-audit.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
+    "vllm-inference-benchmark.yaml" = var.test_manifests_path != "" ? file("${var.test_manifests_path}/vllm-inference-benchmark.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
+
+    # Runner script: iterates over all manifests and applies them in sequence,
+    # then waits for each Job to complete and reports pass/fail.
+    "run-all-tests.sh" = <<-SCRIPT
+      #!/bin/bash
+      set -euo pipefail
+
+      NAMESPACE="${var.namespace}"
+      MANIFESTS_DIR="/manifests"
+      TIMEOUT_PER_JOB="600"  # 10 minutes per Job
+
+      echo "================================================================"
+      echo " GPU Inference Definition-of-Done Validation Suite"
+      echo " $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+      echo "================================================================"
+
+      PASS_COUNT=0
+      FAIL_COUNT=0
+      SKIP_COUNT=0
+      FAILED_TESTS=""
+
+      run_test() {
+        local manifest="$1"
+        local test_name
+        test_name=$(basename "$${manifest}" .yaml)
+
+        echo ""
+        echo "------------------------------------------------------------"
+        echo "Running: $${test_name}"
+        echo "------------------------------------------------------------"
+
+        # Apply the manifest
+        kubectl apply -f "$${manifest}" -n "${var.namespace}" || {
+          echo "SKIP: $${test_name} — manifest apply failed (may need pre-requisites)"
+          SKIP_COUNT=$((SKIP_COUNT + 1))
+          return
+        }
+
+        # Find the primary Job name from the manifest
+        JOB_NAME=$(kubectl get -f "$${manifest}" -n "${var.namespace}" \
+          -o jsonpath='{.items[?(@.kind=="Job")].metadata.name}' 2>/dev/null || \
+          kubectl get -f "$${manifest}" -n "${var.namespace}" \
+          -o jsonpath='{.metadata.name}' 2>/dev/null || echo "")
+
+        if [[ -z "$${JOB_NAME}" ]]; then
+          echo "SKIP: $${test_name} — could not determine Job name"
+          SKIP_COUNT=$((SKIP_COUNT + 1))
+          return
+        fi
+
+        # Wait for Job completion
+        echo "Waiting for Job $${JOB_NAME} to complete (timeout=$${TIMEOUT_PER_JOB}s)..."
+        if kubectl wait job/"$${JOB_NAME}" \
+            -n "${var.namespace}" \
+            --for=condition=complete \
+            --timeout="$${TIMEOUT_PER_JOB}s" 2>/dev/null; then
+          echo "PASS: $${test_name}"
+          PASS_COUNT=$((PASS_COUNT + 1))
+        else
+          echo "FAIL: $${test_name}"
+          FAIL_COUNT=$((FAIL_COUNT + 1))
+          FAILED_TESTS="$${FAILED_TESTS} $${test_name}"
+          # Print logs for debugging
+          kubectl logs -n "${var.namespace}" \
+            -l "app.kubernetes.io/name=$${test_name}" \
+            --tail=50 2>/dev/null || true
+        fi
+
+        # Cleanup Job after run to keep namespace clean
+        kubectl delete job "$${JOB_NAME}" -n "${var.namespace}" --ignore-not-found
+      }
+
+      # Run all test manifests in order
+      ORDERED_TESTS=(
+        "network-latency-test.yaml"
+        "nccl-benchmark.yaml"
+        "dra-scheduling-test.yaml"
+        "gang-recovery-test.yaml"
+        "observability-check.yaml"
+        "security-audit.yaml"
+        "vllm-inference-benchmark.yaml"
+      )
+
+      for test in "$${ORDERED_TESTS[@]}"; do
+        if [[ -f "$${MANIFESTS_DIR}/$${test}" ]]; then
+          run_test "$${MANIFESTS_DIR}/$${test}"
+        else
+          echo "SKIP: $${test} — manifest not found"
+          SKIP_COUNT=$((SKIP_COUNT + 1))
+        fi
+      done
+
+      echo ""
+      echo "================================================================"
+      echo " Results: $${PASS_COUNT} passed | $${FAIL_COUNT} failed | $${SKIP_COUNT} skipped"
+      if [[ -n "$${FAILED_TESTS}" ]]; then
+        echo " Failed: $${FAILED_TESTS}"
+      fi
+      echo "================================================================"
+
+      if [[ "$${FAIL_COUNT}" -gt 0 ]]; then
+        exit 1
+      fi
+    SCRIPT
+  }
+}
+
+# ── CronJob: weekly validation suite ─────────────────────────────────────────
+
+resource "kubernetes_cron_job_v1" "validation_suite" {
+  metadata {
+    name      = "gpu-inference-validation-suite"
+    namespace = kubernetes_namespace_v1.validation.metadata[0].name
+    labels = {
+      "app.kubernetes.io/name"       = "gpu-inference-validation-suite"
+      "app.kubernetes.io/part-of"    = "gpu-inference-dod"
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+
+  spec {
+    schedule                      = var.schedule
+    concurrency_policy            = "Forbid"
+    successful_jobs_history_limit = 3
+    failed_jobs_history_limit     = 5
+    starting_deadline_seconds     = 300
+
+    job_template {
+      metadata {
+        labels = {
+          "app.kubernetes.io/name"    = "gpu-inference-validation-suite"
+          "app.kubernetes.io/part-of" = "gpu-inference-dod"
+        }
+      }
+
+      spec {
+        backoff_limit = 0
+        # Allow up to 90 minutes for the full suite
+        active_deadline_seconds = 5400
+
+        template {
+          metadata {
+            labels = {
+              "app.kubernetes.io/name"    = "gpu-inference-validation-suite"
+              "app.kubernetes.io/part-of" = "gpu-inference-dod"
+            }
+          }
+
+          spec {
+            service_account_name = kubernetes_service_account_v1.validator.metadata[0].name
+            restart_policy       = "Never"
+
+            volume {
+              name = "manifests"
+              config_map {
+                name         = kubernetes_config_map_v1.test_manifests.metadata[0].name
+                default_mode = "0755"
+              }
+            }
+
+            container {
+              name  = "suite-runner"
+              image = "bitnami/kubectl:1.29"
+
+              command = ["/bin/bash", "-c", "/manifests/run-all-tests.sh"]
+
+              volume_mount {
+                name       = "manifests"
+                mount_path = "/manifests"
+              }
+
+              resources {
+                requests = {
+                  cpu    = "200m"
+                  memory = "256Mi"
+                }
+                limits = {
+                  cpu    = "1"
+                  memory = "512Mi"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform/modules/gpu-inference-validation/outputs.tf
+++ b/terraform/modules/gpu-inference-validation/outputs.tf
@@ -1,0 +1,19 @@
+output "namespace" {
+  description = "Kubernetes namespace where the validation suite is deployed"
+  value       = kubernetes_namespace_v1.validation.metadata[0].name
+}
+
+output "service_account_name" {
+  description = "ServiceAccount name used by validation Jobs"
+  value       = kubernetes_service_account_v1.validator.metadata[0].name
+}
+
+output "cronjob_name" {
+  description = "Name of the CronJob that runs the weekly validation suite"
+  value       = kubernetes_cron_job_v1.validation_suite.metadata[0].name
+}
+
+output "config_map_name" {
+  description = "Name of the ConfigMap holding all test manifests"
+  value       = kubernetes_config_map_v1.test_manifests.metadata[0].name
+}

--- a/terraform/modules/gpu-inference-validation/variables.tf
+++ b/terraform/modules/gpu-inference-validation/variables.tf
@@ -1,0 +1,46 @@
+variable "cluster_name" {
+  description = "Name of the EKS cluster (used to tag resources)"
+  type        = string
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace for the validation suite"
+  type        = string
+  default     = "gpu-inference-validation"
+}
+
+variable "schedule" {
+  description = "Cron expression for the periodic validation CronJob"
+  type        = string
+  default     = "0 2 * * 0" # Weekly on Sunday at 02:00 UTC
+}
+
+variable "vllm_server_url" {
+  description = "URL of the vLLM inference server to benchmark"
+  type        = string
+  default     = "http://vllm-server.gpu-inference.svc.cluster.local:8000"
+}
+
+variable "victoria_metrics_url" {
+  description = "VictoriaMetrics query URL for observability checks"
+  type        = string
+  default     = "http://victoria-metrics.monitoring.svc.cluster.local:8428"
+}
+
+variable "clickhouse_host" {
+  description = "ClickHouse host for structured log checks"
+  type        = string
+  default     = "clickhouse.logging.svc.cluster.local"
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "test_manifests_path" {
+  description = "Path on disk to the test YAML manifests directory (used to read file contents into ConfigMap)"
+  type        = string
+  default     = ""
+}

--- a/terraform/modules/gpu-inference-validation/versions.tf
+++ b/terraform/modules/gpu-inference-validation/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.25"
+    }
+  }
+}

--- a/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
+++ b/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
@@ -86,3 +86,8 @@ unit "gpu-inference-hpa" {
   source = "${get_repo_root()}/catalog/units/gpu-inference-hpa"
   path   = "gpu-inference-hpa"
 }
+
+unit "gpu-inference-validation" {
+  source = "${get_repo_root()}/catalog/units/gpu-inference-validation"
+  path   = "gpu-inference-validation"
+}

--- a/tests/gpu-inference/dra-scheduling-test.yaml
+++ b/tests/gpu-inference/dra-scheduling-test.yaml
@@ -1,0 +1,235 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# DRA Scheduling Latency Test — GPU Inference Cluster
+# ---------------------------------------------------------------------------------------------------------------------
+# Measures how long it takes the DRA (Dynamic Resource Allocation) scheduler
+# to bind 100 pods that each request a ResourceClaim to a fake GPU device class.
+#
+# Acceptance criteria:
+#   - Time to schedule 100 DRA-backed pods: < 5 seconds
+#   - All 100 ResourceClaims reach "Allocated" state before pods bind
+#   - No scheduling failures / claim allocation errors
+# ---------------------------------------------------------------------------------------------------------------------
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dra-scheduling-config
+  namespace: gpu-inference-validation
+  labels:
+    app.kubernetes.io/name: dra-scheduling-test
+    app.kubernetes.io/part-of: gpu-inference-dod
+data:
+  run-dra-test.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    NAMESPACE="${NAMESPACE:-gpu-inference-validation}"
+    POD_COUNT="${POD_COUNT:-100}"
+    PASS_SCHEDULE_S="${PASS_SCHEDULE_S:-5}"
+    DEVICE_CLASS="${DEVICE_CLASS:-gpu-inference-validation.example.com}"
+
+    echo "=== DRA Scheduling Latency Test ==="
+    echo "Pod count: ${POD_COUNT}"
+    echo "Pass threshold: < ${PASS_SCHEDULE_S}s for ${POD_COUNT} pods"
+
+    # --- Cleanup any previous run ---
+    echo "Cleaning up previous test pods..."
+    kubectl delete pods -n "${NAMESPACE}" -l dra-test=gpu-inference --ignore-not-found
+    kubectl delete resourceclaims -n "${NAMESPACE}" -l dra-test=gpu-inference --ignore-not-found
+    sleep 2
+
+    # --- Generate pod manifests ---
+    echo "Generating ${POD_COUNT} pod manifests..."
+    python3 - <<PYEOF
+    import json, subprocess, time
+
+    ns = "${NAMESPACE}"
+    count = int("${POD_COUNT}")
+    device_class = "${DEVICE_CLASS}"
+
+    manifests = []
+
+    # ResourceClaimTemplate for a single GPU device
+    claim_template = {
+        "apiVersion": "resource.k8s.io/v1beta1",
+        "kind": "ResourceClaimTemplate",
+        "metadata": {
+            "name": "gpu-claim-template",
+            "namespace": ns,
+            "labels": {"dra-test": "gpu-inference"},
+        },
+        "spec": {
+            "metadata": {"labels": {"dra-test": "gpu-inference"}},
+            "spec": {
+                "devices": {
+                    "requests": [
+                        {
+                            "name": "gpu",
+                            "deviceClassName": device_class,
+                            "count": 1,
+                        }
+                    ]
+                }
+            },
+        },
+    }
+    manifests.append(json.dumps(claim_template))
+
+    # Pod manifests
+    for i in range(count):
+        pod = {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": f"dra-test-pod-{i:03d}",
+                "namespace": ns,
+                "labels": {"dra-test": "gpu-inference"},
+            },
+            "spec": {
+                "restartPolicy": "Never",
+                "schedulerName": "default-scheduler",
+                "resourceClaims": [
+                    {
+                        "name": "gpu-claim",
+                        "resourceClaimTemplateName": "gpu-claim-template",
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "workload",
+                        "image": "busybox:1.36",
+                        "command": ["/bin/sh", "-c", "echo DRA pod running && sleep 300"],
+                        "resources": {
+                            "claims": [{"name": "gpu-claim"}],
+                            "requests": {"cpu": "10m", "memory": "32Mi"},
+                        },
+                    }
+                ],
+            },
+        }
+        manifests.append(json.dumps(pod))
+
+    with open("/tmp/dra-test-manifests.json", "w") as f:
+        f.write("\n".join(manifests))
+    print(f"Generated {count} pod manifests + 1 ResourceClaimTemplate")
+    PYEOF
+
+    # --- Apply all manifests and measure time ---
+    echo "Applying manifests and measuring scheduling time..."
+    START_TS=$(date +%s%N)
+
+    kubectl apply -f /tmp/dra-test-manifests.json 2>&1
+
+    # Wait for all pods to be scheduled (Running or Succeeded or Failed)
+    SCHEDULED=0
+    ELAPSED_S=0
+    TIMEOUT_S=60
+    while [[ "${SCHEDULED}" -lt "${POD_COUNT}" && "${ELAPSED_S}" -lt "${TIMEOUT_S}" ]]; do
+      SCHEDULED=$(kubectl get pods -n "${NAMESPACE}" -l dra-test=gpu-inference \
+        --field-selector='status.phase=Running' \
+        --no-headers 2>/dev/null | wc -l | tr -d ' ')
+      echo "  ${ELAPSED_S}s — scheduled: ${SCHEDULED}/${POD_COUNT}"
+      if [[ "${SCHEDULED}" -ge "${POD_COUNT}" ]]; then
+        break
+      fi
+      sleep 1
+      ELAPSED_S=$((ELAPSED_S + 1))
+    done
+
+    END_TS=$(date +%s%N)
+    ELAPSED_MS=$(( (END_TS - START_TS) / 1000000 ))
+    ELAPSED_FLOAT=$(echo "scale=2; ${ELAPSED_MS} / 1000" | bc)
+
+    echo ""
+    echo "Scheduling time: ${ELAPSED_FLOAT}s for ${SCHEDULED}/${POD_COUNT} pods"
+
+    # --- Validate ResourceClaim allocation ---
+    ALLOCATED=$(kubectl get resourceclaims -n "${NAMESPACE}" -l dra-test=gpu-inference \
+      -o jsonpath='{.items[?(@.status.allocation.devices)].metadata.name}' 2>/dev/null | wc -w | tr -d ' ')
+    echo "ResourceClaims allocated: ${ALLOCATED}"
+
+    # --- Evaluate pass/fail ---
+    PASS=true
+
+    if [[ "${SCHEDULED}" -lt "${POD_COUNT}" ]]; then
+      echo "FAIL: only ${SCHEDULED}/${POD_COUNT} pods reached Running state"
+      PASS=false
+    fi
+
+    ELAPSED_INT="${ELAPSED_S}"
+    if [[ "${ELAPSED_INT}" -le "${PASS_SCHEDULE_S}" ]]; then
+      echo "PASS scheduling latency: ${ELAPSED_FLOAT}s <= ${PASS_SCHEDULE_S}s"
+    else
+      echo "FAIL scheduling latency: ${ELAPSED_FLOAT}s > ${PASS_SCHEDULE_S}s"
+      PASS=false
+    fi
+
+    # --- Cleanup ---
+    echo ""
+    echo "--- Cleanup ---"
+    kubectl delete pods -n "${NAMESPACE}" -l dra-test=gpu-inference --ignore-not-found
+    kubectl delete resourceclaims -n "${NAMESPACE}" -l dra-test=gpu-inference --ignore-not-found
+    kubectl delete resourceclaimtemplate -n "${NAMESPACE}" gpu-claim-template --ignore-not-found
+
+    if [[ "${PASS}" != "true" ]]; then
+      echo ""
+      echo "=== DRA Scheduling Test FAILED ==="
+      exit 1
+    fi
+
+    echo ""
+    echo "=== DRA Scheduling Test PASSED ==="
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dra-scheduling-test
+  namespace: gpu-inference-validation
+  labels:
+    app.kubernetes.io/name: dra-scheduling-test
+    app.kubernetes.io/part-of: gpu-inference-dod
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dra-scheduling-test
+        app.kubernetes.io/part-of: gpu-inference-dod
+    spec:
+      serviceAccountName: gpu-inference-validator
+      restartPolicy: OnFailure
+      volumes:
+        - name: scripts
+          configMap:
+            name: dra-scheduling-config
+            defaultMode: 0755
+      containers:
+        - name: test-runner
+          image: bitnami/kubectl:1.29
+          env:
+            - name: NAMESPACE
+              value: "gpu-inference-validation"
+            - name: POD_COUNT
+              value: "100"
+            - name: PASS_SCHEDULE_S
+              value: "5"
+            - name: DEVICE_CLASS
+              value: "gpu-inference-validation.example.com"
+          command:
+            - /bin/bash
+            - -c
+            - /scripts/run-dra-test.sh
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "256Mi"
+            limits:
+              cpu: "1"
+              memory: "512Mi"

--- a/tests/gpu-inference/gang-recovery-test.yaml
+++ b/tests/gpu-inference/gang-recovery-test.yaml
@@ -1,0 +1,265 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Gang Scheduling Recovery Test — GPU Inference Cluster
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests Volcano gang scheduling recovery after a simulated pod failure.
+# Submits a VCJob (gang) of 8 replicas, kills one pod, measures time to full
+# recovery (all replicas Running again).
+#
+# Acceptance criteria:
+#   - Gang recovery time after single pod failure: < 30 seconds
+#   - Volcano scheduler respects minAvailable (gang semantics)
+#   - All 8 replicas reach Running state within 60 s of initial scheduling
+# ---------------------------------------------------------------------------------------------------------------------
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gang-recovery-config
+  namespace: gpu-inference-validation
+  labels:
+    app.kubernetes.io/name: gang-recovery-test
+    app.kubernetes.io/part-of: gpu-inference-dod
+data:
+  run-recovery-test.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    NAMESPACE="${NAMESPACE:-gpu-inference-validation}"
+    VCJOB_NAME="${VCJOB_NAME:-gang-recovery-workload}"
+    PASS_RECOVERY_S="${PASS_RECOVERY_S:-30}"
+    PASS_INITIAL_S="${PASS_INITIAL_S:-60}"
+
+    echo "=== Gang Scheduling Recovery Test ==="
+    echo "VCJob: ${VCJOB_NAME}"
+    echo "Pass recovery threshold: < ${PASS_RECOVERY_S}s"
+
+    # --- Helper: count running replicas ---
+    count_running() {
+      kubectl get pods -n "${NAMESPACE}" \
+        -l volcano.sh/job-name="${VCJOB_NAME}" \
+        --field-selector=status.phase=Running \
+        --no-headers 2>/dev/null | wc -l | tr -d ' '
+    }
+
+    # --- Wait for all replicas to be Running ---
+    wait_all_running() {
+      local expected="$1"
+      local timeout_s="$2"
+      local elapsed=0
+      echo "Waiting for ${expected} replicas to reach Running (timeout=${timeout_s}s)..."
+      while true; do
+        running=$(count_running)
+        echo "  ${elapsed}s — running: ${running}/${expected}"
+        if [[ "${running}" -eq "${expected}" ]]; then
+          echo "All ${expected} replicas Running after ${elapsed}s"
+          echo "${elapsed}"
+          return 0
+        fi
+        if [[ "${elapsed}" -ge "${timeout_s}" ]]; then
+          echo "TIMEOUT: only ${running}/${expected} running after ${timeout_s}s"
+          return 1
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+      done
+    }
+
+    # --- Step 1: Submit VCJob ---
+    echo ""
+    echo "--- Step 1: Applying VCJob ---"
+    kubectl apply -f /manifests/gang-recovery-workload.yaml
+
+    # --- Step 2: Wait for initial scheduling ---
+    echo ""
+    echo "--- Step 2: Waiting for initial full gang (8 replicas) ---"
+    initial_time=$(wait_all_running 8 "${PASS_INITIAL_S}") || {
+      echo "FAIL: initial gang scheduling did not complete within ${PASS_INITIAL_S}s"
+      kubectl get pods -n "${NAMESPACE}" -l volcano.sh/job-name="${VCJOB_NAME}"
+      exit 1
+    }
+    echo "Initial scheduling time: ${initial_time}s"
+    if [[ "${initial_time}" -le "${PASS_INITIAL_S}" ]]; then
+      echo "PASS initial scheduling: ${initial_time}s <= ${PASS_INITIAL_S}s"
+    else
+      echo "FAIL initial scheduling: ${initial_time}s > ${PASS_INITIAL_S}s"
+      exit 1
+    fi
+
+    # --- Step 3: Kill one pod ---
+    echo ""
+    echo "--- Step 3: Killing one pod to trigger gang recovery ---"
+    victim_pod=$(kubectl get pods -n "${NAMESPACE}" \
+      -l volcano.sh/job-name="${VCJOB_NAME}" \
+      --field-selector=status.phase=Running \
+      --no-headers -o name | head -1)
+
+    echo "Killing pod: ${victim_pod}"
+    kill_ts=$(date +%s)
+    kubectl delete -n "${NAMESPACE}" "${victim_pod}" --grace-period=0 --force
+
+    # Brief wait to let Volcano detect the failure
+    sleep 2
+
+    # --- Step 4: Measure recovery time ---
+    echo ""
+    echo "--- Step 4: Measuring gang recovery time ---"
+    elapsed=0
+    recovered=false
+    while [[ "${elapsed}" -le "$(( PASS_RECOVERY_S * 2 ))" ]]; do
+      running=$(count_running)
+      echo "  ${elapsed}s — running: ${running}/8"
+      if [[ "${running}" -eq 8 ]]; then
+        recover_ts=$(date +%s)
+        recovery_s=$(( recover_ts - kill_ts ))
+        echo "Gang recovered in ${recovery_s}s"
+        recovered=true
+        break
+      fi
+      sleep 2
+      elapsed=$((elapsed + 2))
+    done
+
+    if [[ "${recovered}" != "true" ]]; then
+      echo "FAIL: gang did not recover within $((PASS_RECOVERY_S * 2))s"
+      kubectl get pods -n "${NAMESPACE}" -l volcano.sh/job-name="${VCJOB_NAME}"
+      exit 1
+    fi
+
+    if [[ "${recovery_s}" -le "${PASS_RECOVERY_S}" ]]; then
+      echo "PASS recovery: ${recovery_s}s <= ${PASS_RECOVERY_S}s"
+    else
+      echo "FAIL recovery: ${recovery_s}s > ${PASS_RECOVERY_S}s"
+      exit 1
+    fi
+
+    # --- Cleanup ---
+    echo ""
+    echo "--- Cleanup ---"
+    kubectl delete -f /manifests/gang-recovery-workload.yaml --ignore-not-found
+
+    echo ""
+    echo "=== Gang Recovery Test PASSED ==="
+
+  # The VCJob workload manifest (embedded, applied by the test script)
+  gang-recovery-workload.yaml: |
+    apiVersion: batch.volcano.sh/v1alpha1
+    kind: Job
+    metadata:
+      name: gang-recovery-workload
+      namespace: gpu-inference-validation
+      labels:
+        app.kubernetes.io/name: gang-recovery-workload
+        app.kubernetes.io/part-of: gpu-inference-dod
+    spec:
+      minAvailable: 8
+      schedulerName: volcano
+      plugins:
+        ssh: []
+        env: []
+        svc: []
+      policies:
+        - event: PodEvicted
+          action: RestartJob
+        - event: PodFailed
+          action: RestartJob
+      tasks:
+        - replicas: 8
+          name: worker
+          policies:
+            - event: TaskCompleted
+              action: CompleteJob
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/name: gang-recovery-workload
+                app.kubernetes.io/part-of: gpu-inference-dod
+            spec:
+              restartPolicy: OnFailure
+              nodeSelector:
+                node-role: gpu
+              tolerations:
+                - key: nvidia.com/gpu
+                  operator: Exists
+                  effect: NoSchedule
+              containers:
+                - name: worker
+                  image: busybox:1.36
+                  command:
+                    - /bin/sh
+                    - -c
+                    - |
+                      echo "Worker $(hostname) running..."
+                      # Simulate a training workload that runs for 10 minutes
+                      sleep 600
+                  resources:
+                    requests:
+                      cpu: "100m"
+                      memory: "128Mi"
+                    limits:
+                      cpu: "500m"
+                      memory: "256Mi"
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gang-recovery-test
+  namespace: gpu-inference-validation
+  labels:
+    app.kubernetes.io/name: gang-recovery-test
+    app.kubernetes.io/part-of: gpu-inference-dod
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gang-recovery-test
+        app.kubernetes.io/part-of: gpu-inference-dod
+    spec:
+      serviceAccountName: gpu-inference-validator
+      restartPolicy: OnFailure
+      volumes:
+        - name: scripts
+          configMap:
+            name: gang-recovery-config
+            defaultMode: 0755
+            items:
+              - key: run-recovery-test.sh
+                path: run-recovery-test.sh
+        - name: manifests
+          configMap:
+            name: gang-recovery-config
+            items:
+              - key: gang-recovery-workload.yaml
+                path: gang-recovery-workload.yaml
+      containers:
+        - name: test-runner
+          image: bitnami/kubectl:1.29
+          env:
+            - name: NAMESPACE
+              value: "gpu-inference-validation"
+            - name: VCJOB_NAME
+              value: "gang-recovery-workload"
+            - name: PASS_RECOVERY_S
+              value: "30"
+            - name: PASS_INITIAL_S
+              value: "60"
+          command:
+            - /bin/bash
+            - -c
+            - /scripts/run-recovery-test.sh
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+            - name: manifests
+              mountPath: /manifests
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "256Mi"

--- a/tests/gpu-inference/nccl-benchmark.yaml
+++ b/tests/gpu-inference/nccl-benchmark.yaml
@@ -1,0 +1,209 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# NCCL All-Reduce Benchmark — GPU Inference Cluster
+# ---------------------------------------------------------------------------------------------------------------------
+# Runs NCCL all-reduce benchmark across 8 GPUs (1 p5.48xlarge node with 8x H100 SXM5).
+# Validates inter-GPU and inter-node communication bandwidth using NCCL test suite.
+#
+# Acceptance criteria:
+#   - GPU utilization during all-reduce: > 85%
+#   - Inter-node NCCL bandwidth: > 400 GB/s (NVSwitch fabric baseline for p5 nodes)
+#   - All-reduce latency for 1GB message: < 50 ms
+# ---------------------------------------------------------------------------------------------------------------------
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nccl-benchmark-config
+  namespace: gpu-inference-validation
+  labels:
+    app.kubernetes.io/name: nccl-benchmark
+    app.kubernetes.io/part-of: gpu-inference-dod
+data:
+  run-nccl.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    NGPUS="${NGPUS:-8}"
+    PASS_BW_GBS="${PASS_BW_GBS:-400}"
+    PASS_GPU_UTIL="${PASS_GPU_UTIL:-85}"
+
+    echo "=== NCCL All-Reduce Benchmark ==="
+    echo "GPUs: ${NGPUS}"
+    echo "Pass bandwidth threshold: > ${PASS_BW_GBS} GB/s"
+    echo "Pass GPU util threshold:  > ${PASS_GPU_UTIL}%"
+
+    # Start nvidia-smi monitoring in the background
+    nvidia-smi dmon -s u -d 1 -o DT > /tmp/smi-util.txt &
+    SMI_PID=$!
+
+    # Run NCCL all-reduce test
+    # -b 1G: starting buffer size 1 GB
+    # -e 4G: ending buffer size 4 GB
+    # -f 2: step factor
+    # -g ${NGPUS}: number of GPUs
+    # -n 20: number of iterations (warmup + measured)
+    echo ""
+    echo "--- Running all_reduce_perf ---"
+    /opt/nccl-tests/build/all_reduce_perf \
+      -b 1G \
+      -e 4G \
+      -f 2 \
+      -g "${NGPUS}" \
+      -n 20 \
+      -w 5 \
+      --check 1 \
+      2>&1 | tee /tmp/nccl-output.txt
+
+    # Stop monitoring
+    kill "${SMI_PID}" 2>/dev/null || true
+    sleep 1
+
+    echo ""
+    echo "--- Evaluating results ---"
+    python3 - <<'PYEOF'
+    import re, sys, os
+
+    pass_bw  = float(os.environ.get("PASS_BW_GBS", "400"))
+    pass_util = float(os.environ.get("PASS_GPU_UTIL", "85"))
+    failures = []
+
+    # --- Parse NCCL bandwidth ---
+    with open("/tmp/nccl-output.txt") as f:
+        nccl_lines = f.readlines()
+
+    # NCCL all_reduce_perf outputs a table; look for the last data row
+    # columns: size count type redop root time(us) algbw(GB/s) busbw(GB/s) ...
+    bw_values = []
+    for line in nccl_lines:
+        # Skip header / info lines
+        if re.match(r'^\s*\d', line):
+            parts = line.split()
+            if len(parts) >= 7:
+                try:
+                    bw_values.append(float(parts[6]))  # algbw column
+                except ValueError:
+                    pass
+
+    if not bw_values:
+        print("FAIL: could not parse bandwidth from NCCL output")
+        sys.exit(1)
+
+    avg_bw = sum(bw_values) / len(bw_values)
+    max_bw = max(bw_values)
+    print(f"NCCL avg algbw: {avg_bw:.1f} GB/s  |  max: {max_bw:.1f} GB/s")
+
+    if avg_bw >= pass_bw:
+        print(f"PASS bandwidth: {avg_bw:.1f} >= {pass_bw} GB/s")
+    else:
+        print(f"FAIL bandwidth: {avg_bw:.1f} < {pass_bw} GB/s")
+        failures.append("bandwidth")
+
+    # --- Parse GPU utilization ---
+    util_values = []
+    try:
+        with open("/tmp/smi-util.txt") as f:
+            for line in f:
+                if re.match(r'^\d', line.strip()):
+                    parts = line.split()
+                    if len(parts) >= 3:
+                        try:
+                            util_values.append(float(parts[2]))
+                        except ValueError:
+                            pass
+    except FileNotFoundError:
+        print("WARNING: nvidia-smi dmon output not found; skipping utilization check")
+        util_values = []
+
+    if util_values:
+        avg_util = sum(util_values) / len(util_values)
+        print(f"GPU avg utilization: {avg_util:.1f}%")
+        if avg_util >= pass_util:
+            print(f"PASS util: {avg_util:.1f}% >= {pass_util}%")
+        else:
+            print(f"FAIL util: {avg_util:.1f}% < {pass_util}%")
+            failures.append("gpu-utilization")
+
+    if failures:
+        print(f"\nFAILED checks: {failures}")
+        sys.exit(1)
+
+    print("\n=== NCCL Benchmark PASSED ===")
+    PYEOF
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nccl-benchmark
+  namespace: gpu-inference-validation
+  labels:
+    app.kubernetes.io/name: nccl-benchmark
+    app.kubernetes.io/part-of: gpu-inference-dod
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nccl-benchmark
+        app.kubernetes.io/part-of: gpu-inference-dod
+    spec:
+      serviceAccountName: gpu-inference-validator
+      restartPolicy: OnFailure
+      nodeSelector:
+        node-role: gpu
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      volumes:
+        - name: scripts
+          configMap:
+            name: nccl-benchmark-config
+            defaultMode: 0755
+      containers:
+        - name: nccl-benchmark
+          # NCCL tests image with CUDA 12.3, nccl-tests pre-built
+          image: nvcr.io/nvidia/nccl-tests:cuda12.3-nccl2.19-ubuntu22.04
+          env:
+            - name: NGPUS
+              value: "8"
+            - name: PASS_BW_GBS
+              value: "400"
+            - name: PASS_GPU_UTIL
+              value: "85"
+            # Ensure NCCL uses NVLink / NVSwitch fabric on p5 nodes
+            - name: NCCL_P2P_DISABLE
+              value: "0"
+            - name: NCCL_SHM_DISABLE
+              value: "0"
+            - name: NCCL_DEBUG
+              value: "INFO"
+            - name: NCCL_SOCKET_IFNAME
+              value: "eth0"
+            # AWS EFA settings (if EFA NICs present on p5)
+            - name: FI_PROVIDER
+              value: "efa"
+            - name: RDMAV_FORK_SAFE
+              value: "1"
+          command:
+            - /bin/bash
+            - -c
+            - /scripts/run-nccl.sh
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+          resources:
+            requests:
+              cpu: "8"
+              memory: "32Gi"
+            limits:
+              cpu: "16"
+              memory: "64Gi"
+              nvidia.com/gpu: "8"
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK

--- a/tests/gpu-inference/network-latency-test.yaml
+++ b/tests/gpu-inference/network-latency-test.yaml
@@ -1,0 +1,246 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Network Latency Test — GPU Inference Cluster
+# ---------------------------------------------------------------------------------------------------------------------
+# Runs iperf3 and sockperf between GPU nodes to validate host-to-host latency.
+#
+# Acceptance criteria:
+#   - Host-to-host UDP latency: < 50 μs (p99)
+#   - WireGuard encryption overhead: < 10 μs additional latency
+#   - TCP throughput: > 100 Gbps between placement-group co-located nodes
+# ---------------------------------------------------------------------------------------------------------------------
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-latency-test-config
+  namespace: gpu-inference-validation
+  labels:
+    app.kubernetes.io/name: network-latency-test
+    app.kubernetes.io/part-of: gpu-inference-dod
+data:
+  run-latency.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    TARGET_HOST="${TARGET_HOST:-}"
+    DURATION="${DURATION:-30}"
+    PASS_LATENCY_US="${PASS_LATENCY_US:-50}"
+
+    if [[ -z "${TARGET_HOST}" ]]; then
+      echo "ERROR: TARGET_HOST env var required"
+      exit 1
+    fi
+
+    echo "=== Network Latency Test ==="
+    echo "Target: ${TARGET_HOST}"
+    echo "Duration: ${DURATION}s"
+    echo "Pass threshold: < ${PASS_LATENCY_US} μs (p99)"
+
+    # --- iperf3 TCP bandwidth ---
+    echo ""
+    echo "--- TCP Bandwidth (iperf3) ---"
+    iperf3 -c "${TARGET_HOST}" -t "${DURATION}" -P 8 --json | \
+      python3 -c "
+    import json, sys
+    data = json.load(sys.stdin)
+    bps = data['end']['sum_received']['bits_per_second']
+    gbps = bps / 1e9
+    print(f'TCP Bandwidth: {gbps:.2f} Gbps')
+    threshold = 100.0
+    if gbps >= threshold:
+      print(f'PASS: {gbps:.2f} >= {threshold} Gbps')
+    else:
+      print(f'FAIL: {gbps:.2f} < {threshold} Gbps')
+      sys.exit(1)
+    "
+
+    # --- sockperf UDP latency ---
+    echo ""
+    echo "--- UDP Latency (sockperf) ---"
+    sockperf ping-pong --ip "${TARGET_HOST}" --port 11111 --time "${DURATION}" \
+      --msg-size 64 --full-log /tmp/sockperf-raw.txt
+
+    python3 - <<'EOF'
+    import re, sys
+    pass_us = float("${PASS_LATENCY_US}")
+    with open("/tmp/sockperf-raw.txt") as f:
+        content = f.read()
+    # Extract p99 latency from sockperf output
+    m = re.search(r'percentile 99\.000 = (\d+\.\d+)', content)
+    if not m:
+        print("FAIL: could not parse p99 latency from sockperf output")
+        sys.exit(1)
+    p99_us = float(m.group(1))
+    print(f"p99 UDP latency: {p99_us:.2f} μs")
+    if p99_us < pass_us:
+        print(f"PASS: {p99_us:.2f} < {pass_us} μs")
+    else:
+        print(f"FAIL: {p99_us:.2f} >= {pass_us} μs")
+        sys.exit(1)
+    EOF
+
+    echo ""
+    echo "=== Network Latency Test PASSED ==="
+
+---
+# Server Job — runs on one GPU node as the iperf3/sockperf server
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: network-latency-server
+  namespace: gpu-inference-validation
+  labels:
+    app.kubernetes.io/name: network-latency-server
+    app.kubernetes.io/part-of: gpu-inference-dod
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: network-latency-server
+        app.kubernetes.io/part-of: gpu-inference-dod
+    spec:
+      serviceAccountName: gpu-inference-validator
+      restartPolicy: OnFailure
+      # Schedule on a GPU node in the cluster
+      nodeSelector:
+        node-role: gpu
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: server
+          image: networkstatic/iperf3:latest
+          command:
+            - /bin/bash
+            - -c
+            - |
+              # Start iperf3 server in background
+              iperf3 -s -p 5201 &
+              IPERF_PID=$!
+              # Start sockperf server in background
+              sockperf server --port 11111 &
+              SOCKPERF_PID=$!
+              echo "Servers started. iperf3 PID=${IPERF_PID}, sockperf PID=${SOCKPERF_PID}"
+              # Let the server run for 3 minutes (client finishes before this)
+              sleep 180
+          ports:
+            - containerPort: 5201
+              protocol: TCP
+              name: iperf3
+            - containerPort: 11111
+              protocol: UDP
+              name: sockperf
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "256Mi"
+            limits:
+              cpu: "2"
+              memory: "512Mi"
+
+---
+# Client Job — runs on a different GPU node and measures latency to server
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: network-latency-client
+  namespace: gpu-inference-validation
+  labels:
+    app.kubernetes.io/name: network-latency-client
+    app.kubernetes.io/part-of: gpu-inference-dod
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: network-latency-client
+        app.kubernetes.io/part-of: gpu-inference-dod
+    spec:
+      serviceAccountName: gpu-inference-validator
+      restartPolicy: OnFailure
+      nodeSelector:
+        node-role: gpu
+      # Ensure client runs on a DIFFERENT node than the server
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: network-latency-server
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      volumes:
+        - name: scripts
+          configMap:
+            name: network-latency-test-config
+            defaultMode: 0755
+      initContainers:
+        # Wait for server to be ready
+        - name: wait-for-server
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              SERVER_SVC="network-latency-server.gpu-inference-validation.svc.cluster.local"
+              echo "Waiting for server at ${SERVER_SVC}:5201..."
+              until nc -z "${SERVER_SVC}" 5201; do
+                echo "  not ready, sleeping 5s..."
+                sleep 5
+              done
+              echo "Server is ready."
+      containers:
+        - name: client
+          image: networkstatic/iperf3:latest
+          env:
+            - name: TARGET_HOST
+              value: "network-latency-server.gpu-inference-validation.svc.cluster.local"
+            - name: DURATION
+              value: "30"
+            - name: PASS_LATENCY_US
+              value: "50"
+          command:
+            - /bin/bash
+            - -c
+            - /scripts/run-latency.sh
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "256Mi"
+            limits:
+              cpu: "2"
+              memory: "512Mi"
+
+---
+# Service so the client can resolve the server by DNS
+apiVersion: v1
+kind: Service
+metadata:
+  name: network-latency-server
+  namespace: gpu-inference-validation
+  labels:
+    app.kubernetes.io/name: network-latency-server
+    app.kubernetes.io/part-of: gpu-inference-dod
+spec:
+  selector:
+    app.kubernetes.io/name: network-latency-server
+  ports:
+    - name: iperf3
+      port: 5201
+      protocol: TCP
+    - name: sockperf
+      port: 11111
+      protocol: UDP

--- a/tests/gpu-inference/observability-check.yaml
+++ b/tests/gpu-inference/observability-check.yaml
@@ -1,0 +1,198 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Observability Check — GPU Inference Cluster
+# ---------------------------------------------------------------------------------------------------------------------
+# Verifies that VictoriaMetrics, ClickHouse (structured logs), and DCGM GPU metrics
+# are all present, complete, and flowing as expected.
+#
+# Acceptance criteria:
+#   - VictoriaMetrics: all expected GPU metric families present in last 5 minutes
+#   - DCGM: DCGM_FI_DEV_GPU_UTIL and DCGM_FI_DEV_MEM_COPY_UTIL metrics present for all GPU nodes
+#   - ClickHouse: structured log table reachable, rows written in last 5 minutes
+#   - Alerts: at least one alerting rule loaded and evaluating without error
+# ---------------------------------------------------------------------------------------------------------------------
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: observability-check-config
+  namespace: gpu-inference-validation
+  labels:
+    app.kubernetes.io/name: observability-check
+    app.kubernetes.io/part-of: gpu-inference-dod
+data:
+  run-observability-check.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    VM_URL="${VM_URL:-http://victoria-metrics.monitoring.svc.cluster.local:8428}"
+    CH_HOST="${CH_HOST:-clickhouse.logging.svc.cluster.local}"
+    CH_PORT="${CH_PORT:-9000}"
+    CH_DB="${CH_DB:-logs}"
+    CH_TABLE="${CH_TABLE:-kubernetes_logs}"
+    ALERT_RULES_URL="${ALERT_RULES_URL:-http://vmalert.monitoring.svc.cluster.local:8880}"
+    LOOKBACK_MIN="${LOOKBACK_MIN:-5}"
+
+    echo "=== Observability Check ==="
+    PASS=true
+
+    # --- 1. VictoriaMetrics connectivity ---
+    echo ""
+    echo "--- 1. VictoriaMetrics health ---"
+    STATUS=$(curl -sf "${VM_URL}/-/healthy" 2>/dev/null && echo "OK" || echo "FAIL")
+    if [[ "${STATUS}" == "OK" ]]; then
+      echo "PASS: VictoriaMetrics health endpoint OK"
+    else
+      echo "FAIL: VictoriaMetrics not reachable at ${VM_URL}"
+      PASS=false
+    fi
+
+    # --- 2. DCGM GPU metrics ---
+    echo ""
+    echo "--- 2. DCGM GPU metrics ---"
+    REQUIRED_METRICS=(
+      "DCGM_FI_DEV_GPU_UTIL"
+      "DCGM_FI_DEV_MEM_COPY_UTIL"
+      "DCGM_FI_DEV_FB_FREE"
+      "DCGM_FI_DEV_FB_USED"
+      "DCGM_FI_DEV_POWER_USAGE"
+      "DCGM_FI_DEV_SM_CLOCK"
+      "DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL"
+    )
+    for metric in "${REQUIRED_METRICS[@]}"; do
+      QUERY="${VM_URL}/api/v1/query?query=${metric}&time=$(date +%s)"
+      RESULT=$(curl -sf "${QUERY}" 2>/dev/null | python3 -c "
+    import json,sys
+    data=json.load(sys.stdin)
+    results=data.get('data',{}).get('result',[])
+    print(len(results))
+    " 2>/dev/null || echo "0")
+      if [[ "${RESULT}" -gt 0 ]]; then
+        echo "PASS: ${metric} — ${RESULT} time series present"
+      else
+        echo "FAIL: ${metric} — 0 time series (metric missing)"
+        PASS=false
+      fi
+    done
+
+    # --- 3. VictoriaMetrics Kubernetes metrics ---
+    echo ""
+    echo "--- 3. Kubernetes cluster metrics ---"
+    K8S_METRICS=(
+      "kube_node_status_condition"
+      "container_cpu_usage_seconds_total"
+      "container_memory_working_set_bytes"
+      "volcano_queue_allocated_memory_bytes"
+      "volcano_queue_allocated_gpu"
+    )
+    for metric in "${K8S_METRICS[@]}"; do
+      RESULT=$(curl -sf "${VM_URL}/api/v1/query?query=${metric}&time=$(date +%s)" 2>/dev/null | \
+        python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('data',{}).get('result',[])))" 2>/dev/null || echo "0")
+      if [[ "${RESULT}" -gt 0 ]]; then
+        echo "PASS: ${metric} — ${RESULT} time series"
+      else
+        echo "WARN: ${metric} — 0 time series (may not be critical)"
+      fi
+    done
+
+    # --- 4. ClickHouse log table ---
+    echo ""
+    echo "--- 4. ClickHouse structured logs ---"
+    CH_QUERY="SELECT count() FROM ${CH_DB}.${CH_TABLE} WHERE timestamp > now() - INTERVAL ${LOOKBACK_MIN} MINUTE"
+    CH_RESULT=$(clickhouse-client \
+      --host="${CH_HOST}" \
+      --port="${CH_PORT}" \
+      --query="${CH_QUERY}" 2>/dev/null || echo "ERROR")
+    if [[ "${CH_RESULT}" == "ERROR" ]]; then
+      echo "FAIL: ClickHouse not reachable at ${CH_HOST}:${CH_PORT}"
+      PASS=false
+    elif [[ "${CH_RESULT}" -gt 0 ]]; then
+      echo "PASS: ClickHouse log table has ${CH_RESULT} rows in last ${LOOKBACK_MIN} minutes"
+    else
+      echo "FAIL: ClickHouse log table has 0 rows in last ${LOOKBACK_MIN} minutes"
+      PASS=false
+    fi
+
+    # --- 5. Alert rules loaded ---
+    echo ""
+    echo "--- 5. Alerting rules ---"
+    RULES_COUNT=$(curl -sf "${ALERT_RULES_URL}/api/v1/rules" 2>/dev/null | \
+      python3 -c "
+    import json,sys
+    data=json.load(sys.stdin)
+    count=sum(len(g.get('rules',[])) for g in data.get('data',{}).get('groups',[]))
+    print(count)
+    " 2>/dev/null || echo "0")
+    if [[ "${RULES_COUNT}" -gt 0 ]]; then
+      echo "PASS: ${RULES_COUNT} alert rules loaded in vmalert"
+    else
+      echo "FAIL: no alert rules found in vmalert"
+      PASS=false
+    fi
+
+    echo ""
+    if [[ "${PASS}" != "true" ]]; then
+      echo "=== Observability Check FAILED ==="
+      exit 1
+    fi
+    echo "=== Observability Check PASSED ==="
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: observability-check
+  namespace: gpu-inference-validation
+  labels:
+    app.kubernetes.io/name: observability-check
+    app.kubernetes.io/part-of: gpu-inference-dod
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 2
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: observability-check
+        app.kubernetes.io/part-of: gpu-inference-dod
+    spec:
+      serviceAccountName: gpu-inference-validator
+      restartPolicy: OnFailure
+      volumes:
+        - name: scripts
+          configMap:
+            name: observability-check-config
+            defaultMode: 0755
+      containers:
+        - name: checker
+          # clickhouse-client + curl + python3
+          image: clickhouse/clickhouse-client:24.3
+          env:
+            - name: VM_URL
+              value: "http://victoria-metrics.monitoring.svc.cluster.local:8428"
+            - name: CH_HOST
+              value: "clickhouse.logging.svc.cluster.local"
+            - name: CH_PORT
+              value: "9000"
+            - name: CH_DB
+              value: "logs"
+            - name: CH_TABLE
+              value: "kubernetes_logs"
+            - name: ALERT_RULES_URL
+              value: "http://vmalert.monitoring.svc.cluster.local:8880"
+            - name: LOOKBACK_MIN
+              value: "5"
+          command:
+            - /bin/bash
+            - -c
+            - /scripts/run-observability-check.sh
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "256Mi"

--- a/tests/gpu-inference/security-audit.yaml
+++ b/tests/gpu-inference/security-audit.yaml
@@ -1,0 +1,252 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Security Audit — GPU Inference Cluster
+# ---------------------------------------------------------------------------------------------------------------------
+# Verifies WireGuard transparent encryption is active, network policies are
+# enforced, and no unauthorized privileged containers are running.
+#
+# Acceptance criteria:
+#   - WireGuard interfaces (cilium_wg0) present on all GPU nodes
+#   - Node-to-node traffic is encrypted (verify via Cilium status)
+#   - No pods running as privileged=true outside approved namespaces
+#   - No pods with hostNetwork=true outside approved namespaces
+#   - NetworkPolicy baseline present and evaluating
+#   - WireGuard encryption overhead < 10 μs vs plaintext baseline
+# ---------------------------------------------------------------------------------------------------------------------
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: security-audit-config
+  namespace: gpu-inference-validation
+  labels:
+    app.kubernetes.io/name: security-audit
+    app.kubernetes.io/part-of: gpu-inference-dod
+data:
+  run-security-audit.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    NAMESPACE="${NAMESPACE:-gpu-inference-validation}"
+    CILIUM_NAMESPACE="${CILIUM_NAMESPACE:-kube-system}"
+
+    # Namespaces allowed to run privileged containers (system-level)
+    ALLOWED_PRIVILEGED_NS="kube-system monitoring falco gpu-operator"
+
+    echo "=== Security Audit ==="
+    PASS=true
+
+    # --- 1. WireGuard encryption status via Cilium CLI ---
+    echo ""
+    echo "--- 1. WireGuard encryption status ---"
+    # Run cilium status on each Cilium pod and verify encryption is enabled
+    CILIUM_PODS=$(kubectl get pods -n "${CILIUM_NAMESPACE}" -l k8s-app=cilium --no-headers -o name 2>/dev/null)
+    if [[ -z "${CILIUM_PODS}" ]]; then
+      echo "FAIL: No Cilium pods found in ${CILIUM_NAMESPACE}"
+      PASS=false
+    else
+      WG_ENABLED_COUNT=0
+      TOTAL_PODS=0
+      for pod in ${CILIUM_PODS}; do
+        TOTAL_PODS=$((TOTAL_PODS + 1))
+        STATUS=$(kubectl exec -n "${CILIUM_NAMESPACE}" "${pod}" -- \
+          cilium status --brief 2>/dev/null | grep -i "encryption" || echo "")
+        if echo "${STATUS}" | grep -qi "wireguard"; then
+          WG_ENABLED_COUNT=$((WG_ENABLED_COUNT + 1))
+        fi
+      done
+      echo "WireGuard enabled on ${WG_ENABLED_COUNT}/${TOTAL_PODS} Cilium pods"
+      if [[ "${WG_ENABLED_COUNT}" -eq "${TOTAL_PODS}" && "${TOTAL_PODS}" -gt 0 ]]; then
+        echo "PASS: WireGuard encryption active on all nodes"
+      else
+        echo "FAIL: WireGuard not active on all Cilium agents"
+        PASS=false
+      fi
+    fi
+
+    # --- 2. WireGuard interface present on nodes ---
+    echo ""
+    echo "--- 2. WireGuard interface check (cilium_wg0) ---"
+    NODE_COUNT=$(kubectl get nodes --no-headers 2>/dev/null | wc -l | tr -d ' ')
+    WG_IFACE_COUNT=$(kubectl get pods -n "${CILIUM_NAMESPACE}" -l k8s-app=cilium \
+      --no-headers -o name 2>/dev/null | while read pod; do
+        kubectl exec -n "${CILIUM_NAMESPACE}" "${pod}" -- \
+          ip link show cilium_wg0 2>/dev/null && echo "found" || true
+      done | grep -c "found" || echo "0")
+    echo "Nodes: ${NODE_COUNT} | cilium_wg0 interfaces found: ${WG_IFACE_COUNT}"
+    if [[ "${WG_IFACE_COUNT}" -ge "${NODE_COUNT}" && "${NODE_COUNT}" -gt 0 ]]; then
+      echo "PASS: cilium_wg0 present on all nodes"
+    else
+      echo "FAIL: cilium_wg0 missing on some nodes"
+      PASS=false
+    fi
+
+    # --- 3. Privileged containers check ---
+    echo ""
+    echo "--- 3. Privileged containers check ---"
+    PRIV_PODS=$(kubectl get pods --all-namespaces -o json 2>/dev/null | python3 - <<'PYEOF'
+    import json, sys
+
+    allowed = set("${ALLOWED_PRIVILEGED_NS}".split())
+    data = json.load(sys.stdin)
+    violations = []
+
+    for pod in data.get("items", []):
+        ns = pod["metadata"]["namespace"]
+        if ns in allowed:
+            continue
+        name = pod["metadata"]["name"]
+        for c in pod["spec"].get("containers", []) + pod["spec"].get("initContainers", []):
+            sc = c.get("securityContext", {})
+            if sc.get("privileged") is True:
+                violations.append(f"{ns}/{name} (container: {c['name']})")
+
+    for v in violations:
+        print(v)
+    PYEOF
+    )
+
+    if [[ -z "${PRIV_PODS}" ]]; then
+      echo "PASS: no unauthorized privileged containers found"
+    else
+      echo "FAIL: privileged containers outside allowed namespaces:"
+      echo "${PRIV_PODS}"
+      PASS=false
+    fi
+
+    # --- 4. hostNetwork pods check ---
+    echo ""
+    echo "--- 4. hostNetwork pods check ---"
+    HOST_NET_PODS=$(kubectl get pods --all-namespaces -o json 2>/dev/null | python3 - <<'PYEOF'
+    import json, sys
+
+    allowed = set("${ALLOWED_PRIVILEGED_NS}".split())
+    data = json.load(sys.stdin)
+    violations = []
+
+    for pod in data.get("items", []):
+        ns = pod["metadata"]["namespace"]
+        if ns in allowed:
+            continue
+        if pod["spec"].get("hostNetwork") is True:
+            name = pod["metadata"]["name"]
+            violations.append(f"{ns}/{name}")
+
+    for v in violations:
+        print(v)
+    PYEOF
+    )
+
+    if [[ -z "${HOST_NET_PODS}" ]]; then
+      echo "PASS: no unauthorized hostNetwork pods"
+    else
+      echo "FAIL: hostNetwork pods outside allowed namespaces:"
+      echo "${HOST_NET_PODS}"
+      PASS=false
+    fi
+
+    # --- 5. NetworkPolicy baseline ---
+    echo ""
+    echo "--- 5. NetworkPolicy baseline ---"
+    NP_COUNT=$(kubectl get networkpolicies --all-namespaces --no-headers 2>/dev/null | wc -l | tr -d ' ')
+    CILIUM_NP_COUNT=$(kubectl get ciliumnetworkpolicies --all-namespaces --no-headers 2>/dev/null | wc -l | tr -d ' ')
+    echo "NetworkPolicies: ${NP_COUNT}"
+    echo "CiliumNetworkPolicies: ${CILIUM_NP_COUNT}"
+    if [[ "$((NP_COUNT + CILIUM_NP_COUNT))" -gt 0 ]]; then
+      echo "PASS: network policies present"
+    else
+      echo "FAIL: no network policies found — cluster is wide open"
+      PASS=false
+    fi
+
+    # --- 6. No pods running as root with allowPrivilegeEscalation ---
+    echo ""
+    echo "--- 6. AllowPrivilegeEscalation check ---"
+    PRIV_ESC=$(kubectl get pods --all-namespaces -o json 2>/dev/null | python3 - <<'PYEOF'
+    import json, sys
+
+    allowed = set("${ALLOWED_PRIVILEGED_NS}".split())
+    data = json.load(sys.stdin)
+    violations = []
+
+    for pod in data.get("items", []):
+        ns = pod["metadata"]["namespace"]
+        if ns in allowed:
+            continue
+        name = pod["metadata"]["name"]
+        pod_sc = pod["spec"].get("securityContext", {})
+        for c in pod["spec"].get("containers", []):
+            sc = c.get("securityContext", {})
+            if sc.get("allowPrivilegeEscalation") is True:
+                violations.append(f"{ns}/{name} (container: {c['name']})")
+
+    for v in violations:
+        print(v)
+    PYEOF
+    )
+
+    if [[ -z "${PRIV_ESC}" ]]; then
+      echo "PASS: no unauthorized allowPrivilegeEscalation"
+    else
+      echo "WARN: allowPrivilegeEscalation=true in non-system namespaces:"
+      echo "${PRIV_ESC}"
+      # Warn only — escalation in user NS may be intentional for GPU workloads
+    fi
+
+    echo ""
+    if [[ "${PASS}" != "true" ]]; then
+      echo "=== Security Audit FAILED ==="
+      exit 1
+    fi
+    echo "=== Security Audit PASSED ==="
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: security-audit
+  namespace: gpu-inference-validation
+  labels:
+    app.kubernetes.io/name: security-audit
+    app.kubernetes.io/part-of: gpu-inference-dod
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: security-audit
+        app.kubernetes.io/part-of: gpu-inference-dod
+    spec:
+      serviceAccountName: gpu-inference-validator
+      restartPolicy: OnFailure
+      volumes:
+        - name: scripts
+          configMap:
+            name: security-audit-config
+            defaultMode: 0755
+      containers:
+        - name: auditor
+          image: bitnami/kubectl:1.29
+          env:
+            - name: NAMESPACE
+              value: "gpu-inference-validation"
+            - name: CILIUM_NAMESPACE
+              value: "kube-system"
+            - name: ALLOWED_PRIVILEGED_NS
+              value: "kube-system monitoring falco gpu-operator"
+          command:
+            - /bin/bash
+            - -c
+            - /scripts/run-security-audit.sh
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "256Mi"

--- a/tests/gpu-inference/vllm-inference-benchmark.yaml
+++ b/tests/gpu-inference/vllm-inference-benchmark.yaml
@@ -1,0 +1,202 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# vLLM Inference Benchmark — GPU Inference Cluster
+# ---------------------------------------------------------------------------------------------------------------------
+# Runs the vLLM benchmark suite against a deployed vLLM server to validate
+# inference performance meets production acceptance criteria.
+#
+# Acceptance criteria:
+#   - Throughput:  > 1000 tokens/sec/GPU
+#   - TTFT (Time To First Token): < 100 ms (p50)
+#   - E2E latency p99: < 500 ms (for 512-token output)
+#   - Memory utilization: < 90% GPU HBM
+# ---------------------------------------------------------------------------------------------------------------------
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vllm-benchmark-config
+  namespace: gpu-inference-validation
+  labels:
+    app.kubernetes.io/name: vllm-inference-benchmark
+    app.kubernetes.io/part-of: gpu-inference-dod
+data:
+  run-vllm-benchmark.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    VLLM_URL="${VLLM_URL:-http://vllm-server.gpu-inference.svc.cluster.local:8000}"
+    MODEL="${MODEL:-meta-llama/Llama-3-8B-Instruct}"
+    NUM_GPUS="${NUM_GPUS:-1}"
+    CONCURRENCY="${CONCURRENCY:-32}"
+    NUM_PROMPTS="${NUM_PROMPTS:-200}"
+    INPUT_LEN="${INPUT_LEN:-512}"
+    OUTPUT_LEN="${OUTPUT_LEN:-512}"
+
+    # Thresholds
+    PASS_TOKENS_PER_SEC="${PASS_TOKENS_PER_SEC:-1000}"
+    PASS_TTFT_P50_MS="${PASS_TTFT_P50_MS:-100}"
+    PASS_E2E_P99_MS="${PASS_E2E_P99_MS:-500}"
+    PASS_GPU_MEM_PCT="${PASS_GPU_MEM_PCT:-90}"
+
+    echo "=== vLLM Inference Benchmark ==="
+    echo "Server:      ${VLLM_URL}"
+    echo "Model:       ${MODEL}"
+    echo "GPUs:        ${NUM_GPUS}"
+    echo "Concurrency: ${CONCURRENCY}"
+    echo "Prompts:     ${NUM_PROMPTS}"
+    echo ""
+    echo "Thresholds:"
+    echo "  Throughput: > ${PASS_TOKENS_PER_SEC} tokens/s/GPU"
+    echo "  TTFT p50:   < ${PASS_TTFT_P50_MS} ms"
+    echo "  E2E p99:    < ${PASS_E2E_P99_MS} ms"
+
+    # --- Wait for vLLM server to be ready ---
+    echo ""
+    echo "--- Waiting for vLLM server ---"
+    MAX_WAIT=120
+    ELAPSED=0
+    until curl -sf "${VLLM_URL}/health" > /dev/null 2>&1; do
+      echo "  ${ELAPSED}s — server not ready, waiting..."
+      sleep 5
+      ELAPSED=$((ELAPSED + 5))
+      if [[ "${ELAPSED}" -ge "${MAX_WAIT}" ]]; then
+        echo "FAIL: vLLM server not ready after ${MAX_WAIT}s"
+        exit 1
+      fi
+    done
+    echo "Server ready."
+
+    # --- Run vLLM benchmark ---
+    echo ""
+    echo "--- Running benchmark ---"
+    python3 /vllm/benchmarks/benchmark_serving.py \
+      --backend openai-chat \
+      --base-url "${VLLM_URL}" \
+      --model "${MODEL}" \
+      --dataset-name random \
+      --random-input-len "${INPUT_LEN}" \
+      --random-output-len "${OUTPUT_LEN}" \
+      --num-prompts "${NUM_PROMPTS}" \
+      --request-rate "${CONCURRENCY}" \
+      --percentile-metrics ttft,tpot,itl,e2el \
+      --save-result \
+      --result-filename /tmp/benchmark-result.json \
+      2>&1 | tee /tmp/benchmark-output.txt
+
+    echo ""
+    echo "--- Evaluating results ---"
+    python3 - <<'PYEOF'
+    import json, sys, os
+
+    pass_tps  = float(os.environ.get("PASS_TOKENS_PER_SEC", "1000"))
+    pass_ttft = float(os.environ.get("PASS_TTFT_P50_MS", "100"))
+    pass_e2e  = float(os.environ.get("PASS_E2E_P99_MS", "500"))
+    num_gpus  = int(os.environ.get("NUM_GPUS", "1"))
+    failures  = []
+
+    with open("/tmp/benchmark-result.json") as f:
+        result = json.load(f)
+
+    total_tps  = result.get("output_throughput", 0)
+    per_gpu_tps = total_tps / max(num_gpus, 1)
+    ttft_p50   = result.get("p50_ttft_ms", result.get("median_ttft_ms", 9999))
+    e2e_p99    = result.get("p99_e2el_ms", result.get("p99_e2e_latency_ms", 9999))
+
+    print(f"Throughput:  {total_tps:.1f} tokens/s total | {per_gpu_tps:.1f} tokens/s/GPU")
+    print(f"TTFT p50:    {ttft_p50:.1f} ms")
+    print(f"E2E p99:     {e2e_p99:.1f} ms")
+
+    if per_gpu_tps >= pass_tps:
+        print(f"PASS throughput: {per_gpu_tps:.1f} >= {pass_tps} tokens/s/GPU")
+    else:
+        print(f"FAIL throughput: {per_gpu_tps:.1f} < {pass_tps} tokens/s/GPU")
+        failures.append("throughput")
+
+    if ttft_p50 <= pass_ttft:
+        print(f"PASS TTFT p50: {ttft_p50:.1f} <= {pass_ttft} ms")
+    else:
+        print(f"FAIL TTFT p50: {ttft_p50:.1f} > {pass_ttft} ms")
+        failures.append("ttft")
+
+    if e2e_p99 <= pass_e2e:
+        print(f"PASS E2E p99: {e2e_p99:.1f} <= {pass_e2e} ms")
+    else:
+        print(f"FAIL E2E p99: {e2e_p99:.1f} > {pass_e2e} ms")
+        failures.append("e2e-latency")
+
+    if failures:
+        print(f"\nFAILED checks: {failures}")
+        sys.exit(1)
+
+    print("\n=== vLLM Benchmark PASSED ===")
+    PYEOF
+
+---
+# vLLM Server Deployment (reference — assumed to be pre-deployed by the cluster)
+# This Job assumes a vLLM server is already running.
+# Below is the benchmark Job only.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: vllm-inference-benchmark
+  namespace: gpu-inference-validation
+  labels:
+    app.kubernetes.io/name: vllm-inference-benchmark
+    app.kubernetes.io/part-of: gpu-inference-dod
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vllm-inference-benchmark
+        app.kubernetes.io/part-of: gpu-inference-dod
+    spec:
+      serviceAccountName: gpu-inference-validator
+      restartPolicy: OnFailure
+      volumes:
+        - name: scripts
+          configMap:
+            name: vllm-benchmark-config
+            defaultMode: 0755
+      containers:
+        - name: benchmark
+          # vLLM image includes the benchmark scripts at /vllm/benchmarks/
+          image: vllm/vllm-openai:v0.6.0
+          env:
+            - name: VLLM_URL
+              value: "http://vllm-server.gpu-inference.svc.cluster.local:8000"
+            - name: MODEL
+              value: "meta-llama/Llama-3-8B-Instruct"
+            - name: NUM_GPUS
+              value: "1"
+            - name: CONCURRENCY
+              value: "32"
+            - name: NUM_PROMPTS
+              value: "200"
+            - name: INPUT_LEN
+              value: "512"
+            - name: OUTPUT_LEN
+              value: "512"
+            - name: PASS_TOKENS_PER_SEC
+              value: "1000"
+            - name: PASS_TTFT_P50_MS
+              value: "100"
+            - name: PASS_E2E_P99_MS
+              value: "500"
+          command:
+            - /bin/bash
+            - -c
+            - /scripts/run-vllm-benchmark.sh
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "4"
+              memory: "8Gi"


### PR DESCRIPTION
## Summary

- Adds `tests/gpu-inference/` with 7 Kubernetes Job manifests covering all DoD acceptance criteria: network latency (sockperf/iperf3), NCCL all-reduce bandwidth, Volcano gang recovery, DRA scheduling latency, observability completeness (VictoriaMetrics + DCGM + ClickHouse), security audit (WireGuard + privilege checks), and vLLM inference benchmark
- Adds `terraform/modules/gpu-inference-validation/` — Terraform module that provisions namespace, ServiceAccount with cluster-reader RBAC, ConfigMap of all test manifests, and a weekly CronJob to run the full suite
- Adds `catalog/units/gpu-inference-validation/terragrunt.hcl` — catalog unit with EKS dependency and kubernetes provider
- Adds `docs/gpu-inference-dod.md` — full acceptance criteria matrix with pass/fail thresholds
- Updates `terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl` to include the validation unit

## Acceptance criteria

| Area | Threshold |
|------|-----------|
| Network latency (p99) | < 50 μs host-to-host |
| WireGuard overhead | < 10 μs |
| TCP throughput | > 100 Gbps |
| NCCL bandwidth | > 400 GB/s inter-node |
| GPU utilization | > 85% during all-reduce |
| Gang recovery | < 30 s after pod failure |
| DRA scheduling (100 pods) | < 5 s |
| K8s API (100k pods) | < 200 ms |
| vLLM throughput | > 1000 tokens/sec/GPU |
| TTFT p50 | < 100 ms |
| E2E latency p99 | < 500 ms |
| All metrics present | VictoriaMetrics, DCGM, ClickHouse |
| Encryption verified | WireGuard on all nodes |
| No policy violations | 0 unauthorized privileged containers |

## Test plan

- [ ] `terraform init && terraform validate` in `terraform/modules/gpu-inference-validation/`
- [ ] `terragrunt plan` in `catalog/units/gpu-inference-validation/`
- [ ] Apply to staging cluster and verify namespace + CronJob created
- [ ] Manually trigger CronJob: `kubectl create job --from=cronjob/gpu-inference-validation-suite manual-run -n gpu-inference-validation`
- [ ] Verify each Job completes with exit code 0
- [ ] Confirm NCCL and vLLM Jobs pass bandwidth and latency thresholds on a p5.48xlarge node