### PR TITLE
feat: cross-region DR for terraform state — closes #160

### DIFF
--- a/docs/runbooks/state-backend-failover.md
+++ b/docs/runbooks/state-backend-failover.md
@@ -1,0 +1,192 @@
+# Runbook: Terraform state-backend regional failover
+
+**Severity**: P1 (deploy capability is degraded but no production traffic
+is impacted directly).
+**Audience**: Platform on-call.
+**Trigger**: AWS region containing the primary state bucket
+(`tfstate-<account>-<primary_region>`) is unavailable for terraform reads or
+writes for >15 minutes.
+
+This runbook covers the case where a regional outage in the **primary**
+state region (default `eu-west-1`) prevents `terragrunt init/plan/apply`. It
+fails over to the DR replica created by the `state-backend-dr` module
+(default DR region `eu-central-1`).
+
+---
+
+## Pre-conditions
+
+- The DR replica was provisioned via `state-backend-dr` (PR #160 / issue
+  #160) and has been actively replicating for >24h.
+- You have IAM access to the affected account in the DR region.
+- You can reach github.com to push a config change.
+
+---
+
+## Decision tree
+
+1. **Is it actually a regional outage?**
+   - Check [AWS Health Dashboard](https://health.aws.amazon.com/health/home).
+   - Try `aws s3 ls "s3://tfstate-<account>-eu-west-1" --region eu-west-1`.
+   - If it fails for >15 min and the dashboard confirms eu-west-1 S3 or DDB
+     impairment, proceed.
+   - If only one service is impacted (e.g. S3 fine, DDB degraded), see
+     "Partial-outage" below.
+2. **Is the DR replica healthy?**
+   - `aws s3 ls "s3://tfstate-<account>-eu-central-1" --region eu-central-1`
+     should list current state files with mtimes within the last few minutes
+     (matching the SLA of S3 cross-region replication, typically <15 min).
+   - `aws dynamodb describe-table --table-name "terraform-locks-<account>"
+     --region eu-central-1` should return `TableStatus = ACTIVE` and show
+     `Replicas` containing both regions.
+3. **Are there active terraform runs?** Coordinate stop with anyone running
+   plan/apply pipelines. Once you flip the backend, runs against the old
+   region will fail and may leave stale locks.
+
+---
+
+## Failover steps
+
+### 1. Update terragrunt/root.hcl
+
+In a feature branch:
+
+```hcl
+# terragrunt/root.hcl
+remote_state {
+  backend = "s3"
+  ...
+  config = {
+    bucket = "tfstate-${local.account_name}-eu-central-1"   # was -eu-west-1
+    region = "eu-central-1"                                  # was eu-west-1
+    ...
+    dynamodb_table = "terraform-locks-${local.account_name}" # unchanged — Global Table
+  }
+}
+```
+
+The DDB lock table name does not change because the replica is part of a
+DDB Global Table and the writeable endpoint is per-region. Terragrunt picks
+up the right regional endpoint via the `region` field.
+
+### 2. Open a PR titled "incident: failover state to <dr-region>"
+
+- Body should reference the AWS Health Dashboard event ID and the time of
+  outage detection.
+- Tag platform on-call as reviewers.
+- Merge with the explicit knowledge that this is an emergency path. A
+  follow-up PR will revert it during recovery.
+
+### 3. Verify failover
+
+After merge:
+
+```bash
+# Pick any unit and run plan
+cd terragrunt/dev/eu-west-1/some-unit
+terragrunt plan
+```
+
+`init` should reconfigure the backend automatically (Terragrunt always
+regenerates `backend.tf` via `if_exists = "overwrite_terragrunt"`). Plan
+should succeed against the replica.
+
+### 4. Note locks
+
+If there were locks held in the primary region's DDB at the time of outage,
+they appear in the replica too (Global Tables are bidirectionally
+replicated). Stale locks block new operations. Identify them:
+
+```bash
+aws dynamodb scan --table-name terraform-locks-<account> \
+  --region eu-central-1 \
+  --query 'Items[*].LockID.S'
+```
+
+If a lock is genuinely orphaned (the holder has crashed and is not coming
+back), force-unlock with the lock ID printed by `terragrunt`:
+
+```bash
+terragrunt force-unlock <LOCK_ID>
+```
+
+Document every force-unlock in the incident channel.
+
+---
+
+## Recovery: failing back to primary region
+
+When the primary region recovers:
+
+1. Confirm `aws s3 ls "s3://tfstate-<account>-eu-west-1" --region eu-west-1`
+   works again.
+2. **Sync writes-during-outage** back to primary. Replication is one-way
+   (replica is the read-only side during normal ops). Anything written to
+   the replica during failover is NOT auto-replicated back:
+
+   ```bash
+   aws s3 sync \
+     "s3://tfstate-<account>-eu-central-1/" \
+     "s3://tfstate-<account>-eu-west-1/" \
+     --source-region eu-central-1 \
+     --region eu-west-1 \
+     --copy-props metadata-directive
+   ```
+
+   Spot-check version histories on a few critical state files to confirm
+   no divergence.
+3. **Open a fail-back PR** that reverts step 1 of the failover (point
+   `bucket` and `region` back to the primary). Title:
+   `incident: revert state failover, primary <region> healthy`.
+4. After merge, run `terragrunt plan` against any unit to confirm
+   `init -reconfigure` picks up the primary again.
+5. Inspect `aws_dynamodb_table_replica.locks_dr` — if the table replica
+   remained healthy throughout, no action needed. If anything looks off
+   (table status not ACTIVE), open a follow-up incident.
+
+---
+
+## Partial-outage scenarios
+
+| Symptom | Action |
+|---|---|
+| S3 in primary works, DDB does not | DDB Global Tables are active-active; Terragrunt will use the regional DDB endpoint specified in `region`. Temporarily flip ONLY the `region` field on the lock table side (custom override) — but in practice, since both come from `region`, do the full failover. |
+| DDB works, S3 control plane partially degraded | Wait. Terragrunt retries are configured (`retry_max_attempts = 3` in root.hcl). Most partial S3 control-plane degradations clear within an hour without action. |
+| S3 data plane returns 5xx for a single bucket | Check bucket policy + replication status. Could be a misconfiguration, not an outage. |
+
+---
+
+## What NOT to do
+
+- **Do not** run `aws s3 rb` or `aws dynamodb delete-table` on either
+  side. Both have `prevent_destroy = true` in Terraform; manual deletion
+  would orphan terraform state and require an emergency restore from S3
+  versions.
+- **Do not** disable replication on the primary bucket "to avoid
+  conflicts." Replication is what populated the replica in the first
+  place; turning it off mid-incident breaks the recovery path.
+- **Do not** create a new bucket and copy state into it under a different
+  name. The bucket name is load-bearing in `terragrunt/root.hcl`. Match
+  the naming convention exactly.
+
+---
+
+## Post-incident checklist
+
+- [ ] Fail-back PR merged.
+- [ ] Spot-check confirms no state divergence between primary and replica.
+- [ ] Replication metrics back to baseline (delta < 60s).
+- [ ] All force-unlocks documented in the incident report.
+- [ ] If RTO/RPO targets were missed, file a follow-up to investigate
+      replication lag root cause.
+- [ ] Update this runbook with anything that surprised you.
+
+---
+
+## Related docs
+
+- [`terraform/modules/state-backend-dr/README.md`](../../terraform/modules/state-backend-dr/README.md)
+- [`terraform/modules/state-backend/README.md`](../../terraform/modules/state-backend/README.md)
+- [`bootstrap/state-backend/README.md`](../../bootstrap/state-backend/README.md)
+- [AWS S3 cross-region replication docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication.html)
+- [DynamoDB Global Tables v2](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/V2globaltables_HowItWorks.html)

--- a/terraform/modules/state-backend-dr/README.md
+++ b/terraform/modules/state-backend-dr/README.md
@@ -1,0 +1,173 @@
+# state-backend-dr
+
+Cross-region disaster-recovery for the Terraform state backend. Adds an S3
+replica bucket, IAM replication role, replication configuration on the
+primary bucket, and a DynamoDB Global Tables v2 replica.
+
+Closes #160.
+
+## What it creates
+
+| Resource | Region | Purpose |
+|---|---|---|
+| `aws_s3_bucket.state_replica` | `dr_region` | Read-only replica of the primary state bucket |
+| `aws_s3_bucket_versioning.state_replica` | `dr_region` | Required for replication |
+| `aws_s3_bucket_server_side_encryption_configuration.state_replica` | `dr_region` | aws:kms with optional CMK |
+| `aws_s3_bucket_public_access_block.state_replica` | `dr_region` | All four knobs ON |
+| `aws_s3_bucket_logging.state_replica` | `dr_region` | Self-logging |
+| `aws_s3_bucket_lifecycle_configuration.state_replica` | `dr_region` | Abort multipart, expire noncurrent |
+| `aws_s3_bucket_policy.state_replica` | `dr_region` | Deny non-TLS, deny DeleteBucket |
+| `aws_iam_role.replication` | primary | Service role assumed by S3 |
+| `aws_iam_role_policy.replication` | primary | Read source, write replica, optional KMS grants |
+| `aws_s3_bucket_replication_configuration.state` | primary | Rule on the primary bucket |
+| `aws_dynamodb_table_replica.locks_dr` | `dr_region` | Lock-table replica via DDB Global Tables v2 |
+
+## Prerequisite: enable streams on the primary lock table
+
+`aws_dynamodb_table_replica` requires the source table to have streams
+enabled. Set this on the primary `state-backend` module **before** applying
+this one:
+
+```hcl
+module "state_backend" {
+  source = "../../terraform/modules/state-backend"
+
+  account_name            = "dev"
+  aws_region              = "eu-west-1"
+  enable_dynamodb_streams = true   # <-- required for DR
+}
+```
+
+This is an in-place update on the existing table; it does not recreate.
+
+## Usage
+
+```hcl
+provider "aws" {
+  region = "eu-west-1"
+}
+
+provider "aws" {
+  alias  = "dr"
+  region = "eu-central-1"
+}
+
+module "state_backend" {
+  source = "../../terraform/modules/state-backend"
+
+  account_name            = "dev"
+  aws_region              = "eu-west-1"
+  enable_dynamodb_streams = true
+}
+
+module "state_backend_dr" {
+  source = "../../terraform/modules/state-backend-dr"
+
+  providers = {
+    aws    = aws
+    aws.dr = aws.dr
+  }
+
+  account_name = "dev"
+  primary_region = "eu-west-1"
+  dr_region      = "eu-central-1"
+
+  source_bucket_id      = module.state_backend.state_bucket_name
+  source_bucket_arn     = module.state_backend.state_bucket_arn
+  source_lock_table_arn = module.state_backend.lock_table_arn
+
+  # Optional: pass through any CMKs in use
+  # source_kms_key_arn = aws_kms_key.tfstate_primary.arn
+  # kms_key_arn_dr     = aws_kms_key.tfstate_dr.arn
+}
+```
+
+## Inputs
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `account_name` | string | (required) | Account short name |
+| `primary_region` | string | `eu-west-1` | Primary state-backend region |
+| `dr_region` | string | `eu-central-1` | DR region (must differ from primary) |
+| `source_bucket_id` | string | (required) | Primary state bucket name |
+| `source_bucket_arn` | string | (required) | Primary state bucket ARN |
+| `source_lock_table_arn` | string | (required) | Primary DynamoDB lock table ARN (must have streams enabled) |
+| `source_kms_key_arn` | string | `null` | Optional CMK ARN of the primary bucket — adds kms:Decrypt to replication role |
+| `kms_key_arn_dr` | string | `null` | Optional CMK ARN in `dr_region` for the replica bucket — adds kms:Encrypt to replication role + sets `replica_kms_key_id` on the replication rule |
+| `noncurrent_version_retention_days` | number | `90` | Days to retain noncurrent versions in the replica |
+| `tags` | map(string) | `{}` | Extra tags |
+
+## Outputs
+
+| Name | Description |
+|---|---|
+| `replica_bucket_name` | Replica S3 bucket name |
+| `replica_bucket_arn` | Replica S3 bucket ARN |
+| `replica_bucket_region` | Replica region |
+| `replication_role_arn` | IAM role used by S3 for replication |
+| `replication_rule_id` | Replication rule ID on the primary bucket |
+| `lock_table_replica_arn` | DDB lock-table replica ARN |
+| `lock_table_replica_region` | DDB lock-table replica region |
+| `failover_summary` | Map summarising primary + replica endpoints (use in runbooks) |
+
+## Failover runbook
+
+See [`docs/runbooks/state-backend-failover.md`](../../../docs/runbooks/state-backend-failover.md)
+for the full step-by-step procedure for failing over from a regional outage.
+
+Quick sketch:
+
+1. Confirm primary region is genuinely unavailable (S3 + DynamoDB control
+   planes both impacted; check AWS Health Dashboard).
+2. Update `terragrunt/root.hcl`'s `remote_state.config.bucket` and `region`
+   to point at the DR replica:
+   ```hcl
+   bucket = "tfstate-${local.account_name}-eu-central-1"
+   region = "eu-central-1"
+   ```
+3. The DynamoDB lock table is a Global Table — the replica is already
+   writeable in the DR region; no config change needed (Terragrunt will
+   auto-discover it via the unchanged `dynamodb_table` name).
+4. `terragrunt run-all init -migrate-state` is **not** required — state has
+   been replicated continuously. `terragrunt plan` should succeed against
+   the replica.
+5. After primary recovers, run `aws s3 sync` from replica back to primary
+   for objects that landed during the outage, then revert the root.hcl
+   change. (Bidirectional replication is intentionally NOT enabled — see
+   below.)
+
+## Why one-way replication only
+
+Bidirectional S3 cross-region replication on the same bucket pair creates a
+loop unless every object has a replication-status header that breaks the
+cycle. This is fragile; the AWS-recommended pattern is one-way + a manual
+sync-back step on recovery. The DynamoDB Global Tables side IS bidirectional
+(active-active) — that's the point of DDB GT — but there are no writes to
+the lock table during a healthy run beyond brief lease grabs, so split-brain
+risk is minimal.
+
+## Cost
+
+- S3 cross-region replication: $0.02 per GB transferred + replication PUT
+  cost. State files are kilobytes; expected cost < $0.10 per account per
+  month.
+- DynamoDB Global Tables: replicated writes priced at standard regional
+  WCU/RCU rates. With PAY_PER_REQUEST and infrequent locks, expect under
+  $1 per account per month.
+
+Total expected uplift over #159: ~$5 / month across all accounts.
+
+## Rollback
+
+To remove DR (rare — typically only when retiring an account or changing DR
+region):
+
+1. Remove the module block from the calling stack.
+2. `terraform plan` shows the destroy. Review carefully.
+3. Empty the replica bucket (versioned — needs explicit version delete).
+4. Set `prevent_destroy = false` on the replica bucket via a fork of this
+   module if needed (default has it on).
+5. `terraform apply`.
+
+The DDB replica can be removed without destroying the primary table
+(promotes the global table back to a single-region table).

--- a/terraform/modules/state-backend-dr/examples/basic/main.tf
+++ b/terraform/modules/state-backend-dr/examples/basic/main.tf
@@ -1,0 +1,54 @@
+# -----------------------------------------------------------------------------
+# state-backend-dr — basic example used for `terraform validate`
+#
+# This is a non-deployable harness. It wires up the two providers the module
+# requires and points at fake source-bucket inputs. Do NOT `terraform apply`
+# this example; it exists so CI can validate the module syntactically.
+# -----------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = "eu-west-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  skip_metadata_api_check     = true
+  access_key                  = "validate-only"
+  secret_key                  = "validate-only"
+}
+
+provider "aws" {
+  alias                       = "dr"
+  region                      = "eu-central-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  skip_metadata_api_check     = true
+  access_key                  = "validate-only"
+  secret_key                  = "validate-only"
+}
+
+module "state_backend_dr" {
+  source = "../.."
+
+  providers = {
+    aws    = aws
+    aws.dr = aws.dr
+  }
+
+  account_name   = "dev"
+  primary_region = "eu-west-1"
+  dr_region      = "eu-central-1"
+
+  source_bucket_id      = "tfstate-dev-eu-west-1"
+  source_bucket_arn     = "arn:aws:s3:::tfstate-dev-eu-west-1"
+  source_lock_table_arn = "arn:aws:dynamodb:eu-west-1:111111111111:table/terraform-locks-dev"
+}

--- a/terraform/modules/state-backend-dr/main.tf
+++ b/terraform/modules/state-backend-dr/main.tf
@@ -1,0 +1,301 @@
+# -----------------------------------------------------------------------------
+# state-backend-dr — Cross-region DR for the Terraform state backend
+# -----------------------------------------------------------------------------
+# Adds:
+#   1. An S3 replica bucket in `dr_region` (with the same hardening as the
+#      primary).
+#   2. An IAM role + policy in the primary region's account that S3 uses to
+#      replicate objects from primary -> replica.
+#   3. An `aws_s3_bucket_replication_configuration` on the primary bucket
+#      pointing at the replica.
+#   4. A DynamoDB Global-Tables-v2 replica of the lock table in `dr_region`.
+#
+# Caller is responsible for:
+#   - Passing two aliased AWS providers: default (= primary_region) and `aws.dr`
+#     (= dr_region).
+#   - Setting `enable_dynamodb_streams = true` on the primary state-backend
+#     module before applying this one. The aws_dynamodb_table_replica resource
+#     fails apply otherwise.
+#
+# Closes #160 (cross-region DR for Terraform state).
+# -----------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# DR replica bucket — created via the aliased `aws.dr` provider
+# ---------------------------------------------------------------------------
+resource "aws_s3_bucket" "state_replica" {
+  provider = aws.dr
+
+  bucket        = "tfstate-${var.account_name}-${var.dr_region}"
+  force_destroy = false
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = merge(var.tags, {
+    Name      = "tfstate-${var.account_name}-${var.dr_region}"
+    Purpose   = "terraform-state-dr-replica"
+    ManagedBy = "Terraform"
+    Account   = var.account_name
+    DROf      = "tfstate-${var.account_name}-${var.primary_region}"
+  })
+}
+
+resource "aws_s3_bucket_versioning" "state_replica" {
+  provider = aws.dr
+
+  bucket = aws_s3_bucket.state_replica.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "state_replica" {
+  provider = aws.dr
+
+  bucket = aws_s3_bucket.state_replica.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = var.kms_key_arn_dr != null && var.kms_key_arn_dr != "" ? var.kms_key_arn_dr : null
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "state_replica" {
+  provider = aws.dr
+
+  bucket = aws_s3_bucket.state_replica.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_logging" "state_replica" {
+  provider = aws.dr
+
+  bucket        = aws_s3_bucket.state_replica.id
+  target_bucket = aws_s3_bucket.state_replica.id
+  target_prefix = "access-logs/"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "state_replica" {
+  provider = aws.dr
+
+  bucket = aws_s3_bucket.state_replica.id
+
+  rule {
+    id     = "AbortIncompleteMultipartUpload"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+
+  rule {
+    id     = "NoncurrentVersionExpiration"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = var.noncurrent_version_retention_days
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "state_replica" {
+  provider = aws.dr
+
+  bucket = aws_s3_bucket.state_replica.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyUnencryptedTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.state_replica.arn,
+          "${aws_s3_bucket.state_replica.arn}/*",
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      },
+      {
+        Sid       = "DenyDeleteBucket"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:DeleteBucket"
+        Resource  = aws_s3_bucket.state_replica.arn
+      },
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# IAM role used by S3 to replicate primary -> replica
+# ---------------------------------------------------------------------------
+resource "aws_iam_role" "replication" {
+  name = "state-replication-${var.account_name}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "s3.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = merge(var.tags, {
+    Name    = "state-replication-${var.account_name}"
+    Purpose = "s3-cross-region-replication"
+  })
+}
+
+resource "aws_iam_role_policy" "replication" {
+  name = "state-replication-${var.account_name}"
+  role = aws_iam_role.replication.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(
+      [
+        {
+          Effect = "Allow"
+          Action = [
+            "s3:GetReplicationConfiguration",
+            "s3:ListBucket",
+          ]
+          Resource = var.source_bucket_arn
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "s3:GetObjectVersionForReplication",
+            "s3:GetObjectVersionAcl",
+            "s3:GetObjectVersionTagging",
+          ]
+          Resource = "${var.source_bucket_arn}/*"
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "s3:ReplicateObject",
+            "s3:ReplicateDelete",
+            "s3:ReplicateTags",
+          ]
+          Resource = "${aws_s3_bucket.state_replica.arn}/*"
+        },
+      ],
+      # If the source bucket uses a CMK, the role needs kms:Decrypt against
+      # that key. If the destination uses a CMK in the DR region, it needs
+      # kms:Encrypt against that one. AWS-managed keys are handled
+      # automatically and don't need explicit grants.
+      var.source_kms_key_arn != null && var.source_kms_key_arn != "" ? [
+        {
+          Effect   = "Allow"
+          Action   = ["kms:Decrypt"]
+          Resource = var.source_kms_key_arn
+        }
+      ] : [],
+      var.kms_key_arn_dr != null && var.kms_key_arn_dr != "" ? [
+        {
+          Effect   = "Allow"
+          Action   = ["kms:Encrypt", "kms:GenerateDataKey"]
+          Resource = var.kms_key_arn_dr
+        }
+      ] : [],
+    )
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Primary-bucket replication configuration
+# ---------------------------------------------------------------------------
+resource "aws_s3_bucket_replication_configuration" "state" {
+  # Replication can only be configured on a versioned bucket — make sure the
+  # replica is in place first.
+  depends_on = [aws_s3_bucket_versioning.state_replica]
+
+  bucket = var.source_bucket_id
+  role   = aws_iam_role.replication.arn
+
+  rule {
+    id     = "replicate-all-state"
+    status = "Enabled"
+
+    filter {}
+
+    delete_marker_replication {
+      status = "Enabled"
+    }
+
+    destination {
+      bucket        = aws_s3_bucket.state_replica.arn
+      storage_class = "STANDARD"
+
+      # If a DR-region CMK is provided, ask S3 to re-encrypt with it on
+      # arrival. Otherwise we let the destination bucket's default encryption
+      # apply (`aws/s3`), which is also fine for state.
+      dynamic "encryption_configuration" {
+        for_each = var.kms_key_arn_dr != null && var.kms_key_arn_dr != "" ? [1] : []
+        content {
+          replica_kms_key_id = var.kms_key_arn_dr
+        }
+      }
+    }
+
+    # If the source side is encrypted with a CMK we have to opt-in to
+    # replicating SSE-KMS objects.
+    dynamic "source_selection_criteria" {
+      for_each = var.source_kms_key_arn != null && var.source_kms_key_arn != "" ? [1] : []
+      content {
+        sse_kms_encrypted_objects {
+          status = "Enabled"
+        }
+      }
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# DynamoDB Global Tables v2 replica
+# ---------------------------------------------------------------------------
+# Promotes the existing lock table into a global table by attaching a replica
+# in `dr_region`. Requires `stream_enabled = true` on the source table — gated
+# at the state-backend module via `enable_dynamodb_streams`.
+resource "aws_dynamodb_table_replica" "locks_dr" {
+  provider = aws.dr
+
+  global_table_arn = var.source_lock_table_arn
+
+  # PITR mirrors the source's setting.
+  point_in_time_recovery = true
+
+  tags = merge(var.tags, {
+    Name    = "terraform-locks-${var.account_name}-dr"
+    Purpose = "terraform-locks-dr-replica"
+    Account = var.account_name
+    DROf    = var.source_lock_table_arn
+  })
+}

--- a/terraform/modules/state-backend-dr/outputs.tf
+++ b/terraform/modules/state-backend-dr/outputs.tf
@@ -1,0 +1,54 @@
+# -----------------------------------------------------------------------------
+# state-backend-dr — outputs
+# -----------------------------------------------------------------------------
+
+output "replica_bucket_name" {
+  description = "Name of the DR replica S3 bucket."
+  value       = aws_s3_bucket.state_replica.id
+}
+
+output "replica_bucket_arn" {
+  description = "ARN of the DR replica S3 bucket."
+  value       = aws_s3_bucket.state_replica.arn
+}
+
+output "replica_bucket_region" {
+  description = "Region the replica bucket lives in."
+  value       = var.dr_region
+}
+
+output "replication_role_arn" {
+  description = "ARN of the IAM role S3 uses to replicate from primary to replica."
+  value       = aws_iam_role.replication.arn
+}
+
+output "replication_rule_id" {
+  description = "ID of the replication rule attached to the primary bucket."
+  value       = aws_s3_bucket_replication_configuration.state.id
+}
+
+output "lock_table_replica_arn" {
+  description = "ARN of the DynamoDB lock-table replica in the DR region."
+  value       = aws_dynamodb_table_replica.locks_dr.arn
+}
+
+output "lock_table_replica_region" {
+  description = "Region of the DynamoDB lock-table replica."
+  value       = var.dr_region
+}
+
+output "failover_summary" {
+  description = "Convenience map summarising the failover endpoints."
+  value = {
+    primary = {
+      bucket = var.source_bucket_id
+      region = var.primary_region
+    }
+    replica = {
+      bucket = aws_s3_bucket.state_replica.id
+      region = var.dr_region
+    }
+    lock_table_global_arn  = var.source_lock_table_arn
+    lock_table_replica_arn = aws_dynamodb_table_replica.locks_dr.arn
+  }
+}

--- a/terraform/modules/state-backend-dr/variables.tf
+++ b/terraform/modules/state-backend-dr/variables.tf
@@ -1,0 +1,81 @@
+# -----------------------------------------------------------------------------
+# state-backend-dr — input variables
+# -----------------------------------------------------------------------------
+
+variable "account_name" {
+  description = "Account short name. Must match the account that owns the primary state-backend (resources are colocated in the same account, just in a second region)."
+  type        = string
+
+  validation {
+    condition = contains([
+      "management", "network", "dev", "staging", "prod", "dr", "gcp-staging",
+    ], var.account_name)
+    error_message = "account_name must be one of: management, network, dev, staging, prod, dr, gcp-staging."
+  }
+}
+
+variable "primary_region" {
+  description = "Region of the primary state bucket and DynamoDB lock table (where state-backend was applied)."
+  type        = string
+  default     = "eu-west-1"
+
+  validation {
+    condition     = can(regex("^[a-z]{2}-[a-z]+-[0-9]+$", var.primary_region))
+    error_message = "primary_region must be a valid AWS region identifier (e.g. eu-west-1)."
+  }
+}
+
+variable "dr_region" {
+  description = "Region for the DR replica bucket and DynamoDB replica. Must be different from primary_region."
+  type        = string
+  default     = "eu-central-1"
+
+  validation {
+    condition     = can(regex("^[a-z]{2}-[a-z]+-[0-9]+$", var.dr_region))
+    error_message = "dr_region must be a valid AWS region identifier (e.g. eu-central-1)."
+  }
+}
+
+variable "source_bucket_id" {
+  description = "ID (name) of the primary S3 state bucket — value of state-backend's `state_bucket_name` output."
+  type        = string
+}
+
+variable "source_bucket_arn" {
+  description = "ARN of the primary S3 state bucket — value of state-backend's `state_bucket_arn` output."
+  type        = string
+}
+
+variable "source_lock_table_arn" {
+  description = "ARN of the primary DynamoDB lock table — value of state-backend's `lock_table_arn` output. The primary table MUST have streams enabled (set `enable_dynamodb_streams = true` on the state-backend module)."
+  type        = string
+}
+
+variable "kms_key_arn_dr" {
+  description = "Optional CMK in the DR region for encrypting the replica bucket. If null/empty, AWS-managed `aws/s3` is used. Note: the primary and replica buckets can use different keys — but if the source bucket is encrypted with a CMK, the replication role needs kms:Decrypt on it (handled below)."
+  type        = string
+  default     = null
+}
+
+variable "source_kms_key_arn" {
+  description = "If the primary bucket uses a CMK, pass its ARN here so the replication role gets kms:Decrypt against it. Leave null if the primary uses the AWS-managed key."
+  type        = string
+  default     = null
+}
+
+variable "noncurrent_version_retention_days" {
+  description = "Days to retain noncurrent S3 versions in the replica bucket."
+  type        = number
+  default     = 90
+
+  validation {
+    condition     = var.noncurrent_version_retention_days >= 30 && var.noncurrent_version_retention_days <= 3650
+    error_message = "noncurrent_version_retention_days must be between 30 and 3650 (10 years)."
+  }
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/state-backend-dr/versions.tf
+++ b/terraform/modules/state-backend-dr/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = ">= 5.0, < 7.0"
+      configuration_aliases = [aws.dr]
+    }
+  }
+}

--- a/terraform/modules/state-backend/main.tf
+++ b/terraform/modules/state-backend/main.tf
@@ -172,7 +172,16 @@ resource "aws_dynamodb_table" "locks" {
     kms_key_arn = var.kms_key_arn != null && var.kms_key_arn != "" ? var.kms_key_arn : null
   }
 
-  # Prevent accidental deletion of lock table.
+  # Streams are required if a cross-region replica is going to be attached
+  # via state-backend-dr (DynamoDB Global Tables v2). Optional and additive —
+  # default `false` matches #159 behaviour. NEW_AND_OLD_IMAGES is required by
+  # `aws_dynamodb_table_replica`.
+  stream_enabled   = var.enable_dynamodb_streams
+  stream_view_type = var.enable_dynamodb_streams ? "NEW_AND_OLD_IMAGES" : null
+
+  # Prevent accidental deletion of lock table. The data inside is just
+  # ephemeral lease rows, but dropping the table out from under live state
+  # operations causes corruption and is exactly the failure mode this guards.
   lifecycle {
     prevent_destroy = true
   }

--- a/terraform/modules/state-backend/variables.tf
+++ b/terraform/modules/state-backend/variables.tf
@@ -48,6 +48,12 @@ variable "noncurrent_version_retention_days" {
   }
 }
 
+variable "enable_dynamodb_streams" {
+  description = "Enable DynamoDB streams on the lock table. Required if you plan to add cross-region replicas via the state-backend-dr module (DDB Global Tables v2). Default false to keep #159 behaviour. Setting this to true is an in-place table update — no recreation."
+  type        = bool
+  default     = false
+}
+
 variable "tags" {
   description = "Tags to apply to all resources. Merged with module-defined tags (Name, Purpose, ManagedBy, Account)."
   type        = map(string)


### PR DESCRIPTION
Closes #160. Builds on #159 (merged in #189).

## Summary

Cross-region disaster-recovery for the Terraform state backend:
- S3 cross-region replication (one-way, primary -> replica) with the same hardening as the primary bucket.
- DynamoDB Global Tables v2 replica of the lock table.
- Failover runbook covering detection, failover, fail-back, partial outage, and post-incident checklist.

## What this PR adds

| Path | Purpose |
|---|---|
| `terraform/modules/state-backend-dr/` | New module — replica bucket, IAM replication role, replication config, DDB replica |
| `terraform/modules/state-backend-dr/examples/basic/` | Validation harness (fake credentials, two providers wired) so CI can `terraform validate` |
| `terraform/modules/state-backend/` | `enable_dynamodb_streams` toggle (default off, additive) — needed by DDB Global Tables |
| `docs/runbooks/state-backend-failover.md` | Step-by-step failover and fail-back procedure |

## Hardening (CIS / Well-Architected, mirrors #159)

Replica bucket:
- `prevent_destroy = true`
- Versioning ON
- `aws:kms` encryption with optional CMK in DR region
- Public access block (4 knobs ON)
- Self-logging
- Lifecycle: abort multipart 7d, expire noncurrent 90d
- Bucket policy: deny non-TLS, deny DeleteBucket

Replication IAM role:
- Trust limited to `s3.amazonaws.com`
- Inline policy scoped to source ARN + replica ARN
- Conditional `kms:Decrypt` on source CMK and `kms:Encrypt` on dest CMK only when CMKs are provided
- No wildcards on Resource

DynamoDB replica:
- Inherits encryption settings from source
- PITR enabled

## Acceptance criteria from #160

- [x] `modules/state-backend-dr` module
- [x] S3 replication rule to DR region
- [x] DynamoDB global tables across primary + DR regions
- [x] Documented fail-over runbook (`docs/runbooks/state-backend-failover.md`)

## Verification (local)

```
$ terraform fmt -recursive -check terraform/modules/state-backend terraform/modules/state-backend-dr
(clean)

$ terraform -chdir=terraform/modules/state-backend-dr/examples/basic init -backend=false && terraform -chdir=terraform/modules/state-backend-dr/examples/basic validate
Success! The configuration is valid.

$ terraform -chdir=terraform/modules/state-backend init -backend=false && terraform -chdir=terraform/modules/state-backend validate
Success! The configuration is valid.

$ tflint --chdir=terraform/modules/state-backend-dr --config $PWD/.tflint.hcl
(clean, exit 0)
```

`terraform plan` is run per-account against assumed `OrganizationAccountAccessRole` after the bootstrap stack from #159 is in place — not from CI.

## Cost summary

- S3 cross-region replication: ~$0.02 per GB transferred + replication PUT cost. State files are kilobytes; expected < $0.10 per account per month.
- DynamoDB Global Tables: replicated writes priced at standard regional WCU/RCU. With PAY_PER_REQUEST and infrequent locks, < $1 per account per month.

Total uplift over #159: under $5 per month across all accounts.

## Security review notes

- Replication IAM role policy is scoped per ARN — no `s3:*` allows, no wildcards on `Resource` for the put-side rules.
- KMS grants are conditional: only added when a CMK is actually in use. Avoids unnecessary `kms:*` allows on the AWS-managed key (which has its own implicit grants anyway).
- One-way replication only. Bidirectional replication on the same bucket pair creates loops; the AWS-recommended pattern is one-way + manual sync-back on recovery, documented in the runbook.
- DDB Global Tables ARE bidirectional but writes are tiny (ephemeral lease rows), so split-brain risk during failover is minimal. The runbook documents force-unlock procedure.
- Replica bucket carries `prevent_destroy = true` matching the primary. Same rollback pain, same tradeoff.

## Rollback plan

To remove DR (rare):

1. Remove the module call from the consuming stack.
2. `terraform plan` — review the destroy carefully.
3. Empty the replica bucket (versioned — `aws s3 rm` is not enough; use `aws s3api delete-objects` against `list-object-versions` output).
4. Set `prevent_destroy = false` on the replica bucket via a fork or `lifecycle.prevent_destroy = var.allow_destroy` extension (left as a follow-up; default keeps `true`).
5. `terraform apply` to destroy.

Removing the DDB replica via `terraform destroy` of the `aws_dynamodb_table_replica` resource demotes the global table back to a single-region table without affecting primary.

## Dependencies

- Requires #159 merged (state-backend module + bootstrap stack). Merged in #189.
- Caller must set `enable_dynamodb_streams = true` on the primary `state-backend` module before applying this one. Documented in module README.

## Out of scope (follow-ups)

- Wiring the module into a per-account terragrunt unit. Will land alongside actual account-ID population (separate ticket — placeholder IDs in `terragrunt/<account>/account.hcl` block real apply).
- KMS CMK provisioning per account in DR region (matches #159's approach — pass an existing CMK via `kms_key_arn_dr` or use AWS-managed keys).
- Automated failover testing (chaos engineering on regional outages) — separate work, not blocked by this.