### PR TITLE
style: terraform fmt gpu-inference-vllm and validation modules

### DIFF
--- a/terraform/modules/gpu-inference-validation/main.tf
+++ b/terraform/modules/gpu-inference-validation/main.tf
@@ -164,12 +164,12 @@ resource "kubernetes_config_map_v1" "test_manifests" {
     # The paths are relative to the repository root (tests/gpu-inference/).
     # When test_manifests_path is set, file() reads from disk.
     # Otherwise a placeholder is stored (update the ConfigMap out-of-band).
-    "network-latency-test.yaml" = var.test_manifests_path != "" ? file("${var.test_manifests_path}/network-latency-test.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
-    "nccl-benchmark.yaml"       = var.test_manifests_path != "" ? file("${var.test_manifests_path}/nccl-benchmark.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
-    "gang-recovery-test.yaml"   = var.test_manifests_path != "" ? file("${var.test_manifests_path}/gang-recovery-test.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
-    "dra-scheduling-test.yaml"  = var.test_manifests_path != "" ? file("${var.test_manifests_path}/dra-scheduling-test.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
-    "observability-check.yaml"  = var.test_manifests_path != "" ? file("${var.test_manifests_path}/observability-check.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
-    "security-audit.yaml"       = var.test_manifests_path != "" ? file("${var.test_manifests_path}/security-audit.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
+    "network-latency-test.yaml"     = var.test_manifests_path != "" ? file("${var.test_manifests_path}/network-latency-test.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
+    "nccl-benchmark.yaml"           = var.test_manifests_path != "" ? file("${var.test_manifests_path}/nccl-benchmark.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
+    "gang-recovery-test.yaml"       = var.test_manifests_path != "" ? file("${var.test_manifests_path}/gang-recovery-test.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
+    "dra-scheduling-test.yaml"      = var.test_manifests_path != "" ? file("${var.test_manifests_path}/dra-scheduling-test.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
+    "observability-check.yaml"      = var.test_manifests_path != "" ? file("${var.test_manifests_path}/observability-check.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
+    "security-audit.yaml"           = var.test_manifests_path != "" ? file("${var.test_manifests_path}/security-audit.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
     "vllm-inference-benchmark.yaml" = var.test_manifests_path != "" ? file("${var.test_manifests_path}/vllm-inference-benchmark.yaml") : "# placeholder — apply via kubectl or set test_manifests_path"
 
     # Runner script: iterates over all manifests and applies them in sequence,

--- a/terraform/modules/gpu-inference-vllm/main.tf
+++ b/terraform/modules/gpu-inference-vllm/main.tf
@@ -12,10 +12,10 @@
 locals {
   common_labels = merge(
     {
-      "app.kubernetes.io/name"      = "vllm"
-      "app.kubernetes.io/component" = "inference-server"
-      "app.kubernetes.io/version"   = var.vllm_version
-      "app.kubernetes.io/part-of"   = "gpu-inference"
+      "app.kubernetes.io/name"       = "vllm"
+      "app.kubernetes.io/component"  = "inference-server"
+      "app.kubernetes.io/version"    = var.vllm_version
+      "app.kubernetes.io/part-of"    = "gpu-inference"
       "app.kubernetes.io/managed-by" = "terraform"
     },
     var.tags
@@ -137,21 +137,21 @@ resource "kubernetes_manifest" "configmap" {
       "enable-lora"          = tostring(var.enable_lora)
       "max-loras"            = tostring(var.max_loras)
       "vllm-config.yaml" = yamlencode({
-        model                    = local.model_path
-        tensor-parallel-size     = var.tensor_parallel_size
-        max-model-len            = var.max_model_len
-        enable-lora              = var.enable_lora
-        max-loras                = var.max_loras
-        lora-extra-vocab-size    = 256
-        max-cpu-loras            = 32
-        gpu-memory-utilization   = var.gpu_memory_utilization
-        dtype                    = "bfloat16"
-        disable-log-requests     = false
-        uvicorn-log-level        = "warning"
-        port                     = 8000
-        host                     = "0.0.0.0"
-        served-model-name        = local.served_model_name
-        lora-modules             = var.lora_modules
+        model                  = local.model_path
+        tensor-parallel-size   = var.tensor_parallel_size
+        max-model-len          = var.max_model_len
+        enable-lora            = var.enable_lora
+        max-loras              = var.max_loras
+        lora-extra-vocab-size  = 256
+        max-cpu-loras          = 32
+        gpu-memory-utilization = var.gpu_memory_utilization
+        dtype                  = "bfloat16"
+        disable-log-requests   = false
+        uvicorn-log-level      = "warning"
+        port                   = 8000
+        host                   = "0.0.0.0"
+        served-model-name      = local.served_model_name
+        lora-modules           = var.lora_modules
       })
     }
   }
@@ -202,9 +202,9 @@ resource "kubernetes_manifest" "deployment" {
           }
         }
         spec = {
-          schedulerName              = var.scheduler_name
-          priorityClassName          = var.priority_class_name
-          serviceAccountName         = "vllm"
+          schedulerName                 = var.scheduler_name
+          priorityClassName             = var.priority_class_name
+          serviceAccountName            = "vllm"
           terminationGracePeriodSeconds = 120
 
           affinity = {
@@ -339,19 +339,19 @@ resource "kubernetes_manifest" "deployment" {
                 { name = "shm", mountPath = "/dev/shm" }
               ]
               livenessProbe = {
-                httpGet            = { path = "/health", port = "http" }
+                httpGet             = { path = "/health", port = "http" }
                 initialDelaySeconds = 120
                 periodSeconds       = 30
                 failureThreshold    = 5
               }
               readinessProbe = {
-                httpGet            = { path = "/health", port = "http" }
+                httpGet             = { path = "/health", port = "http" }
                 initialDelaySeconds = 90
                 periodSeconds       = 15
                 failureThreshold    = 3
               }
               startupProbe = {
-                httpGet            = { path = "/health", port = "http" }
+                httpGet             = { path = "/health", port = "http" }
                 initialDelaySeconds = 60
                 periodSeconds       = 10
                 failureThreshold    = 30


### PR DESCRIPTION
## Summary
- Fix terraform formatting in `gpu-inference-vllm/main.tf` and `gpu-inference-validation/main.tf`
- Alignment-only changes (no logic changes)

## Test plan
- [ ] `terraform fmt -check -recursive terraform/modules/` passes
- [ ] CI Format Check green