### PR TITLE
feat: GuardDuty findings publishing destination — closes #163

### DIFF
--- a/terraform/modules/guardduty-org/README.md
+++ b/terraform/modules/guardduty-org/README.md
@@ -1,0 +1,97 @@
+# guardduty-org
+
+Organization-wide GuardDuty with delegated administration, auto-enrollment
+of all member accounts, full feature coverage (S3, EKS audit logs + runtime,
+malware protection, RDS login, Lambda network), and optional S3 publishing
+of findings to a centralized log-archive bucket.
+
+Closes #163.
+
+## Coverage
+
+| #163 acceptance criterion | How it's met |
+|---|---|
+| `modules/guardduty-org` module | This module |
+| Delegated admin = security account | `delegated_admin_account_id` input -> `aws_guardduty_organization_admin_account` (count=1 when delegating) |
+| All accounts auto-enrolled | `auto_enable_org_members = true` -> `auto_enable_organization_members = "ALL"` on `aws_guardduty_organization_configuration` |
+| EKS Audit Logs | `enable_eks_audit_log_monitoring = true` (default) |
+| EKS Runtime monitoring | `enable_eks_runtime_monitoring = true` (default) |
+| Malware Protection | `enable_malware_protection = true` (default) — EBS scan-on-finding |
+| RDS protection | `enable_rds_protection = true` (default) — `RDS_LOGIN_EVENTS` feature |
+| Findings published to centralized location | **NEW**: `findings_destination_bucket_arn` -> `aws_guardduty_publishing_destination` writing findings to S3 in the log-archive account |
+
+Plus, beyond the issue:
+- S3 data event protection (`enable_s3_protection`)
+- Lambda network activity monitoring (`enable_lambda_protection`)
+
+## Usage
+
+```hcl
+module "guardduty_org" {
+  source = "../../terraform/modules/guardduty-org"
+
+  delegated_admin_account_id = "111122223333"  # security account
+  auto_enable_org_members    = true
+
+  # Findings centralization (cross-account to log-archive)
+  findings_destination_bucket_arn  = "arn:aws:s3:::platform-design-guardduty-findings"
+  findings_destination_kms_key_arn = aws_kms_key.findings.arn
+
+  # All feature toggles default to true; flip off if you don't need a feature
+  # enable_lambda_protection = false
+
+  tags = {
+    Environment = "security"
+    ManagedBy   = "terragrunt"
+  }
+}
+```
+
+## Pre-conditions for findings publishing
+
+The `findings_destination_bucket_arn` bucket (in log-archive account) must:
+1. Have a bucket policy granting `guardduty.amazonaws.com` `s3:PutObject` on
+   `<bucket>/*` with the GuardDuty service principal.
+2. Be encrypted with a KMS CMK whose key policy allows
+   `kms:GenerateDataKey` to `guardduty.amazonaws.com`.
+
+A separate `centralized-logging` (or similar) module in the log-archive
+account creates the bucket + key + policies. Pass its outputs to this
+module's inputs.
+
+## Inputs (selected)
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `delegated_admin_account_id` | string | `""` | Security account ID to delegate GD to |
+| `auto_enable_org_members` | bool | `true` | Auto-enable for all current and future members |
+| `enable_s3_protection` | bool | `true` | S3 data event monitoring |
+| `enable_eks_audit_log_monitoring` | bool | `true` | EKS audit logs |
+| `enable_eks_runtime_monitoring` | bool | `true` | EKS runtime agent (`EKS_RUNTIME_MONITORING`) |
+| `enable_malware_protection` | bool | `true` | EBS volume scan-on-finding |
+| `enable_rds_protection` | bool | `true` | `RDS_LOGIN_EVENTS` feature |
+| `enable_lambda_protection` | bool | `true` | `LAMBDA_NETWORK_LOGS` feature |
+| `findings_destination_bucket_arn` | string | `null` | S3 bucket ARN for centralized findings (NEW in #163) |
+| `findings_destination_kms_key_arn` | string | `null` | KMS CMK for findings encryption |
+| `tags` | map(string) | `{}` | Tags |
+
+## Outputs
+
+| Name | Description |
+|---|---|
+| `detector_id` | GuardDuty detector ID |
+| `detector_arn` | GuardDuty detector ARN |
+| `delegated_admin_account_id` | Configured delegated admin account |
+
+## Compliance
+
+- PCI-DSS Req 10.6 — daily log/event review (automated via GuardDuty)
+- PCI-DSS Req 11.4 — IDS/IPS (GuardDuty as cloud-native IDS)
+- PCI-DSS Req 11.5 — change-detection (EBS malware scanning)
+
+## Related
+
+- [`docs/scps.md`](../../../docs/scps.md#denyguarddutychanges) — SCP that
+  protects the GuardDuty configuration from being disabled
+- AWS GuardDuty docs:
+  <https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_settingup.html>

--- a/terraform/modules/guardduty-org/main.tf
+++ b/terraform/modules/guardduty-org/main.tf
@@ -141,3 +141,27 @@ resource "aws_guardduty_organization_admin_account" "this" {
 
   admin_account_id = local.admin_account_id
 }
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Findings publishing destination — S3 in the log-archive account
+# Closes #163 acceptance criterion: "findings published to centralized location"
+# ---------------------------------------------------------------------------------------------------------------------
+# Wires GuardDuty's `aws_guardduty_publishing_destination` to dump findings as
+# objects into the supplied S3 bucket. The bucket is expected to live in the
+# log-archive account; cross-account write is authorized via the bucket
+# policy on that side. Only created when both the bucket ARN and KMS key are
+# set — otherwise findings stay in the GuardDuty service (still queryable, just
+# not centralized).
+
+resource "aws_guardduty_publishing_destination" "this" {
+  count = var.findings_destination_bucket_arn != null && var.findings_destination_bucket_arn != "" ? 1 : 0
+
+  detector_id     = aws_guardduty_detector.this.id
+  destination_arn = var.findings_destination_bucket_arn
+  kms_key_arn     = var.findings_destination_kms_key_arn
+
+  # The destination bucket policy must already grant
+  # guardduty.amazonaws.com put-object on `destination_arn` and the KMS key
+  # must allow `kms:GenerateDataKey` for that principal. Provisioned in the
+  # log-archive account by a sibling unit.
+}

--- a/terraform/modules/guardduty-org/variables.tf
+++ b/terraform/modules/guardduty-org/variables.tf
@@ -62,6 +62,18 @@ variable "auto_enable_org_members" {
 # Common
 # ---------------------------------------------------------------------------------------------------------------------
 
+variable "findings_destination_bucket_arn" {
+  description = "S3 bucket ARN (typically in the log-archive account) where GuardDuty findings are published. If null/empty, findings stay in the GuardDuty service only — set this for centralized retention. Closes the #163 'findings published to centralized location' criterion."
+  type        = string
+  default     = null
+}
+
+variable "findings_destination_kms_key_arn" {
+  description = "KMS CMK ARN used to encrypt findings on write to the destination bucket. Required when findings_destination_bucket_arn is set."
+  type        = string
+  default     = null
+}
+
 variable "tags" {
   description = "Tags to apply to resources"
   type        = map(string)


### PR DESCRIPTION
Closes #163.

## Summary

The existing \`terraform/modules/guardduty-org\` module already met 4 of 5 acceptance criteria from #163. This PR fills the last gap (centralized findings publishing) and adds module-level documentation showing the full mapping.

## Coverage matrix

| #163 acceptance criterion | Status | Where |
|---|---|---|
| \`modules/guardduty-org\` module | already present | this module |
| Delegated admin = security account | already present | \`delegated_admin_account_id\` -> \`aws_guardduty_organization_admin_account\` |
| All accounts auto-enrolled | already present | \`auto_enable_org_members = true\` -> \`auto_enable_organization_members = "ALL"\` |
| EKS Audit Logs, Malware Protection, RDS protection | already present | \`enable_eks_audit_log_monitoring\`, \`enable_malware_protection\`, \`enable_rds_protection\` (defaults all \`true\`) |
| **Findings published to centralized location** | **NEW** | \`findings_destination_bucket_arn\` -> \`aws_guardduty_publishing_destination\` |

## What this PR adds

| Path | Purpose |
|---|---|
| \`terraform/modules/guardduty-org/main.tf\` | Adds \`aws_guardduty_publishing_destination\` (count-gated on \`findings_destination_bucket_arn\` being set) |
| \`terraform/modules/guardduty-org/variables.tf\` | Two new optional inputs: \`findings_destination_bucket_arn\` and \`findings_destination_kms_key_arn\` (both default \`null\` — backwards compatible) |
| \`terraform/modules/guardduty-org/README.md\` | Module documentation with the coverage matrix above |

## Verification (local)

\`\`\`
$ terraform fmt -recursive -check terraform/modules/guardduty-org
(clean)

$ terraform -chdir=terraform/modules/guardduty-org init -backend=false && terraform -chdir=terraform/modules/guardduty-org validate
Success! The configuration is valid.

$ terraform -chdir=terraform/modules/guardduty-org test
Success! 11 passed, 0 failed.

$ tflint --chdir=terraform/modules/guardduty-org --config $PWD/.tflint.hcl
(clean, exit 0)
\`\`\`

(Pre-existing deprecation warning on \`datasources {}\` blocks remains — they should migrate to \`aws_guardduty_detector_feature\` resources. Tracked as separate cleanup; not blocking #163.)

## Pre-conditions for findings publishing

The destination bucket (in log-archive account) must:
1. Have a bucket policy granting \`guardduty.amazonaws.com\` \`s3:PutObject\` on \`<bucket>/*\`.
2. Be encrypted with a KMS CMK whose key policy allows \`kms:GenerateDataKey\` to \`guardduty.amazonaws.com\`.

A separate centralized-logging unit in the log-archive account should provision this bucket + key + policies; this module just wires the GuardDuty detector to consume them.

## Cost summary

GuardDuty pricing is event-volume based, unchanged by this PR. Findings publishing to S3 adds standard S3 PUT + storage charges (findings are small JSON, expect well under $1/account/month).

## Security review notes

- The new resource is count-gated; if \`findings_destination_bucket_arn\` is null, no publishing destination is created and behaviour matches today.
- KMS key requirement is enforced at apply time (`aws_guardduty_publishing_destination` rejects S3 destinations without an associated KMS key for SSE-KMS).
- The destination bucket policy is provisioned out-of-module (in log-archive account) so cross-account principal grants live with the bucket, not the consumer.

## Rollback plan

Revert the PR. \`terragrunt apply\` after revert removes \`aws_guardduty_publishing_destination\` (no findings retention beyond what GuardDuty itself stores). The detector and its features stay intact.

## Dependencies

- Requires #159 (state backend) — merged in #189.
- Independent of all other P0 issues.

## Out of scope (follow-ups)

- Migrating from deprecated \`datasources {}\` blocks to per-feature \`aws_guardduty_detector_feature\` resources — pre-existing, separate cleanup.
- Provisioning the centralized findings bucket in the log-archive account — separate module / unit.