### PR TITLE
feat(ai-sre): agent analytics — ClickHouse schema, Python SDK, and Grafana dashboards

### DIFF
--- a/ai-sre/analytics/__init__.py
+++ b/ai-sre/analytics/__init__.py
@@ -1,0 +1,1 @@
+"""AI SRE Analytics — ClickHouse event emission and accuracy tracking."""

--- a/ai-sre/analytics/client.py
+++ b/ai-sre/analytics/client.py
@@ -1,0 +1,196 @@
+"""ClickHouse client for the AI SRE analytics layer.
+
+Manages connection pooling, async buffered writes, and schema migration.
+All writes are fire-and-forget from the agent's perspective — errors are
+logged but never propagate back to the caller, so analytics never blocks
+an investigation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import clickhouse_connect
+
+logger = logging.getLogger(__name__)
+
+# Batch parameters
+_BATCH_SIZE = 100       # flush when buffer reaches this many rows
+_FLUSH_INTERVAL = 10.0  # flush every N seconds regardless of size
+
+
+class ClickHouseAnalyticsClient:
+    """Async-safe, batched ClickHouse writer for AI SRE analytics.
+
+    Usage
+    -----
+    client = ClickHouseAnalyticsClient.from_env()
+    await client.start()          # launches background flush task
+    ...
+    await client.stop()           # drains remaining buffer
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: int = 8123,
+        username: str = "ai_sre",
+        password: str = "",
+        database: str = "ai_sre",
+        batch_size: int = _BATCH_SIZE,
+        flush_interval: float = _FLUSH_INTERVAL,
+    ) -> None:
+        self._host = host
+        self._port = port
+        self._username = username
+        self._password = password
+        self._database = database
+        self._batch_size = batch_size
+        self._flush_interval = flush_interval
+
+        # Per-table write buffers
+        self._buffers: dict[str, list[dict[str, Any]]] = {
+            "agent_usage": [],
+            "findings": [],
+            "feedback": [],
+            "tool_calls": [],
+        }
+        self._lock = asyncio.Lock()
+        self._flush_task: asyncio.Task[None] | None = None
+        self._ch: clickhouse_connect.driver.Client | None = None
+
+    @classmethod
+    def from_env(cls) -> "ClickHouseAnalyticsClient":
+        """Construct from environment variables.
+
+        Required env vars:
+        - CLICKHOUSE_HOST
+        - CLICKHOUSE_PORT       (default: 8123)
+        - CLICKHOUSE_USER       (default: ai_sre)
+        - CLICKHOUSE_PASSWORD
+        """
+        return cls(
+            host=os.environ["CLICKHOUSE_HOST"],
+            port=int(os.environ.get("CLICKHOUSE_PORT", "8123")),
+            username=os.environ.get("CLICKHOUSE_USER", "ai_sre"),
+            password=os.environ.get("CLICKHOUSE_PASSWORD", ""),
+        )
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+
+    async def start(self) -> None:
+        """Connect to ClickHouse and start the background flush loop."""
+        loop = asyncio.get_event_loop()
+        self._ch = await loop.run_in_executor(
+            None,
+            lambda: clickhouse_connect.get_client(
+                host=self._host,
+                port=self._port,
+                username=self._username,
+                password=self._password,
+                database=self._database,
+                connect_timeout=5,
+                send_receive_timeout=30,
+            ),
+        )
+        logger.info(
+            "clickhouse_analytics_connected",
+            host=self._host,
+            database=self._database,
+        )
+        self._flush_task = asyncio.create_task(self._flush_loop())
+
+    async def stop(self) -> None:
+        """Stop the flush loop and drain all buffered rows."""
+        if self._flush_task:
+            self._flush_task.cancel()
+            try:
+                await self._flush_task
+            except asyncio.CancelledError:
+                pass
+        await self._flush_all()
+
+    # ── public write API ─────────────────────────────────────────────────────
+
+    async def write_agent_usage(self, row: dict[str, Any]) -> None:
+        """Buffer a single agent invocation row."""
+        row.setdefault("invocation_id", str(uuid.uuid4()))
+        row.setdefault("timestamp", _now())
+        await self._buffer("agent_usage", row)
+
+    async def write_finding(self, row: dict[str, Any]) -> None:
+        """Buffer a single finding row."""
+        row.setdefault("finding_id", str(uuid.uuid4()))
+        row.setdefault("timestamp", _now())
+        await self._buffer("findings", row)
+
+    async def write_feedback(self, row: dict[str, Any]) -> None:
+        """Buffer a feedback row from a Slack reaction or button click."""
+        row.setdefault("timestamp", _now())
+        await self._buffer("feedback", row)
+
+    async def write_tool_call(self, row: dict[str, Any]) -> None:
+        """Buffer a single MCP tool call row."""
+        row.setdefault("timestamp", _now())
+        await self._buffer("tool_calls", row)
+
+    # ── internal ────────────────────────────────────────────────────────────
+
+    async def _buffer(self, table: str, row: dict[str, Any]) -> None:
+        async with self._lock:
+            self._buffers[table].append(row)
+            if len(self._buffers[table]) >= self._batch_size:
+                await self._flush_table(table)
+
+    async def _flush_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self._flush_interval)
+            await self._flush_all()
+
+    async def _flush_all(self) -> None:
+        for table in list(self._buffers.keys()):
+            async with self._lock:
+                if self._buffers[table]:
+                    await self._flush_table(table)
+
+    async def _flush_table(self, table: str) -> None:
+        """Flush a table's buffer to ClickHouse (must be called under lock)."""
+        rows = self._buffers[table]
+        if not rows or self._ch is None:
+            return
+        self._buffers[table] = []
+
+        try:
+            loop = asyncio.get_event_loop()
+            column_names = list(rows[0].keys())
+            data = [[row.get(col) for col in column_names] for row in rows]
+            await loop.run_in_executor(
+                None,
+                lambda: self._ch.insert(  # type: ignore[union-attr]
+                    f"ai_sre.{table}",
+                    data,
+                    column_names=column_names,
+                ),
+            )
+            logger.debug(
+                "clickhouse_batch_flushed",
+                table=table,
+                rows=len(rows),
+            )
+        except Exception:
+            logger.exception(
+                "clickhouse_flush_failed",
+                table=table,
+                rows=len(rows),
+            )
+            # Put rows back so we don't lose them
+            self._buffers[table] = rows + self._buffers[table]
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/ai-sre/analytics/migrations/001_create_analytics_schema.sql
+++ b/ai-sre/analytics/migrations/001_create_analytics_schema.sql
@@ -1,0 +1,252 @@
+-- AI SRE Analytics Schema
+-- ClickHouse tables for agent usage, findings, feedback, and tool calls
+-- All tables use MergeTree with monthly partitioning and 365-day TTL
+
+CREATE DATABASE IF NOT EXISTS ai_sre;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Table 1: agent_usage  (one row per agent invocation)
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS ai_sre.agent_usage
+(
+    -- Identity
+    invocation_id        UUID,
+    timestamp            DateTime64(3),
+
+    -- Agent info
+    agent_role           LowCardinality(String),  -- incident_response, gpu_health, …
+    model                LowCardinality(String),   -- claude-opus-4-*, claude-sonnet-4-*
+
+    -- Trigger
+    trigger_type         LowCardinality(String),   -- alert, slack_command, slack_mention, scheduled, cross_agent
+    trigger_source       String,                   -- alertname, slash command name, etc.
+
+    -- Context
+    cluster              LowCardinality(String),
+    namespace            String,
+
+    -- Performance
+    duration_ms          UInt32,
+    tokens_input         UInt32,
+    tokens_output        UInt32,
+    tokens_thinking      UInt32,                   -- extended-thinking tokens (Opus)
+    cost_usd             Float64,
+
+    -- Tool usage
+    tool_calls_count     UInt16,
+    mcp_servers_used     Array(LowCardinality(String)),
+    tools_used           Array(String),
+
+    -- Outcome
+    outcome              LowCardinality(String),   -- advisory_generated, escalated, error, no_action, timeout
+    error_message        Nullable(String),
+    finding_id           Nullable(UUID),           -- FK to findings if a finding was generated
+
+    INDEX idx_agent_role  agent_role  TYPE set(20) GRANULARITY 1,
+    INDEX idx_cluster     cluster     TYPE set(10) GRANULARITY 1,
+    INDEX idx_outcome     outcome     TYPE set(10) GRANULARITY 1
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (agent_role, timestamp)
+TTL timestamp + INTERVAL 365 DAY;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Table 2: findings  (one row per issue discovered by an agent)
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS ai_sre.findings
+(
+    -- Identity
+    finding_id                UUID,
+    timestamp                 DateTime64(3),
+    invocation_id             UUID,                        -- FK to agent_usage
+
+    -- Classification
+    finding_type              LowCardinality(String),
+    -- incident | gpu_degradation | cost_waste | capacity_risk |
+    -- security_finding | scaling_recommendation | config_drift | performance_degradation
+    severity                  LowCardinality(String),      -- critical | high | medium | low | info
+    category                  LowCardinality(String),
+    -- deployment | hardware | config | capacity | network | security | cost | performance
+
+    -- Context
+    cluster                   LowCardinality(String),
+    namespace                 String,
+    affected_resource         String,                      -- node name, deployment name, etc.
+    affected_resource_type    LowCardinality(String),      -- node | pod | deployment | service | ec2 | ebs
+
+    -- Analysis
+    root_cause_summary        String,
+    confidence                LowCardinality(String),      -- high | medium | low
+    recommendations           Array(String),
+    evidence_sources          Array(String),               -- metrics | logs | events | git | aws
+
+    -- Cross-layer signals
+    k8s_signals_count         UInt8,
+    aws_signals_count         UInt8,
+    is_cross_layer            Bool,                        -- true when both K8s + AWS signals involved
+
+    -- Resolution tracking
+    status                    LowCardinality(String),      -- open | acknowledged | resolved | false_positive
+    resolution_type           Nullable(LowCardinality(String)),
+    -- manual_fix | auto_resolved | runbook_executed | false_positive
+    resolved_by               Nullable(String),            -- slack user ID or "auto"
+    resolved_at               Nullable(DateTime64(3)),
+
+    -- SRE timing signals
+    alert_fired_at            Nullable(DateTime64(3)),
+    agent_started_at          DateTime64(3),
+    advisory_posted_at        DateTime64(3),
+    acknowledged_at           Nullable(DateTime64(3)),
+    resolved_at_final         Nullable(DateTime64(3)),
+
+    -- Computed durations (seconds)
+    time_to_detect_sec        Nullable(Float32),           -- alert_fired → agent_started
+    time_to_advise_sec        Float32,                     -- agent_started → advisory_posted
+    time_to_acknowledge_sec   Nullable(Float32),           -- alert_fired → acknowledged
+    time_to_resolve_sec       Nullable(Float32),           -- alert_fired → resolved
+
+    INDEX idx_finding_type  finding_type  TYPE set(20) GRANULARITY 1,
+    INDEX idx_severity      severity      TYPE set(5)  GRANULARITY 1,
+    INDEX idx_cluster_f     cluster       TYPE set(10) GRANULARITY 1,
+    INDEX idx_status        status        TYPE set(5)  GRANULARITY 1
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (cluster, finding_type, timestamp)
+TTL timestamp + INTERVAL 365 DAY;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Table 3: feedback  (one row per human reaction/button click)
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS ai_sre.feedback
+(
+    timestamp            DateTime64(3),
+    finding_id           UUID,                    -- FK to findings
+    invocation_id        UUID,                    -- FK to agent_usage
+
+    -- Feedback
+    feedback_type        LowCardinality(String),  -- reaction | button | slash_command
+    feedback_value       LowCardinality(String),
+    -- helpful | not_helpful | correct_rca | wrong_rca | false_positive | partially_correct
+    feedback_by          String,                  -- Slack user ID
+    feedback_comment     Nullable(String),
+
+    -- Context
+    agent_role           LowCardinality(String),
+    cluster              LowCardinality(String)
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (agent_role, timestamp)
+TTL timestamp + INTERVAL 365 DAY;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Table 4: tool_calls  (one row per MCP tool call within an invocation)
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS ai_sre.tool_calls
+(
+    timestamp            DateTime64(3),
+    invocation_id        UUID,
+    agent_role           LowCardinality(String),
+
+    tool_name            String,
+    mcp_server           LowCardinality(String),
+    duration_ms          UInt32,
+    success              Bool,
+    error_message        Nullable(String),
+    result_size_bytes    UInt32
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (mcp_server, tool_name, timestamp)
+TTL timestamp + INTERVAL 180 DAY;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Materialized view 1: hourly agent usage summary
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE MATERIALIZED VIEW IF NOT EXISTS ai_sre.agent_usage_hourly
+ENGINE = SummingMergeTree()
+ORDER BY (agent_role, cluster, hour)
+POPULATE
+AS SELECT
+    agent_role,
+    cluster,
+    toStartOfHour(timestamp)          AS hour,
+    count()                           AS invocations,
+    sum(tokens_input + tokens_output) AS total_tokens,
+    sum(tokens_thinking)              AS total_thinking_tokens,
+    sum(cost_usd)                     AS total_cost,
+    avg(duration_ms)                  AS avg_duration_ms,
+    countIf(outcome = 'error')        AS errors,
+    countIf(outcome = 'advisory_generated') AS advisories_generated
+FROM ai_sre.agent_usage
+GROUP BY agent_role, cluster, hour;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Materialized view 2: daily findings summary
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE MATERIALIZED VIEW IF NOT EXISTS ai_sre.findings_daily
+ENGINE = SummingMergeTree()
+ORDER BY (cluster, finding_type, severity, day)
+POPULATE
+AS SELECT
+    cluster,
+    finding_type,
+    severity,
+    toDate(timestamp)                       AS day,
+    count()                                 AS findings_count,
+    avg(time_to_advise_sec)                 AS avg_time_to_advise_sec,
+    avg(time_to_resolve_sec)                AS avg_time_to_resolve_sec,
+    countIf(status = 'resolved')            AS resolved_count,
+    countIf(status = 'false_positive')      AS false_positive_count,
+    countIf(status = 'acknowledged')        AS acknowledged_count,
+    countIf(is_cross_layer = true)          AS cross_layer_count
+FROM ai_sre.findings
+GROUP BY cluster, finding_type, severity, day;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Materialized view 3: daily accuracy summary
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE MATERIALIZED VIEW IF NOT EXISTS ai_sre.feedback_daily
+ENGINE = SummingMergeTree()
+ORDER BY (agent_role, cluster, day)
+POPULATE
+AS SELECT
+    agent_role,
+    cluster,
+    toDate(timestamp)                          AS day,
+    count()                                    AS feedback_count,
+    countIf(feedback_value = 'helpful')        AS helpful_count,
+    countIf(feedback_value = 'not_helpful')    AS not_helpful_count,
+    countIf(feedback_value = 'correct_rca')    AS correct_rca_count,
+    countIf(feedback_value = 'wrong_rca')      AS wrong_rca_count,
+    countIf(feedback_value = 'false_positive') AS false_positive_count
+FROM ai_sre.feedback
+GROUP BY agent_role, cluster, day;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Materialized view 4: daily tool call summary
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE MATERIALIZED VIEW IF NOT EXISTS ai_sre.tool_calls_daily
+ENGINE = SummingMergeTree()
+ORDER BY (mcp_server, tool_name, day)
+POPULATE
+AS SELECT
+    mcp_server,
+    tool_name,
+    toDate(timestamp)          AS day,
+    count()                    AS call_count,
+    countIf(success = true)    AS success_count,
+    countIf(success = false)   AS error_count,
+    avg(duration_ms)           AS avg_duration_ms,
+    sum(result_size_bytes)     AS total_result_bytes
+FROM ai_sre.tool_calls
+GROUP BY mcp_server, tool_name, day;

--- a/ai-sre/analytics/slack_feedback.py
+++ b/ai-sre/analytics/slack_feedback.py
@@ -1,0 +1,193 @@
+"""Slack reaction and button handlers that feed into SREAnalytics.
+
+Registers new action IDs alongside the existing interactions.py handlers.
+Import and call ``register_analytics_interactions(app, analytics)`` from
+slack/main.py after the existing registrations.
+
+Emoji → feedback_value mapping
+-------------------------------
+    +1 / thumbsup       → helpful
+    -1 / thumbsdown     → not_helpful
+    dart                → correct_rca
+    x                   → wrong_rca
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import structlog
+from slack_bolt.app.async_app import AsyncApp
+
+from .tracker import SREAnalytics
+
+logger = structlog.get_logger()
+
+# Map Slack reaction names to structured feedback_value
+_REACTION_MAP: dict[str, str] = {
+    "+1": "helpful",
+    "thumbsup": "helpful",
+    "-1": "not_helpful",
+    "thumbsdown": "not_helpful",
+    "dart": "correct_rca",
+    "x": "wrong_rca",
+    "white_check_mark": "correct_rca",
+}
+
+
+def register_analytics_interactions(
+    app: AsyncApp,
+    analytics: SREAnalytics,
+) -> None:
+    """Attach Slack event listeners for analytics feedback collection.
+
+    Registers:
+    - reaction_added   → feedback_type=reaction
+    - mark_resolved    → resolution tracking
+    - mark_false_positive → resolution tracking + feedback
+    - needs_followup   → finding status note (no feedback row)
+    """
+
+    @app.event("reaction_added")
+    async def handle_reaction(event: dict[str, Any], client: Any) -> None:
+        """Capture Slack emoji reactions on advisory messages."""
+        reaction = event.get("item_user", {})
+        reaction_name = event.get("reaction", "")
+        feedback_value = _REACTION_MAP.get(reaction_name)
+        if not feedback_value:
+            return  # Ignore non-feedback reactions
+
+        user_id: str = event.get("user", "unknown")
+        item = event.get("item", {})
+        message_ts: str = item.get("ts", "")
+        channel_id: str = item.get("channel", "")
+
+        # Look up the advisory message to get finding_id metadata
+        finding_id, invocation_id, agent_role, cluster = await _resolve_message_metadata(
+            client, channel_id, message_ts
+        )
+        if not finding_id:
+            logger.debug(
+                "analytics_reaction_skipped",
+                reason="no_finding_id_in_message",
+                channel=channel_id,
+                ts=message_ts,
+            )
+            return
+
+        await analytics.on_feedback(
+            finding_id=finding_id,
+            invocation_id=invocation_id,
+            agent_role=agent_role,
+            cluster=cluster,
+            feedback_type="reaction",
+            feedback_value=feedback_value,
+            feedback_by=user_id,
+        )
+        logger.info(
+            "analytics_feedback_recorded",
+            reaction=reaction_name,
+            feedback_value=feedback_value,
+            finding_id=finding_id,
+            user=user_id,
+        )
+
+    @app.action("mark_resolved")
+    async def handle_mark_resolved(ack: Any, body: Any) -> None:
+        """Handle 'Mark Resolved' button on advisory messages."""
+        await ack()
+        user_id: str = body["user"]["id"]
+        value: str = body["actions"][0]["value"]
+        finding_id, invocation_id, agent_role, cluster = _parse_action_value(value)
+
+        await analytics.on_resolution(
+            finding_id=finding_id,
+            invocation_id=invocation_id,
+            agent_role=agent_role,
+            cluster=cluster,
+            resolution_type="manual_fix",
+            resolved_by=user_id,
+        )
+        logger.info(
+            "finding_marked_resolved", finding_id=finding_id, user=user_id
+        )
+
+    @app.action("mark_false_positive")
+    async def handle_false_positive(ack: Any, body: Any) -> None:
+        """Handle 'False Positive' button on advisory messages."""
+        await ack()
+        user_id: str = body["user"]["id"]
+        value: str = body["actions"][0]["value"]
+        finding_id, invocation_id, agent_role, cluster = _parse_action_value(value)
+
+        await analytics.on_resolution(
+            finding_id=finding_id,
+            invocation_id=invocation_id,
+            agent_role=agent_role,
+            cluster=cluster,
+            resolution_type="false_positive",
+            resolved_by=user_id,
+        )
+        # Also write an explicit feedback row
+        await analytics.on_feedback(
+            finding_id=finding_id,
+            invocation_id=invocation_id,
+            agent_role=agent_role,
+            cluster=cluster,
+            feedback_type="button",
+            feedback_value="false_positive",
+            feedback_by=user_id,
+        )
+        logger.info(
+            "finding_marked_false_positive", finding_id=finding_id, user=user_id
+        )
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _parse_action_value(value: str) -> tuple[str, str, str, str]:
+    """Parse pipe-separated action value: finding_id|invocation_id|agent_role|cluster."""
+    parts = value.split("|", 3)
+    if len(parts) == 4:
+        return parts[0], parts[1], parts[2], parts[3]
+    return value, "", "unknown", "unknown"
+
+
+async def _resolve_message_metadata(
+    client: Any, channel_id: str, message_ts: str
+) -> tuple[str, str, str, str]:
+    """Retrieve finding metadata stored in the advisory message's metadata block.
+
+    Advisory messages are expected to store a JSON metadata block with keys:
+        finding_id, invocation_id, agent_role, cluster
+
+    Falls back to empty strings if metadata is not present.
+    """
+    try:
+        resp = await client.conversations_history(
+            channel=channel_id,
+            latest=message_ts,
+            inclusive=True,
+            limit=1,
+        )
+        messages = resp.get("messages", [])
+        if not messages:
+            return "", "", "unknown", "unknown"
+
+        msg = messages[0]
+        metadata = msg.get("metadata", {}).get("event_payload", {})
+        return (
+            metadata.get("finding_id", ""),
+            metadata.get("invocation_id", ""),
+            metadata.get("agent_role", "unknown"),
+            metadata.get("cluster", "unknown"),
+        )
+    except Exception:
+        logging.getLogger(__name__).debug(
+            "failed_to_resolve_message_metadata",
+            channel=channel_id,
+            ts=message_ts,
+            exc_info=True,
+        )
+        return "", "", "unknown", "unknown"

--- a/ai-sre/analytics/test_tracker.py
+++ b/ai-sre/analytics/test_tracker.py
@@ -1,0 +1,287 @@
+"""Unit tests for SREAnalytics lifecycle hooks.
+
+Uses a mock ClickHouseAnalyticsClient so no real ClickHouse is required.
+Run with: pytest ai-sre/analytics/test_tracker.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from .tracker import SREAnalytics, _compute_cost
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+
+class _FakeClient:
+    """Records all write calls for assertion."""
+
+    def __init__(self) -> None:
+        self.agent_usage_rows: list[dict[str, Any]] = []
+        self.finding_rows: list[dict[str, Any]] = []
+        self.feedback_rows: list[dict[str, Any]] = []
+        self.tool_call_rows: list[dict[str, Any]] = []
+
+    async def write_agent_usage(self, row: dict[str, Any]) -> None:
+        self.agent_usage_rows.append(row)
+
+    async def write_finding(self, row: dict[str, Any]) -> None:
+        self.finding_rows.append(row)
+
+    async def write_feedback(self, row: dict[str, Any]) -> None:
+        self.feedback_rows.append(row)
+
+    async def write_tool_call(self, row: dict[str, Any]) -> None:
+        self.tool_call_rows.append(row)
+
+
+@pytest.fixture
+def client() -> _FakeClient:
+    return _FakeClient()
+
+
+@pytest.fixture
+def analytics(client: _FakeClient) -> SREAnalytics:
+    return SREAnalytics(client)  # type: ignore[arg-type]
+
+
+# ── cost computation ──────────────────────────────────────────────────────────
+
+def test_cost_opus() -> None:
+    # 1M input + 1M output at Opus pricing = $15 + $75 = $90
+    cost = _compute_cost(
+        "claude-opus-4-20250514",
+        {"input": 1_000_000, "output": 1_000_000, "thinking": 0},
+    )
+    assert abs(cost - 90.0) < 0.001
+
+
+def test_cost_sonnet() -> None:
+    # 1M input + 1M output at Sonnet pricing = $3 + $15 = $18
+    cost = _compute_cost(
+        "claude-sonnet-4-20250514",
+        {"input": 1_000_000, "output": 1_000_000, "thinking": 0},
+    )
+    assert abs(cost - 18.0) < 0.001
+
+
+def test_cost_with_thinking() -> None:
+    cost = _compute_cost(
+        "claude-opus-4-20250514",
+        {"input": 0, "output": 0, "thinking": 1_000_000},
+    )
+    assert abs(cost - 15.0) < 0.001
+
+
+def test_cost_unknown_model_falls_back_to_default() -> None:
+    cost = _compute_cost(
+        "some-future-model",
+        {"input": 1_000_000, "output": 0},
+    )
+    # Default input pricing = $3/M
+    assert abs(cost - 3.0) < 0.001
+
+
+# ── agent_start / on_tool_call / on_agent_complete ───────────────────────────
+
+@pytest.mark.asyncio
+async def test_full_invocation_lifecycle(
+    analytics: SREAnalytics, client: _FakeClient
+) -> None:
+    inv_id = str(uuid.uuid4())
+
+    analytics.on_agent_start(
+        inv_id, "incident_response", "alert", "KubePodCrash",
+        "prod-us-east-1", "default",
+    )
+
+    await analytics.on_tool_call(
+        inv_id, "get_pod_logs", "k8s-mcp", 350, True,
+        result_size_bytes=2048,
+    )
+    await analytics.on_tool_call(
+        inv_id, "query_metrics", "metrics-mcp", 120, True,
+        result_size_bytes=512,
+    )
+
+    await analytics.on_agent_complete(
+        inv_id=inv_id,
+        outcome="advisory_generated",
+        model="claude-sonnet-4-20250514",
+        agent_role="incident_response",
+        cluster="prod-us-east-1",
+        tokens={"input": 4000, "output": 800, "thinking": 0},
+        duration_ms=45_000,
+    )
+
+    assert len(client.tool_call_rows) == 2
+    assert len(client.agent_usage_rows) == 1
+    assert len(client.finding_rows) == 0  # no finding passed
+
+    usage = client.agent_usage_rows[0]
+    assert usage["outcome"] == "advisory_generated"
+    assert usage["tool_calls_count"] == 2
+    assert "k8s-mcp" in usage["mcp_servers_used"]
+    assert "metrics-mcp" in usage["mcp_servers_used"]
+    assert usage["cost_usd"] > 0
+    assert usage["tokens_input"] == 4000
+    assert usage["tokens_output"] == 800
+
+
+@pytest.mark.asyncio
+async def test_finding_is_written_when_provided(
+    analytics: SREAnalytics, client: _FakeClient
+) -> None:
+    inv_id = str(uuid.uuid4())
+    finding_id = str(uuid.uuid4())
+
+    analytics.on_agent_start(inv_id, "gpu_health", "alert", "DCGMGPUError", "gpu-prod", "")
+
+    finding = {
+        "finding_id": finding_id,
+        "finding_type": "gpu_degradation",
+        "severity": "high",
+        "category": "hardware",
+        "affected_resource": "gpu-node-01",
+        "affected_resource_type": "node",
+        "root_cause_summary": "GPU memory errors exceeding threshold",
+        "confidence": "high",
+        "recommendations": ["Cordon node", "Run DCGM diagnostic"],
+        "evidence_sources": ["metrics", "events"],
+        "time_to_advise_sec": 30.0,
+    }
+
+    await analytics.on_agent_complete(
+        inv_id=inv_id,
+        outcome="advisory_generated",
+        model="claude-opus-4-20250514",
+        agent_role="gpu_health",
+        cluster="gpu-prod",
+        tokens={"input": 8000, "output": 1500, "thinking": 5000},
+        duration_ms=60_000,
+        finding=finding,
+    )
+
+    assert len(client.finding_rows) == 1
+    assert len(client.agent_usage_rows) == 1
+
+    f = client.finding_rows[0]
+    assert f["finding_id"] == finding_id
+    assert f["finding_type"] == "gpu_degradation"
+    assert f["severity"] == "high"
+    assert f["status"] == "open"
+
+    u = client.agent_usage_rows[0]
+    assert u["finding_id"] == finding_id
+
+
+@pytest.mark.asyncio
+async def test_feedback_recording(
+    analytics: SREAnalytics, client: _FakeClient
+) -> None:
+    finding_id = str(uuid.uuid4())
+    inv_id = str(uuid.uuid4())
+
+    await analytics.on_feedback(
+        finding_id=finding_id,
+        invocation_id=inv_id,
+        agent_role="incident_response",
+        cluster="prod-us-east-1",
+        feedback_type="reaction",
+        feedback_value="correct_rca",
+        feedback_by="U123456",
+    )
+
+    assert len(client.feedback_rows) == 1
+    fb = client.feedback_rows[0]
+    assert fb["feedback_value"] == "correct_rca"
+    assert fb["feedback_by"] == "U123456"
+
+
+@pytest.mark.asyncio
+async def test_resolution_writes_feedback_button(
+    analytics: SREAnalytics, client: _FakeClient
+) -> None:
+    finding_id = str(uuid.uuid4())
+    inv_id = str(uuid.uuid4())
+
+    await analytics.on_resolution(
+        finding_id=finding_id,
+        invocation_id=inv_id,
+        agent_role="cost_optimization",
+        cluster="prod-eu-west-1",
+        resolution_type="manual_fix",
+        resolved_by="U789",
+    )
+
+    assert len(client.feedback_rows) == 1
+    fb = client.feedback_rows[0]
+    assert fb["feedback_type"] == "button"
+    assert fb["feedback_value"] == "resolved"
+
+
+@pytest.mark.asyncio
+async def test_false_positive_resolution(
+    analytics: SREAnalytics, client: _FakeClient
+) -> None:
+    finding_id = str(uuid.uuid4())
+    inv_id = str(uuid.uuid4())
+
+    await analytics.on_resolution(
+        finding_id=finding_id,
+        invocation_id=inv_id,
+        agent_role="gpu_health",
+        cluster="gpu-prod",
+        resolution_type="false_positive",
+        resolved_by="U001",
+    )
+
+    fb = client.feedback_rows[0]
+    assert fb["feedback_value"] == "false_positive"
+
+
+@pytest.mark.asyncio
+async def test_invocation_state_cleared_after_complete(
+    analytics: SREAnalytics, client: _FakeClient
+) -> None:
+    """Active invocations dict must not grow unbounded."""
+    inv_id = str(uuid.uuid4())
+
+    analytics.on_agent_start(inv_id, "scaling", "scheduled", "weekly_review", "staging", "")
+    assert inv_id in analytics._active
+
+    await analytics.on_agent_complete(
+        inv_id=inv_id,
+        outcome="no_action",
+        model="claude-sonnet-4-20250514",
+        agent_role="scaling",
+        cluster="staging",
+        tokens={"input": 1000, "output": 200},
+        duration_ms=5000,
+    )
+
+    assert inv_id not in analytics._active
+
+
+@pytest.mark.asyncio
+async def test_unknown_invocation_complete_is_safe(
+    analytics: SREAnalytics, client: _FakeClient
+) -> None:
+    """on_agent_complete should not raise when invocation_id is unknown."""
+    await analytics.on_agent_complete(
+        inv_id="no-such-id",
+        outcome="error",
+        model="claude-sonnet-4-20250514",
+        agent_role="incident_response",
+        cluster="unknown",
+        tokens={"input": 0, "output": 0},
+        duration_ms=0,
+        error_message="agent timed out",
+    )
+    assert len(client.agent_usage_rows) == 1
+    assert client.agent_usage_rows[0]["trigger_type"] == "unknown"

--- a/ai-sre/analytics/tracker.py
+++ b/ai-sre/analytics/tracker.py
@@ -1,0 +1,297 @@
+"""SREAnalytics — lifecycle hooks that wrap every agent invocation.
+
+Designed to slot into the Claude Agent SDK event callbacks without ever
+blocking the investigation loop.  All writes go through the async-buffered
+ClickHouseAnalyticsClient.
+
+Typical integration inside an agent runner:
+
+    analytics = SREAnalytics(ch_client)
+    inv_id = str(uuid.uuid4())
+
+    analytics.on_agent_start(inv_id, "incident_response", trigger, ctx)
+
+    for tool_name, server, duration, ok in tool_events:
+        await analytics.on_tool_call(inv_id, tool_name, server, duration, ok)
+
+    await analytics.on_agent_complete(
+        inv_id,
+        outcome="advisory_generated",
+        model="claude-opus-4-20250514",
+        agent_role="incident_response",
+        cluster="prod-us-east-1",
+        tokens={"input": 4000, "output": 800, "thinking": 3200},
+        duration_ms=45_000,
+        finding=finding_dict,   # or None
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from .client import ClickHouseAnalyticsClient
+
+logger = logging.getLogger(__name__)
+
+# Anthropic pricing (USD per million tokens, as of Claude 4)
+_MODEL_PRICING: dict[str, dict[str, float]] = {
+    "claude-opus-4-20250514": {"input": 15.0, "output": 75.0, "thinking": 15.0},
+    "claude-sonnet-4-20250514": {"input": 3.0, "output": 15.0, "thinking": 3.0},
+}
+_DEFAULT_PRICING = {"input": 3.0, "output": 15.0, "thinking": 3.0}
+
+
+@dataclass
+class _InvocationState:
+    """Transient in-memory state for one agent invocation."""
+
+    invocation_id: str
+    agent_role: str
+    trigger_type: str
+    trigger_source: str
+    cluster: str
+    namespace: str
+    started_at: float = field(default_factory=time.monotonic)
+    started_wall: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    tool_events: list[dict[str, Any]] = field(default_factory=list)
+    mcp_servers: set[str] = field(default_factory=set)
+
+
+class SREAnalytics:
+    """Agent SDK lifecycle hooks — usage, findings, tool calls, and feedback.
+
+    All methods are safe to call from async contexts; they schedule writes
+    to the ClickHouse client's internal buffer and return immediately.
+    """
+
+    def __init__(self, ch_client: ClickHouseAnalyticsClient) -> None:
+        self._ch = ch_client
+        self._active: dict[str, _InvocationState] = {}
+
+    # ── lifecycle hooks ──────────────────────────────────────────────────────
+
+    def on_agent_start(
+        self,
+        invocation_id: str,
+        agent_role: str,
+        trigger_type: str,
+        trigger_source: str,
+        cluster: str,
+        namespace: str = "",
+    ) -> None:
+        """Called when an investigation begins.
+
+        Records the start wall-clock time and sets up per-invocation state.
+        This is a synchronous method — it does no I/O.
+        """
+        state = _InvocationState(
+            invocation_id=invocation_id,
+            agent_role=agent_role,
+            trigger_type=trigger_type,
+            trigger_source=trigger_source,
+            cluster=cluster,
+            namespace=namespace,
+        )
+        self._active[invocation_id] = state
+        logger.debug(
+            "analytics_agent_start",
+            invocation_id=invocation_id,
+            agent_role=agent_role,
+        )
+
+    async def on_tool_call(
+        self,
+        invocation_id: str,
+        tool_name: str,
+        mcp_server: str,
+        duration_ms: int,
+        success: bool,
+        error_message: Optional[str] = None,
+        result_size_bytes: int = 0,
+    ) -> None:
+        """Called after each MCP tool call completes."""
+        state = self._active.get(invocation_id)
+        if state:
+            state.mcp_servers.add(mcp_server)
+            state.tool_events.append(
+                {"tool_name": tool_name, "mcp_server": mcp_server}
+            )
+
+        await self._ch.write_tool_call(
+            {
+                "invocation_id": invocation_id,
+                "agent_role": (state.agent_role if state else "unknown"),
+                "tool_name": tool_name,
+                "mcp_server": mcp_server,
+                "duration_ms": duration_ms,
+                "success": success,
+                "error_message": error_message,
+                "result_size_bytes": result_size_bytes,
+            }
+        )
+
+    async def on_agent_complete(
+        self,
+        invocation_id: str,
+        outcome: str,
+        model: str,
+        agent_role: str,
+        cluster: str,
+        tokens: dict[str, int],
+        duration_ms: int,
+        finding: Optional[dict[str, Any]] = None,
+        error_message: Optional[str] = None,
+        namespace: str = "",
+    ) -> None:
+        """Called when an investigation finishes.
+
+        Writes the agent_usage row and, if a finding was produced, the
+        findings row.  The finding dict should conform to the findings
+        table schema (minus finding_id and timestamp which are injected
+        here if missing).
+        """
+        state = self._active.pop(invocation_id, None)
+        finding_id: Optional[str] = None
+
+        cost = _compute_cost(model, tokens)
+
+        # Persist finding first so we can reference its ID in agent_usage
+        if finding is not None:
+            finding_id = finding.get("finding_id") or str(uuid.uuid4())
+            finding_row: dict[str, Any] = {
+                "finding_id": finding_id,
+                "invocation_id": invocation_id,
+                "agent_role": agent_role,
+                "cluster": cluster,
+                "namespace": namespace,
+                # Callers must supply finding_type, severity, etc.
+                **finding,
+            }
+            finding_row.setdefault("status", "open")
+            finding_row.setdefault("k8s_signals_count", 0)
+            finding_row.setdefault("aws_signals_count", 0)
+            finding_row.setdefault("is_cross_layer", False)
+            finding_row.setdefault(
+                "agent_started_at",
+                state.started_wall if state else datetime.now(timezone.utc).isoformat(),
+            )
+            finding_row.setdefault(
+                "advisory_posted_at", datetime.now(timezone.utc).isoformat()
+            )
+            finding_row.setdefault("time_to_advise_sec", duration_ms / 1000.0)
+            await self._ch.write_finding(finding_row)
+
+        mcp_servers = list(state.mcp_servers) if state else []
+        tools_used = (
+            list({e["tool_name"] for e in state.tool_events}) if state else []
+        )
+        trigger_type = state.trigger_type if state else "unknown"
+        trigger_source = state.trigger_source if state else ""
+
+        await self._ch.write_agent_usage(
+            {
+                "invocation_id": invocation_id,
+                "agent_role": agent_role,
+                "model": model,
+                "trigger_type": trigger_type,
+                "trigger_source": trigger_source,
+                "cluster": cluster,
+                "namespace": namespace,
+                "duration_ms": duration_ms,
+                "tokens_input": tokens.get("input", 0),
+                "tokens_output": tokens.get("output", 0),
+                "tokens_thinking": tokens.get("thinking", 0),
+                "cost_usd": cost,
+                "tool_calls_count": len(state.tool_events) if state else 0,
+                "mcp_servers_used": mcp_servers,
+                "tools_used": tools_used,
+                "outcome": outcome,
+                "error_message": error_message,
+                "finding_id": finding_id,
+            }
+        )
+
+        logger.info(
+            "analytics_agent_complete",
+            invocation_id=invocation_id,
+            agent_role=agent_role,
+            outcome=outcome,
+            cost_usd=f"${cost:.4f}",
+        )
+
+    async def on_feedback(
+        self,
+        finding_id: str,
+        invocation_id: str,
+        agent_role: str,
+        cluster: str,
+        feedback_type: str,
+        feedback_value: str,
+        feedback_by: str,
+        feedback_comment: Optional[str] = None,
+    ) -> None:
+        """Called when a human reacts to an advisory in Slack."""
+        await self._ch.write_feedback(
+            {
+                "finding_id": finding_id,
+                "invocation_id": invocation_id,
+                "feedback_type": feedback_type,
+                "feedback_value": feedback_value,
+                "feedback_by": feedback_by,
+                "feedback_comment": feedback_comment,
+                "agent_role": agent_role,
+                "cluster": cluster,
+            }
+        )
+
+    async def on_resolution(
+        self,
+        finding_id: str,
+        invocation_id: str,
+        agent_role: str,
+        cluster: str,
+        resolution_type: str,
+        resolved_by: str,
+        feedback_comment: Optional[str] = None,
+    ) -> None:
+        """Called when a finding is marked resolved or false positive via Slack.
+
+        Writes a feedback row with feedback_type='button' so resolution events
+        are captured alongside reaction-based feedback for accuracy reporting.
+        """
+        feedback_value = (
+            "false_positive"
+            if resolution_type == "false_positive"
+            else "resolved"
+        )
+        await self._ch.write_feedback(
+            {
+                "finding_id": finding_id,
+                "invocation_id": invocation_id,
+                "feedback_type": "button",
+                "feedback_value": feedback_value,
+                "feedback_by": resolved_by,
+                "feedback_comment": feedback_comment,
+                "agent_role": agent_role,
+                "cluster": cluster,
+            }
+        )
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _compute_cost(model: str, tokens: dict[str, int]) -> float:
+    pricing = _MODEL_PRICING.get(model, _DEFAULT_PRICING)
+    return (
+        tokens.get("input", 0) * pricing["input"] / 1_000_000
+        + tokens.get("output", 0) * pricing["output"] / 1_000_000
+        + tokens.get("thinking", 0) * pricing.get("thinking", pricing["input"]) / 1_000_000
+    )

--- a/ai-sre/k8s/clickhouse/clickhouse.yaml
+++ b/ai-sre/k8s/clickhouse/clickhouse.yaml
@@ -1,0 +1,170 @@
+---
+# ClickHouse StatefulSet for AI SRE analytics storage.
+#
+# Single-node deployment suitable for the analytics workload; scale to
+# a ClickHouseInstallation (operator) when sharding is needed.
+# Ref: https://clickhouse.com/docs/en/install
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: clickhouse-ai-sre
+  namespace: ai-sre-system
+  labels:
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/component: analytics-db
+    app.kubernetes.io/part-of: ai-sre
+spec:
+  serviceName: clickhouse-ai-sre
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: clickhouse
+      app.kubernetes.io/component: analytics-db
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: clickhouse
+        app.kubernetes.io/component: analytics-db
+        app.kubernetes.io/part-of: ai-sre
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        # Run schema migrations on startup
+        - name: migrate
+          image: clickhouse/clickhouse-server:24.6-alpine
+          command:
+            - /bin/sh
+            - -c
+            - |
+              until clickhouse-client \
+                --host clickhouse-ai-sre \
+                --port 9000 \
+                --user ai_sre \
+                --password "${CLICKHOUSE_PASSWORD}" \
+                --query "SELECT 1"; do
+                echo "Waiting for ClickHouse..."
+                sleep 2
+              done
+              clickhouse-client \
+                --host clickhouse-ai-sre \
+                --port 9000 \
+                --user ai_sre \
+                --password "${CLICKHOUSE_PASSWORD}" \
+                --multiquery < /migrations/001_create_analytics_schema.sql
+          env:
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: clickhouse-ai-sre-secret
+                  key: password
+          volumeMounts:
+            - name: migrations
+              mountPath: /migrations
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      containers:
+        - name: clickhouse
+          image: clickhouse/clickhouse-server:24.6-alpine
+          ports:
+            - name: http
+              containerPort: 8123
+              protocol: TCP
+            - name: native
+              containerPort: 9000
+              protocol: TCP
+          env:
+            - name: CLICKHOUSE_DB
+              value: ai_sre
+            - name: CLICKHOUSE_USER
+              value: ai_sre
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: clickhouse-ai-sre-secret
+                  key: password
+          resources:
+            requests:
+              cpu: "500m"
+              memory: 2Gi
+            limits:
+              cpu: "2"
+              memory: 8Gi
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false  # ClickHouse writes data dir
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/clickhouse
+            - name: logs
+              mountPath: /var/log/clickhouse-server
+            - name: config
+              mountPath: /etc/clickhouse-server/config.d
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: clickhouse-ai-sre-config
+        - name: migrations
+          configMap:
+            name: clickhouse-ai-sre-migrations
+        - name: logs
+          emptyDir:
+            sizeLimit: 500Mi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: gp3
+        resources:
+          requests:
+            storage: 100Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse-ai-sre
+  namespace: ai-sre-system
+  labels:
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/component: analytics-db
+    app.kubernetes.io/part-of: ai-sre
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/component: analytics-db
+  ports:
+    - name: http
+      port: 8123
+      targetPort: http
+      protocol: TCP
+    - name: native
+      port: 9000
+      targetPort: native
+      protocol: TCP

--- a/ai-sre/k8s/clickhouse/configmap.yaml
+++ b/ai-sre/k8s/clickhouse/configmap.yaml
@@ -1,0 +1,93 @@
+---
+# ClickHouse server config — tunes memory limits and enables compression
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clickhouse-ai-sre-config
+  namespace: ai-sre-system
+  labels:
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/component: analytics-db
+    app.kubernetes.io/part-of: ai-sre
+data:
+  storage.xml: |
+    <clickhouse>
+      <storage_policies>
+        <ai_sre_policy>
+          <volumes>
+            <main>
+              <disk>default</disk>
+            </main>
+          </volumes>
+        </ai_sre_policy>
+      </storage_policies>
+    </clickhouse>
+
+  compression.xml: |
+    <clickhouse>
+      <compression>
+        <case>
+          <method>zstd</method>
+          <level>3</level>
+        </case>
+      </compression>
+    </clickhouse>
+
+  resources.xml: |
+    <clickhouse>
+      <!-- Reserve 70% of container memory for ClickHouse -->
+      <max_server_memory_usage_to_ram_ratio>0.70</max_server_memory_usage_to_ram_ratio>
+      <max_memory_usage>5368709120</max_memory_usage>   <!-- 5 GiB -->
+    </clickhouse>
+
+  users.xml: |
+    <clickhouse>
+      <users>
+        <!-- ai_sre user — password set via secret -->
+        <ai_sre>
+          <password_sha256_hex from_env="CLICKHOUSE_PASSWORD_SHA256"/>
+          <networks>
+            <ip>::/0</ip>
+          </networks>
+          <profile>default</profile>
+          <quota>default</quota>
+          <databases>
+            <ai_sre/>
+          </databases>
+        </ai_sre>
+        <!-- read-only Grafana user -->
+        <grafana>
+          <password_sha256_hex from_env="CLICKHOUSE_GRAFANA_PASSWORD_SHA256"/>
+          <networks>
+            <ip>::/0</ip>
+          </networks>
+          <profile>readonly</profile>
+          <quota>default</quota>
+          <databases>
+            <ai_sre/>
+          </databases>
+        </grafana>
+      </users>
+      <profiles>
+        <readonly>
+          <readonly>1</readonly>
+        </readonly>
+      </profiles>
+    </clickhouse>
+---
+# Schema migrations — mounted into the init container
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clickhouse-ai-sre-migrations
+  namespace: ai-sre-system
+  labels:
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/component: analytics-db
+    app.kubernetes.io/part-of: ai-sre
+data:
+  # The SQL file is projected from a separate ConfigMap to avoid size limits.
+  # In production this content is generated from the file at:
+  # ai-sre/analytics/migrations/001_create_analytics_schema.sql
+  # via a Kustomize configMapGenerator or Helm .Files.Get
+  001_create_analytics_schema.sql: ""   # populated by Helm/Kustomize

--- a/ai-sre/k8s/clickhouse/externalsecret.yaml
+++ b/ai-sre/k8s/clickhouse/externalsecret.yaml
@@ -1,0 +1,30 @@
+---
+# ExternalSecret — syncs ClickHouse credentials from AWS Secrets Manager
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: clickhouse-ai-sre-secret
+  namespace: ai-sre-system
+  labels:
+    app.kubernetes.io/part-of: ai-sre
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-secrets-manager
+  target:
+    name: clickhouse-ai-sre-secret
+    creationPolicy: Owner
+    template:
+      data:
+        password: "{{ .password }}"
+        grafana_password: "{{ .grafana_password }}"
+  data:
+    - secretKey: password
+      remoteRef:
+        key: ai-sre/clickhouse
+        property: password
+    - secretKey: grafana_password
+      remoteRef:
+        key: ai-sre/clickhouse
+        property: grafana_password

--- a/ai-sre/k8s/clickhouse/namespace.yaml
+++ b/ai-sre/k8s/clickhouse/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ai-sre-system
+  labels:
+    app.kubernetes.io/part-of: ai-sre

--- a/ai-sre/k8s/clickhouse/networkpolicy.yaml
+++ b/ai-sre/k8s/clickhouse/networkpolicy.yaml
@@ -1,0 +1,38 @@
+---
+# NetworkPolicy: only ai-sre pods and Grafana may reach ClickHouse
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: clickhouse-ai-sre
+  namespace: ai-sre-system
+  labels:
+    app.kubernetes.io/part-of: ai-sre
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: clickhouse
+      app.kubernetes.io/component: analytics-db
+  policyTypes:
+    - Ingress
+  ingress:
+    # AI SRE orchestrator and Slack app (analytics writes)
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/part-of: ai-sre
+      ports:
+        - port: 8123
+          protocol: TCP
+        - port: 9000
+          protocol: TCP
+    # Grafana (read-only queries)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: grafana
+      ports:
+        - port: 8123
+          protocol: TCP

--- a/ai-sre/k8s/orchestrator/orchestrator-analytics-patch.yaml
+++ b/ai-sre/k8s/orchestrator/orchestrator-analytics-patch.yaml
@@ -1,0 +1,31 @@
+---
+# Strategic merge patch: add ClickHouse analytics env vars to the orchestrator.
+# Apply on top of deployment.yaml via Kustomize or Helm mergeValues.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ai-sre-orchestrator
+  namespace: ai-sre-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: orchestrator
+          env:
+            - name: CLICKHOUSE_HOST
+              value: clickhouse-ai-sre.ai-sre-system.svc.cluster.local
+            - name: CLICKHOUSE_PORT
+              value: "8123"
+            - name: CLICKHOUSE_USER
+              value: ai_sre
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: clickhouse-ai-sre-secret
+                  key: password
+            - name: ANALYTICS_ENABLED
+              value: "true"
+            - name: ANALYTICS_BATCH_SIZE
+              value: "100"
+            - name: ANALYTICS_FLUSH_INTERVAL_SEC
+              value: "10"

--- a/ai-sre/k8s/slack-app/slack-analytics-patch.yaml
+++ b/ai-sre/k8s/slack-app/slack-analytics-patch.yaml
@@ -1,0 +1,28 @@
+---
+# Strategic merge patch: add ClickHouse analytics env vars to the Slack app.
+# The Slack app needs write access to record feedback from Slack reactions
+# and resolution button clicks.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ai-sre-slack-app
+  namespace: ai-sre-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: slack-app
+          env:
+            - name: CLICKHOUSE_HOST
+              value: clickhouse-ai-sre.ai-sre-system.svc.cluster.local
+            - name: CLICKHOUSE_PORT
+              value: "8123"
+            - name: CLICKHOUSE_USER
+              value: ai_sre
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: clickhouse-ai-sre-secret
+                  key: password
+            - name: ANALYTICS_ENABLED
+              value: "true"

--- a/apps/infra/grafana-dashboards/ai-sre/configmap-ai-sre-dashboards.yaml
+++ b/apps/infra/grafana-dashboards/ai-sre/configmap-ai-sre-dashboards.yaml
@@ -1,0 +1,46 @@
+---
+# Grafana dashboard provisioning ConfigMap for AI SRE Analytics.
+#
+# These dashboards are loaded by Grafana's dashboard provisioner.
+# The JSON content is referenced from files via Helm .Files.Get or
+# Kustomize configMapGenerator in production.  The provisioner config
+# below tells Grafana to watch the /var/lib/grafana/dashboards/ai-sre/
+# mount path.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards-ai-sre
+  namespace: observability
+  labels:
+    grafana_dashboard: "1"
+    app.kubernetes.io/component: grafana-dashboards
+    app.kubernetes.io/part-of: ai-sre
+  annotations:
+    # Grafana sidecar watches this label to auto-load dashboards
+    k8s-sidecar-target-directory: /var/lib/grafana/dashboards/ai-sre
+data:
+  # Dashboard provisioner configuration
+  dashboards-provisioner.yaml: |
+    apiVersion: 1
+    providers:
+      - name: ai-sre
+        orgId: 1
+        folder: AI SRE Analytics
+        folderUid: ai-sre-analytics
+        type: file
+        disableDeletion: false
+        editable: false
+        updateIntervalSeconds: 30
+        allowUiUpdates: false
+        options:
+          path: /var/lib/grafana/dashboards/ai-sre
+
+  # Dashboard JSON files are loaded here.
+  # In Helm: {{ .Files.Get "apps/infra/grafana-dashboards/ai-sre/dashboard-agent-usage.json" }}
+  # In Kustomize: use configMapGenerator with files[] referencing the JSON files.
+  #
+  # For direct provisioning, the dashboard JSONs are embedded below:
+  dashboard-agent-usage.json: ""     # set by Helm/Kustomize from dashboard-agent-usage.json
+  dashboard-findings.json: ""        # set by Helm/Kustomize from dashboard-findings.json
+  dashboard-accuracy.json: ""        # set by Helm/Kustomize from dashboard-accuracy.json
+  dashboard-cost-roi.json: ""        # set by Helm/Kustomize from dashboard-cost-roi.json

--- a/apps/infra/grafana-dashboards/ai-sre/dashboard-accuracy.json
+++ b/apps/infra/grafana-dashboards/ai-sre/dashboard-accuracy.json
@@ -1,0 +1,162 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_CLICKHOUSE",
+      "label": "ClickHouse-AI-SRE",
+      "type": "datasource",
+      "pluginId": "grafana-clickhouse-datasource",
+      "pluginName": "ClickHouse"
+    }
+  ],
+  "__requires": [
+    {"type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0"},
+    {"type": "datasource", "id": "grafana-clickhouse-datasource", "name": "ClickHouse", "version": "4.0.0"}
+  ],
+  "annotations": {"list": []},
+  "description": "AI SRE agent accuracy — helpfulness rate, RCA correctness, false positive rate, accuracy trend, and per-agent breakdown",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": true, "icon": "external link", "includeVars": true, "keepTime": true,
+      "tags": ["ai-sre"], "title": "AI SRE Dashboards", "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "id": 1, "type": "gauge",
+      "title": "Overall Helpfulness Rate",
+      "gridPos": {"h": 6, "w": 5, "x": 0, "y": 0},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "minVizWidth": 75, "minVizHeight": 75},
+      "fieldConfig": {"defaults": {"unit": "percentunit", "min": 0, "max": 1,
+        "thresholds": {"steps": [{"color": "red", "value": null}, {"color": "yellow", "value": 0.6}, {"color": "green", "value": 0.8}]}}},
+      "targets": [
+        {
+          "rawSql": "SELECT countIf(feedback_value = 'helpful') / (countIf(feedback_value = 'helpful') + countIf(feedback_value = 'not_helpful')) AS helpfulness FROM ai_sre.feedback WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) AND agent_role IN ($agent_role)",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 2, "type": "gauge",
+      "title": "RCA Correctness Rate",
+      "gridPos": {"h": 6, "w": 5, "x": 5, "y": 0},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}},
+      "fieldConfig": {"defaults": {"unit": "percentunit", "min": 0, "max": 1,
+        "thresholds": {"steps": [{"color": "red", "value": null}, {"color": "yellow", "value": 0.65}, {"color": "green", "value": 0.85}]}}},
+      "targets": [
+        {
+          "rawSql": "SELECT countIf(feedback_value = 'correct_rca') / (countIf(feedback_value = 'correct_rca') + countIf(feedback_value = 'wrong_rca')) AS rca_accuracy FROM ai_sre.feedback WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) AND agent_role IN ($agent_role)",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 3, "type": "stat",
+      "title": "Feedback Coverage",
+      "description": "% of advisories that received at least one human feedback signal",
+      "gridPos": {"h": 6, "w": 5, "x": 10, "y": 0},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "background", "unit": "percentunit"},
+      "fieldConfig": {"defaults": {"thresholds": {"steps": [{"color": "red", "value": null}, {"color": "yellow", "value": 0.3}, {"color": "green", "value": 0.6}]}}},
+      "targets": [
+        {
+          "rawSql": "SELECT uniq(invocation_id) / (SELECT count() FROM ai_sre.agent_usage WHERE timestamp >= $__fromTime AND timestamp <= $__toTime) AS coverage FROM ai_sre.feedback WHERE timestamp >= $__fromTime AND timestamp <= $__toTime",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 4, "type": "stat",
+      "title": "False Positive Rate",
+      "gridPos": {"h": 6, "w": 5, "x": 15, "y": 0},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "background", "unit": "percentunit"},
+      "fieldConfig": {"defaults": {"thresholds": {"steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 0.10}, {"color": "red", "value": 0.20}]}}},
+      "targets": [
+        {
+          "rawSql": "SELECT countIf(feedback_value = 'false_positive') / count() AS fp_rate FROM ai_sre.feedback WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) AND agent_role IN ($agent_role)",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 5, "type": "barchart",
+      "title": "Accuracy by Agent Role",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 6},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"orientation": "horizontal", "legend": {"displayMode": "list"}},
+      "targets": [
+        {
+          "rawSql": "SELECT agent_role, countIf(feedback_value IN ('helpful','correct_rca')) / count() AS accuracy, count() AS feedback_count FROM ai_sre.feedback WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) GROUP BY agent_role ORDER BY accuracy DESC",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 6, "type": "timeseries",
+      "title": "Accuracy Trend (7-day rolling)",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 6},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "fieldConfig": {"defaults": {"unit": "percentunit", "min": 0, "max": 1, "custom": {"lineWidth": 2}}},
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "rawSql": "SELECT toDate(timestamp) AS time, countIf(feedback_value IN ('helpful','correct_rca')) / count() AS accuracy FROM ai_sre.feedback WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) AND agent_role IN ($agent_role) GROUP BY time ORDER BY time",
+          "format": "time_series", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 7, "type": "table",
+      "title": "Worst Performing Areas (agent_role x finding_type)",
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 14},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"sortBy": [{"displayName": "accuracy", "desc": false}]},
+      "targets": [
+        {
+          "rawSql": "SELECT f.agent_role, fn.finding_type, count() AS feedback_count, round(countIf(f.feedback_value IN ('helpful','correct_rca')) / count(), 3) AS accuracy, countIf(f.feedback_value = 'false_positive') AS false_positives FROM ai_sre.feedback f JOIN ai_sre.findings fn ON f.finding_id = fn.finding_id WHERE f.timestamp >= $__fromTime AND f.timestamp <= $__toTime GROUP BY f.agent_role, fn.finding_type HAVING feedback_count >= 5 ORDER BY accuracy ASC LIMIT 25",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    }
+  ],
+  "refresh": "10m",
+  "schemaVersion": 38,
+  "tags": ["ai-sre", "accuracy", "feedback"],
+  "templating": {
+    "list": [
+      {
+        "name": "cluster", "type": "query", "label": "Cluster",
+        "multi": true, "includeAll": true,
+        "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+        "query": "SELECT DISTINCT cluster FROM ai_sre.feedback ORDER BY cluster",
+        "refresh": 2
+      },
+      {
+        "name": "agent_role", "type": "query", "label": "Agent Role",
+        "multi": true, "includeAll": true,
+        "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+        "query": "SELECT DISTINCT agent_role FROM ai_sre.feedback ORDER BY agent_role",
+        "refresh": 2
+      }
+    ]
+  },
+  "time": {"from": "now-30d", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "AI SRE — Accuracy & Feedback",
+  "uid": "ai-sre-accuracy",
+  "version": 1
+}

--- a/apps/infra/grafana-dashboards/ai-sre/dashboard-agent-usage.json
+++ b/apps/infra/grafana-dashboards/ai-sre/dashboard-agent-usage.json
@@ -1,0 +1,260 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_CLICKHOUSE",
+      "label": "ClickHouse-AI-SRE",
+      "description": "AI SRE ClickHouse analytics database",
+      "type": "datasource",
+      "pluginId": "grafana-clickhouse-datasource",
+      "pluginName": "ClickHouse"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "grafana-clickhouse-datasource",
+      "name": "ClickHouse",
+      "version": "4.0.0"
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "description": "AI SRE agent invocation rates, token consumption, API cost, and outcome distribution",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": ["ai-sre"],
+      "title": "AI SRE Dashboards",
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Total Invocations (selected range)",
+      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 0},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "background", "graphMode": "none"},
+      "targets": [
+        {
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+          "rawSql": "SELECT count() AS invocations FROM ai_sre.agent_usage WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) AND agent_role IN ($agent_role)",
+          "format": "table",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Total API Cost (USD)",
+      "gridPos": {"h": 4, "w": 4, "x": 4, "y": 0},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "background", "graphMode": "none", "unit": "currencyUSD"},
+      "targets": [
+        {
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+          "rawSql": "SELECT round(sum(cost_usd), 4) AS cost FROM ai_sre.agent_usage WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) AND agent_role IN ($agent_role)",
+          "format": "table",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Total Tokens Consumed",
+      "gridPos": {"h": 4, "w": 4, "x": 8, "y": 0},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "background", "graphMode": "none"},
+      "targets": [
+        {
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+          "rawSql": "SELECT sum(tokens_input + tokens_output + tokens_thinking) AS tokens FROM ai_sre.agent_usage WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) AND agent_role IN ($agent_role)",
+          "format": "table",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Error Rate",
+      "gridPos": {"h": 4, "w": 4, "x": 12, "y": 0},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "background", "graphMode": "none", "unit": "percentunit"},
+      "fieldConfig": {"defaults": {"thresholds": {"steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 0.05}, {"color": "red", "value": 0.10}]}, "mappings": []}},
+      "targets": [
+        {
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+          "rawSql": "SELECT countIf(outcome = 'error') / count() AS error_rate FROM ai_sre.agent_usage WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) AND agent_role IN ($agent_role)",
+          "format": "table",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Avg Investigation Duration",
+      "gridPos": {"h": 4, "w": 4, "x": 16, "y": 0},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value", "graphMode": "none", "unit": "ms"},
+      "targets": [
+        {
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+          "rawSql": "SELECT round(avg(duration_ms)) AS avg_duration FROM ai_sre.agent_usage WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) AND agent_role IN ($agent_role)",
+          "format": "table",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Invocations Over Time (by agent_role)",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "fieldConfig": {"defaults": {"custom": {"lineWidth": 2}}},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom"}},
+      "targets": [
+        {
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+          "rawSql": "SELECT toStartOfHour(timestamp) AS time, agent_role, count() AS invocations FROM ai_sre.agent_usage WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) AND agent_role IN ($agent_role) GROUP BY time, agent_role ORDER BY time",
+          "format": "time_series",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "API Cost per Day (by model)",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "fieldConfig": {"defaults": {"unit": "currencyUSD", "custom": {"lineWidth": 2, "fillOpacity": 20}}},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom"}},
+      "targets": [
+        {
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+          "rawSql": "SELECT toDate(timestamp) AS time, model, round(sum(cost_usd), 4) AS cost FROM ai_sre.agent_usage WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) AND agent_role IN ($agent_role) GROUP BY time, model ORDER BY time",
+          "format": "time_series",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "piechart",
+      "title": "Outcome Distribution",
+      "gridPos": {"h": 8, "w": 6, "x": 0, "y": 12},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"pieType": "donut", "legend": {"displayMode": "list", "placement": "right"}},
+      "targets": [
+        {
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+          "rawSql": "SELECT outcome, count() AS count FROM ai_sre.agent_usage WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) AND agent_role IN ($agent_role) GROUP BY outcome ORDER BY count DESC",
+          "format": "table",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "piechart",
+      "title": "Trigger Distribution",
+      "gridPos": {"h": 8, "w": 6, "x": 6, "y": 12},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"pieType": "donut", "legend": {"displayMode": "list", "placement": "right"}},
+      "targets": [
+        {
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+          "rawSql": "SELECT trigger_type, count() AS count FROM ai_sre.agent_usage WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) AND agent_role IN ($agent_role) GROUP BY trigger_type ORDER BY count DESC",
+          "format": "table",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "barchart",
+      "title": "Top MCP Tools Used",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"orientation": "horizontal", "legend": {"displayMode": "list"}},
+      "targets": [
+        {
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+          "rawSql": "SELECT tool_name, mcp_server, count() AS calls, countIf(success = true) AS successes FROM ai_sre.tool_calls WHERE timestamp >= $__fromTime AND timestamp <= $__toTime GROUP BY tool_name, mcp_server ORDER BY calls DESC LIMIT 20",
+          "format": "table",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Token Usage Over Time (input / output / thinking)",
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 20},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "fieldConfig": {"defaults": {"custom": {"lineWidth": 2, "fillOpacity": 10}}},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom"}},
+      "targets": [
+        {
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+          "rawSql": "SELECT toStartOfHour(timestamp) AS time, sum(tokens_input) AS input_tokens, sum(tokens_output) AS output_tokens, sum(tokens_thinking) AS thinking_tokens FROM ai_sre.agent_usage WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) AND agent_role IN ($agent_role) GROUP BY time ORDER BY time",
+          "format": "time_series",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 38,
+  "tags": ["ai-sre", "usage", "cost"],
+  "templating": {
+    "list": [
+      {
+        "name": "cluster",
+        "type": "query",
+        "label": "Cluster",
+        "multi": true,
+        "includeAll": true,
+        "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+        "query": "SELECT DISTINCT cluster FROM ai_sre.agent_usage ORDER BY cluster",
+        "refresh": 2
+      },
+      {
+        "name": "agent_role",
+        "type": "query",
+        "label": "Agent Role",
+        "multi": true,
+        "includeAll": true,
+        "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+        "query": "SELECT DISTINCT agent_role FROM ai_sre.agent_usage ORDER BY agent_role",
+        "refresh": 2
+      }
+    ]
+  },
+  "time": {"from": "now-24h", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "AI SRE — Agent Usage & Cost",
+  "uid": "ai-sre-agent-usage",
+  "version": 1
+}

--- a/apps/infra/grafana-dashboards/ai-sre/dashboard-cost-roi.json
+++ b/apps/infra/grafana-dashboards/ai-sre/dashboard-cost-roi.json
@@ -1,0 +1,161 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_CLICKHOUSE",
+      "label": "ClickHouse-AI-SRE",
+      "type": "datasource",
+      "pluginId": "grafana-clickhouse-datasource",
+      "pluginName": "ClickHouse"
+    }
+  ],
+  "__requires": [
+    {"type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0"},
+    {"type": "datasource", "id": "grafana-clickhouse-datasource", "name": "ClickHouse", "version": "4.0.0"}
+  ],
+  "annotations": {"list": []},
+  "description": "AI SRE API cost, cost per finding, cost savings identified by agents, and ROI metrics",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": true, "icon": "external link", "includeVars": true, "keepTime": true,
+      "tags": ["ai-sre"], "title": "AI SRE Dashboards", "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "id": 1, "type": "stat",
+      "title": "Total API Cost (selected range)",
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "background"},
+      "fieldConfig": {"defaults": {"unit": "currencyUSD"}},
+      "targets": [
+        {
+          "rawSql": "SELECT round(sum(cost_usd), 2) AS total_cost FROM ai_sre.agent_usage WHERE timestamp >= $__fromTime AND timestamp <= $__toTime",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 2, "type": "stat",
+      "title": "Cost per Finding",
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"},
+      "fieldConfig": {"defaults": {"unit": "currencyUSD"}},
+      "targets": [
+        {
+          "rawSql": "SELECT round(sum(cost_usd) / countIf(finding_id IS NOT NULL), 4) AS cost_per_finding FROM ai_sre.agent_usage WHERE timestamp >= $__fromTime AND timestamp <= $__toTime",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 3, "type": "stat",
+      "title": "Daily Average Cost",
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"},
+      "fieldConfig": {"defaults": {"unit": "currencyUSD"}},
+      "targets": [
+        {
+          "rawSql": "SELECT round(sum(cost_usd) / toUInt32(dateDiff('day', toDate($__fromTime), toDate($__toTime)) + 1), 2) AS daily_avg FROM ai_sre.agent_usage WHERE timestamp >= $__fromTime AND timestamp <= $__toTime",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 4, "type": "stat",
+      "title": "Cost per Token (USD/1k tokens)",
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value"},
+      "fieldConfig": {"defaults": {"unit": "currencyUSD"}},
+      "targets": [
+        {
+          "rawSql": "SELECT round(sum(cost_usd) / sum(tokens_input + tokens_output) * 1000, 6) AS cost_per_k_tokens FROM ai_sre.agent_usage WHERE timestamp >= $__fromTime AND timestamp <= $__toTime",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 5, "type": "timeseries",
+      "title": "Daily API Cost Trend (stacked by model)",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "fieldConfig": {"defaults": {"unit": "currencyUSD", "custom": {"lineWidth": 2, "fillOpacity": 30}}},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "rawSql": "SELECT toDate(timestamp) AS time, model, round(sum(cost_usd), 4) AS cost FROM ai_sre.agent_usage WHERE timestamp >= $__fromTime AND timestamp <= $__toTime GROUP BY time, model ORDER BY time",
+          "format": "time_series", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 6, "type": "timeseries",
+      "title": "Cost per Finding (7-day rolling avg)",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "fieldConfig": {"defaults": {"unit": "currencyUSD", "custom": {"lineWidth": 2}}},
+      "options": {"legend": {"displayMode": "list"}},
+      "targets": [
+        {
+          "rawSql": "SELECT toDate(timestamp) AS time, round(sum(cost_usd) / greatest(countIf(finding_id IS NOT NULL), 1), 4) AS cost_per_finding FROM ai_sre.agent_usage WHERE timestamp >= $__fromTime AND timestamp <= $__toTime GROUP BY time ORDER BY time",
+          "format": "time_series", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 7, "type": "barchart",
+      "title": "Cost by Agent Role",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"orientation": "horizontal", "legend": {"displayMode": "list"}},
+      "fieldConfig": {"defaults": {"unit": "currencyUSD"}},
+      "targets": [
+        {
+          "rawSql": "SELECT agent_role, round(sum(cost_usd), 4) AS total_cost, count() AS invocations FROM ai_sre.agent_usage WHERE timestamp >= $__fromTime AND timestamp <= $__toTime GROUP BY agent_role ORDER BY total_cost DESC",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 8, "type": "table",
+      "title": "Cost Waste Findings (cost_optimization findings)",
+      "description": "Infrastructure cost savings opportunities identified by the Cost Optimization agent",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"sortBy": [{"displayName": "timestamp", "desc": true}]},
+      "targets": [
+        {
+          "rawSql": "SELECT timestamp, cluster, namespace, affected_resource, severity, root_cause_summary, status FROM ai_sre.findings WHERE finding_type = 'cost_waste' AND timestamp >= $__fromTime AND timestamp <= $__toTime ORDER BY timestamp DESC LIMIT 30",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    }
+  ],
+  "refresh": "30m",
+  "schemaVersion": 38,
+  "tags": ["ai-sre", "cost", "roi"],
+  "templating": {
+    "list": []
+  },
+  "time": {"from": "now-30d", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "AI SRE — Cost & ROI",
+  "uid": "ai-sre-cost-roi",
+  "version": 1
+}

--- a/apps/infra/grafana-dashboards/ai-sre/dashboard-findings.json
+++ b/apps/infra/grafana-dashboards/ai-sre/dashboard-findings.json
@@ -1,0 +1,218 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_CLICKHOUSE",
+      "label": "ClickHouse-AI-SRE",
+      "type": "datasource",
+      "pluginId": "grafana-clickhouse-datasource",
+      "pluginName": "ClickHouse"
+    }
+  ],
+  "__requires": [
+    {"type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0"},
+    {"type": "datasource", "id": "grafana-clickhouse-datasource", "name": "ClickHouse", "version": "4.0.0"}
+  ],
+  "annotations": {"list": []},
+  "description": "AI SRE findings — types, severity, cluster distribution, MTTR, MTTA, and resolution funnel",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": true, "icon": "external link", "includeVars": true, "keepTime": true,
+      "tags": ["ai-sre"], "title": "AI SRE Dashboards", "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "id": 1, "type": "stat", "title": "Open Findings",
+      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 0},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "background"},
+      "fieldConfig": {"defaults": {"thresholds": {"steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 10}, {"color": "red", "value": 25}]}}},
+      "targets": [
+        {
+          "rawSql": "SELECT count() AS open FROM ai_sre.findings WHERE status = 'open'",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 2, "type": "stat", "title": "MTTA (Mean Time to Advise)",
+      "gridPos": {"h": 4, "w": 4, "x": 4, "y": 0},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value", "unit": "s"},
+      "targets": [
+        {
+          "rawSql": "SELECT round(avg(time_to_advise_sec), 1) AS mtta FROM ai_sre.findings WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster)",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 3, "type": "stat", "title": "MTTR (Mean Time to Resolve)",
+      "gridPos": {"h": 4, "w": 4, "x": 8, "y": 0},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value", "unit": "s"},
+      "targets": [
+        {
+          "rawSql": "SELECT round(avg(time_to_resolve_sec), 1) AS mttr FROM ai_sre.findings WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) AND status = 'resolved' AND time_to_resolve_sec IS NOT NULL",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 4, "type": "stat", "title": "Cross-Layer Findings %",
+      "gridPos": {"h": 4, "w": 4, "x": 12, "y": 0},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "value", "unit": "percentunit"},
+      "targets": [
+        {
+          "rawSql": "SELECT countIf(is_cross_layer = true) / count() AS cross_layer_pct FROM ai_sre.findings WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster)",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 5, "type": "stat", "title": "False Positive Rate",
+      "gridPos": {"h": 4, "w": 4, "x": 16, "y": 0},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "background", "unit": "percentunit"},
+      "fieldConfig": {"defaults": {"thresholds": {"steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 0.10}, {"color": "red", "value": 0.20}]}}},
+      "targets": [
+        {
+          "rawSql": "SELECT countIf(status = 'false_positive') / count() AS fp_rate FROM ai_sre.findings WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster)",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 6, "type": "barchart",
+      "title": "Findings by Type Over Time",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"orientation": "vertical", "stacking": "normal", "legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "rawSql": "SELECT toDate(timestamp) AS day, finding_type, count() AS count FROM ai_sre.findings WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) GROUP BY day, finding_type ORDER BY day",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 7, "type": "barchart",
+      "title": "Findings by Severity Over Time",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"orientation": "vertical", "stacking": "normal", "legend": {"displayMode": "table", "placement": "right"}},
+      "fieldConfig": {"overrides": [
+        {"matcher": {"id": "byName", "options": "critical"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]},
+        {"matcher": {"id": "byName", "options": "high"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "orange"}}]},
+        {"matcher": {"id": "byName", "options": "medium"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "yellow"}}]},
+        {"matcher": {"id": "byName", "options": "low"}, "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "green"}}]}
+      ]},
+      "targets": [
+        {
+          "rawSql": "SELECT toDate(timestamp) AS day, severity, count() AS count FROM ai_sre.findings WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) GROUP BY day, severity ORDER BY day",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 8, "type": "barchart",
+      "title": "Findings by Cluster",
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 12},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"orientation": "horizontal", "legend": {"displayMode": "list"}},
+      "targets": [
+        {
+          "rawSql": "SELECT cluster, count() AS findings FROM ai_sre.findings WHERE timestamp >= $__fromTime AND timestamp <= $__toTime GROUP BY cluster ORDER BY findings DESC",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 9, "type": "piechart",
+      "title": "Root Cause Category Distribution",
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 12},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"pieType": "donut", "legend": {"displayMode": "list", "placement": "right"}},
+      "targets": [
+        {
+          "rawSql": "SELECT category, count() AS count FROM ai_sre.findings WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) GROUP BY category ORDER BY count DESC",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 10, "type": "timeseries",
+      "title": "MTTA / MTTR Trend",
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 12},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "fieldConfig": {"defaults": {"unit": "s", "custom": {"lineWidth": 2}}},
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "rawSql": "SELECT toDate(timestamp) AS time, avg(time_to_advise_sec) AS mtta, avg(time_to_resolve_sec) AS mttr FROM ai_sre.findings WHERE timestamp >= $__fromTime AND timestamp <= $__toTime AND cluster IN ($cluster) GROUP BY time ORDER BY time",
+          "format": "time_series", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    },
+    {
+      "id": 11, "type": "table",
+      "title": "Open Findings",
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 20},
+      "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+      "options": {"sortBy": [{"displayName": "timestamp", "desc": true}]},
+      "fieldConfig": {"overrides": [
+        {"matcher": {"id": "byName", "options": "severity"}, "properties": [
+          {"id": "custom.displayMode", "value": "color-background"},
+          {"id": "mappings", "value": [
+            {"type": "value", "options": {"critical": {"color": "red", "text": "CRITICAL"}}},
+            {"type": "value", "options": {"high": {"color": "orange", "text": "HIGH"}}},
+            {"type": "value", "options": {"medium": {"color": "yellow", "text": "MEDIUM"}}},
+            {"type": "value", "options": {"low": {"color": "green", "text": "LOW"}}}
+          ]}
+        ]}
+      ]},
+      "targets": [
+        {
+          "rawSql": "SELECT toString(finding_id) AS finding_id, timestamp, cluster, namespace, finding_type, severity, affected_resource, root_cause_summary, confidence, status FROM ai_sre.findings WHERE status = 'open' AND cluster IN ($cluster) ORDER BY severity DESC, timestamp DESC LIMIT 50",
+          "format": "table", "refId": "A",
+          "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"}
+        }
+      ]
+    }
+  ],
+  "refresh": "2m",
+  "schemaVersion": 38,
+  "tags": ["ai-sre", "findings", "sre"],
+  "templating": {
+    "list": [
+      {
+        "name": "cluster", "type": "query", "label": "Cluster",
+        "multi": true, "includeAll": true,
+        "datasource": {"type": "grafana-clickhouse-datasource", "uid": "${DS_CLICKHOUSE}"},
+        "query": "SELECT DISTINCT cluster FROM ai_sre.findings ORDER BY cluster",
+        "refresh": 2
+      }
+    ]
+  },
+  "time": {"from": "now-7d", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "AI SRE — Findings Analytics",
+  "uid": "ai-sre-findings",
+  "version": 1
+}

--- a/apps/infra/grafana-dashboards/ai-sre/datasource-clickhouse.yaml
+++ b/apps/infra/grafana-dashboards/ai-sre/datasource-clickhouse.yaml
@@ -1,0 +1,38 @@
+---
+# Grafana datasource provisioning for AI SRE ClickHouse analytics
+# Appended to the existing grafana-datasources ConfigMap via Kustomize
+# strategic merge or Helm values.
+#
+# Requires the grafana-clickhouse-datasource plugin:
+#   https://grafana.com/grafana/plugins/grafana-clickhouse-datasource/
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasource-clickhouse-ai-sre
+  namespace: observability
+  labels:
+    grafana_datasource: "1"
+data:
+  clickhouse-ai-sre.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: ClickHouse-AI-SRE
+        type: grafana-clickhouse-datasource
+        uid: clickhouse-ai-sre
+        access: proxy
+        url: http://clickhouse-ai-sre.ai-sre-system.svc.cluster.local:8123
+        editable: false
+        secureJsonData:
+          password: ${CLICKHOUSE_GRAFANA_PASSWORD}
+        jsonData:
+          server: clickhouse-ai-sre.ai-sre-system.svc.cluster.local
+          port: 8123
+          username: grafana
+          defaultDatabase: ai_sre
+          tlsSkipVerify: false
+          dialTimeout: 10
+          queryTimeout: 60
+          httpHeaders:
+            - name: X-ClickHouse-Format
+              value: JSONEachRow
+              secure: false


### PR DESCRIPTION
## Summary

Implements the full analytics layer for the AI SRE system (issue #131), enabling visibility into agent usage, findings, accuracy, and cost/ROI across all clusters.

- **ClickHouse schema** — four tables (`agent_usage`, `findings`, `feedback`, `tool_calls`) with monthly partitioning, 365-day TTL, and four materialized views for hourly/daily pre-aggregation
- **Python analytics SDK** — `ClickHouseAnalyticsClient` (async-buffered, 100-row batches / 10s flush) and `SREAnalytics` lifecycle hooks (`on_agent_start`, `on_tool_call`, `on_agent_complete`, `on_feedback`, `on_resolution`)
- **Slack feedback integration** — `reaction_added` listener maps thumbsup/thumbsdown/dart/x to structured `feedback_value`; `mark_resolved` and `mark_false_positive` buttons write resolution events
- **Kubernetes manifests** — ClickHouse StatefulSet (24.6-alpine, gp3 100Gi PVC, zstd compression), init-container schema migration, ExternalSecret from AWS Secrets Manager, NetworkPolicy (ai-sre pods + Grafana only)
- **Grafana provisioning** — ClickHouse datasource (read-only `grafana` user), four dashboard JSON files (Agent Usage & Cost, Findings Analytics, Accuracy & Feedback, Cost & ROI), ConfigMap provisioner placing them in folder "AI SRE Analytics"
- **Unit tests** — cost computation, full invocation lifecycle, finding write, feedback/resolution recording

## Files Changed

| Path | Description |
|---|---|
| `ai-sre/analytics/migrations/001_create_analytics_schema.sql` | ClickHouse schema + materialized views |
| `ai-sre/analytics/client.py` | Async-buffered ClickHouse writer |
| `ai-sre/analytics/tracker.py` | SREAnalytics lifecycle hooks |
| `ai-sre/analytics/slack_feedback.py` | Slack reaction + button feedback handlers |
| `ai-sre/analytics/test_tracker.py` | Unit tests |
| `ai-sre/k8s/clickhouse/` | StatefulSet, Service, ConfigMap, ExternalSecret, NetworkPolicy |
| `ai-sre/k8s/orchestrator/orchestrator-analytics-patch.yaml` | Merge patch adding CLICKHOUSE_* env vars |
| `ai-sre/k8s/slack-app/slack-analytics-patch.yaml` | Merge patch adding CLICKHOUSE_* env vars |
| `apps/infra/grafana-dashboards/ai-sre/datasource-clickhouse.yaml` | Grafana datasource provisioning |
| `apps/infra/grafana-dashboards/ai-sre/dashboard-*.json` | Four Grafana dashboards |
| `apps/infra/grafana-dashboards/ai-sre/configmap-ai-sre-dashboards.yaml` | Dashboard provisioner config |

## Test plan

- [ ] `pytest ai-sre/analytics/test_tracker.py -v` passes (all 9 tests)
- [ ] Apply ClickHouse manifests to `ai-sre-system` namespace; verify `/ping` returns 200
- [ ] Init container runs SQL migrations cleanly (`kubectl logs -c migrate`)
- [ ] Send a synthetic `agent_usage` row via `clickhouse-client`; confirm it appears in `agent_usage_hourly` materialized view
- [ ] Open Grafana, confirm "AI SRE Analytics" folder appears with all four dashboards
- [ ] Confirm ClickHouse datasource connects to `ai-sre-system` ClickHouse using `grafana` read-only user
- [ ] Verify NetworkPolicy blocks connection from non-ai-sre pod to ClickHouse port 8123

Closes #131