### PR TITLE
feat: cloudtrail-org wrapper module — closes #161

### DIFF
--- a/terraform/modules/cloudtrail-org/README.md
+++ b/terraform/modules/cloudtrail-org/README.md
@@ -1,0 +1,107 @@
+# cloudtrail-org
+
+Organization-wide CloudTrail with multi-region coverage, log file
+validation, KMS CMK encryption, S3 Object Lock + lifecycle, and CloudWatch
+Logs integration.
+
+Closes #161. This is the canonically-named wrapper around the
+[`cloudtrail`](../cloudtrail/) module which already produces an
+organization trail; new code should reference this module name to match
+the source repo (qbiq-ai/infra) convention.
+
+## What it produces
+
+The underlying `cloudtrail` module creates:
+
+- `aws_cloudtrail` with `is_organization_trail = true`,
+  `is_multi_region_trail = true`,
+  `enable_log_file_validation = true`, KMS CMK encryption, management
+  events + S3/Lambda data events.
+- `aws_s3_bucket` for log storage with versioning, KMS encryption,
+  public-access block, lifecycle (STANDARD -> STANDARD_IA -> GLACIER
+  -> EXPIRE), Object Lock (COMPLIANCE mode, retention configurable).
+- `aws_iam_role` for CloudTrail-to-CloudWatch delivery.
+- `aws_cloudwatch_log_group` for real-time analysis.
+
+## Why a wrapper, not a rename?
+
+Issue #161 asks for a module named `cloudtrail-org` mirroring the
+source repo. The existing `cloudtrail` module already meets every #161
+acceptance criterion (`is_organization_trail`, `is_multi_region_trail`,
+log file validation, KMS, S3 delivery to log-archive). Renaming the
+existing module would force state moves and break every test reference.
+The wrapper gives the canonical name without churn.
+
+## Usage
+
+```hcl
+module "cloudtrail_org" {
+  source = "../../terraform/modules/cloudtrail-org"
+
+  trail_name      = "platform-design-org-trail"
+  organization_id = "o-xxxxxxxxxx"
+  kms_key_arn     = aws_kms_key.cloudtrail.arn
+
+  s3_bucket_name = "platform-design-cloudtrail-${local.account_id}"
+
+  # Defaults are sensible — these are the most-tweaked knobs:
+  # lifecycle_glacier_days        = 365
+  # lifecycle_expiration_days     = 2555  # 7 years (PCI-DSS compliant)
+  # object_lock_retention_days    = 365
+  # cloudwatch_log_retention_days = 365
+
+  tags = {
+    Environment = "log-archive"
+    ManagedBy   = "terragrunt"
+  }
+}
+```
+
+## Inputs
+
+Identical to `terraform/modules/cloudtrail/`. See its variables.tf for
+the full list. Most-tweaked:
+
+| Name | Default | Description |
+|---|---|---|
+| `trail_name` | `org-trail` | CloudTrail trail name |
+| `organization_id` | (required) | Used in S3 bucket policy for org-trail PUT permissions |
+| `kms_key_arn` | (required) | CMK ARN for trail + S3 default encryption |
+| `s3_bucket_name` | (required) | Bucket holding the logs (in log-archive account) |
+| `enable_object_lock` | `true` | WORM via S3 Object Lock |
+| `object_lock_retention_days` | `365` | COMPLIANCE-mode retention; **irreversible** |
+| `lifecycle_expiration_days` | `2555` | 7 years (PCI-DSS Req 10.7) |
+| `cloudwatch_log_retention_days` | `365` | CW Logs retention |
+
+## Outputs
+
+Delegated 1:1 to `terraform/modules/cloudtrail`:
+
+`trail_arn`, `trail_name`, `s3_bucket_name`, `s3_bucket_arn`,
+`cloudwatch_log_group_name`, `cloudwatch_log_group_arn`,
+`cloudtrail_cloudwatch_role_arn`.
+
+## Where it gets deployed
+
+The org trail lives in the **management** account (only the management
+account, or the AWS Organizations delegated administrator, can create an
+organization trail). The S3 destination bucket should live in the
+**log-archive** account for tamper resistance. Cross-account write is
+authorized via the bucket policy on the log-archive bucket.
+
+The accompanying terragrunt unit
+[`terragrunt/_org/_global/cloudtrail/terragrunt.hcl`](../../../terragrunt/_org/_global/cloudtrail/terragrunt.hcl)
+runs in the management account by virtue of being under `_org/`.
+
+## Compliance
+
+The underlying module documents PCI-DSS Req 10.1, 10.2, 10.3, 10.5,
+10.5.3, 10.5.5, and 10.7 alignment. See the comments in
+`terraform/modules/cloudtrail/main.tf` for the per-requirement breakdown.
+
+## Related
+
+- [`terraform/modules/cloudtrail/`](../cloudtrail/) — underlying module
+- [`docs/scps.md`](../../../docs/scps.md#denydisablecloudtrail) — SCP that
+  protects the trail from being disabled
+- AWS docs: <https://docs.aws.amazon.com/awscloudtrail/latest/userguide/creating-trail-organization.html>

--- a/terraform/modules/cloudtrail-org/main.tf
+++ b/terraform/modules/cloudtrail-org/main.tf
@@ -1,0 +1,41 @@
+# -----------------------------------------------------------------------------
+# cloudtrail-org — Organization-wide CloudTrail
+# -----------------------------------------------------------------------------
+# Closes #161. This is a thin alias / consistency-naming wrapper around the
+# existing `cloudtrail` module, which already produces an organization trail
+# (is_organization_trail = true, is_multi_region_trail = true, log file
+# validation, KMS CMK, S3 with Object Lock + lifecycle).
+#
+# Why a wrapper instead of renaming the underlying module?
+#   - Issue #161 asks for a module named `cloudtrail-org` (mirroring the
+#     source repo qbiq-ai/infra naming).
+#   - The existing `cloudtrail` module already meets every acceptance
+#     criterion in #161 and is referenced from terragrunt + tests.
+#   - Renaming would churn a stable surface and require state moves on any
+#     applied environments.
+#
+# This wrapper gives the canonical name without forcing a churn.
+# Callers (new code) should reference `cloudtrail-org`. Existing
+# `cloudtrail` callers continue to work; converging happens organically.
+# -----------------------------------------------------------------------------
+
+module "cloudtrail" {
+  source = "../cloudtrail"
+
+  trail_name      = var.trail_name
+  organization_id = var.organization_id
+  kms_key_arn     = var.kms_key_arn
+
+  s3_bucket_name             = var.s3_bucket_name
+  s3_key_prefix              = var.s3_key_prefix
+  enable_object_lock         = var.enable_object_lock
+  object_lock_retention_days = var.object_lock_retention_days
+
+  lifecycle_standard_days   = var.lifecycle_standard_days
+  lifecycle_glacier_days    = var.lifecycle_glacier_days
+  lifecycle_expiration_days = var.lifecycle_expiration_days
+
+  cloudwatch_log_retention_days = var.cloudwatch_log_retention_days
+
+  tags = var.tags
+}

--- a/terraform/modules/cloudtrail-org/outputs.tf
+++ b/terraform/modules/cloudtrail-org/outputs.tf
@@ -1,0 +1,38 @@
+# -----------------------------------------------------------------------------
+# cloudtrail-org — outputs (delegated to the underlying cloudtrail module)
+# -----------------------------------------------------------------------------
+
+output "trail_arn" {
+  description = "ARN of the CloudTrail organization trail"
+  value       = module.cloudtrail.trail_arn
+}
+
+output "trail_name" {
+  description = "Name of the CloudTrail organization trail"
+  value       = module.cloudtrail.trail_name
+}
+
+output "s3_bucket_name" {
+  description = "Name of the S3 bucket storing CloudTrail logs"
+  value       = module.cloudtrail.s3_bucket_name
+}
+
+output "s3_bucket_arn" {
+  description = "ARN of the S3 bucket storing CloudTrail logs"
+  value       = module.cloudtrail.s3_bucket_arn
+}
+
+output "cloudwatch_log_group_name" {
+  description = "Name of the CloudWatch Logs group for real-time trail analysis"
+  value       = module.cloudtrail.cloudwatch_log_group_name
+}
+
+output "cloudwatch_log_group_arn" {
+  description = "ARN of the CloudWatch Logs group"
+  value       = module.cloudtrail.cloudwatch_log_group_arn
+}
+
+output "cloudtrail_cloudwatch_role_arn" {
+  description = "ARN of the IAM role used by CloudTrail to write to CloudWatch Logs"
+  value       = module.cloudtrail.cloudtrail_cloudwatch_role_arn
+}

--- a/terraform/modules/cloudtrail-org/variables.tf
+++ b/terraform/modules/cloudtrail-org/variables.tf
@@ -1,0 +1,93 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# CloudTrail Module Variables
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "trail_name" {
+  description = "Name of the CloudTrail trail"
+  type        = string
+  default     = "org-trail"
+}
+
+variable "organization_id" {
+  description = "AWS Organization ID — required for organization trail S3 bucket policy"
+  type        = string
+}
+
+variable "kms_key_arn" {
+  description = "ARN of the KMS CMK for encrypting CloudTrail logs and CloudWatch Logs"
+  type        = string
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# S3 Bucket Configuration
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "s3_bucket_name" {
+  description = "Name of the S3 bucket for CloudTrail log storage"
+  type        = string
+}
+
+variable "s3_key_prefix" {
+  description = "S3 key prefix for CloudTrail log files"
+  type        = string
+  default     = ""
+}
+
+variable "enable_object_lock" {
+  description = "Enable S3 Object Lock (WORM) for tamper-proof log retention. PCI-DSS Req 10.5."
+  type        = bool
+  default     = true
+}
+
+variable "object_lock_retention_days" {
+  description = "Number of days for Object Lock COMPLIANCE mode retention (irreversible — objects cannot be deleted until retention expires)"
+  type        = number
+  default     = 365
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Lifecycle Configuration
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "lifecycle_standard_days" {
+  description = "Days before transitioning logs to STANDARD_IA storage class"
+  type        = number
+  default     = 90
+}
+
+variable "lifecycle_glacier_days" {
+  description = "Days before transitioning logs to GLACIER storage class"
+  type        = number
+  default     = 365
+}
+
+variable "lifecycle_expiration_days" {
+  description = "Days before expiring logs. PCI-DSS Req 10.7 requires >= 365. Default 2555 (7 years)."
+  type        = number
+  default     = 2555
+
+  validation {
+    condition     = var.lifecycle_expiration_days >= 365
+    error_message = "PCI-DSS Requirement 10.7: Audit trail history must be retained for at least 1 year (365 days)."
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CloudWatch Logs
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "cloudwatch_log_retention_days" {
+  description = "CloudWatch Logs retention period in days for real-time analysis"
+  type        = number
+  default     = 365
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Common
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/cloudtrail-org/versions.tf
+++ b/terraform/modules/cloudtrail-org/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
Closes #161.

## Summary

Adds \`terraform/modules/cloudtrail-org\` as a thin alias around the existing \`terraform/modules/cloudtrail\` module. Every acceptance criterion from #161 is already implemented by the underlying module — this PR adds the canonically-named wrapper so new code references the same name as the source repo (qbiq-ai/infra: \`modules/cloudtrail-org\`).

## Why a wrapper, not a rename or new module?

The existing \`cloudtrail\` module already creates:
- \`aws_cloudtrail\` with \`is_organization_trail = true\`, \`is_multi_region_trail = true\`, \`enable_log_file_validation = true\`, KMS CMK encryption.
- S3 bucket with versioning, KMS encryption, public-access block, Object Lock (COMPLIANCE mode), lifecycle (STANDARD -> IA -> GLACIER -> EXPIRE @ 7y for PCI-DSS).
- CloudWatch Logs integration with IAM role.

Renaming the existing module would force state moves on any applied environments and break every test reference (\`cloudtrail.tftest.hcl\`, BDD compliance tests, etc). The wrapper gives the canonical name without churn.

## Acceptance criteria from #161

- [x] \`modules/cloudtrail-org\` module — added as wrapper
- [x] Organization trail enabled — underlying module: \`is_organization_trail = true\`
- [x] Logs delivered to log-archive S3 bucket — underlying module: configurable \`s3_bucket_name\`
- [x] Multi-region enabled — underlying module: \`is_multi_region_trail = true\`
- [x] Log file validation enabled — underlying module: \`enable_log_file_validation = true\`
- [x] CMK encryption — underlying module requires \`kms_key_arn\`

## Verification (local)

\`\`\`
$ terraform fmt -recursive -check terraform/modules/cloudtrail-org
(clean)

$ terraform -chdir=terraform/modules/cloudtrail-org init -backend=false && terraform -chdir=terraform/modules/cloudtrail-org validate
Success! The configuration is valid.
(One pre-existing deprecation warning in the underlying cloudtrail module — \`data.aws_region.current.name\` should become \`.region\`. Tracked separately.)

$ tflint --chdir=terraform/modules/cloudtrail-org --config $PWD/.tflint.hcl
(clean, exit 0)
\`\`\`

## Cost summary

No new AWS resources — wrapper is pure delegation. The underlying module's cost profile applies (S3 storage @ standard rates with lifecycle to GLACIER after 1y; CloudWatch Logs ingestion + retention; CloudTrail itself charges only for management events beyond the free tier).

## Security review notes

- Wrapper carries no inputs the underlying doesn't — no privilege uplift.
- Underlying module enforces TLS-only via bucket policy (deny non-TLS), KMS encryption (CMK required), and S3 Object Lock.
- The matching \`DenyDisableCloudTrail\` SCP from #166 protects the trail from being disabled by anyone but the management-account org-trail unit itself.

## Rollback plan

Revert the PR. No state migrations involved (the wrapper has no resources of its own).

## Dependencies

- Requires #159 (state backend) — merged in #189.
- Requires the org's log-archive account to exist with a CloudTrail destination bucket. Currently a placeholder until account vending lands.
- Independent of all other P0 issues (parallel-safe).

## Out of scope (follow-ups)

- Migrating existing \`cloudtrail\` callers to \`cloudtrail-org\` — purely cosmetic, can land any time.
- Fixing the \`data.aws_region.current.name\` deprecation in the underlying \`cloudtrail\` module — separate small fix.