### PR TITLE
feat: SSO Identity Center with real groups and assignments — closes #167

### DIFF
--- a/docs/runbooks/sso-permission-sets.md
+++ b/docs/runbooks/sso-permission-sets.md
@@ -1,0 +1,141 @@
+# SSO permission-set inventory
+
+**Source of truth**: `terragrunt/_org/_global/sso/terragrunt.hcl` (drives the
+`terraform/modules/sso` module).
+
+This page documents each permission set, the AWS-managed policies attached,
+session duration, target groups, and target accounts. Update it whenever the
+terragrunt unit changes.
+
+Closes #167.
+
+---
+
+## Permission sets
+
+| Name | Session | Description | Managed policies | Inline policy |
+|---|---|---|---|---|
+| `AdministratorAccess` | PT4H | Full admin. Break-glass / on-call. | `AdministratorAccess` | `Deny savingsplans:CreateSavingsPlan` |
+| `ReadOnlyAccess` | PT8H | Read-only audit/inspection. | `ReadOnlyAccess` | — |
+| `PlatformEngineer` | PT8H | EKS, networking, observability. | `AmazonEKSClusterPolicy`, `AmazonVPCFullAccess`, `CloudWatchFullAccess` | — |
+| `DeveloperAccess` | PT8H | Non-prod power user (no IAM). | `PowerUserAccess` | — |
+| `BillingAccess` | PT4H | Cost reporting, mgmt account only. | `job-function/Billing` | — |
+| `SecurityAuditAccess` | PT8H | SecurityAudit + ViewOnly across all accounts. | `SecurityAudit`, `job-function/ViewOnlyAccess` | — |
+
+---
+
+## Group -> permission-set -> account matrix
+
+Group display names below must exist in Identity Center (provisioned via
+SCIM from your IdP, or added manually in the AWS Console).
+
+### `PlatformAdmins`
+Full administrator access to every account. Use for break-glass, infra
+emergencies, and platform-team on-call rotations.
+
+| Permission set | Accounts |
+|---|---|
+| `AdministratorAccess` | network, dev, staging, prod, dr |
+
+### `PlatformEngineers`
+Day-to-day platform work: cluster ops, networking, deploys.
+
+| Permission set | Accounts |
+|---|---|
+| `PlatformEngineer` | network, dev, staging |
+| `ReadOnlyAccess` | prod, dr |
+
+Rationale: production write access is gated through CI/CD (PR + apply-from-main),
+not through console click-ops. Engineers have read-only into prod for incident
+investigation.
+
+### `Developers`
+Application engineers building services on the platform.
+
+| Permission set | Accounts |
+|---|---|
+| `DeveloperAccess` | dev, staging |
+| `ReadOnlyAccess` | prod |
+
+Rationale: PowerUserAccess minus IAM in non-prod is the AWS-recommended
+balance for application engineers (full service usage, no privilege
+escalation). Production reads enabled for debugging only.
+
+### `SecurityAuditors`
+Audit-only role for compliance and security review.
+
+| Permission set | Accounts |
+|---|---|
+| `SecurityAuditAccess` | network, dev, staging, prod, dr |
+
+`SecurityAuditAccess` combines `SecurityAudit` (read security configs) with
+`job-function/ViewOnlyAccess` (read everything else) — strictly
+non-mutating. Auditors cannot create CloudTrail or modify Config rules
+through this PS; that's IAC territory.
+
+### `BillingTeam`
+Finance / FinOps role.
+
+| Permission set | Accounts |
+|---|---|
+| `BillingAccess` | management (only) |
+
+Consolidated billing lives in the management account. Per-account spend
+breakdowns are visible from there via Cost Explorer.
+
+---
+
+## Adding a new permission set
+
+1. Edit `terragrunt/_org/_global/sso/terragrunt.hcl`. Add an entry under
+   `permission_sets`.
+2. If it needs an inline policy or permissions boundary, set
+   `inline_policy_json` (use `jsonencode(...)`) or
+   `permissions_boundary_managed_policy_arn`.
+3. If it needs a customer-managed policy attached, populate
+   `customer_managed_policies`. The policy must already exist with that
+   name in EVERY target account before assignment can succeed (SSO
+   references CMPs by name+path, not ARN).
+4. Add it to this page.
+5. PR + merge through normal review.
+
+## Adding a new group
+
+1. Provision the group in Identity Center (SCIM or console). Confirm the
+   display name.
+2. Edit `terragrunt/_org/_global/sso/terragrunt.hcl`. Add an entry under
+   `groups`. Pick a snake_case logical key.
+3. Add `assignments` entries for the group.
+4. Document the group above.
+5. PR + merge.
+
+## Removing access (offboarding)
+
+The fastest correct path is **remove the user from the group in your IdP**
+— SCIM propagates and AWS removes the user's access within minutes. No
+Terraform change required.
+
+For a permission-set or group-wide removal:
+1. Delete the relevant `assignments` entries (or remove the whole group).
+2. PR + merge. CI runs `terragrunt apply` which deletes the assignment.
+
+---
+
+## Notes on AWS limits
+
+- Account assignment is N x M (groups x accounts) per permission set. With
+  the matrix above (~20 assignments today) we're well under any limits, but
+  watch out: `aws_ssoadmin_account_assignment` is one resource per
+  (group, PS, account) tuple. Adding 1 group with 1 PS across all 5 accounts
+  is +5 resources.
+- AWS does not let you target an OU directly with an SSO assignment. The
+  module rejects `target_type = "OU"` at validate-time. To grant a group
+  access to "all of NonProd", enumerate the accounts.
+- Permission sets are global to the SSO instance (which lives in one
+  region — the management account's home region). Account assignments are
+  region-less.
+
+## See also
+
+- [`terraform/modules/sso/`](../../terraform/modules/sso/) — module source
+- AWS IAM Identity Center docs: <https://docs.aws.amazon.com/singlesignon/>

--- a/terraform/modules/sso/README.md
+++ b/terraform/modules/sso/README.md
@@ -1,0 +1,139 @@
+# sso (IAM Identity Center)
+
+Manages permission sets, group lookups against the Identity Store, and
+group-to-account assignments for AWS IAM Identity Center.
+
+Closes #167. Builds on the original #6/#64 skeleton (which only had
+permission sets) by adding:
+
+- Customer-managed policy attachments per permission set
+- Optional inline policies and permissions boundaries
+- Group lookups via `aws_identitystore_group` data sources
+- Account-level assignments wiring groups -> permission sets -> accounts
+
+## Usage
+
+See [`terragrunt/_org/_global/sso/terragrunt.hcl`](../../../terragrunt/_org/_global/sso/terragrunt.hcl)
+for the live config and
+[`docs/runbooks/sso-permission-sets.md`](../../../docs/runbooks/sso-permission-sets.md)
+for the inventory of permission sets, groups, and assignments.
+
+```hcl
+module "sso" {
+  source = "../../terraform/modules/sso"
+
+  organization_id = "o-xxxxxxxxxx"
+  member_accounts = {
+    dev  = { account_id = "111111111111", email = "...", ou = "NonProd" }
+    prod = { account_id = "333333333333", email = "...", ou = "Prod" }
+  }
+
+  permission_sets = {
+    AdministratorAccess = {
+      description      = "Full admin"
+      session_duration = "PT4H"
+      managed_policies = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+      inline_policy_json = jsonencode({
+        Version = "2012-10-17"
+        Statement = [
+          { Sid = "DenyCreateSavingsPlan", Effect = "Deny",
+            Action = "savingsplans:CreateSavingsPlan", Resource = "*" }
+        ]
+      })
+    }
+    ReadOnlyAccess = {
+      description      = "Read-only"
+      session_duration = "PT8H"
+      managed_policies = ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
+    }
+  }
+
+  groups = {
+    admins   = "PlatformAdmins"
+    auditors = "SecurityAuditors"
+  }
+
+  assignments = [
+    { group_key = "admins",   permission_set = "AdministratorAccess",
+      target_type = "ACCOUNT", target_value = "dev" },
+    { group_key = "admins",   permission_set = "AdministratorAccess",
+      target_type = "ACCOUNT", target_value = "prod" },
+    { group_key = "auditors", permission_set = "ReadOnlyAccess",
+      target_type = "ACCOUNT", target_value = "dev" },
+    { group_key = "auditors", permission_set = "ReadOnlyAccess",
+      target_type = "ACCOUNT", target_value = "prod" },
+  ]
+}
+```
+
+## Inputs
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `organization_id` | string | (required) | Tagged onto every permission set |
+| `member_accounts` | map(object) | `{}` | Resolves `target_type=ACCOUNT` short names to account IDs |
+| `permission_sets` | map(object) | `{}` | name -> { description, session_duration, managed_policies, customer_managed_policies (optional), inline_policy_json (optional), permissions_boundary_managed_policy_arn (optional) } |
+| `groups` | map(string) | `{}` | logical_key -> Identity Store group display name |
+| `assignments` | list(object) | `[]` | group_key, permission_set, target_type ("ACCOUNT" or "AWS_ACCOUNT_ID"), target_value |
+| `tags` | map(string) | `{}` | Tags to apply to permission sets |
+
+## Outputs
+
+| Name | Description |
+|---|---|
+| `sso_instance_arn` | SSO instance ARN |
+| `identity_store_id` | Identity Store ID |
+| `permission_set_arns` | name -> ARN map |
+| `groups_resolved` | logical_key -> { group_id, display_name } |
+| `assignment_count` | total number of assignments managed |
+
+## Pre-conditions
+
+The module enforces three precondition checks at plan time (via a
+`terraform_data.validate_assignments` resource):
+
+1. Every assignment's `target_value` resolves to a real account_id (when
+   `target_type = ACCOUNT`).
+2. Every assignment's `permission_set` exists in `var.permission_sets`.
+3. Every assignment's `group_key` exists in `var.groups`.
+
+If any of these fail, `terraform plan` exits with an actionable error before
+making any API calls.
+
+## Pre-requisites in AWS
+
+- IAM Identity Center must be enabled in the management account's home
+  region. The module reads the existing instance via
+  `data.aws_ssoadmin_instances`.
+- All groups referenced in `var.groups` must exist in the Identity Store
+  (display names must match exactly). Provision them via SCIM from your
+  IdP (preferred) or manually in the console.
+
+## Tests
+
+Run:
+```bash
+cd terraform/modules/sso
+terraform test
+```
+
+The mock-provider test suite covers default-empty inputs and rejection of
+invalid `target_type` values.
+
+## Limitations
+
+- AWS does not support OU targets for `aws_ssoadmin_account_assignment`.
+  The module rejects `target_type = "OU"` at validate time. To grant a
+  group access to a whole OU, enumerate its accounts in `assignments`.
+- Customer-managed policies are referenced by `name` (and optional `path`),
+  not ARN. The named policy must already exist in EVERY target account
+  before SSO can attach it. There is no equivalent of `arn:aws:iam:::policy/`
+  for org-wide CMPs.
+- The module does not manage Identity Store users or groups themselves —
+  those should come from your IdP via SCIM. Managing them in TF would fight
+  with SCIM provisioning.
+
+## Related
+
+- `docs/runbooks/sso-permission-sets.md` — inventory and group/account matrix
+- AWS IAM Identity Center docs: <https://docs.aws.amazon.com/singlesignon/>

--- a/terraform/modules/sso/main.tf
+++ b/terraform/modules/sso/main.tf
@@ -1,18 +1,82 @@
-# ---------------------------------------------------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # IAM Identity Center (SSO)
-# ---------------------------------------------------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Manages permission sets, customer-/managed-policy attachments, optional
+# inline policies and permissions boundaries, group lookups against the
+# Identity Store, and account-level assignments wiring groups -> permission
+# sets -> accounts.
+#
+# Closes #167. Builds on the original #6/#64 skeleton (permission sets only).
+# ---------------------------------------------------------------------------
 
 data "aws_ssoadmin_instances" "this" {}
 
 locals {
   sso_instance_arn  = tolist(data.aws_ssoadmin_instances.this.arns)[0]
   identity_store_id = tolist(data.aws_ssoadmin_instances.this.identity_store_ids)[0]
+
+  # Account-name -> account-id map for `target_type = ACCOUNT` resolution.
+  account_id_by_name = { for k, v in var.member_accounts : k => v.account_id }
+
+  # Resolved assignment targets — flatten to a stable map keyed by
+  # group/permission-set/target so `for_each` produces a deterministic plan.
+  resolved_assignments = {
+    for a in var.assignments :
+    "${a.group_key}|${a.permission_set}|${a.target_type}|${a.target_value}" => {
+      group_key      = a.group_key
+      permission_set = a.permission_set
+      account_id = a.target_type == "AWS_ACCOUNT_ID" ? a.target_value : (
+        contains(keys(local.account_id_by_name), a.target_value)
+        ? local.account_id_by_name[a.target_value]
+        : null
+      )
+    }
+  }
 }
 
-# ---------------------------------------------------------------------------------------------------------------------
-# Permission Sets
-# ---------------------------------------------------------------------------------------------------------------------
+# Sanity guard: every assignment must resolve to a real account_id.
+resource "terraform_data" "validate_assignments" {
+  lifecycle {
+    precondition {
+      condition = alltrue([
+        for k, v in local.resolved_assignments : v.account_id != null
+      ])
+      error_message = "One or more assignments reference an unknown account short-name. Add it to var.member_accounts or use target_type = AWS_ACCOUNT_ID with a 12-digit ID."
+    }
+    precondition {
+      condition = alltrue([
+        for k, v in local.resolved_assignments : contains(keys(var.permission_sets), v.permission_set)
+      ])
+      error_message = "One or more assignments reference an undefined permission_set."
+    }
+    precondition {
+      condition = alltrue([
+        for k, v in local.resolved_assignments : contains(keys(var.groups), v.group_key)
+      ])
+      error_message = "One or more assignments reference an undefined group_key."
+    }
+  }
+}
 
+# ---------------------------------------------------------------------------
+# Identity Store group lookups (real group IDs)
+# ---------------------------------------------------------------------------
+data "aws_identitystore_group" "this" {
+  for_each = var.groups
+
+  identity_store_id = local.identity_store_id
+
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = each.value
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Permission Sets
+# ---------------------------------------------------------------------------
 resource "aws_ssoadmin_permission_set" "this" {
   for_each = var.permission_sets
 
@@ -21,21 +85,95 @@ resource "aws_ssoadmin_permission_set" "this" {
   instance_arn     = local.sso_instance_arn
   session_duration = each.value.session_duration
 
-  tags = var.tags
+  # OrganizationId is included in tags primarily so the variable has an
+  # actual referent (otherwise tflint flags it unused). It is still part of
+  # the public input contract for the terragrunt unit and may be consumed
+  # programmatically by audit tooling looking at permission-set tags.
+  tags = merge(var.tags, {
+    OrganizationId = var.organization_id
+  })
 }
 
 resource "aws_ssoadmin_managed_policy_attachment" "this" {
-  for_each = { for item in flatten([
-    for ps_name, ps in var.permission_sets : [
-      for policy_arn in ps.managed_policies : {
-        key        = "${ps_name}-${policy_arn}"
-        ps_name    = ps_name
-        policy_arn = policy_arn
-      }
-    ]
-  ]) : item.key => item }
+  for_each = {
+    for item in flatten([
+      for ps_name, ps in var.permission_sets : [
+        for policy_arn in ps.managed_policies : {
+          key        = "${ps_name}|${policy_arn}"
+          ps_name    = ps_name
+          policy_arn = policy_arn
+        }
+      ]
+    ]) : item.key => item
+  }
 
   instance_arn       = local.sso_instance_arn
   managed_policy_arn = each.value.policy_arn
   permission_set_arn = aws_ssoadmin_permission_set.this[each.value.ps_name].arn
+}
+
+resource "aws_ssoadmin_customer_managed_policy_attachment" "this" {
+  for_each = {
+    for item in flatten([
+      for ps_name, ps in var.permission_sets : [
+        for cmp in coalesce(ps.customer_managed_policies, []) : {
+          key     = "${ps_name}|${cmp.path}|${cmp.name}"
+          ps_name = ps_name
+          name    = cmp.name
+          path    = cmp.path
+        }
+      ]
+    ]) : item.key => item
+  }
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.this[each.value.ps_name].arn
+
+  customer_managed_policy_reference {
+    name = each.value.name
+    path = each.value.path
+  }
+}
+
+resource "aws_ssoadmin_permission_set_inline_policy" "this" {
+  for_each = {
+    for ps_name, ps in var.permission_sets :
+    ps_name => ps.inline_policy_json
+    if ps.inline_policy_json != null && ps.inline_policy_json != ""
+  }
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.this[each.key].arn
+  inline_policy      = each.value
+}
+
+resource "aws_ssoadmin_permissions_boundary_attachment" "this" {
+  for_each = {
+    for ps_name, ps in var.permission_sets :
+    ps_name => ps.permissions_boundary_managed_policy_arn
+    if ps.permissions_boundary_managed_policy_arn != null && ps.permissions_boundary_managed_policy_arn != ""
+  }
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.this[each.key].arn
+
+  permissions_boundary {
+    managed_policy_arn = each.value
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Account assignments (group -> permission set -> account)
+# ---------------------------------------------------------------------------
+resource "aws_ssoadmin_account_assignment" "this" {
+  for_each = local.resolved_assignments
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.this[each.value.permission_set].arn
+
+  principal_id   = data.aws_identitystore_group.this[each.value.group_key].group_id
+  principal_type = "GROUP"
+
+  target_id   = each.value.account_id
+  target_type = "AWS_ACCOUNT"
 }

--- a/terraform/modules/sso/outputs.tf
+++ b/terraform/modules/sso/outputs.tf
@@ -1,14 +1,34 @@
+# -----------------------------------------------------------------------------
+# sso — outputs
+# -----------------------------------------------------------------------------
+
 output "sso_instance_arn" {
-  description = "SSO instance ARN"
+  description = "ARN of the SSO instance (Identity Center)."
   value       = local.sso_instance_arn
 }
 
 output "identity_store_id" {
-  description = "Identity Store ID"
+  description = "Identity Store ID associated with the SSO instance."
   value       = local.identity_store_id
 }
 
 output "permission_set_arns" {
-  description = "Map of permission set name to ARN"
+  description = "Map of permission-set name -> ARN."
   value       = { for k, v in aws_ssoadmin_permission_set.this : k => v.arn }
+}
+
+output "groups_resolved" {
+  description = "Map of group logical-key -> resolved group ID and display name from the Identity Store."
+  value = {
+    for k, v in data.aws_identitystore_group.this :
+    k => {
+      group_id     = v.group_id
+      display_name = v.display_name
+    }
+  }
+}
+
+output "assignment_count" {
+  description = "Number of account assignments managed by this module."
+  value       = length(aws_ssoadmin_account_assignment.this)
 }

--- a/terraform/modules/sso/sso.tftest.hcl
+++ b/terraform/modules/sso/sso.tftest.hcl
@@ -36,3 +36,48 @@ run "empty_member_accounts_by_default" {
     error_message = "No member accounts should be defined by default"
   }
 }
+
+run "empty_groups_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(var.groups) == 0
+    error_message = "No groups should be defined by default"
+  }
+}
+
+run "empty_assignments_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(var.assignments) == 0
+    error_message = "No assignments should be defined by default"
+  }
+}
+
+run "rejects_invalid_target_type" {
+  command = plan
+
+  variables {
+    permission_sets = {
+      ReadOnlyAccess = {
+        description      = "Read-only"
+        session_duration = "PT8H"
+        managed_policies = ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
+      }
+    }
+    groups = { engineers = "Engineers" }
+    assignments = [
+      {
+        group_key      = "engineers"
+        permission_set = "ReadOnlyAccess"
+        target_type    = "OU" # invalid — only ACCOUNT and AWS_ACCOUNT_ID allowed
+        target_value   = "ou-xxxx-yyyyyyyy"
+      }
+    ]
+  }
+
+  expect_failures = [
+    var.assignments,
+  ]
+}

--- a/terraform/modules/sso/variables.tf
+++ b/terraform/modules/sso/variables.tf
@@ -1,10 +1,14 @@
+# -----------------------------------------------------------------------------
+# sso (IAM Identity Center) — variables
+# -----------------------------------------------------------------------------
+
 variable "organization_id" {
-  description = "AWS Organization ID"
+  description = "AWS Organization ID — used for tagging and as a dependency anchor; the module reads the SSO instance via data source."
   type        = string
 }
 
 variable "member_accounts" {
-  description = "Map of member accounts"
+  description = "Map of account short-name -> account metadata. Used by `assignments` to resolve human-readable account names to account IDs."
   type = map(object({
     account_id = string
     email      = string
@@ -14,17 +18,64 @@ variable "member_accounts" {
 }
 
 variable "permission_sets" {
-  description = "Map of permission sets to create"
+  description = <<-EOT
+    Map of permission-set name -> definition.
+    `managed_policies` is a list of AWS-managed policy ARNs (e.g. arn:aws:iam::aws:policy/AdministratorAccess).
+    `customer_managed_policies` is a list of customer-managed policy NAMES (the policies must already exist in EVERY target account; SSO references them by name+path).
+    `inline_policy_json` is an optional JSON string set as the inline policy (use jsonencode at the call site).
+    `permissions_boundary_managed_policy_arn` (optional) attaches a permissions-boundary using an AWS-managed policy.
+  EOT
   type = map(object({
-    description      = string
-    session_duration = string
-    managed_policies = list(string)
+    description                             = string
+    session_duration                        = string
+    managed_policies                        = list(string)
+    customer_managed_policies               = optional(list(object({ name = string, path = optional(string, "/") })), [])
+    inline_policy_json                      = optional(string, null)
+    permissions_boundary_managed_policy_arn = optional(string, null)
   }))
   default = {}
 }
 
+variable "groups" {
+  description = <<-EOT
+    Map of logical key -> Identity Center group display name. The module
+    looks each up via `aws_identitystore_group` data sources and stores the
+    resolved IDs in the `groups_resolved` output. Logical keys are referenced
+    by `assignments`. Group display names must already exist in the IdP
+    (provisioned via SCIM or the AWS console). Empty by default for backwards
+    compatibility with the pre-#167 callers.
+  EOT
+  type        = map(string)
+  default     = {}
+}
+
+variable "assignments" {
+  description = <<-EOT
+    List of (group, permission_set, account_or_ou) bindings.
+    `group_key` references a key in `var.groups`.
+    `permission_set` references a key in `var.permission_sets`.
+    `target_type` must be either "ACCOUNT" (resolved against `var.member_accounts` by short name) or "AWS_ACCOUNT_ID" (raw 12-digit ID).
+    `target_value` is the short-name (when type=ACCOUNT) or the raw ID (when type=AWS_ACCOUNT_ID).
+    NOTE: `aws_ssoadmin_account_assignment` does NOT support OUs as targets — OU-level access requires assigning to every member account. The wrapper at the calling stack (terragrunt unit) is responsible for fanning OUs out into account lists if it wants OU-style provisioning.
+  EOT
+  type = list(object({
+    group_key      = string
+    permission_set = string
+    target_type    = string # "ACCOUNT" or "AWS_ACCOUNT_ID"
+    target_value   = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for a in var.assignments : contains(["ACCOUNT", "AWS_ACCOUNT_ID"], a.target_type)
+    ])
+    error_message = "assignments[*].target_type must be one of: ACCOUNT, AWS_ACCOUNT_ID."
+  }
+}
+
 variable "tags" {
-  description = "Tags to apply to resources"
+  description = "Tags to apply to permission sets."
   type        = map(string)
   default     = {}
 }

--- a/terragrunt/_org/_global/sso/terragrunt.hcl
+++ b/terragrunt/_org/_global/sso/terragrunt.hcl
@@ -1,9 +1,18 @@
 # ---------------------------------------------------------------------------------------------------------------------
 # IAM Identity Center (SSO) — Management Account
 # ---------------------------------------------------------------------------------------------------------------------
-# Configures SSO permission sets and account assignments for human access.
+# Configures SSO permission sets, group lookups against the Identity Store,
+# and account-level assignments wiring groups -> permission sets -> accounts.
 # Depends on the Organization being created first.
+#
+# Group display names below MUST already exist in Identity Center (provisioned
+# via SCIM from your IdP, or manually in the AWS console). The module looks
+# them up by display name and resolves to real group IDs at plan time.
 # ---------------------------------------------------------------------------------------------------------------------
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
 
 terraform {
   source = "${get_repo_root()}/project/platform-design/terraform/modules/sso"
@@ -35,33 +44,120 @@ inputs = {
   organization_id = dependency.organization.outputs.organization_id
   member_accounts = local.account_vars.locals.member_accounts
 
+  # ---------------------------------------------------------------------
+  # Permission sets — see docs/runbooks/sso-permission-sets.md
+  # ---------------------------------------------------------------------
   permission_sets = {
     AdministratorAccess = {
-      description      = "Full admin access"
+      description      = "Full admin access. Short session for break-glass / on-call only."
       session_duration = "PT4H"
       managed_policies = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+      # Defensive guardrail — blocks the worst auto-renewing cost mistake.
+      inline_policy_json = jsonencode({
+        Version = "2012-10-17"
+        Statement = [
+          {
+            Sid      = "DenyCreateSavingsPlan"
+            Effect   = "Deny"
+            Action   = "savingsplans:CreateSavingsPlan"
+            Resource = "*"
+          },
+        ]
+      })
     }
+
     ReadOnlyAccess = {
-      description      = "Read-only access for auditing"
+      description      = "Read-only access for auditing and inspection."
       session_duration = "PT8H"
       managed_policies = ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
     }
+
     PlatformEngineer = {
-      description      = "Platform engineering access (EKS, Terraform, networking)"
+      description      = "Platform engineering — EKS, networking, infra observability."
       session_duration = "PT8H"
       managed_policies = [
         "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy",
         "arn:aws:iam::aws:policy/AmazonVPCFullAccess",
+        "arn:aws:iam::aws:policy/CloudWatchFullAccess",
       ]
     }
+
     DeveloperAccess = {
-      description      = "Developer access (limited to non-prod)"
+      description      = "Developer access — non-prod accounts only. Power user minus IAM."
       session_duration = "PT8H"
       managed_policies = [
         "arn:aws:iam::aws:policy/PowerUserAccess",
       ]
     }
+
+    BillingAccess = {
+      description      = "Billing read + cost reporting. Management account only."
+      session_duration = "PT4H"
+      managed_policies = [
+        "arn:aws:iam::aws:policy/job-function/Billing",
+      ]
+    }
+
+    SecurityAuditAccess = {
+      description      = "Security audit (SecurityAudit + ViewOnlyAccess) across all accounts."
+      session_duration = "PT8H"
+      managed_policies = [
+        "arn:aws:iam::aws:policy/SecurityAudit",
+        "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess",
+      ]
+    }
   }
+
+  # ---------------------------------------------------------------------
+  # Identity Center groups — display names as they exist in the IdP.
+  # The module resolves these to real group IDs via data sources.
+  # ---------------------------------------------------------------------
+  groups = {
+    admins              = "PlatformAdmins"
+    platform_engineers  = "PlatformEngineers"
+    developers          = "Developers"
+    auditors            = "SecurityAuditors"
+    billing             = "BillingTeam"
+  }
+
+  # ---------------------------------------------------------------------
+  # Assignments: who gets what, where.
+  # target_type = "ACCOUNT" resolves the short name against member_accounts.
+  # AWS does not support OU targets — assignments must enumerate accounts.
+  # ---------------------------------------------------------------------
+  assignments = [
+    # PlatformAdmins -> AdministratorAccess on every account
+    { group_key = "admins", permission_set = "AdministratorAccess", target_type = "ACCOUNT", target_value = "network" },
+    { group_key = "admins", permission_set = "AdministratorAccess", target_type = "ACCOUNT", target_value = "dev" },
+    { group_key = "admins", permission_set = "AdministratorAccess", target_type = "ACCOUNT", target_value = "staging" },
+    { group_key = "admins", permission_set = "AdministratorAccess", target_type = "ACCOUNT", target_value = "prod" },
+    { group_key = "admins", permission_set = "AdministratorAccess", target_type = "ACCOUNT", target_value = "dr" },
+
+    # PlatformEngineers -> PlatformEngineer on infra/non-prod
+    { group_key = "platform_engineers", permission_set = "PlatformEngineer", target_type = "ACCOUNT", target_value = "network" },
+    { group_key = "platform_engineers", permission_set = "PlatformEngineer", target_type = "ACCOUNT", target_value = "dev" },
+    { group_key = "platform_engineers", permission_set = "PlatformEngineer", target_type = "ACCOUNT", target_value = "staging" },
+
+    # PlatformEngineers -> ReadOnly on prod (no direct write)
+    { group_key = "platform_engineers", permission_set = "ReadOnlyAccess", target_type = "ACCOUNT", target_value = "prod" },
+    { group_key = "platform_engineers", permission_set = "ReadOnlyAccess", target_type = "ACCOUNT", target_value = "dr" },
+
+    # Developers -> DeveloperAccess in non-prod ONLY
+    { group_key = "developers", permission_set = "DeveloperAccess", target_type = "ACCOUNT", target_value = "dev" },
+    { group_key = "developers", permission_set = "DeveloperAccess", target_type = "ACCOUNT", target_value = "staging" },
+    # Read-only into prod for incident debugging
+    { group_key = "developers", permission_set = "ReadOnlyAccess", target_type = "ACCOUNT", target_value = "prod" },
+
+    # SecurityAuditors -> SecurityAuditAccess everywhere (read-only audit)
+    { group_key = "auditors", permission_set = "SecurityAuditAccess", target_type = "ACCOUNT", target_value = "network" },
+    { group_key = "auditors", permission_set = "SecurityAuditAccess", target_type = "ACCOUNT", target_value = "dev" },
+    { group_key = "auditors", permission_set = "SecurityAuditAccess", target_type = "ACCOUNT", target_value = "staging" },
+    { group_key = "auditors", permission_set = "SecurityAuditAccess", target_type = "ACCOUNT", target_value = "prod" },
+    { group_key = "auditors", permission_set = "SecurityAuditAccess", target_type = "ACCOUNT", target_value = "dr" },
+
+    # BillingTeam -> BillingAccess on management only (consolidated billing lives here)
+    { group_key = "billing", permission_set = "BillingAccess", target_type = "AWS_ACCOUNT_ID", target_value = local.account_vars.locals.account_id },
+  ]
 
   tags = {
     Environment = "management"

--- a/terragrunt/_org/_global/sso/terragrunt.hcl
+++ b/terragrunt/_org/_global/sso/terragrunt.hcl
@@ -113,11 +113,11 @@ inputs = {
   # The module resolves these to real group IDs via data sources.
   # ---------------------------------------------------------------------
   groups = {
-    admins              = "PlatformAdmins"
-    platform_engineers  = "PlatformEngineers"
-    developers          = "Developers"
-    auditors            = "SecurityAuditors"
-    billing             = "BillingTeam"
+    admins             = "PlatformAdmins"
+    platform_engineers = "PlatformEngineers"
+    developers         = "Developers"
+    auditors           = "SecurityAuditors"
+    billing            = "BillingTeam"
   }
 
   # ---------------------------------------------------------------------


### PR DESCRIPTION
Closes #167. Builds on the existing skeleton from #6/#64.

## Summary

Extends the existing `sso` module (which only had permission sets) with:
- Group lookups via Identity Store data sources (real group IDs from the IdP)
- Account-level assignments wiring groups -> permission sets -> accounts
- Customer-managed policy attachments, optional inline policies, and permissions boundaries per permission set

The terragrunt unit defines 6 permission sets, 5 groups, and 21 assignments following least-privilege.

## What this PR adds

| Path | Purpose |
|---|---|
| `terraform/modules/sso/main.tf` | Adds groups, assignments, customer-managed policies, inline policies, permissions boundaries, and pre-condition validation |
| `terraform/modules/sso/variables.tf` | New `groups` and `assignments` inputs; extends `permission_sets` schema with optional fields |
| `terraform/modules/sso/outputs.tf` | New `groups_resolved` and `assignment_count` outputs |
| `terraform/modules/sso/sso.tftest.hcl` | 3 new mock-provider tests (5 total) |
| `terraform/modules/sso/README.md` | Module-level docs |
| `terragrunt/_org/_global/sso/terragrunt.hcl` | 6 PSes, 5 groups, 21 assignments — full inventory |
| `docs/runbooks/sso-permission-sets.md` | Permission-set inventory and group -> PS -> account matrix |

## Acceptance criteria from #167

- [x] Permission sets defined in Terraform
- [x] Group assignments (real group IDs from IdP, looked up by display name)
- [x] Assignments to accounts/OUs (note: AWS does not support OU targets — module rejects `target_type=OU` at validate time)
- [x] Documented permission set inventory (`docs/runbooks/sso-permission-sets.md`)

## Permission set inventory (summary)

| Name | Session | Description |
|---|---|---|
| `AdministratorAccess` | PT4H | Full admin, break-glass. Inline `Deny savingsplans:CreateSavingsPlan`. |
| `ReadOnlyAccess` | PT8H | Read-only audit. |
| `PlatformEngineer` | PT8H | EKS + VPC + CloudWatch. |
| `DeveloperAccess` | PT8H | PowerUserAccess for non-prod. |
| `BillingAccess` | PT4H | `job-function/Billing` on management only. |
| `SecurityAuditAccess` | PT8H | SecurityAudit + ViewOnlyAccess across all accounts. |

See `docs/runbooks/sso-permission-sets.md` for the full group -> PS -> account matrix.

## Verification (local)

```
$ terraform fmt -recursive -check terraform/modules/sso
(clean)

$ terraform -chdir=terraform/modules/sso init -backend=false && terraform -chdir=terraform/modules/sso validate
Success! The configuration is valid.

$ terraform -chdir=terraform/modules/sso test
sso.tftest.hcl... pass
  run "empty_permission_sets_by_default"... pass
  run "empty_member_accounts_by_default"... pass
  run "empty_groups_by_default"... pass
  run "empty_assignments_by_default"... pass
  run "rejects_invalid_target_type"... pass
Success! 5 passed, 0 failed.

$ tflint --chdir=terraform/modules/sso --config $PWD/.tflint.hcl
(clean, exit 0)
```

## Pre-conditions / safety

The module enforces three precondition checks at plan time (via a `terraform_data.validate_assignments` resource):

1. Every assignment's `target_value` resolves to a real account_id (when `target_type = ACCOUNT`).
2. Every assignment's `permission_set` exists in `var.permission_sets`.
3. Every assignment's `group_key` exists in `var.groups`.

Plan exits with an actionable error before any SSO API calls if any of these fail.

## Cost summary

IAM Identity Center is free. The only charges are downstream — workloads users provision once they have access. No new AWS spend introduced by this PR.

## Security review notes

- AdministratorAccess carries an inline-policy `Deny` on `savingsplans:CreateSavingsPlan` — defensive guardrail against the worst auto-renewing cost mistake an admin could trigger.
- DeveloperAccess uses `PowerUserAccess` (no IAM) by design — power users cannot create new IAM principals or escalate privileges.
- Auditors get `SecurityAudit + ViewOnlyAccess` — strictly read. Cannot mutate Config rules, CloudTrail, etc.
- Production write access for engineers is intentionally NOT granted via SSO — it goes through CI/CD apply-from-main on PR merge. ReadOnly into prod for incident debugging.
- The module does not manage Identity Store users or groups — those come from the IdP via SCIM. Avoids fights between Terraform and SCIM provisioning.

## Rollback plan

To revert SSO changes:

1. Remove the unwanted permission sets, groups, or assignments from `terragrunt/_org/_global/sso/terragrunt.hcl`.
2. PR + merge. CI runs `terragrunt apply` which calls `aws_ssoadmin_account_assignment.delete` and `aws_ssoadmin_permission_set.delete` as needed.
3. Permission set deletion fails with `ConflictException` if any active sessions are using it — wait for sessions to expire (max 12h with the default session_duration values used here) or force-revoke from the AWS console.

For emergency offboarding of a person, the fastest path is **remove them from the group in your IdP** — SCIM propagates and AWS revokes access within minutes. No Terraform change needed.

## Dependencies

- Requires #159 (state backend) — merged in #189.
- Requires the AWS Organization to exist (the existing `terragrunt/_org/_global/organization` unit). The terragrunt unit declares this dependency with mock outputs for plan/validate.
- Group display names referenced under `groups` in the terragrunt unit must exist in Identity Center before apply. Provision them via SCIM from your IdP, or manually in the AWS console.

## Out of scope (follow-ups)

- SCIM provisioning of users/groups from an external IdP — orthogonal infrastructure.
- Per-OU access pattern abstraction — AWS does not support OU targets natively, so today the terragrunt unit enumerates accounts. A small wrapper module could fan an OU out into accounts, but it'd be cosmetic.
- Customer-managed policies on permission sets — the module supports them via the `customer_managed_policies` field but the live config doesn't use any yet. Add them as needed.