### PR TITLE
feat(gpu-inference): Cilium advanced eBPF — socket LB, XDP+DSR, Hubble L7, ClusterMesh

### DIFF
--- a/.github/workflows/infracost.yml
+++ b/.github/workflows/infracost.yml
@@ -198,13 +198,51 @@ jobs:
           fi
 
       # ---------------------------------------------------------------------------
-      # Post cost breakdown as PR comment
+      # Post cost breakdown as PR comment using GitHub API directly
+      # (infracost/actions/comment is deprecated)
       # ---------------------------------------------------------------------------
       - name: Post cost comment
-        uses: infracost/actions/comment@v3
+        uses: actions/github-script@v7
         with:
-          path: /tmp/infracost/combined.json
-          behavior: update
+          script: |
+            const fs = require('fs');
+            const combinedPath = '/tmp/infracost/combined.json';
+
+            let body = '### Infracost Cost Estimate\n\n';
+
+            if (fs.existsSync(combinedPath)) {
+              const data = JSON.parse(fs.readFileSync(combinedPath, 'utf8'));
+              const diff = data.diffTotalMonthlyCost || '0';
+              body += `**Monthly cost change:** $${diff}\n\n`;
+              body += 'See the workflow run for detailed breakdown.';
+            } else {
+              body += 'No cost data available.';
+            }
+
+            // Find existing comment
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            const botComment = comments.data.find(c => c.body.includes('### Infracost Cost Estimate'));
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body
+              });
+            }
 
       # ---------------------------------------------------------------------------
       # Enforce cost policy thresholds

--- a/.github/workflows/infracost.yml
+++ b/.github/workflows/infracost.yml
@@ -64,8 +64,8 @@ jobs:
             | sort -u \
             | jq -R -s -c 'split("\n") | map(select(. != ""))')
 
-          # Merge both arrays
-          ALL_ROOTS=$(jq -n \
+          # Merge both arrays into a single-line compact JSON
+          ALL_ROOTS=$(jq -c -n \
             --argjson a "${CHANGED_ROOTS:-[]}" \
             --argjson b "${CATALOG_CHANGED:-[]}" \
             '$a + $b | unique')

--- a/catalog/units/gpu-inference-cilium-advanced/terragrunt.hcl
+++ b/catalog/units/gpu-inference-cilium-advanced/terragrunt.hcl
@@ -1,0 +1,84 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference Cilium Advanced eBPF — Catalog Unit (Issue #144)
+# ---------------------------------------------------------------------------------------------------------------------
+# Extends the base gpu-inference-cilium unit with advanced eBPF capabilities:
+#   - Socket-level LB (sockops): zero NAT east-west — connect() rewritten once
+#   - XDP + DSR: north-south LB at NIC level, return traffic skips NLB
+#   - Maglev consistent hashing: connection affinity for long-lived gRPC/NCCL
+#   - Hubble L7: selective HTTP visibility for vLLM, DNS-only for training
+#   - ClusterMesh: gpu-inference cluster (ID=4) joins the platform mesh
+#
+# This unit manages monitoring resources and identity policies.
+# The Helm values for socket LB / XDP / DSR / Hubble L7 / ClusterMesh are
+# controlled via the gpu-inference-cilium unit (main Helm release).
+#
+# Deployment order (terragrunt.stack.hcl):
+#   gpu-inference-cilium → gpu-inference-cilium-encryption → gpu-inference-cilium-advanced
+#
+# ClusterMesh post-steps (after apply):
+#   1. Retrieve TLS certs from each cluster's clustermesh-apiserver-remote-cert secret
+#   2. Populate remote_clusters endpoints in _global/clustermesh-connect/terragrunt.hcl
+#   3. Run: cilium clustermesh status --wait (from any cluster context)
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/gpu-inference-cilium-advanced"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  environment = local.account_vars.locals.environment
+  aws_region  = local.region_vars.locals.aws_region
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPENDENCIES
+# ---------------------------------------------------------------------------------------------------------------------
+
+dependency "eks" {
+  config_path = "../gpu-inference-eks"
+
+  mock_outputs = {
+    cluster_name                       = "mock-gpu-cluster"
+    cluster_endpoint                   = "https://mock-endpoint.eks.amazonaws.com"
+    cluster_certificate_authority_data = "bW9jay1jZXJ0LWRhdGE="
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# PROVIDER GENERATION
+# ---------------------------------------------------------------------------------------------------------------------
+
+generate "k8s_providers" {
+  path      = "k8s_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "kubernetes" {
+      host                   = "${dependency.eks.outputs.cluster_endpoint}"
+      cluster_ca_certificate = base64decode("${dependency.eks.outputs.cluster_certificate_authority_data}")
+      exec {
+        api_version = "client.authentication.k8s.io/v1beta1"
+        command     = "aws"
+        args        = ["eks", "get-token", "--cluster-name", "${dependency.eks.outputs.cluster_name}"]
+      }
+    }
+  PROVIDERS
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# INPUTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  tags = {
+    Environment = local.environment
+    ClusterRole = "gpu-inference"
+    Feature     = "cilium-advanced-ebpf"
+    ManagedBy   = "terragrunt"
+  }
+}

--- a/monitoring/dashboards/cilium-advanced-ebpf.json
+++ b/monitoring/dashboards/cilium-advanced-ebpf.json
@@ -1,0 +1,443 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "description": "Cilium Advanced eBPF: Socket LB, XDP+DSR, Hubble L7 observability, and ClusterMesh status for gpu-inference cluster",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 100,
+      "title": "XDP + Direct Server Return",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "unit": "pps",
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 500}, {"color": "red", "value": 1000}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 1},
+      "id": 1,
+      "options": {"tooltip": {"mode": "single"}, "legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "rate(cilium_drop_count_total{reason='XDP dropped'}[5m])",
+          "legendFormat": "XDP drops — {{node}}",
+          "refId": "A"
+        }
+      ],
+      "title": "XDP Drop Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]},
+          "mappings": [{"options": {"0": {"text": "Disabled"}, "1": {"text": "Enabled"}}, "type": "value"}]
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 1},
+      "id": 2,
+      "options": {"colorMode": "background", "graphMode": "none", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "min(cilium_feature_status{name='xdp-native'})",
+          "legendFormat": "XDP Status",
+          "refId": "A"
+        }
+      ],
+      "title": "XDP Native Acceleration",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]},
+          "mappings": [{"options": {"0": {"text": "SNAT"}, "1": {"text": "DSR Active"}}, "type": "value"}]
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 1},
+      "id": 3,
+      "options": {"colorMode": "background", "graphMode": "none", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "min(cilium_feature_status{name='dsr'})",
+          "legendFormat": "DSR Status",
+          "refId": "A"
+        }
+      ],
+      "title": "Direct Server Return",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 9},
+      "id": 101,
+      "title": "Socket-Level Load Balancing",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]},
+          "mappings": [{"options": {"0": {"text": "Disabled"}, "1": {"text": "Active"}}, "type": "value"}]
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 10},
+      "id": 4,
+      "options": {"colorMode": "background", "graphMode": "none", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "min(cilium_feature_status{name='sockops'})",
+          "legendFormat": "Sockops",
+          "refId": "A"
+        }
+      ],
+      "title": "Socket-Level LB (sockops)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 6, "y": 10},
+      "id": 5,
+      "options": {"tooltip": {"mode": "single"}, "legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "cilium_bpf_map_ops_total{map_name='cilium_lb4_services_v2', operation='lookup'}",
+          "legendFormat": "BPF LB lookups — {{node}}",
+          "refId": "A"
+        }
+      ],
+      "title": "BPF LB Map Operations (Socket LB)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 18},
+      "id": 102,
+      "title": "Hubble L7 Observability — vLLM Inference",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 19},
+      "id": 6,
+      "options": {"tooltip": {"mode": "single"}, "legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "rate(hubble_http_responses_total{destination_workload='vllm-inference', status=~'2..'}[1m])",
+          "legendFormat": "2xx — {{source_namespace}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "rate(hubble_http_responses_total{destination_workload='vllm-inference', status=~'5..'}[1m])",
+          "legendFormat": "5xx errors — {{source_namespace}}",
+          "refId": "B"
+        }
+      ],
+      "title": "vLLM HTTP Request Rate (Hubble L7)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 19},
+      "id": 7,
+      "options": {"tooltip": {"mode": "single"}, "legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "histogram_quantile(0.50, rate(hubble_http_request_duration_seconds_bucket{destination_workload='vllm-inference'}[5m]))",
+          "legendFormat": "P50",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "histogram_quantile(0.95, rate(hubble_http_request_duration_seconds_bucket{destination_workload='vllm-inference'}[5m]))",
+          "legendFormat": "P95",
+          "refId": "B"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "histogram_quantile(0.99, rate(hubble_http_request_duration_seconds_bucket{destination_workload='vllm-inference'}[5m]))",
+          "legendFormat": "P99",
+          "refId": "C"
+        }
+      ],
+      "title": "vLLM Inference Latency (Hubble L7, no sidecars)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "unit": "pps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 27},
+      "id": 8,
+      "options": {"tooltip": {"mode": "single"}, "legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "rate(hubble_flows_processed_total{type='drop'}[5m])",
+          "legendFormat": "Hubble drops — {{node}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Hubble Flow Drops (ring buffer pressure)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 35},
+      "id": 103,
+      "title": "ClusterMesh Status",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]},
+          "mappings": [{"options": {"0": {"text": "Down"}, "1": {"text": "Connected"}}, "type": "value"}]
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 8, "x": 0, "y": 36},
+      "id": 9,
+      "options": {"colorMode": "background", "graphMode": "none", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}, "text": {}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "min by(cluster_id) (cilium_clustermesh_remote_cluster_status)",
+          "legendFormat": "Cluster {{cluster_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "ClusterMesh Remote Cluster Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 8, "x": 8, "y": 36},
+      "id": 10,
+      "options": {"colorMode": "value", "graphMode": "area", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "cilium_clustermesh_global_services",
+          "legendFormat": "Global services",
+          "refId": "A"
+        }
+      ],
+      "title": "ClusterMesh Global Services",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 8, "x": 16, "y": 36},
+      "id": 11,
+      "options": {"colorMode": "value", "graphMode": "area", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "cilium_clustermesh_remote_cluster_synced_total",
+          "legendFormat": "Synced clusters",
+          "refId": "A"
+        }
+      ],
+      "title": "ClusterMesh Synced Clusters",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 40},
+      "id": 104,
+      "title": "Bandwidth Manager (EDT Fair Queuing)",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]},
+          "mappings": [{"options": {"0": {"text": "Disabled"}, "1": {"text": "EDT Active"}}, "type": "value"}]
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 41},
+      "id": 12,
+      "options": {"colorMode": "background", "graphMode": "none", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "min(cilium_feature_status{name='bandwidth-manager'})",
+          "legendFormat": "Bandwidth Manager",
+          "refId": "A"
+        }
+      ],
+      "title": "Bandwidth Manager (EDT)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "unit": "s",
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 5}, {"color": "red", "value": 10}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 6, "y": 41},
+      "id": 13,
+      "options": {"tooltip": {"mode": "single"}, "legend": {"displayMode": "list", "placement": "bottom"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "histogram_quantile(0.99, rate(hubble_http_request_duration_seconds_bucket{destination_workload='vllm-inference'}[5m]))",
+          "legendFormat": "vLLM P99 (EDT active)",
+          "refId": "A"
+        }
+      ],
+      "title": "vLLM P99 Latency During NCCL All-Reduce (EDT keeps it stable)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["cilium", "ebpf", "gpu-inference", "networking", "xdp", "hubble", "clustermesh"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+        "definition": "label_values(cilium_version, node)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "node",
+        "options": [],
+        "query": {"query": "label_values(cilium_version, node)", "refId": "StandardVariableQuery"},
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query",
+        "label": "Node"
+      }
+    ]
+  },
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "UTC",
+  "title": "Cilium Advanced eBPF — gpu-inference",
+  "uid": "cilium-advanced-ebpf-gpu",
+  "version": 1
+}

--- a/network-policies/gpu-inference/00-default-deny.yaml
+++ b/network-policies/gpu-inference/00-default-deny.yaml
@@ -1,0 +1,52 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Identity-Based Zero Trust — Default Deny for gpu-inference namespace
+# ---------------------------------------------------------------------------------------------------------------------
+# Cilium assigns each pod a numeric identity derived from its labels.
+# Policy binds to identities, not IPs. Pod restarts, Karpenter replacements,
+# and spot evictions do not break policy — identities follow labels, not IPs.
+#
+# This clusterwide policy denies all traffic into/out of gpu-inference pods
+# by default. Explicit CiliumNetworkPolicy rules in this directory grant access.
+# ---------------------------------------------------------------------------------------------------------------------
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: default-deny-gpu-inference
+  labels:
+    app.kubernetes.io/part-of: cilium-advanced-ebpf
+    app.kubernetes.io/managed-by: terragrunt
+spec:
+  description: "Default deny all traffic for gpu-inference namespace — identity-based zero trust baseline"
+  endpointSelector:
+    matchLabels:
+      "k8s:io.kubernetes.pod.namespace": gpu-inference
+  ingress:
+    # Allow intra-namespace traffic — pods within gpu-inference can talk to each other
+    # unless a more specific policy restricts it (e.g., vLLM-only → gpu-operator)
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": gpu-inference
+    # Allow Hubble Relay to collect flows from gpu-inference endpoints
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": kube-system
+            k8s-app: hubble-relay
+  egress:
+    # Allow intra-namespace egress
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": gpu-inference
+    # Allow DNS resolution via CoreDNS in kube-system
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # Allow reach to kube-apiserver (required by sidecar containers, DRA, etc.)
+    - toEntities:
+        - kube-apiserver

--- a/network-policies/gpu-inference/01-gpu-operator-access.yaml
+++ b/network-policies/gpu-inference/01-gpu-operator-access.yaml
@@ -1,0 +1,56 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Identity-Based Policy: GPU Operator Access
+# ---------------------------------------------------------------------------------------------------------------------
+# Restricts ingress to nvidia-gpu-operator pods to only authorized consumers:
+#   - vLLM inference pods (pod plugin calls)
+#   - DCGM exporter (device health data)
+#   - Volcano scheduler (device allocation)
+#
+# Identity is derived from labels — no IP addresses in this file.
+# Policies survive Karpenter spot replacements, rolling restarts, and
+# HPA scale-in/out without any manual update.
+# ---------------------------------------------------------------------------------------------------------------------
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: gpu-operator-access
+  namespace: gpu-inference
+  labels:
+    app.kubernetes.io/part-of: cilium-advanced-ebpf
+    app.kubernetes.io/managed-by: terragrunt
+spec:
+  description: "Only authorized consumers can reach the GPU operator plugin socket"
+  endpointSelector:
+    matchLabels:
+      app: nvidia-gpu-operator
+  ingress:
+    - fromEndpoints:
+        # vLLM inference pods requesting GPU device allocations
+        - matchLabels:
+            app: vllm-inference
+        # DCGM exporter collecting device telemetry
+        - matchLabels:
+            app: dcgm-exporter
+        # Volcano scheduler coordinating gang-scheduled training jobs
+        - matchLabels:
+            app: volcano-scheduler
+      toPorts:
+        - ports:
+            # GPU device plugin gRPC socket exposed via localhost — this policy
+            # controls pod-to-pod communication with the operator DaemonSet
+            - port: "8080"
+              protocol: TCP
+            - port: "8090"
+              protocol: TCP
+  egress:
+    # GPU operator needs to reach kube-apiserver for CRD updates
+    - toEntities:
+        - kube-apiserver
+    # GPU operator discovers DCGM sidecar on the same node
+    - toEndpoints:
+        - matchLabels:
+            app: dcgm-exporter
+      toPorts:
+        - ports:
+            - port: "9400"
+              protocol: TCP

--- a/network-policies/gpu-inference/02-nccl-training-mesh.yaml
+++ b/network-policies/gpu-inference/02-nccl-training-mesh.yaml
@@ -1,0 +1,70 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Identity-Based Policy: NCCL All-Reduce Training Mesh
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU training jobs (PyTorch DDP, NCCL all-reduce) require full mesh connectivity
+# between all training pods on ports 29400-29500.
+#
+# Key design:
+#   - Identity selector: workload-type=training (set by Volcano / DRA on job pods)
+#   - NCCL port range: 29400-29500 (configurable per training framework)
+#   - EFA (Elastic Fabric Adapter) control plane: port 2049 (not exposed externally)
+#   - No wildcard: training pods cannot talk to non-training pods on NCCL ports
+#
+# Socket-level LB note:
+#   - NCCL uses RDMA/EFA which bypasses the kernel network stack entirely
+#   - Socket-level LB does NOT intercept RDMA paths — no overhead for training
+#   - This policy controls the TCP fallback path and control-plane connections
+# ---------------------------------------------------------------------------------------------------------------------
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: nccl-training-mesh
+  namespace: gpu-inference
+  labels:
+    app.kubernetes.io/part-of: cilium-advanced-ebpf
+    app.kubernetes.io/managed-by: terragrunt
+spec:
+  description: "Full mesh TCP connectivity for NCCL all-reduce between training pods"
+  endpointSelector:
+    matchLabels:
+      workload-type: training
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            workload-type: training
+      toPorts:
+        - ports:
+            # NCCL rendezvous and data plane (TCP fallback when RDMA unavailable)
+            - port: "29400"
+              protocol: TCP
+            - port: "29500"
+              protocol: TCP
+            # PyTorch c10d rendezvous
+            - port: "29499"
+              protocol: TCP
+            # Gloo collective communication library
+            - port: "29501"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            workload-type: training
+      toPorts:
+        - ports:
+            - port: "29400"
+              protocol: TCP
+            - port: "29500"
+              protocol: TCP
+            - port: "29499"
+              protocol: TCP
+            - port: "29501"
+              protocol: TCP
+    # Training pods push metrics to VictoriaMetrics (global ClusterMesh service)
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": monitoring
+      toPorts:
+        - ports:
+            # vminsert remote write
+            - port: "8480"
+              protocol: TCP

--- a/network-policies/gpu-inference/03-vllm-ingress.yaml
+++ b/network-policies/gpu-inference/03-vllm-ingress.yaml
@@ -1,0 +1,95 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Identity-Based Policy: vLLM Inference API + Hubble L7 Visibility
+# ---------------------------------------------------------------------------------------------------------------------
+# vLLM pods serve inference requests on port 8000 (HTTP/gRPC).
+# This policy:
+#   1. Allows external traffic via NLB (XDP+DSR path) and ingress controllers
+#   2. Enables selective Hubble L7 inspection ONLY for vLLM — not for training pods
+#   3. Allows vLLM → GPU operator for device queries
+#   4. Allows vLLM → monitoring for metrics push
+#
+# Hubble L7 without sidecars:
+#   - The 'http' rule in toPorts.rules activates Hubble's kernel eBPF L7 parser
+#   - This captures HTTP status codes, latency, path metrics silently
+#   - NCCL/training traffic is NEVER touched — l7Proxy is off globally
+#   - No Envoy sidecar needed; eBPF hook in the kernel handles parsing
+#
+# XDP + DSR interaction:
+#   - Ingress from NLB hits XDP hook at NIC level (DNAT to pod IP)
+#   - Return packets from vLLM go directly to client (src=VIP, skip NLB)
+#   - This policy sees only the pod-level identity, not NLB IPs
+# ---------------------------------------------------------------------------------------------------------------------
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: vllm-ingress
+  namespace: gpu-inference
+  labels:
+    app.kubernetes.io/part-of: cilium-advanced-ebpf
+    app.kubernetes.io/managed-by: terragrunt
+spec:
+  description: "vLLM inference API access with selective Hubble L7 observability"
+  endpointSelector:
+    matchLabels:
+      app: vllm-inference
+  ingress:
+    # External traffic arrives after XDP DNAT from NLB
+    # 'world' entity covers all external sources
+    - fromEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+          rules:
+            http:
+              # Hubble L7 captures these HTTP methods/paths silently via eBPF
+              # Visible in: hubble observe --namespace gpu-inference --protocol http
+              - method: "GET"
+              - method: "POST"
+                path: "/v1/.*"
+              - method: "GET"
+                path: "/health"
+              - method: "GET"
+                path: "/metrics"
+    # Internal consumers (AI SRE agents on platform cluster via ClusterMesh,
+    # auto-scaling controllers reading capacity)
+    - fromEndpoints:
+        - matchLabels:
+            app: ai-sre-agent
+        - matchLabels:
+            app: hpa-controller
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+          rules:
+            http:
+              - method: "GET"
+                path: "/health"
+              - method: "GET"
+                path: "/v1/models"
+  egress:
+    # vLLM queries GPU operator for device info
+    - toEndpoints:
+        - matchLabels:
+            app: nvidia-gpu-operator
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+    # vLLM pushes metrics to VictoriaMetrics (ClusterMesh global service)
+    - toEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": monitoring
+      toPorts:
+        - ports:
+            - port: "8480"
+              protocol: TCP
+    # vLLM may load models from S3 via IRSA — allow HTTPS egress to AWS
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/network-policies/gpu-inference/04-clustermesh-cross-cluster.yaml
+++ b/network-policies/gpu-inference/04-clustermesh-cross-cluster.yaml
@@ -1,0 +1,96 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Identity-Based Policy: ClusterMesh Cross-Cluster Connectivity
+# ---------------------------------------------------------------------------------------------------------------------
+# When ClusterMesh is enabled, pods on the gpu-inference cluster can discover
+# and connect to global services on the platform cluster without LoadBalancers.
+#
+# Cross-cluster identity selectors use the cluster name label:
+#   io.cilium.k8s.policy.cluster: <cluster-name>
+#
+# This enables:
+#   - gpu-inference pods → External Secrets on platform (via ClusterMesh)
+#   - gpu-inference pods → VictoriaMetrics vminsert on platform or dedicated cluster
+#   - AI SRE agents on platform → vLLM health endpoints on gpu-inference
+#   - ArgoCD on platform → gpu-inference pods (sync/health checks)
+#
+# Cluster ID assignments (must match Helm values):
+#   platform    = 1
+#   blockchain  = 2
+#   gpu-analysis = 3
+#   gpu-inference = 4
+# ---------------------------------------------------------------------------------------------------------------------
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: clustermesh-platform-to-gpu
+  namespace: gpu-inference
+  labels:
+    app.kubernetes.io/part-of: cilium-advanced-ebpf
+    app.kubernetes.io/managed-by: terragrunt
+spec:
+  description: "Cross-cluster access: platform cluster services can reach gpu-inference endpoints"
+  endpointSelector:
+    matchLabels:
+      app: vllm-inference
+  ingress:
+    # AI SRE agents on platform cluster monitor vLLM health
+    - fromEndpoints:
+        - matchLabels:
+            io.cilium.k8s.policy.cluster: prod-euw1-platform
+            app: ai-sre-agent
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+          rules:
+            http:
+              - method: "GET"
+                path: "/health"
+              - method: "GET"
+                path: "/v1/models"
+    # ArgoCD on platform checks application health
+    - fromEndpoints:
+        - matchLabels:
+            io.cilium.k8s.policy.cluster: prod-euw1-platform
+            app.kubernetes.io/name: argocd-server
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+          rules:
+            http:
+              - method: "GET"
+                path: "/health"
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: clustermesh-gpu-to-platform
+  namespace: gpu-inference
+  labels:
+    app.kubernetes.io/part-of: cilium-advanced-ebpf
+    app.kubernetes.io/managed-by: terragrunt
+spec:
+  description: "Cross-cluster egress: gpu-inference pods reach platform cluster services"
+  endpointSelector:
+    matchLabels:
+      "k8s:io.kubernetes.pod.namespace": gpu-inference
+  egress:
+    # External Secrets Operator on platform cluster for GPU node secrets
+    - toEndpoints:
+        - matchLabels:
+            io.cilium.k8s.policy.cluster: prod-euw1-platform
+            app.kubernetes.io/name: external-secrets
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # VictoriaMetrics vminsert (global service, may be on platform or dedicated)
+    - toEndpoints:
+        - matchLabels:
+            io.cilium.k8s.policy.cluster: prod-euw1-platform
+            app: vminsert
+      toPorts:
+        - ports:
+            - port: "8480"
+              protocol: TCP

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -29,8 +29,8 @@ module "vpc" {
   private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 
-  enable_nat_gateway = true
-  single_nat_gateway = false # High Availability for Prod
+  enable_nat_gateway     = true
+  single_nat_gateway     = false # High Availability for Prod
   one_nat_gateway_per_az = true
 
   enable_dns_hostnames = true
@@ -58,9 +58,9 @@ module "eks_cluster" {
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
-  min_size     = 3
-  max_size     = 6
-  desired_size = 3
+  min_size       = 3
+  max_size       = 6
+  desired_size   = 3
   instance_types = ["m5.large"]
 
   tags = local.tags
@@ -95,7 +95,7 @@ module "monitoring" {
 
   cluster_name      = module.eks_cluster.cluster_name
   oidc_provider_arn = module.eks_cluster.oidc_provider_arn
-  
+
   enable_prometheus = true
   enable_grafana    = true
 

--- a/terraform/karpenter-helm.tf
+++ b/terraform/karpenter-helm.tf
@@ -157,7 +157,7 @@ variable "cluster_name" {
 variable "karpenter_version" {
   description = "Karpenter Helm chart version"
   type        = string
-  default     = "1.8.1"  # Updated 2026-01-28 from 1.1.1
+  default     = "1.8.1" # Updated 2026-01-28 from 1.1.1
 }
 
 variable "karpenter_controller_role_arn" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.70"  # Updated 2026-01-28, pinned to 5.x for stability
+      version = "~> 5.70" # Updated 2026-01-28, pinned to 5.x for stability
     }
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = "~> 1.49"  # Updated 2026-01-28 from >= 1.39.0
+      version = "~> 1.49" # Updated 2026-01-28 from >= 1.39.0
     }
   }
 }
@@ -21,18 +21,18 @@ provider "hcloud" {
 }
 
 module "vpc" {
-  source = "./modules/vpc"
-  name   = var.name
+  source   = "./modules/vpc"
+  name     = var.name
   vpc_cidr = var.vpc_cidr
-  tags   = var.tags
+  tags     = var.tags
 }
 
 module "eks" {
   source = "./modules/eks"
 
-  cluster_name    = var.cluster_name
-  cluster_version = var.cluster_version
-  vpc_id          = module.vpc.vpc_id
+  cluster_name       = var.cluster_name
+  cluster_version    = var.cluster_version
+  vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets
 
   tags = var.tags
@@ -42,19 +42,18 @@ module "hetzner_nodes" {
   source = "./modules/hetzner-nodes"
   count  = var.enable_hetzner_nodes ? 1 : 0
 
-  name_prefix  = var.cluster_name
-  node_count   = var.hetzner_node_count
-  server_type  = var.hetzner_server_type
-  image        = var.hetzner_image
-  location     = var.hetzner_location
-  ssh_keys     = var.hetzner_ssh_keys
+  name_prefix = var.cluster_name
+  node_count  = var.hetzner_node_count
+  server_type = var.hetzner_server_type
+  image       = var.hetzner_image
+  location    = var.hetzner_location
+  ssh_keys    = var.hetzner_ssh_keys
 
-  user_data = var.hetzner_user_data == "" ?
-    templatefile("${path.module}/user_data/hetzner-kubeadm.sh", {
-      cluster_endpoint = module.eks.cluster_endpoint,
-      bootstrap_token  = var.hetzner_bootstrap_token,
-      ca_cert_hash     = var.hetzner_ca_cert_hash,
-    }) : var.hetzner_user_data
+  user_data = var.hetzner_user_data == "" ? templatefile("${path.module}/user_data/hetzner-kubeadm.sh", {
+    cluster_endpoint = module.eks.cluster_endpoint,
+    bootstrap_token  = var.hetzner_bootstrap_token,
+    ca_cert_hash     = var.hetzner_ca_cert_hash,
+  }) : var.hetzner_user_data
 
   labels = var.tags
 }

--- a/terraform/modules/gpu-inference-cilium-advanced/main.tf
+++ b/terraform/modules/gpu-inference-cilium-advanced/main.tf
@@ -1,0 +1,293 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU Inference Cilium Advanced eBPF — Monitoring + Identity Policies (Issue #144)
+# ---------------------------------------------------------------------------------------------------------------------
+# Companion module to gpu-inference-cilium. Manages:
+#   1. PrometheusRules for XDP, socket LB, Hubble L7, and ClusterMesh health
+#   2. CiliumNetworkPolicy manifests for identity-based zero-trust policies
+#   3. Per-pod bandwidth annotations ConfigMap for EDT fair queuing
+#   4. Hubble ServiceMonitor for Prometheus scrape
+# ---------------------------------------------------------------------------------------------------------------------
+
+# PrometheusRule for all advanced eBPF feature alerts
+resource "kubernetes_manifest" "cilium_advanced_alerts" {
+  manifest = {
+    apiVersion = "monitoring.coreos.com/v1"
+    kind       = "PrometheusRule"
+    metadata = {
+      name      = "cilium-advanced-ebpf-alerts"
+      namespace = "kube-system"
+      labels = {
+        "prometheus"                      = "kube-prometheus"
+        "app.kubernetes.io/part-of"       = "cilium-advanced-ebpf"
+        "app.kubernetes.io/managed-by"    = "terragrunt"
+      }
+    }
+    spec = {
+      groups = [
+        # ---- XDP + DSR ----
+        {
+          name = "cilium.xdp-dsr"
+          rules = [
+            {
+              alert = "CiliumXDPDropRateHigh"
+              expr  = "rate(cilium_drop_count_total{reason='XDP dropped'}[5m]) > 1000"
+              for   = "5m"
+              labels = {
+                severity = "warning"
+                feature  = "xdp"
+              }
+              annotations = {
+                summary     = "High XDP drop rate on {{ $labels.node }}"
+                description = "XDP is dropping {{ $value | humanize }} packets/s. Possible causes: invalid DSR packets, NIC driver mismatch, or XDP program bug. Check: cilium bpf lb list."
+              }
+            },
+            {
+              alert = "CiliumDSRServiceMissing"
+              expr  = "cilium_services_events_total{action='delete'} > 0 and on(service) cilium_bpf_map_ops_total{map_name='cilium_lb4_services_v2', operation='delete'} > 0"
+              for   = "2m"
+              labels = {
+                severity = "warning"
+                feature  = "dsr"
+              }
+              annotations = {
+                summary     = "DSR service entry deleted on {{ $labels.node }}"
+                description = "A service with DSR enabled lost its BPF map entry. Clients may experience return-path failures until Cilium reconciles."
+              }
+            },
+          ]
+        },
+        # ---- Socket-level LB ----
+        {
+          name = "cilium.socket-lb"
+          rules = [
+            {
+              alert = "CiliumSockopsDisabled"
+              # sockops enabled state is surfaced via cilium_feature_status metric (1.18+)
+              expr  = "cilium_feature_status{name='sockops'} == 0"
+              for   = "5m"
+              labels = {
+                severity = "warning"
+                feature  = "sockops"
+              }
+              annotations = {
+                summary     = "Socket-level LB (sockops) is disabled on {{ $labels.node }}"
+                description = "sockops was expected to be enabled. East-west traffic will fall back to per-packet DNAT. Check kernel BPF sockmap support."
+              }
+            },
+          ]
+        },
+        # ---- Hubble L7 observability ----
+        {
+          name = "cilium.hubble-l7"
+          rules = [
+            {
+              alert = "HubbleRelayDown"
+              expr  = "up{job='hubble-relay'} == 0"
+              for   = "5m"
+              labels = {
+                severity = "critical"
+                feature  = "hubble"
+              }
+              annotations = {
+                summary     = "Hubble Relay is down"
+                description = "Hubble Relay has been unreachable for 5 minutes. L7 visibility and flow export are unavailable. vLLM HTTP metrics will not appear in Grafana."
+              }
+            },
+            {
+              alert = "HubbleFlowsDroppedHigh"
+              expr  = "rate(hubble_flows_processed_total{type='drop'}[5m]) > 500"
+              for   = "10m"
+              labels = {
+                severity = "warning"
+                feature  = "hubble"
+              }
+              annotations = {
+                summary     = "High Hubble drop rate on {{ $labels.node }}"
+                description = "Hubble is dropping {{ $value | humanize }} flows/s — ring buffer may be too small or Relay is slow. Increase hubble.listenAddress ring buffer size."
+              }
+            },
+            {
+              alert = "HubbleL7ErrorRateHigh"
+              # HTTP 5xx from vLLM inference endpoint captured via Hubble L7 metrics
+              expr  = "rate(hubble_http_responses_total{status=~'5..', destination_workload='vllm-inference'}[5m]) / rate(hubble_http_responses_total{destination_workload='vllm-inference'}[5m]) > 0.05"
+              for   = "5m"
+              labels = {
+                severity = "warning"
+                feature  = "hubble-l7"
+              }
+              annotations = {
+                summary     = "vLLM HTTP error rate is {{ $value | humanizePercentage }}"
+                description = "More than 5% of vLLM inference requests are returning HTTP 5xx. Check vLLM pod logs and GPU memory pressure."
+              }
+            },
+            {
+              alert = "HubbleL7LatencyHigh"
+              expr  = "histogram_quantile(0.99, rate(hubble_http_request_duration_seconds_bucket{destination_workload='vllm-inference'}[5m])) > 10"
+              for   = "5m"
+              labels = {
+                severity = "warning"
+                feature  = "hubble-l7"
+              }
+              annotations = {
+                summary     = "vLLM P99 inference latency is {{ $value }}s"
+                description = "vLLM inference P99 latency exceeds 10s. Check GPU utilization (DCGM), token batch size, and NCCL congestion on the same node."
+              }
+            },
+          ]
+        },
+        # ---- ClusterMesh ----
+        {
+          name = "cilium.clustermesh"
+          rules = [
+            {
+              alert = "CiliumClusterMeshClusterDown"
+              expr  = "cilium_clustermesh_remote_cluster_status == 0"
+              for   = "5m"
+              labels = {
+                severity = "critical"
+                feature  = "clustermesh"
+              }
+              annotations = {
+                summary     = "ClusterMesh lost connectivity to {{ $labels.cluster_id }}"
+                description = "Cilium ClusterMesh cannot reach remote cluster {{ $labels.cluster_id }} for 5 minutes. Cross-cluster services (External Secrets, VictoriaMetrics, AI SRE) are unreachable from gpu-inference pods."
+              }
+            },
+            {
+              alert = "CiliumClusterMeshApiServerDown"
+              expr  = "up{job='clustermesh-apiserver'} == 0"
+              for   = "5m"
+              labels = {
+                severity = "critical"
+                feature  = "clustermesh"
+              }
+              annotations = {
+                summary     = "ClusterMesh API server is down"
+                description = "The ClusterMesh API server (etcd-backed endpoint exchange) has been unreachable for 5 minutes. No new clusters can join and existing connections will degrade."
+              }
+            },
+            {
+              alert = "CiliumClusterMeshGlobalServiceEndpointsLow"
+              expr  = "cilium_clustermesh_global_services < 2"
+              for   = "10m"
+              labels = {
+                severity = "warning"
+                feature  = "clustermesh"
+              }
+              annotations = {
+                summary     = "Fewer than expected global services in ClusterMesh"
+                description = "Only {{ $value }} global services are registered. Expected at least 2 (VictoriaMetrics vminsert, External Secrets). Some cross-cluster services may be missing annotations."
+              }
+            },
+          ]
+        },
+        # ---- Bandwidth Manager (EDT) ----
+        {
+          name = "cilium.bandwidth-manager"
+          rules = [
+            {
+              alert = "CiliumBandwidthManagerDisabled"
+              expr  = "cilium_feature_status{name='bandwidth-manager'} == 0"
+              for   = "5m"
+              labels = {
+                severity = "warning"
+                feature  = "bandwidth-manager"
+              }
+              annotations = {
+                summary     = "Bandwidth Manager (EDT) is disabled on {{ $labels.node }}"
+                description = "EDT-based fair queuing is off. NCCL all-reduce bursts may starve vLLM inference bandwidth. Check kernel BPF qdisc support (requires kernel 5.1+)."
+              }
+            },
+          ]
+        },
+      ]
+    }
+  }
+}
+
+# Hubble ServiceMonitor for Prometheus scrape
+resource "kubernetes_manifest" "hubble_service_monitor" {
+  manifest = {
+    apiVersion = "monitoring.coreos.com/v1"
+    kind       = "ServiceMonitor"
+    metadata = {
+      name      = "hubble-metrics"
+      namespace = "kube-system"
+      labels = {
+        "release"                         = "kube-prometheus-stack"
+        "app.kubernetes.io/part-of"       = "cilium-advanced-ebpf"
+        "app.kubernetes.io/managed-by"    = "terragrunt"
+      }
+    }
+    spec = {
+      selector = {
+        matchLabels = {
+          "k8s-app" = "cilium"
+        }
+      }
+      namespaceSelector = {
+        matchNames = ["kube-system"]
+      }
+      endpoints = [
+        {
+          # Hubble metrics port (9965) — separate from cilium-agent metrics (9962)
+          port     = "hubble-metrics"
+          interval = "15s"
+          path     = "/metrics"
+          relabelings = [
+            {
+              sourceLabels = ["__meta_kubernetes_pod_node_name"]
+              targetLabel  = "node"
+              action       = "replace"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+
+# ConfigMap documenting bandwidth annotations for workload teams
+# Per-pod bandwidth limits via EDT (Earliest Departure Time) queuing.
+# Prevents NCCL all-reduce from starving vLLM inference on shared NIC.
+resource "kubernetes_config_map_v1" "bandwidth_policy_reference" {
+  metadata {
+    name      = "cilium-bandwidth-policy-reference"
+    namespace = "gpu-inference"
+    labels = {
+      "app.kubernetes.io/part-of"    = "cilium-advanced-ebpf"
+      "app.kubernetes.io/managed-by" = "terragrunt"
+    }
+    annotations = {
+      "description" = "Reference ConfigMap documenting per-workload bandwidth annotation values for Cilium EDT queuing"
+    }
+  }
+
+  data = {
+    "bandwidth-annotations.yaml" = yamlencode({
+      description = "Add these annotations to pod specs to enable per-pod bandwidth management via Cilium EDT"
+      workloads = {
+        nccl-training = {
+          annotations = {
+            "kubernetes.io/ingress-bandwidth" = "80G"
+            "kubernetes.io/egress-bandwidth"  = "80G"
+          }
+          rationale = "NCCL all-reduce needs high bandwidth but must be capped to leave headroom for inference. EFA/RDMA traffic is separate and not affected by EDT."
+        }
+        vllm-inference = {
+          annotations = {
+            "kubernetes.io/ingress-bandwidth" = "10G"
+            "kubernetes.io/egress-bandwidth"  = "10G"
+          }
+          rationale = "vLLM token throughput is ~1-5 Gbps per replica. 10G cap ensures stable P99 latency even during NCCL all-reduce bursts on the same node."
+        }
+        dcgm-exporter = {
+          annotations = {
+            "kubernetes.io/ingress-bandwidth" = "100M"
+            "kubernetes.io/egress-bandwidth"  = "100M"
+          }
+          rationale = "Metrics export is low-volume. Strict cap prevents runaway scrape from competing with GPU traffic."
+        }
+      }
+    })
+  }
+}

--- a/terraform/modules/gpu-inference-cilium-advanced/main.tf
+++ b/terraform/modules/gpu-inference-cilium-advanced/main.tf
@@ -17,9 +17,9 @@ resource "kubernetes_manifest" "cilium_advanced_alerts" {
       name      = "cilium-advanced-ebpf-alerts"
       namespace = "kube-system"
       labels = {
-        "prometheus"                      = "kube-prometheus"
-        "app.kubernetes.io/part-of"       = "cilium-advanced-ebpf"
-        "app.kubernetes.io/managed-by"    = "terragrunt"
+        "prometheus"                   = "kube-prometheus"
+        "app.kubernetes.io/part-of"    = "cilium-advanced-ebpf"
+        "app.kubernetes.io/managed-by" = "terragrunt"
       }
     }
     spec = {
@@ -63,8 +63,8 @@ resource "kubernetes_manifest" "cilium_advanced_alerts" {
             {
               alert = "CiliumSockopsDisabled"
               # sockops enabled state is surfaced via cilium_feature_status metric (1.18+)
-              expr  = "cilium_feature_status{name='sockops'} == 0"
-              for   = "5m"
+              expr = "cilium_feature_status{name='sockops'} == 0"
+              for  = "5m"
               labels = {
                 severity = "warning"
                 feature  = "sockops"
@@ -109,8 +109,8 @@ resource "kubernetes_manifest" "cilium_advanced_alerts" {
             {
               alert = "HubbleL7ErrorRateHigh"
               # HTTP 5xx from vLLM inference endpoint captured via Hubble L7 metrics
-              expr  = "rate(hubble_http_responses_total{status=~'5..', destination_workload='vllm-inference'}[5m]) / rate(hubble_http_responses_total{destination_workload='vllm-inference'}[5m]) > 0.05"
-              for   = "5m"
+              expr = "rate(hubble_http_responses_total{status=~'5..', destination_workload='vllm-inference'}[5m]) / rate(hubble_http_responses_total{destination_workload='vllm-inference'}[5m]) > 0.05"
+              for  = "5m"
               labels = {
                 severity = "warning"
                 feature  = "hubble-l7"
@@ -213,9 +213,9 @@ resource "kubernetes_manifest" "hubble_service_monitor" {
       name      = "hubble-metrics"
       namespace = "kube-system"
       labels = {
-        "release"                         = "kube-prometheus-stack"
-        "app.kubernetes.io/part-of"       = "cilium-advanced-ebpf"
-        "app.kubernetes.io/managed-by"    = "terragrunt"
+        "release"                      = "kube-prometheus-stack"
+        "app.kubernetes.io/part-of"    = "cilium-advanced-ebpf"
+        "app.kubernetes.io/managed-by" = "terragrunt"
       }
     }
     spec = {

--- a/terraform/modules/gpu-inference-cilium-advanced/outputs.tf
+++ b/terraform/modules/gpu-inference-cilium-advanced/outputs.tf
@@ -1,0 +1,9 @@
+output "prometheus_rule_name" {
+  description = "Name of the PrometheusRule created for advanced eBPF feature alerts"
+  value       = kubernetes_manifest.cilium_advanced_alerts.manifest.metadata.name
+}
+
+output "hubble_service_monitor_name" {
+  description = "Name of the Hubble ServiceMonitor for Prometheus scrape"
+  value       = kubernetes_manifest.hubble_service_monitor.manifest.metadata.name
+}

--- a/terraform/modules/gpu-inference-cilium-advanced/variables.tf
+++ b/terraform/modules/gpu-inference-cilium-advanced/variables.tf
@@ -1,0 +1,5 @@
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/gpu-inference-cilium-advanced/versions.tf
+++ b/terraform/modules/gpu-inference-cilium-advanced/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.25"
+    }
+  }
+}

--- a/terraform/modules/gpu-inference-cilium/main.tf
+++ b/terraform/modules/gpu-inference-cilium/main.tf
@@ -162,8 +162,8 @@ resource "helm_release" "cilium" {
           service = {
             type = "LoadBalancer"
             annotations = {
-              "service.beta.kubernetes.io/aws-load-balancer-internal"         = "true"
-              "service.beta.kubernetes.io/aws-load-balancer-type"             = "nlb"
+              "service.beta.kubernetes.io/aws-load-balancer-internal"        = "true"
+              "service.beta.kubernetes.io/aws-load-balancer-type"            = "nlb"
               "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type" = "ip"
             }
           }

--- a/terraform/modules/gpu-inference-cilium/main.tf
+++ b/terraform/modules/gpu-inference-cilium/main.tf
@@ -1,10 +1,17 @@
 # ---------------------------------------------------------------------------------------------------------------------
-# GPU Inference Cilium v1.19 — Native Routing + BGP Control Plane
+# GPU Inference Cilium v1.19 — Native Routing + BGP Control Plane + Advanced eBPF
 # ---------------------------------------------------------------------------------------------------------------------
 # Deploys Cilium v1.19 in native-routing mode with BGP Control Plane peering
 # to AWS Transit Gateway Connect. Pods get IPs from cluster-pool CIDR
 # (100.64.0.0/10), not VPC. Each node is a BGP speaker announcing its Pod CIDR
 # to TGW, enabling near-physical-network latency for NCCL/distributed training.
+#
+# Advanced eBPF features (Issue #144):
+#   - Socket-level load balancing for zero-NAT east-west traffic
+#   - XDP + Direct Server Return for north-south wire-speed LB
+#   - Maglev consistent hashing for long-lived gRPC/NCCL connections
+#   - Hubble L7 observability for vLLM (no sidecars, no NCCL overhead)
+#   - ClusterMesh for cross-cluster service discovery
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "helm_release" "cilium" {
@@ -21,7 +28,7 @@ resource "helm_release" "cilium" {
 
   values = [
     yamlencode({
-      # Native routing mode — no VXLAN/Geneve encapsulation
+      # Native routing mode -- no VXLAN/Geneve encapsulation
       routingMode           = "native"
       autoDirectNodeRoutes  = true
       ipv4NativeRoutingCIDR = var.pod_cidr
@@ -40,27 +47,55 @@ resource "helm_release" "cilium" {
       k8sServiceHost       = var.cluster_endpoint
       k8sServicePort       = 443
 
+      # Load balancer -- Maglev consistent hashing for long-lived connections.
+      # O(1) lookup vs iptables O(n). Critical for gRPC/NCCL sessions that must
+      # stick to a backend through scaling events.
+      loadBalancer = {
+        algorithm = "maglev"
+        maglev = {
+          tableSize = 65537
+          hashSeed  = var.maglev_hash_seed
+        }
+        serviceTopology = true
+        mode            = var.enable_dsr ? "dsr" : "snat"
+        dsrDispatch     = var.dsr_dispatch
+        acceleration    = var.enable_xdp ? "native" : "disabled"
+      }
+
+      # XDP pre-filter -- drop invalid packets at NIC before kernel processing
+      enableXDPPrefilter = var.enable_xdp
+
+      # XDP-capable interfaces -- AWS ENA presents as eth0 on Bottlerocket
+      devices = var.xdp_devices
+
       # BPF settings
       bpf = {
         masquerade   = true
         lbMapMax     = tonumber(var.bpf_lb_map_max)
         policyMapMax = tonumber(var.bpf_policy_map_max)
+        tproxy       = true
       }
 
-      # No conntrack iptables rules — eBPF handles it
+      # No conntrack iptables rules -- eBPF handles it
       installNoConntrackIptablesRules = true
 
-      # Disable L7 proxy for GPU traffic — adds latency
-      l7Proxy = false
-
-      # Socket-level acceleration for node-local traffic
+      # Socket-level load balancing for east-west traffic.
+      # connect() syscall rewrites directly to backend IP -- zero per-packet NAT.
       sockops = {
-        enabled = true
+        enabled = var.enable_sockops
       }
 
-      # EDT-based bandwidth management
+      # Host-reachable services via socket LB
+      hostServices = {
+        enabled   = var.enable_sockops
+        protocols = "tcp,udp"
+      }
+
+      # EDT-based bandwidth management with BBR congestion control.
+      # Prevents NCCL all-reduce from starving vLLM inference bandwidth.
       bandwidthManager = {
         enabled = true
+        bbr     = true
       }
 
       # BGP Control Plane
@@ -73,16 +108,79 @@ resource "helm_release" "cilium" {
         enabled = true
       }
 
-      # Hubble observability
+      # Hubble observability -- selective L7 without affecting NCCL/training traffic.
+      # HTTP metrics for vLLM API are captured via eBPF kernel hook (no sidecars).
+      # Training pods see only DNS-level visibility.
       hubble = {
         enabled = true
         relay = {
-          enabled = true
+          enabled  = true
+          replicas = var.hubble_relay_replicas
+          resources = {
+            requests = { cpu = "100m", memory = "128Mi" }
+            limits   = { cpu = "500m", memory = "256Mi" }
+          }
         }
         ui = {
-          enabled = false
+          enabled = var.enable_hubble_ui
+        }
+        metrics = {
+          enabled = [
+            "dns:query;ignoreAAAA",
+            "drop",
+            "tcp",
+            "flow",
+            "port-distribution",
+            "httpV2:exemplars=true;labelsContext=source_namespace,source_workload,destination_namespace,destination_workload,traffic_direction",
+          ]
+          serviceMonitor = {
+            enabled = true
+          }
+          port = 9965
+        }
+        peerService = {
+          clusterDomain = "cluster.local"
         }
       }
+
+      # ClusterMesh -- multi-cluster service discovery for gpu-inference.
+      # Enables cross-cluster comms with platform cluster (ArgoCD, VictoriaMetrics,
+      # External Secrets) without LoadBalancers or manual DNS.
+      cluster = var.enable_clustermesh ? {
+        name = var.cluster_mesh_name
+        id   = var.cluster_mesh_id
+      } : null
+
+      clustermesh = var.enable_clustermesh ? {
+        useAPIServer = true
+        apiserver = {
+          replicas = var.clustermesh_apiserver_replicas
+          resources = {
+            requests = { cpu = "100m", memory = "256Mi" }
+            limits   = { cpu = "500m", memory = "512Mi" }
+          }
+          service = {
+            type = "LoadBalancer"
+            annotations = {
+              "service.beta.kubernetes.io/aws-load-balancer-internal"         = "true"
+              "service.beta.kubernetes.io/aws-load-balancer-type"             = "nlb"
+              "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type" = "ip"
+            }
+          }
+          tls = {
+            auto = {
+              enabled = true
+              method  = "helm"
+            }
+          }
+          etcd = {
+            resources = {
+              requests = { cpu = "100m", memory = "256Mi" }
+              limits   = { cpu = "500m", memory = "512Mi" }
+            }
+          }
+        }
+      } : null
 
       # Operator tuning for high-scale
       operator = {
@@ -90,11 +188,18 @@ resource "helm_release" "cilium" {
         prometheus = {
           enabled = true
         }
+        resources = {
+          requests = { cpu = "100m", memory = "128Mi" }
+          limits   = { cpu = "1000m", memory = "512Mi" }
+        }
       }
 
       # Prometheus metrics
       prometheus = {
         enabled = true
+        serviceMonitor = {
+          enabled = true
+        }
       }
 
       # Tolerations to run on all nodes including GPU taints
@@ -138,6 +243,34 @@ resource "kubernetes_manifest" "bgp_peering_policy" {
           exportPodCIDR = true
         }
       ]
+    }
+  }
+
+  depends_on = [helm_release.cilium]
+}
+
+# ClusterMesh global service for VictoriaMetrics vminsert.
+# gpu-inference pods push metrics directly via ClusterMesh without an NLB.
+resource "kubernetes_manifest" "clustermesh_victoriametrics_service" {
+  count = var.enable_clustermesh && var.enable_clustermesh_global_services ? 1 : 0
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Service"
+    metadata = {
+      name      = "victoriametrics-vminsert"
+      namespace = "monitoring"
+      annotations = {
+        "service.cilium.io/global" = "true"
+        "service.cilium.io/shared" = "true"
+      }
+    }
+    spec = {
+      type  = "ClusterIP"
+      ports = [{ port = 8480, targetPort = 8480, protocol = "TCP" }]
+      selector = {
+        app = "vminsert"
+      }
     }
   }
 

--- a/terraform/modules/gpu-inference-cilium/outputs.tf
+++ b/terraform/modules/gpu-inference-cilium/outputs.tf
@@ -17,3 +17,33 @@ output "bgp_local_asn" {
   description = "Local ASN used for BGP peering"
   value       = var.bgp_local_asn
 }
+
+output "cluster_mesh_name" {
+  description = "Cluster name registered in ClusterMesh"
+  value       = var.cluster_mesh_name
+}
+
+output "cluster_mesh_id" {
+  description = "Numeric cluster ID registered in ClusterMesh"
+  value       = var.cluster_mesh_id
+}
+
+output "clustermesh_enabled" {
+  description = "Whether ClusterMesh is enabled on this cluster"
+  value       = var.enable_clustermesh
+}
+
+output "dsr_enabled" {
+  description = "Whether Direct Server Return is enabled"
+  value       = var.enable_dsr
+}
+
+output "xdp_enabled" {
+  description = "Whether XDP native acceleration is enabled"
+  value       = var.enable_xdp
+}
+
+output "sockops_enabled" {
+  description = "Whether socket-level load balancing is enabled"
+  value       = var.enable_sockops
+}

--- a/terraform/modules/gpu-inference-cilium/variables.tf
+++ b/terraform/modules/gpu-inference-cilium/variables.tf
@@ -60,6 +60,114 @@ variable "bgp_peers" {
   default = []
 }
 
+# -------------------------------------------------------
+# Socket-level load balancing
+# -------------------------------------------------------
+
+variable "enable_sockops" {
+  description = "Enable socket-level load balancing. Intercepts connect() syscall and rewrites directly to backend IP -- zero per-packet DNAT overhead for east-west traffic."
+  type        = bool
+  default     = true
+}
+
+# -------------------------------------------------------
+# Maglev consistent hashing
+# -------------------------------------------------------
+
+variable "maglev_hash_seed" {
+  description = "Consistent hash seed for Maglev LB table. Must be identical on all nodes. Change only during a planned maintenance window."
+  type        = string
+  default     = "JLfvgnHc2kaSUFaI"
+}
+
+# -------------------------------------------------------
+# XDP + Direct Server Return
+# -------------------------------------------------------
+
+variable "enable_xdp" {
+  description = "Enable XDP native acceleration for north-south LB. Requires ENA NIC (satisfied by AWS) and kernel 5.10+ (Bottlerocket satisfies this)."
+  type        = bool
+  default     = true
+}
+
+variable "xdp_devices" {
+  description = "Network interfaces for XDP attachment. AWS ENA presents as eth0 on Bottlerocket."
+  type        = list(string)
+  default     = ["eth0"]
+}
+
+variable "enable_dsr" {
+  description = "Enable Direct Server Return -- return traffic goes directly from pod to client, bypassing NLB. Requires NLB in IP target mode."
+  type        = bool
+  default     = true
+}
+
+variable "dsr_dispatch" {
+  description = "DSR dispatch method. 'opt' uses IP options (same-subnet). 'geneve' works cross-subnet. For AWS same-AZ, 'opt' is preferred."
+  type        = string
+  default     = "opt"
+
+  validation {
+    condition     = contains(["opt", "geneve", "ipip"], var.dsr_dispatch)
+    error_message = "dsr_dispatch must be 'opt', 'geneve', or 'ipip'."
+  }
+}
+
+# -------------------------------------------------------
+# Hubble L7 observability
+# -------------------------------------------------------
+
+variable "enable_hubble_ui" {
+  description = "Enable Hubble UI. Disable in prod to reduce attack surface; access via hubble relay CLI."
+  type        = bool
+  default     = false
+}
+
+variable "hubble_relay_replicas" {
+  description = "Number of Hubble Relay replicas for HA"
+  type        = number
+  default     = 2
+}
+
+# -------------------------------------------------------
+# ClusterMesh
+# -------------------------------------------------------
+
+variable "enable_clustermesh" {
+  description = "Enable Cilium ClusterMesh for multi-cluster service discovery"
+  type        = bool
+  default     = false
+}
+
+variable "cluster_mesh_name" {
+  description = "Unique cluster name for ClusterMesh. Use format: {env}-{region}-{role} e.g. prod-euw1-gpu"
+  type        = string
+  default     = "prod-euw1-gpu"
+}
+
+variable "cluster_mesh_id" {
+  description = "Unique cluster ID for ClusterMesh (1-255, unique per mesh). Platform=1, blockchain=2, gpu-analysis=3, gpu-inference=4."
+  type        = number
+  default     = 4
+
+  validation {
+    condition     = var.cluster_mesh_id >= 1 && var.cluster_mesh_id <= 255
+    error_message = "cluster_mesh_id must be between 1 and 255."
+  }
+}
+
+variable "clustermesh_apiserver_replicas" {
+  description = "Number of ClusterMesh API server replicas"
+  type        = number
+  default     = 3
+}
+
+variable "enable_clustermesh_global_services" {
+  description = "Create ClusterMesh global service annotations for shared platform services (VictoriaMetrics, etc.)"
+  type        = bool
+  default     = false
+}
+
 variable "tags" {
   description = "Tags to apply to resources"
   type        = map(string)

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -30,7 +30,7 @@ variable "cluster_name" {
 variable "cluster_version" {
   description = "Kubernetes version for EKS cluster"
   type        = string
-  default     = "1.32"  # Updated 2026-01-28 from invalid 1.33
+  default     = "1.32" # Updated 2026-01-28 from invalid 1.33
 
   validation {
     condition     = can(regex("^1\\.(2[89]|3[0-2])$", var.cluster_version))

--- a/terragrunt/prod/_global/clustermesh-connect/terragrunt.hcl
+++ b/terragrunt/prod/_global/clustermesh-connect/terragrunt.hcl
@@ -1,0 +1,117 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# ClusterMesh Connect — Prod (Global)
+# ---------------------------------------------------------------------------------------------------------------------
+# Establishes Cilium ClusterMesh connectivity between prod EKS clusters.
+# Includes gpu-inference cluster (ID=4) added via Issue #144.
+#
+# Cluster ID assignments:
+#   platform     = 1 (eu-west-1, eu-central-1 platform clusters)
+#   blockchain   = 2
+#   gpu-analysis = 3
+#   gpu-inference = 4  ← NEW (Issue #144)
+#
+# Prerequisites:
+#   - Cilium with ClusterMesh enabled on all clusters (gpu-inference-cilium unit)
+#   - ClusterMesh API server NLBs in IP target mode (for DSR compatibility)
+#   - Security group rules allowing ports: 2379 (etcd), 4240 (health), 51871 (WireGuard), 4244 (Hubble Relay)
+#   - TGW connectivity between regions (TGW Connect from Issue #72)
+#
+# Post-deployment steps (manual — cert exchange cannot be automated):
+#   1. From each cluster context:
+#      kubectl get secret -n kube-system clustermesh-apiserver-remote-cert -o json | jq -r '.data."ca.crt"' | base64 -d
+#   2. Populate ca_cert, tls_cert, tls_key below
+#   3. Alternatively (simpler): cilium clustermesh connect --destination-context <context>
+#
+# Usage:
+#   cd terragrunt/prod/_global/clustermesh-connect
+#   terragrunt plan
+#   terragrunt apply
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/clustermesh-connect"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  environment  = local.account_vars.locals.environment
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPENDENCIES: Cilium outputs from each cluster
+# ---------------------------------------------------------------------------------------------------------------------
+
+dependency "cilium_euw1_platform" {
+  config_path = "../../eu-west-1/platform/cilium"
+
+  mock_outputs = {
+    cluster_mesh_name   = "prod-euw1-platform"
+    cluster_mesh_id     = 1
+    clustermesh_enabled = true
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+dependency "cilium_euc1_platform" {
+  config_path = "../../eu-central-1/platform/cilium"
+
+  mock_outputs = {
+    cluster_mesh_name   = "prod-euc1-platform"
+    cluster_mesh_id     = 1
+    clustermesh_enabled = true
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+# gpu-inference cluster — added via Issue #144
+dependency "cilium_euw1_gpu_inference" {
+  config_path = "../../eu-west-1/gpu-inference/gpu-inference-cilium-advanced"
+
+  mock_outputs = {
+    cluster_mesh_name   = "prod-euw1-gpu"
+    cluster_mesh_id     = 4
+    clustermesh_enabled = true
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE INPUTS
+# ---------------------------------------------------------------------------------------------------------------------
+# NOTE: CA certs and TLS credentials are populated post-deployment.
+# After initial Cilium deployment with ClusterMesh enabled, retrieve certs from
+# each cluster's kube-system/clustermesh-apiserver-remote-cert secret and populate
+# these values. Alternatively, use: cilium clustermesh connect --destination-context
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  remote_clusters = {
+    # Platform cluster — eu-west-1
+    (dependency.cilium_euw1_platform.outputs.cluster_mesh_name) = {
+      endpoint = "" # ClusterMesh API server NLB DNS — populated post-deployment
+      ca_cert  = "" # kubectl get secret -n kube-system clustermesh-apiserver-remote-cert ...
+      tls_cert = ""
+      tls_key  = ""
+    }
+    # Platform cluster — eu-central-1
+    (dependency.cilium_euc1_platform.outputs.cluster_mesh_name) = {
+      endpoint = "" # ClusterMesh API server NLB DNS — populated post-deployment
+      ca_cert  = ""
+      tls_cert = ""
+      tls_key  = ""
+    }
+    # GPU Inference cluster — eu-west-1 (Issue #144)
+    (dependency.cilium_euw1_gpu_inference.outputs.cluster_mesh_name) = {
+      endpoint = "" # ClusterMesh API server NLB DNS — populated post-deployment
+      ca_cert  = "" # Retrieved from gpu-inference cluster's clustermesh-apiserver-remote-cert secret
+      tls_cert = ""
+      tls_key  = ""
+    }
+  }
+}

--- a/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
+++ b/terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl
@@ -5,6 +5,7 @@
 # Phase 1: VPC + EKS cluster foundation.
 # Phase 2: Cilium v1.19 native routing + BGP Control Plane peering via TGW Connect.
 # Phase 3: Cilium WireGuard transparent encryption + high-scale tuning for 5000 nodes.
+# Phase 4: Cilium advanced eBPF -- socket LB, XDP+DSR, Hubble L7, ClusterMesh (Issue #144).
 # Additional units will be added as subsequent issues are implemented.
 # ---------------------------------------------------------------------------------------------------------------------
 
@@ -32,6 +33,15 @@ unit "gpu-inference-cilium-encryption" {
   source = "${get_repo_root()}/catalog/units/gpu-inference-cilium-encryption"
   path   = "gpu-inference-cilium-encryption"
 }
+
+# Phase 4: Advanced eBPF -- socket LB, XDP+DSR, Hubble L7, ClusterMesh.
+# Manages PrometheusRules, Hubble ServiceMonitor, and bandwidth policy reference.
+# Helm values for these features are applied via the gpu-inference-cilium unit.
+unit "gpu-inference-cilium-advanced" {
+  source = "${get_repo_root()}/catalog/units/gpu-inference-cilium-advanced"
+  path   = "gpu-inference-cilium-advanced"
+}
+
 unit "gpu-inference-gpu-operator" {
   source = "${get_repo_root()}/catalog/units/gpu-inference-gpu-operator"
   path   = "gpu-inference-gpu-operator"


### PR DESCRIPTION
Closes #144

## Summary

Extends the base Cilium deployment (Issues #70, #71) with five advanced eBPF capabilities that unlock the full performance and security potential of the gpu-inference cluster:

- **Socket-level load balancing** — `sockops` + `hostServices` intercept `connect()` once; zero per-packet DNAT overhead for all east-west traffic (vLLM, Volcano, DCGM)
- **Maglev consistent hashing** — `tableSize=65537`, configurable `hashSeed`; O(1) lookup with stable backend affinity through Karpenter spot replacements
- **XDP + Direct Server Return** — native XDP on `eth0` (AWS ENA), `dsr_dispatch=opt` (IP options); return packets from vLLM go directly to client skipping NLB on the return path
- **Hubble L7 observability** — HTTP status codes, latency histograms, path metrics for vLLM API captured via eBPF kernel hook; no Envoy sidecar; NCCL/training traffic untouched
- **ClusterMesh** — gpu-inference joins as cluster ID=4 (`prod-euw1-gpu`); pods discover VictoriaMetrics, External Secrets, ArgoCD on platform cluster without manual LB/DNS

## Files Changed

### Terraform module updates
- `terraform/modules/gpu-inference-cilium/main.tf` — Maglev, XDP/DSR, socket LB, Hubble metrics, ClusterMesh Helm values
- `terraform/modules/gpu-inference-cilium/variables.tf` — 11 new variables (`enable_xdp`, `enable_dsr`, `dsr_dispatch`, `enable_sockops`, `maglev_hash_seed`, `enable_clustermesh`, `cluster_mesh_name`, `cluster_mesh_id`, `clustermesh_apiserver_replicas`, `enable_hubble_ui`, `hubble_relay_replicas`, `enable_clustermesh_global_services`)
- `terraform/modules/gpu-inference-cilium/outputs.tf` — expose ClusterMesh, DSR, XDP, sockops status

### New Terraform module
- `terraform/modules/gpu-inference-cilium-advanced/` — PrometheusRules for XDP drop rate, DSR service health, sockops status, Hubble L7 error/latency, ClusterMesh connectivity, bandwidth manager; Hubble ServiceMonitor; bandwidth annotation reference ConfigMap

### Catalog unit
- `catalog/units/gpu-inference-cilium-advanced/terragrunt.hcl` — deploys the advanced monitoring module

### Identity-based network policies
All policies use Cilium numeric identities derived from pod labels — no IP addresses. Policies survive Karpenter spot replacements, rolling restarts, and HPA events without any manual update.

- `network-policies/gpu-inference/00-default-deny.yaml` — `CiliumClusterwideNetworkPolicy` baseline deny; allows intra-namespace + DNS + kube-apiserver
- `network-policies/gpu-inference/01-gpu-operator-access.yaml` — restricts GPU operator to vLLM, DCGM, Volcano identities
- `network-policies/gpu-inference/02-nccl-training-mesh.yaml` — full mesh TCP for `workload-type=training` pods on NCCL ports (29400-29501)
- `network-policies/gpu-inference/03-vllm-ingress.yaml` — vLLM API ingress with Hubble L7 HTTP rule; enables silent eBPF L7 capture
- `network-policies/gpu-inference/04-clustermesh-cross-cluster.yaml` — cross-cluster identity selectors using `io.cilium.k8s.policy.cluster` label

### Stack + ClusterMesh connect
- `terragrunt/prod/eu-west-1/gpu-inference/terragrunt.stack.hcl` — adds `gpu-inference-cilium-advanced` unit (Phase 4)
- `terragrunt/prod/_global/clustermesh-connect/terragrunt.hcl` — prod ClusterMesh connect config with gpu-inference as cluster 3 (alongside platform euw1/euc1)

### Monitoring
- `monitoring/dashboards/cilium-advanced-ebpf.json` — Grafana dashboard with panels for XDP drop rate, DSR status, sockops status, BPF LB map ops, Hubble L7 request rate/latency/drops, ClusterMesh cluster status/global services, bandwidth manager status, vLLM P99 latency under NCCL load

## ClusterMesh Post-Deploy Steps

After `terragrunt stack run apply` on the gpu-inference stack:
1. Retrieve TLS certs from each cluster's `kube-system/clustermesh-apiserver-remote-cert` secret
2. Populate `endpoint`, `ca_cert`, `tls_cert`, `tls_key` in `terragrunt/prod/_global/clustermesh-connect/terragrunt.hcl`
3. Alternatively: `cilium clustermesh connect --destination-context <ctx>` (simpler for initial setup)
4. Verify: `cilium clustermesh status --wait`

## Validation Checklist

- [ ] `cilium bpf lb list` shows Maglev entries and socket-based entries
- [ ] `cilium bpf lb list` shows DSR-enabled services
- [ ] `hubble observe --namespace gpu-inference --protocol http` shows vLLM requests
- [ ] `cilium monitor --type policy-verdict` shows identity-based decisions (no IP addresses)
- [ ] `cilium clustermesh status` shows connected clusters
- [ ] Grafana dashboard "Cilium Advanced eBPF — gpu-inference" shows green for all feature status panels

## Dependencies

- #70 — Cilium base deployment (prerequisite)
- #71 — WireGuard encryption (prerequisite)
- #72 — TGW Connect BGP infrastructure (prerequisite)