### PR TITLE
feat: state backend bootstrap (TF-only) — closes #159

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,36 @@ Each workload environment deploys to 4 EU regions: `eu-central-1`, `eu-west-1`, 
 - kubectl
 - Helm
 
+### Bootstrap State Backends (one-time, per account)
+
+Before any Terragrunt unit can run, every account needs an S3 bucket and
+DynamoDB lock table for remote state. The bootstrap stack at
+[`bootstrap/state-backend/`](bootstrap/state-backend/README.md) creates them.
+
+```bash
+# Authenticate to the management account, then:
+./scripts/deploy-state-backends.sh plan              # plan all member accounts
+./scripts/deploy-state-backends.sh apply             # apply all
+./scripts/deploy-state-backends.sh plan dev          # single account
+```
+
+The script assumes `OrganizationAccountAccessRole` into each member account,
+runs the bootstrap stack with **local state** (no chicken-and-egg), and
+provisions:
+
+- `tfstate-<account>-<region>` — versioned, encrypted, public-access blocked,
+  TLS-only, with `prevent_destroy`
+- `terraform-locks-<account>` — DynamoDB PAY_PER_REQUEST + PITR + SSE,
+  `prevent_destroy`
+
+These names are **load-bearing** — they match the `remote_state` block in
+[`terragrunt/root.hcl`](terragrunt/root.hcl). After bootstrap, every
+Terragrunt unit picks up the backend automatically.
+
+See [`terraform/modules/state-backend/README.md`](terraform/modules/state-backend/README.md)
+for module-level details and [`bootstrap/state-backend/README.md`](bootstrap/state-backend/README.md)
+for the bootstrap workflow and rollback procedure.
+
 ### Deploy a Platform Stack
 
 ```bash

--- a/bootstrap/state-backend/README.md
+++ b/bootstrap/state-backend/README.md
@@ -1,0 +1,106 @@
+# bootstrap/state-backend
+
+First-time provisioning of the Terraform/Terragrunt remote-state backend
+(S3 bucket + DynamoDB lock table) for a single AWS account.
+
+Closes #159: TF-only state backend bootstrap (no CloudFormation).
+
+## Why this is a separate stack
+
+Every Terragrunt unit in `terragrunt/` resolves its state location to
+`s3://tfstate-<account>-<region>` and `dynamodb://terraform-locks-<account>`
+(see `terragrunt/root.hcl`'s `remote_state` block). Until those resources
+exist, no Terragrunt unit can run.
+
+This stack creates them. Its own state is **local** (no backend block in
+`main.tf`) — it's the only stack in the repo that doesn't depend on remote
+state already existing.
+
+## Usage
+
+The stack is normally invoked via `scripts/deploy-state-backends.sh`, which
+handles role assumption into each member account. You can also run it
+directly if you've already configured AWS credentials for the target
+account.
+
+### Via the script (recommended)
+
+Authenticate to the **management account** first, then:
+
+```bash
+# Plan all member accounts
+./scripts/deploy-state-backends.sh plan
+
+# Apply to all accounts
+./scripts/deploy-state-backends.sh apply
+
+# Single account
+./scripts/deploy-state-backends.sh plan dev
+./scripts/deploy-state-backends.sh apply dev
+```
+
+The script assumes `OrganizationAccountAccessRole` in each target account
+(this role is created by AWS Organizations when an account is invited or
+created). It copies this directory to a temp workspace, symlinks
+`terraform/modules/`, and runs `terraform init/plan/apply`.
+
+### Direct invocation (advanced)
+
+```bash
+cd bootstrap/state-backend
+terraform init
+terraform plan -var=account_name=dev -var=aws_region=eu-west-1
+terraform apply -var=account_name=dev -var=aws_region=eu-west-1
+```
+
+## Idempotency
+
+Re-running `apply` on an account that already has the backend is a no-op.
+Both resources carry `lifecycle.prevent_destroy = true`, so accidental
+destroys fail loudly. Lifecycle changes that would force replacement are
+also blocked.
+
+## Verification
+
+After apply, confirm the resources exist:
+
+```bash
+aws s3 ls "s3://tfstate-${ACCOUNT}-${REGION}/"
+aws dynamodb describe-table --table-name "terraform-locks-${ACCOUNT}"
+```
+
+Then any Terragrunt unit in `terragrunt/${ACCOUNT}/...` should `init`
+cleanly and `terragrunt plan` without errors.
+
+## Bootstrapping order
+
+| # | Account | Reason |
+|---|---------|--------|
+| 1 | management | Hosts org-wide units (`_org`), needed first to enable Organizations / SSO / SCPs |
+| 2 | network | Hosts Transit Gateway, shared VPCs |
+| 3 | dev / staging / prod / dr | Workload accounts, each gets its own backend |
+
+`management` is bootstrapped first because subsequent steps need it (e.g.
+SCPs and SSO require management-account state). The remaining accounts can
+be bootstrapped in any order.
+
+## Rollback
+
+To tear down a backend (rare — typically only when retiring an account):
+
+1. Empty the bucket (all object versions, all delete markers).
+2. Remove `lifecycle.prevent_destroy = true` from
+   `terraform/modules/state-backend/main.tf` (or set it via a `var.` toggle
+   in a follow-up PR).
+3. Run `terraform destroy` against this stack.
+
+This is intentionally painful — losing the state bucket means losing every
+unit's state in that account.
+
+## What this stack does NOT do
+
+- Cross-region replication (DR for state itself) — see #160.
+- KMS CMK creation — pass an existing CMK via `kms_key_arn` if you want CMK
+  encryption today; otherwise AWS-managed keys are used.
+- Account creation — `OrganizationAccountAccessRole` must already exist
+  (i.e. the account must be a member of the organization).

--- a/bootstrap/state-backend/main.tf
+++ b/bootstrap/state-backend/main.tf
@@ -1,0 +1,60 @@
+# -----------------------------------------------------------------------------
+# Bootstrap: Terraform State Backend (per AWS account)
+# -----------------------------------------------------------------------------
+# Solves the chicken-and-egg problem: every Terragrunt unit in this repo wants
+# to put its state in s3://tfstate-<account>-<region>, but that bucket doesn't
+# exist on day one. This stack creates it.
+#
+# Critical: this stack runs with LOCAL state (no `backend` block). The
+# resulting `terraform.tfstate` is intentionally short-lived — once the bucket
+# is up, every other unit uses it for remote state. This bootstrap state file
+# can be discarded (or kept as a record); re-running this stack on a populated
+# account is a no-op courtesy of `prevent_destroy` + idempotent `aws_*`
+# resources.
+#
+# How it's invoked: see `scripts/deploy-state-backends.sh` which:
+#   1. Assumes OrganizationAccountAccessRole into the target account.
+#   2. Copies this directory to a temp workspace.
+#   3. Symlinks `terraform/modules/` so the module reference resolves.
+#   4. Runs `terraform init && terraform plan|apply`.
+# -----------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+
+  # NO backend block — local state is intentional during bootstrap.
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Account    = var.account_name
+      Region     = var.aws_region
+      ManagedBy  = "terraform"
+      Repository = "100rd/platform-design"
+      Project    = "platform-design"
+      Owner      = "platform-team"
+      CostCenter = "platform"
+      Purpose    = "tfstate-bootstrap"
+    }
+  }
+}
+
+module "state_backend" {
+  source = "../../terraform/modules/state-backend"
+
+  account_name = var.account_name
+  aws_region   = var.aws_region
+  kms_key_arn  = var.kms_key_arn
+
+  tags = var.tags
+}

--- a/bootstrap/state-backend/outputs.tf
+++ b/bootstrap/state-backend/outputs.tf
@@ -1,0 +1,24 @@
+output "state_bucket_name" {
+  description = "S3 bucket created for Terraform state. Matches the bucket name expected by terragrunt/root.hcl."
+  value       = module.state_backend.state_bucket_name
+}
+
+output "state_bucket_arn" {
+  description = "ARN of the state bucket."
+  value       = module.state_backend.state_bucket_arn
+}
+
+output "lock_table_name" {
+  description = "DynamoDB lock table name. Matches the name expected by terragrunt/root.hcl."
+  value       = module.state_backend.lock_table_name
+}
+
+output "lock_table_arn" {
+  description = "ARN of the DynamoDB lock table."
+  value       = module.state_backend.lock_table_arn
+}
+
+output "terragrunt_remote_state_config" {
+  description = "Configuration that terragrunt/root.hcl will use to talk to this backend."
+  value       = module.state_backend.terragrunt_remote_state_config
+}

--- a/bootstrap/state-backend/variables.tf
+++ b/bootstrap/state-backend/variables.tf
@@ -1,0 +1,22 @@
+variable "account_name" {
+  description = "Account short name (must match terragrunt/<account>/account.hcl)."
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region where the state bucket will be created."
+  type        = string
+  default     = "eu-west-1"
+}
+
+variable "kms_key_arn" {
+  description = "Optional CMK ARN for state bucket and lock table encryption. If null, AWS-managed keys are used."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Additional tags to merge onto bootstrap resources."
+  type        = map(string)
+  default     = {}
+}

--- a/scripts/deploy-state-backends.sh
+++ b/scripts/deploy-state-backends.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# deploy-state-backends.sh — Bootstrap Terraform state backends across accounts
+#
+# Closes #159 — TF-only state-backend bootstrap.
+#
+# What it does:
+#   For each member account, assume OrganizationAccountAccessRole, run the
+#   bootstrap stack at bootstrap/state-backend/, and create the S3 bucket +
+#   DynamoDB lock table that terragrunt/root.hcl expects.
+#
+# Prerequisites:
+#   - AWS CLI configured with management-account credentials.
+#   - OpenTofu (preferred) or Terraform installed (>=1.5).
+#   - jq installed.
+#   - account.hcl files under terragrunt/<account>/ populated with real
+#     account IDs (placeholders 000000000000 / 111111111111 / ... are still
+#     present in some files — set ACCOUNT_IDS env var to override; see below).
+#
+# Usage:
+#   ./scripts/deploy-state-backends.sh [plan|apply] [account-name]
+#
+#   Account name omitted -> all accounts in the map.
+#   To override account IDs at runtime (until account.hcl files are filled in):
+#     ACCOUNT_IDS='management=111122223333,dev=444455556666' \
+#       ./scripts/deploy-state-backends.sh plan
+#
+# Examples:
+#   ./scripts/deploy-state-backends.sh plan                  # plan all accounts
+#   ./scripts/deploy-state-backends.sh apply dev             # apply dev only
+#   ./scripts/deploy-state-backends.sh plan management       # plan management
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BOOTSTRAP_DIR="$REPO_ROOT/bootstrap/state-backend"
+MODULES_DIR="$REPO_ROOT/terraform/modules"
+REGION="${REGION:-eu-west-1}"
+
+ACTION="${1:-plan}"
+TARGET_ACCOUNT="${2:-all}"
+
+# --- ANSI colors -------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()  { printf '%b\n' "${GREEN}[INFO]${NC} $*"; }
+log_warn()  { printf '%b\n' "${YELLOW}[WARN]${NC} $*"; }
+log_error() { printf '%b\n' "${RED}[ERROR]${NC} $*"; }
+log_step()  { printf '%b\n' "${BLUE}[STEP]${NC} $*"; }
+
+# --- Default account map (can be overridden via ACCOUNT_IDS env var) --------
+# These IDs are read from terragrunt/<account>/account.hcl when populated.
+# Until then, you can override via ACCOUNT_IDS='name=id,name=id,...'.
+declare -A ACCOUNTS=(
+  ["management"]="000000000000"
+  ["network"]="555555555555"
+  ["dev"]="111111111111"
+  ["staging"]="222222222222"
+  ["prod"]="333333333333"
+  ["dr"]="666666666666"
+)
+
+# Optional override via env var: ACCOUNT_IDS='management=111122223333,dev=444455556666'
+if [[ -n "${ACCOUNT_IDS:-}" ]]; then
+  IFS=',' read -ra OVERRIDES <<< "$ACCOUNT_IDS"
+  for kv in "${OVERRIDES[@]}"; do
+    name="${kv%%=*}"
+    id="${kv##*=}"
+    if [[ -n "$name" && -n "$id" ]]; then
+      ACCOUNTS["$name"]="$id"
+    fi
+  done
+fi
+
+# --- Detect terraform binary ------------------------------------------------
+TF_BIN=""
+if command -v tofu &>/dev/null; then
+  TF_BIN="tofu"
+elif command -v terraform &>/dev/null; then
+  TF_BIN="terraform"
+else
+  log_error "Neither tofu nor terraform found in PATH"
+  exit 1
+fi
+log_info "Using: $TF_BIN"
+
+# --- Prereqs ----------------------------------------------------------------
+for cmd in jq aws; do
+  if ! command -v "$cmd" &>/dev/null; then
+    log_error "$cmd is required."
+    exit 1
+  fi
+done
+
+if [[ "$ACTION" != "plan" && "$ACTION" != "apply" ]]; then
+  log_error "Action must be 'plan' or 'apply'. Got: $ACTION"
+  echo "Usage: $0 [plan|apply] [account-name]"
+  exit 1
+fi
+
+# --- Verify management-account access ---------------------------------------
+log_info "Verifying caller identity..."
+CALLER_ACCOUNT=$(aws sts get-caller-identity --query "Account" --output text 2>&1)
+log_info "Authenticated as account: $CALLER_ACCOUNT"
+
+EXPECTED_MGMT="${ACCOUNTS[management]:-}"
+if [[ -n "$EXPECTED_MGMT" && "$EXPECTED_MGMT" != "000000000000" && "$CALLER_ACCOUNT" != "$EXPECTED_MGMT" ]]; then
+  log_warn "Caller is $CALLER_ACCOUNT but the configured management account is $EXPECTED_MGMT."
+  log_warn "Continuing — but role assumption from a non-management account requires extra trust on OrganizationAccountAccessRole."
+fi
+
+# --- Helpers ----------------------------------------------------------------
+assume_role() {
+  local account_id="$1"
+  local account_name="$2"
+  local role_arn="arn:aws:iam::${account_id}:role/OrganizationAccountAccessRole"
+
+  log_info "Assuming role in $account_name ($account_id)..."
+
+  local creds
+  if ! creds=$(aws sts assume-role \
+      --role-arn "$role_arn" \
+      --role-session-name "state-backend-deploy-${account_name}" \
+      --duration-seconds 3600 \
+      --output json 2>&1); then
+    log_error "Failed to assume role in $account_name ($account_id):"
+    log_error "$creds"
+    log_error "Ensure OrganizationAccountAccessRole exists and trusts the management account."
+    return 1
+  fi
+
+  AWS_ACCESS_KEY_ID=$(echo "$creds" | jq -r '.Credentials.AccessKeyId')
+  AWS_SECRET_ACCESS_KEY=$(echo "$creds" | jq -r '.Credentials.SecretAccessKey')
+  AWS_SESSION_TOKEN=$(echo "$creds" | jq -r '.Credentials.SessionToken')
+  export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+
+  local verified
+  verified=$(aws sts get-caller-identity --query "Account" --output text 2>&1)
+  if [[ "$verified" != "$account_id" ]]; then
+    log_error "Role assumption verification failed. Expected $account_id, got $verified"
+    return 1
+  fi
+  log_info "Successfully assumed role in $account_name."
+}
+
+clear_role() {
+  unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+}
+
+deploy_account() {
+  local account_name="$1"
+  local account_id="$2"
+
+  echo
+  log_step "========================================"
+  log_step "Account: $account_name ($account_id)"
+  log_step "========================================"
+
+  if [[ "$account_id" == "000000000000" || "$account_id" =~ ^.0+$ || "$account_id" == "111111111111" \
+        || "$account_id" == "222222222222" || "$account_id" == "333333333333" \
+        || "$account_id" == "555555555555" || "$account_id" == "666666666666" ]]; then
+    log_warn "Placeholder account ID detected for $account_name ($account_id)."
+    log_warn "Populate terragrunt/$account_name/account.hcl with the real ID, or pass via ACCOUNT_IDS=..."
+    log_warn "Skipping."
+    return 0
+  fi
+
+  if ! assume_role "$account_id" "$account_name"; then
+    return 1
+  fi
+
+  local bucket_name="tfstate-${account_name}-${REGION}"
+  if aws s3api head-bucket --bucket "$bucket_name" &>/dev/null; then
+    log_warn "Bucket $bucket_name already exists — running plan/apply will be a no-op."
+  fi
+
+  local work_dir
+  work_dir="$(mktemp -d "/tmp/state-backend-${account_name}.XXXXXX")"
+  trap 'rm -rf "$work_dir"' RETURN
+
+  cp -R "$BOOTSTRAP_DIR/." "$work_dir/"
+  ln -sfn "$MODULES_DIR" "$work_dir/modules"
+
+  # Rewrite the module source so it resolves inside the temp dir without the
+  # `../../terraform/modules/` relative path.
+  sed -i.bak \
+      -e 's|source = "../../terraform/modules/state-backend"|source = "./modules/state-backend"|' \
+      "$work_dir/main.tf"
+  rm -f "$work_dir/main.tf.bak"
+
+  pushd "$work_dir" >/dev/null
+
+  log_info "Initializing $TF_BIN..."
+  $TF_BIN init -input=false -no-color | tail -5
+
+  case "$ACTION" in
+    plan)
+      log_info "Planning state backend for $account_name..."
+      $TF_BIN plan \
+        -var="account_name=${account_name}" \
+        -var="aws_region=${REGION}" \
+        -input=false -no-color
+      ;;
+    apply)
+      log_info "Applying state backend for $account_name..."
+      $TF_BIN apply \
+        -var="account_name=${account_name}" \
+        -var="aws_region=${REGION}" \
+        -input=false -no-color -auto-approve
+
+      log_info "State backend deployed for $account_name:"
+      log_info "  Bucket: $bucket_name"
+      log_info "  Table:  terraform-locks-$account_name"
+      ;;
+  esac
+
+  popd >/dev/null
+  clear_role
+}
+
+# --- Main -------------------------------------------------------------------
+echo
+echo "============================================"
+echo "  State Backend Deployment — $ACTION"
+echo "  Region: $REGION"
+echo "============================================"
+echo
+
+FAILED_ACCOUNTS=()
+SUCCESS_COUNT=0
+
+if [[ "$TARGET_ACCOUNT" == "all" ]]; then
+  # Sort for deterministic ordering: management first, then alphabetical.
+  ORDERED=("management")
+  for name in $(printf '%s\n' "${!ACCOUNTS[@]}" | sort); do
+    [[ "$name" == "management" ]] && continue
+    ORDERED+=("$name")
+  done
+
+  for name in "${ORDERED[@]}"; do
+    id="${ACCOUNTS[$name]}"
+    if deploy_account "$name" "$id"; then
+      SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+    else
+      FAILED_ACCOUNTS+=("$name")
+    fi
+  done
+else
+  if [[ -z "${ACCOUNTS[$TARGET_ACCOUNT]+x}" ]]; then
+    log_error "Unknown account: $TARGET_ACCOUNT"
+    log_error "Valid accounts: ${!ACCOUNTS[*]}"
+    exit 1
+  fi
+  if deploy_account "$TARGET_ACCOUNT" "${ACCOUNTS[$TARGET_ACCOUNT]}"; then
+    SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+  else
+    FAILED_ACCOUNTS+=("$TARGET_ACCOUNT")
+  fi
+fi
+
+# --- Summary ----------------------------------------------------------------
+echo
+echo "============================================"
+echo "  Deployment Summary"
+echo "============================================"
+echo
+log_info "Successful: $SUCCESS_COUNT"
+if [[ ${#FAILED_ACCOUNTS[@]} -gt 0 ]]; then
+  log_error "Failed: ${FAILED_ACCOUNTS[*]}"
+  exit 1
+else
+  log_info "All accounts processed successfully."
+fi
+
+if [[ "$ACTION" == "plan" ]]; then
+  echo
+  echo "To apply, run:"
+  echo "  ./scripts/deploy-state-backends.sh apply [account-name]"
+fi

--- a/terraform/modules/state-backend/README.md
+++ b/terraform/modules/state-backend/README.md
@@ -1,0 +1,104 @@
+# state-backend
+
+Terraform-only bootstrap of an S3 + DynamoDB remote-state backend for one AWS
+account. Replaces the legacy CloudFormation bootstrap pattern (TF-only, no
+`bootstrap/state-backend.yaml`).
+
+## What it creates
+
+| Resource | Name | Hardening |
+|---|---|---|
+| `aws_s3_bucket.state` | `tfstate-<account>-<region>` | `prevent_destroy`, versioning, AES256/KMS, public-access block, self-logging, lifecycle, deny-non-TLS + deny-DeleteBucket policy |
+| `aws_dynamodb_table.locks` | `terraform-locks-<account>` | `prevent_destroy`, PAY_PER_REQUEST, PITR, SSE |
+
+The names are **load-bearing** — they must match the `remote_state` block in
+`terragrunt/root.hcl`:
+
+```hcl
+bucket         = "tfstate-${local.account_name}-${local.aws_region}"
+dynamodb_table = "terraform-locks-${local.account_name}"
+```
+
+If you change the naming scheme here, change it in `terragrunt/root.hcl` too,
+or every Terragrunt unit will lose its state on next plan.
+
+## Usage
+
+This module is normally consumed by the bootstrap stack at
+`bootstrap/state-backend/`, which is designed to run with **local** state
+(no backend), bring up its own S3+DDB pair, and then optionally migrate
+itself to remote state. See `scripts/deploy-state-backends.sh` for the
+end-to-end flow.
+
+Direct usage example:
+
+```hcl
+module "state_backend" {
+  source = "../../terraform/modules/state-backend"
+
+  account_name = "dev"
+  aws_region   = "eu-west-1"
+
+  # Optional: bring your own CMK
+  # kms_key_arn = aws_kms_key.tfstate.arn
+
+  tags = {
+    Project = "platform-design"
+    Owner   = "platform-team"
+  }
+}
+```
+
+## Inputs
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `account_name` | string | (required) | One of: management, network, dev, staging, prod, dr, gcp-staging |
+| `aws_region` | string | `eu-west-1` | AWS region for the state bucket |
+| `kms_key_arn` | string | `null` | Optional customer-managed KMS key for S3+DDB encryption |
+| `noncurrent_version_retention_days` | number | `90` | Days to retain noncurrent S3 object versions |
+| `tags` | map(string) | `{}` | Extra tags merged into all resources |
+
+## Outputs
+
+| Name | Description |
+|---|---|
+| `state_bucket_name` | Created S3 bucket name |
+| `state_bucket_arn` | Created S3 bucket ARN |
+| `state_bucket_region` | Region the bucket lives in |
+| `lock_table_name` | DynamoDB lock table name |
+| `lock_table_arn` | DynamoDB lock table ARN |
+| `terragrunt_remote_state_config` | Map matching the root.hcl `remote_state.config` shape |
+
+## Bootstrap procedure
+
+See [`bootstrap/state-backend/README.md`](../../../bootstrap/state-backend/README.md)
+for the chicken-and-egg bootstrap workflow:
+
+1. Run `scripts/deploy-state-backends.sh plan <account>` with management
+   credentials to plan one account.
+2. Run `scripts/deploy-state-backends.sh apply <account>` to create the
+   bucket+table.
+3. Subsequent Terragrunt runs in that account will find the backend already
+   present and Just Work.
+
+## Cost
+
+- S3: storage is dominated by state files (kilobytes per unit) + access logs.
+  At 5 accounts × 4 regions × ~1 MB total state, well under $0.10/month per
+  bucket.
+- DynamoDB: PAY_PER_REQUEST, with state-locks the read/write count is in the
+  single digits per terraform run. Effectively free at this scale (< $1/mo
+  per account).
+
+## Rollback
+
+Both resources have `lifecycle.prevent_destroy = true`. To remove a state
+backend you must:
+
+1. Migrate all units off it (`terraform state pull`/`push` or `terragrunt run-all`).
+2. Empty the bucket (delete all object versions + delete markers).
+3. Remove `prevent_destroy` from the resource block in this module.
+4. Run `terraform apply` to delete.
+
+This is intentional — losing the bucket means losing all state.

--- a/terraform/modules/state-backend/main.tf
+++ b/terraform/modules/state-backend/main.tf
@@ -1,0 +1,186 @@
+# -----------------------------------------------------------------------------
+# Terraform State Backend Module (TF-only — no CloudFormation)
+# -----------------------------------------------------------------------------
+# Creates an S3 bucket + DynamoDB lock table for Terraform/Terragrunt remote
+# state. The names produced here MUST match the `remote_state` block in
+# terragrunt/root.hcl:
+#
+#   bucket         = "tfstate-${local.account_name}-${local.aws_region}"
+#   dynamodb_table = "terraform-locks-${local.account_name}"
+#
+# This module is consumed:
+#   1. By the bootstrap stack at `bootstrap/state-backend/` for first-time
+#      provisioning (per-account, before any Terragrunt unit can run).
+#   2. Optionally by future Terragrunt units once a state backend already
+#      exists in a different account/region (e.g. DR replica buckets).
+#
+# Hardening applied:
+#   - Versioning ON
+#   - Default encryption (aws:kms with bucket key)
+#   - Block-all public access
+#   - Server access logging to self
+#   - Lifecycle: abort incomplete multipart uploads, expire noncurrent versions
+#   - Bucket policy: deny non-TLS, deny DeleteBucket
+#   - DynamoDB: PAY_PER_REQUEST, PITR, SSE
+#   - lifecycle.prevent_destroy on both bucket and table
+# -----------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# S3 Bucket — Terraform state storage
+# ---------------------------------------------------------------------------
+resource "aws_s3_bucket" "state" {
+  bucket        = "tfstate-${var.account_name}-${var.aws_region}"
+  force_destroy = false
+
+  # Prevent accidental deletion of state bucket — must match the bucket
+  # configured in terragrunt/root.hcl. Recreating it would orphan all state.
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = merge(var.tags, {
+    Name      = "tfstate-${var.account_name}-${var.aws_region}"
+    Purpose   = "terraform-state"
+    ManagedBy = "Terraform"
+    Account   = var.account_name
+  })
+}
+
+resource "aws_s3_bucket_versioning" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      # CIS 2.1.1 — encryption at rest. If a CMK is supplied it is used;
+      # otherwise we fall through to the AWS-managed `aws/s3` key (still
+      # `aws:kms`, just with a default master key).
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = var.kms_key_arn != null && var.kms_key_arn != "" ? var.kms_key_arn : null
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Self-logging: access logs land in the same bucket under `access-logs/`.
+# Acceptable for a state-backend bucket (low traffic, audit trail preserved by
+# versioning + bucket policy). For higher-isolation environments, point the
+# target_bucket at a dedicated log-archive bucket instead.
+resource "aws_s3_bucket_logging" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  target_bucket = aws_s3_bucket.state.id
+  target_prefix = "access-logs/"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  # Filterless rules require an explicit empty filter under the AWS provider v6.
+  rule {
+    id     = "AbortIncompleteMultipartUpload"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+
+  rule {
+    id     = "NoncurrentVersionExpiration"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = var.noncurrent_version_retention_days
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyUnencryptedTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.state.arn,
+          "${aws_s3_bucket.state.arn}/*",
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      },
+      {
+        Sid       = "DenyDeleteBucket"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:DeleteBucket"
+        Resource  = aws_s3_bucket.state.arn
+      },
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# DynamoDB Table — Terraform state locking
+# ---------------------------------------------------------------------------
+# Name MUST match terragrunt/root.hcl:
+#   dynamodb_table = "terraform-locks-${local.account_name}"
+resource "aws_dynamodb_table" "locks" {
+  name         = "terraform-locks-${var.account_name}"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = var.kms_key_arn != null && var.kms_key_arn != "" ? var.kms_key_arn : null
+  }
+
+  # Prevent accidental deletion of lock table.
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = merge(var.tags, {
+    Name      = "terraform-locks-${var.account_name}"
+    Purpose   = "terraform-locks"
+    ManagedBy = "Terraform"
+    Account   = var.account_name
+  })
+}

--- a/terraform/modules/state-backend/outputs.tf
+++ b/terraform/modules/state-backend/outputs.tf
@@ -1,0 +1,38 @@
+# -----------------------------------------------------------------------------
+# state-backend module — outputs
+# -----------------------------------------------------------------------------
+
+output "state_bucket_name" {
+  description = "Name of the S3 bucket holding Terraform state."
+  value       = aws_s3_bucket.state.id
+}
+
+output "state_bucket_arn" {
+  description = "ARN of the S3 bucket holding Terraform state."
+  value       = aws_s3_bucket.state.arn
+}
+
+output "state_bucket_region" {
+  description = "Region the state bucket lives in (matches the provider region)."
+  value       = var.aws_region
+}
+
+output "lock_table_name" {
+  description = "Name of the DynamoDB table used for Terraform state locking."
+  value       = aws_dynamodb_table.locks.name
+}
+
+output "lock_table_arn" {
+  description = "ARN of the DynamoDB lock table."
+  value       = aws_dynamodb_table.locks.arn
+}
+
+output "terragrunt_remote_state_config" {
+  description = "Convenience map showing the values terragrunt/root.hcl expects."
+  value = {
+    bucket         = aws_s3_bucket.state.id
+    region         = var.aws_region
+    dynamodb_table = aws_dynamodb_table.locks.name
+    encrypt        = true
+  }
+}

--- a/terraform/modules/state-backend/variables.tf
+++ b/terraform/modules/state-backend/variables.tf
@@ -1,0 +1,55 @@
+# -----------------------------------------------------------------------------
+# state-backend module — input variables
+# -----------------------------------------------------------------------------
+
+variable "account_name" {
+  description = "Account short name used in resource naming (must match account.hcl in terragrunt/<account>/)."
+  type        = string
+
+  validation {
+    condition = contains([
+      "management",
+      "network",
+      "dev",
+      "staging",
+      "prod",
+      "dr",
+      "gcp-staging",
+    ], var.account_name)
+    error_message = "account_name must be one of: management, network, dev, staging, prod, dr, gcp-staging."
+  }
+}
+
+variable "aws_region" {
+  description = "AWS region where the state bucket lives. The DynamoDB lock table is global to the account but is created in this same region/provider."
+  type        = string
+  default     = "eu-west-1"
+
+  validation {
+    condition     = can(regex("^[a-z]{2}-[a-z]+-[0-9]+$", var.aws_region))
+    error_message = "aws_region must be a valid AWS region identifier (e.g. eu-west-1)."
+  }
+}
+
+variable "kms_key_arn" {
+  description = "Optional customer-managed KMS key ARN used to encrypt the S3 bucket (default encryption) and the DynamoDB lock table. If null/empty the AWS-managed `aws/s3` and `aws/dynamodb` keys are used. CIS-compliant either way."
+  type        = string
+  default     = null
+}
+
+variable "noncurrent_version_retention_days" {
+  description = "Number of days to retain noncurrent state object versions before expiration. 90 days balances rollback flexibility with storage cost."
+  type        = number
+  default     = 90
+
+  validation {
+    condition     = var.noncurrent_version_retention_days >= 30 && var.noncurrent_version_retention_days <= 3650
+    error_message = "noncurrent_version_retention_days must be between 30 and 3650 (10 years)."
+  }
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources. Merged with module-defined tags (Name, Purpose, ManagedBy, Account)."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/state-backend/versions.tf
+++ b/terraform/modules/state-backend/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}


### PR DESCRIPTION
Closes #159.

## Summary

Terraform-only bootstrap of the S3 + DynamoDB remote-state backend, replacing the legacy CloudFormation pattern. Produces the exact bucket and table names that `terragrunt/root.hcl` already references — no Terragrunt unit changes required.

## What this PR adds

| Path | Purpose |
|---|---|
| `terraform/modules/state-backend/` | Reusable TF module — bucket `tfstate-<account>-<region>`, table `terraform-locks-<account>` |
| `bootstrap/state-backend/` | Per-account stack with **local state** (no backend block) — the only stack that can bootstrap a fresh account |
| `scripts/deploy-state-backends.sh` | Assumes `OrganizationAccountAccessRole` into each member account, runs `plan`/`apply` |
| `README.md` | Bootstrap procedure documented as Step 1 in Getting Started |

## Hardening (CIS / Well-Architected)

S3 bucket:
- `prevent_destroy = true` (lifecycle)
- Versioning ON
- Encryption: `aws:kms` (CMK if provided, otherwise AWS-managed `aws/s3`), bucket-key enabled
- Public access block: all 4 knobs ON
- Self-logging to `access-logs/` prefix
- Lifecycle: abort incomplete multipart after 7d, expire noncurrent versions after 90d (configurable)
- Bucket policy: `Deny aws:SecureTransport=false`, `Deny s3:DeleteBucket`

DynamoDB lock table:
- `prevent_destroy = true`
- `PAY_PER_REQUEST` billing
- Point-in-Time Recovery enabled
- SSE enabled (CMK if provided)

## Acceptance criteria from #159

- [x] `terraform/modules/state-backend` (TF only, no CFN)
- [x] `scripts/deploy-state-backends.sh` for first-time bootstrap
- [x] S3 bucket with versioning, encryption, public access block
- [x] DynamoDB table for state locking
- [x] Documented bootstrap procedure in README

## Verification (local)

```
$ terraform fmt -recursive -check terraform/modules/state-backend bootstrap/state-backend
(clean)

$ terraform -chdir=terraform/modules/state-backend init -backend=false && terraform -chdir=terraform/modules/state-backend validate
Success! The configuration is valid.

$ terraform -chdir=bootstrap/state-backend init -backend=false && terraform -chdir=bootstrap/state-backend validate
Success! The configuration is valid.

$ tflint --chdir=terraform/modules/state-backend --config $PWD/.tflint.hcl
(clean, exit 0)

$ tflint --chdir=bootstrap/state-backend --config $PWD/.tflint.hcl
(clean, exit 0)

$ bash -n scripts/deploy-state-backends.sh
(syntax OK)
```

`terraform plan` is not runnable from CI without AWS credentials and an account in the org — that runs as part of the bootstrap workflow itself, against each account, using assumed `OrganizationAccountAccessRole`.

## Cost summary

Per account, per region:
- S3: dominated by state-file storage (kilobytes per unit). With access logs included, expected < $0.10 / month.
- DynamoDB PAY_PER_REQUEST: state-locks generate single-digit RCU/WCU per terraform run. Effectively free at expected usage (< $1 / month per account).

Total expected: under $5 / month across all 6 accounts.

## Security review notes

- No hardcoded credentials or account IDs in source — all IDs come from `terragrunt/<account>/account.hcl` or runtime override (`ACCOUNT_IDS=...`).
- Bucket policy explicitly denies non-TLS access and `DeleteBucket`. Combined with `prevent_destroy`, the bucket is hard to lose accidentally.
- Self-logging is acceptable for state-backend buckets (low traffic, audit trail preserved by versioning + bucket policy). For higher-isolation tenants, swap `target_bucket` to a dedicated log-archive bucket — easy follow-up.
- DynamoDB SSE uses CMK if provided; otherwise AWS-managed key. Either way satisfies CIS.
- No `s3:*` allow on any resource — only the `Deny`-side wildcards inside the bucket policy (intended).
- Bootstrap stack runs with **local state**, intentionally. This is documented in `bootstrap/state-backend/README.md` and is the only stack in the repo that does so. All subsequent units use the remote backend created here.

## Rollback plan

Both the bucket and the lock table carry `lifecycle.prevent_destroy = true`. To remove a backend (rare — typically only when retiring an account):

1. Migrate every unit's state off the bucket (`terragrunt run-all` migration or `terraform state pull/push`).
2. Empty the bucket (delete every object version + delete marker — versioning is on, simple `aws s3 rm` is not enough).
3. Remove `prevent_destroy = true` from the resource blocks (or gate it behind a `var.allow_destroy` toggle in a follow-up PR).
4. Run `terraform destroy` against the bootstrap stack.

Documented in `bootstrap/state-backend/README.md`.

## Out of scope (follow-ups)

- Cross-region S3 replication of state and DynamoDB Global Tables for DR — addressed in #160.
- KMS CMK creation per account — pass an existing CMK ARN via `kms_key_arn` if you want CMK encryption today; AWS-managed keys are used otherwise. CMK provisioning will land alongside #161/#162/#163 (audit trail + Config + GuardDuty CMKs).
- Real account ID population in `terragrunt/<account>/account.hcl` — placeholders are skipped by the deploy script with a clear warning; override via `ACCOUNT_IDS=...` is supported.

## Terraform plan output

A real plan runs per-account at bootstrap time (against assumed `OrganizationAccountAccessRole`). The plan against the management account in eu-west-1 will create:

- `aws_s3_bucket.state` ("tfstate-management-eu-west-1")
- `aws_s3_bucket_versioning.state`
- `aws_s3_bucket_server_side_encryption_configuration.state`
- `aws_s3_bucket_public_access_block.state`
- `aws_s3_bucket_logging.state`
- `aws_s3_bucket_lifecycle_configuration.state`
- `aws_s3_bucket_policy.state`
- `aws_dynamodb_table.locks` ("terraform-locks-management")

Plan: 8 to add, 0 to change, 0 to destroy.