### PR TITLE
feat: config-org wrapper + org aggregator + conformance pack — closes #162

### DIFF
--- a/terraform/modules/aws-config/main.tf
+++ b/terraform/modules/aws-config/main.tf
@@ -433,3 +433,94 @@ resource "aws_config_config_rule" "s3_bucket_public_read" {
 
   depends_on = [aws_config_configuration_recorder_status.this]
 }
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Org-wide aggregator (#162) — runs in the security/aggregator account
+# ---------------------------------------------------------------------------------------------------------------------
+# When `enable_organization_aggregator = true`, creates an
+# `aws_config_configuration_aggregator` collecting findings from every
+# member account in the organization. Typically applied in the security
+# account after the org has delegated Config admin to it.
+#
+# The aggregator IAM role MUST have the
+# AWSConfigRoleForOrganizations managed policy. We attach it explicitly
+# below.
+#
+# Closes the #162 acceptance criterion: "Aggregator in security account".
+
+resource "aws_iam_role" "config_aggregator" {
+  count = var.enable_organization_aggregator ? 1 : 0
+
+  name = "aws-config-org-aggregator"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "config.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "config_aggregator" {
+  count = var.enable_organization_aggregator ? 1 : 0
+
+  role       = aws_iam_role.config_aggregator[0].name
+  policy_arn = "arn:${local.partition}:iam::aws:policy/service-role/AWSConfigRoleForOrganizations"
+}
+
+resource "aws_config_configuration_aggregator" "organization" {
+  count = var.enable_organization_aggregator ? 1 : 0
+
+  name = var.organization_aggregator_name
+
+  organization_aggregation_source {
+    all_regions = true
+    role_arn    = aws_iam_role.config_aggregator[0].arn
+  }
+
+  tags = merge(var.tags, {
+    Name    = var.organization_aggregator_name
+    Purpose = "config-org-aggregator"
+  })
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Baseline conformance pack (#162) — applied at organization level when running in the management account
+# ---------------------------------------------------------------------------------------------------------------------
+# Conformance packs bundle Config rules + remediation actions. The simplest
+# baseline is the AWS-managed "Operational Best Practices for AWS
+# Foundational Security Best Practices" pack, applied org-wide.
+#
+# Set `baseline_conformance_pack_template_s3_uri` (or
+# `baseline_conformance_pack_template_body`) to provision. Empty by default
+# to keep this opt-in.
+#
+# Closes the #162 acceptance criterion: "Baseline conformance pack applied".
+
+resource "aws_config_organization_conformance_pack" "baseline" {
+  count = var.enable_organization_conformance_pack ? 1 : 0
+
+  name = var.organization_conformance_pack_name
+
+  # Template body OR S3 URI — exactly one must be set.
+  template_body = var.baseline_conformance_pack_template_body != "" ? var.baseline_conformance_pack_template_body : null
+  template_s3_uri = (
+    var.baseline_conformance_pack_template_body == "" && var.baseline_conformance_pack_template_s3_uri != ""
+    ? var.baseline_conformance_pack_template_s3_uri
+    : null
+  )
+
+  delivery_s3_bucket     = aws_s3_bucket.config.id
+  delivery_s3_key_prefix = "conformance-packs"
+
+  depends_on = [
+    aws_config_configuration_recorder_status.this,
+    aws_config_configuration_aggregator.organization,
+  ]
+}

--- a/terraform/modules/aws-config/variables.tf
+++ b/terraform/modules/aws-config/variables.tf
@@ -78,6 +78,46 @@ variable "include_global_resource_types" {
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
+# Organization aggregator + conformance pack (#162)
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "enable_organization_aggregator" {
+  description = "When true, create an aws_config_configuration_aggregator collecting findings from every member account. Typically applied in the security/aggregator account after Config admin has been delegated to it. Closes the #162 'Aggregator in security account' criterion."
+  type        = bool
+  default     = false
+}
+
+variable "organization_aggregator_name" {
+  description = "Name of the organization aggregator (only used when enable_organization_aggregator = true)."
+  type        = string
+  default     = "platform-design-org-aggregator"
+}
+
+variable "enable_organization_conformance_pack" {
+  description = "When true, deploy a baseline conformance pack across the organization. Must be applied in the org management account or in an account with delegated Config administration. Closes the #162 'Baseline conformance pack applied' criterion."
+  type        = bool
+  default     = false
+}
+
+variable "organization_conformance_pack_name" {
+  description = "Name of the baseline conformance pack."
+  type        = string
+  default     = "platform-design-baseline-best-practices"
+}
+
+variable "baseline_conformance_pack_template_body" {
+  description = "Inline YAML body for the baseline conformance pack. Mutually exclusive with baseline_conformance_pack_template_s3_uri."
+  type        = string
+  default     = ""
+}
+
+variable "baseline_conformance_pack_template_s3_uri" {
+  description = "S3 URI of the baseline conformance pack template (e.g. an AWS-published 'Operational Best Practices for AWS Foundational Security Best Practices' template). Mutually exclusive with baseline_conformance_pack_template_body."
+  type        = string
+  default     = ""
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
 # Common
 # ---------------------------------------------------------------------------------------------------------------------
 

--- a/terraform/modules/config-org/README.md
+++ b/terraform/modules/config-org/README.md
@@ -1,0 +1,128 @@
+# config-org
+
+Organization-wide AWS Config: per-account recorder + delivery channel,
+org-wide aggregator (in the security/aggregator account), and a baseline
+conformance pack applied across the organization.
+
+Closes #162. Thin alias around the existing `aws-config` module which now
+exposes the org-aggregator and conformance-pack additions made for this
+issue.
+
+## Coverage
+
+| #162 acceptance criterion | How it's met |
+|---|---|
+| `modules/config-org` module | This module (alias of `aws-config`) |
+| Aggregator in security account | **NEW**: `enable_organization_aggregator = true` -> `aws_config_configuration_aggregator` with org-wide source |
+| Config recorder + delivery channel in each account | already in `aws-config` (recorder + delivery channel + S3 + IAM role + CIS rules) |
+| Baseline conformance pack applied | **NEW**: `enable_organization_conformance_pack = true` -> `aws_config_organization_conformance_pack` |
+| Logs to log-archive | already supported via `kms_key_arn` + `s3_bucket_name` (point at log-archive cross-account bucket) |
+
+## Why a wrapper, not a rename?
+
+Issue #162 asks for `modules/config-org` mirroring qbiq-ai/infra naming.
+The existing `aws-config` module already creates the recorder, delivery
+channel, IAM role, CIS managed rules, and S3 bucket. Renaming would force
+state moves and break tests. The wrapper gives the canonical name without
+churn; new code references `config-org`, existing `aws-config` callers
+continue to work.
+
+## Usage — per-account recorder
+
+Deploy in every member account (typically via a per-account terragrunt
+unit fan-out):
+
+```hcl
+module "config" {
+  source = "../../terraform/modules/config-org"
+
+  s3_bucket_name = "platform-design-config-${local.account_id}-${local.region}"
+  kms_key_arn    = aws_kms_key.config.arn
+
+  # Default: aggregator/conformance pack OFF — those run in the security
+  # account only.
+
+  tags = {
+    Environment = "dev"
+    ManagedBy   = "terragrunt"
+  }
+}
+```
+
+## Usage — security/aggregator account
+
+In the security account (which has been delegated as Config administrator):
+
+```hcl
+module "config_aggregator" {
+  source = "../../terraform/modules/config-org"
+
+  s3_bucket_name = "platform-design-config-security-eu-west-1"
+  kms_key_arn    = aws_kms_key.config.arn
+
+  enable_organization_aggregator = true
+  organization_aggregator_name   = "platform-design-org-aggregator"
+
+  enable_organization_conformance_pack       = true
+  baseline_conformance_pack_template_s3_uri  = "s3://aws-public-config-conformance-packs/Operational-Best-Practices-for-AWS-Foundational-Security-Best-Practices.yaml"
+  organization_conformance_pack_name         = "platform-design-baseline-best-practices"
+
+  tags = {
+    Environment = "security"
+    ManagedBy   = "terragrunt"
+  }
+}
+```
+
+## Pre-conditions
+
+- The security account must have been registered as a Config delegated
+  administrator (call `aws organizations register-delegated-administrator`
+  with `service-principal=config.amazonaws.com` from the management
+  account, or Terraform: `aws_organizations_delegated_administrator`).
+- The S3 bucket can live in the same account as the recorder, or
+  cross-account in log-archive (recommended). Cross-account requires the
+  bucket policy to grant `config.amazonaws.com` write access from each
+  member-account recorder.
+- For the conformance pack, either `baseline_conformance_pack_template_body`
+  (inline YAML) or `baseline_conformance_pack_template_s3_uri` (S3 URI to
+  a YAML template) must be set when `enable_organization_conformance_pack
+  = true`. AWS publishes ready-to-use templates in
+  `s3://aws-public-config-conformance-packs/`.
+
+## Inputs
+
+Pass-through to `aws-config`. See
+[`terraform/modules/aws-config/variables.tf`](../aws-config/variables.tf)
+for full descriptions and validation rules. Highlights:
+
+| Name | Default | Description |
+|---|---|---|
+| `s3_bucket_name` | (required) | Bucket holding Config snapshots |
+| `kms_key_arn` | `""` | CMK for bucket SSE; empty -> AES-256 |
+| `enable_organization_aggregator` | `false` | **NEW** — flip to `true` only in the security/aggregator account |
+| `enable_organization_conformance_pack` | `false` | **NEW** — flip to `true` only where conformance packs should be deployed |
+| `baseline_conformance_pack_template_s3_uri` | `""` | S3 URI to a Config conformance-pack template |
+
+## Outputs
+
+| Name | Description |
+|---|---|
+| `recorder_name` | Configuration recorder name |
+| `s3_bucket_name` | S3 bucket name |
+| `s3_bucket_arn` | S3 bucket ARN |
+
+## Compliance
+
+- PCI-DSS Req 1.1.1 (change tracking), Req 2.4 (resource inventory),
+  Req 10.6 (log review), Req 11.5 (change detection)
+- CIS managed rules already in `aws-config`: 1.5, 1.8-1.14, 1.10, 1.14,
+  3.1, 3.2, 3.5, 3.7, 2.1.2
+
+## Related
+
+- [`terraform/modules/aws-config/`](../aws-config/) — underlying module
+- AWS Config conformance packs:
+  <https://docs.aws.amazon.com/config/latest/developerguide/conformance-packs.html>
+- AWS Config aggregator:
+  <https://docs.aws.amazon.com/config/latest/developerguide/aggregate-data.html>

--- a/terraform/modules/config-org/main.tf
+++ b/terraform/modules/config-org/main.tf
@@ -1,0 +1,42 @@
+# -----------------------------------------------------------------------------
+# config-org — Organization-wide AWS Config wrapper
+# -----------------------------------------------------------------------------
+# Closes #162. Thin alias around the existing `aws-config` module which now
+# supports organization aggregation and baseline conformance packs.
+#
+# Why a wrapper instead of renaming `aws-config`?
+#   - Issue #162 asks for `modules/config-org` (mirroring qbiq-ai/infra
+#     naming).
+#   - The existing `aws-config` module already creates the recorder +
+#     delivery channel + S3 + IAM role + CIS managed rules; renaming would
+#     force state moves and break tests.
+#   - The aggregator + conformance pack additions for #162 landed in the
+#     existing module. This wrapper exposes them via the canonical name.
+# -----------------------------------------------------------------------------
+
+module "config" {
+  source = "../aws-config"
+
+  recorder_name = var.recorder_name
+
+  s3_bucket_name              = var.s3_bucket_name
+  s3_key_prefix               = var.s3_key_prefix
+  snapshot_delivery_frequency = var.snapshot_delivery_frequency
+  kms_key_arn                 = var.kms_key_arn
+
+  lifecycle_glacier_days    = var.lifecycle_glacier_days
+  lifecycle_expiration_days = var.lifecycle_expiration_days
+
+  recording_all_resources       = var.recording_all_resources
+  include_global_resource_types = var.include_global_resource_types
+
+  # #162: org-wide aggregation + conformance pack
+  enable_organization_aggregator            = var.enable_organization_aggregator
+  organization_aggregator_name              = var.organization_aggregator_name
+  enable_organization_conformance_pack      = var.enable_organization_conformance_pack
+  organization_conformance_pack_name        = var.organization_conformance_pack_name
+  baseline_conformance_pack_template_body   = var.baseline_conformance_pack_template_body
+  baseline_conformance_pack_template_s3_uri = var.baseline_conformance_pack_template_s3_uri
+
+  tags = var.tags
+}

--- a/terraform/modules/config-org/outputs.tf
+++ b/terraform/modules/config-org/outputs.tf
@@ -1,0 +1,16 @@
+# Outputs are delegated 1:1 to the underlying aws-config module.
+
+output "recorder_name" {
+  value       = module.config.recorder_name
+  description = "Config configuration recorder name"
+}
+
+output "s3_bucket_name" {
+  value       = module.config.s3_bucket_name
+  description = "S3 bucket holding Config snapshots and history"
+}
+
+output "s3_bucket_arn" {
+  value       = module.config.s3_bucket_arn
+  description = "ARN of the Config S3 bucket"
+}

--- a/terraform/modules/config-org/variables.tf
+++ b/terraform/modules/config-org/variables.tf
@@ -1,0 +1,106 @@
+# Variables are passed through 1:1 to the underlying aws-config module.
+# See terraform/modules/aws-config/variables.tf for full descriptions of
+# defaults and validation rules.
+
+variable "recorder_name" {
+  description = "Name of the AWS Config configuration recorder."
+  type        = string
+  default     = "default"
+}
+
+variable "s3_bucket_name" {
+  description = "Name of the S3 bucket holding Config snapshots and history."
+  type        = string
+}
+
+variable "s3_key_prefix" {
+  description = "S3 key prefix for Config delivery channel objects."
+  type        = string
+  default     = "config"
+}
+
+variable "snapshot_delivery_frequency" {
+  description = "Frequency for Config snapshot delivery (One_Hour, Three_Hours, Six_Hours, Twelve_Hours, TwentyFour_Hours)."
+  type        = string
+  default     = "TwentyFour_Hours"
+}
+
+variable "kms_key_arn" {
+  description = "ARN of the KMS CMK for encrypting the Config S3 bucket. Empty -> AES-256."
+  type        = string
+  default     = ""
+}
+
+variable "lifecycle_expiration_days" {
+  description = "Days before expiring Config snapshots. PCI-DSS Req 10.7 requires >= 365."
+  type        = number
+  default     = 2555
+}
+
+variable "lifecycle_glacier_days" {
+  description = "Days before transitioning Config snapshots to Glacier."
+  type        = number
+  default     = 365
+}
+
+variable "recording_all_resources" {
+  description = "Record all resource types in the region."
+  type        = bool
+  default     = true
+}
+
+variable "include_global_resource_types" {
+  description = "Include global resource types (IAM, etc.) — set true in exactly one region per account."
+  type        = bool
+  default     = true
+}
+
+# ---------------------------------------------------------------------------
+# Organization aggregator (#162)
+# ---------------------------------------------------------------------------
+
+variable "enable_organization_aggregator" {
+  description = "Enable the org-wide Config aggregator. Typically true in the security/aggregator account after Config admin has been delegated."
+  type        = bool
+  default     = false
+}
+
+variable "organization_aggregator_name" {
+  description = "Name of the organization aggregator (only used when enable_organization_aggregator = true)."
+  type        = string
+  default     = "platform-design-org-aggregator"
+}
+
+# ---------------------------------------------------------------------------
+# Baseline conformance pack (#162)
+# ---------------------------------------------------------------------------
+
+variable "enable_organization_conformance_pack" {
+  description = "Deploy a baseline conformance pack across the organization. Provide either template_body or template_s3_uri."
+  type        = bool
+  default     = false
+}
+
+variable "organization_conformance_pack_name" {
+  description = "Name of the baseline conformance pack."
+  type        = string
+  default     = "platform-design-baseline-best-practices"
+}
+
+variable "baseline_conformance_pack_template_body" {
+  description = "Inline YAML body for the baseline conformance pack. Mutually exclusive with baseline_conformance_pack_template_s3_uri."
+  type        = string
+  default     = ""
+}
+
+variable "baseline_conformance_pack_template_s3_uri" {
+  description = "S3 URI of the baseline conformance pack template (e.g. AWS-published 'Operational Best Practices for AWS Foundational Security Best Practices')."
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Tags to apply to resources."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/config-org/versions.tf
+++ b/terraform/modules/config-org/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
Closes #162. Builds on the existing \`aws-config\` module (recorder + delivery channel + S3 + IAM + CIS rules) by adding org aggregation and baseline conformance pack support.

## Coverage matrix

| #162 acceptance criterion | Status | Where |
|---|---|---|
| \`modules/config-org\` module | **NEW** wrapper | \`terraform/modules/config-org/\` |
| Aggregator in security account | **NEW** | \`enable_organization_aggregator\` -> \`aws_config_configuration_aggregator\` + IAM role with \`AWSConfigRoleForOrganizations\` |
| Config recorder + delivery channel in each account | already in \`aws-config\` | \`aws_config_configuration_recorder\` + \`aws_config_delivery_channel\` |
| Baseline conformance pack applied | **NEW** | \`enable_organization_conformance_pack\` -> \`aws_config_organization_conformance_pack\` (accepts inline template_body or S3 URI) |
| Logs to log-archive | already supported | \`s3_bucket_name\` + \`kms_key_arn\` (point at log-archive cross-account bucket) |

## What this PR adds

| Path | Purpose |
|---|---|
| \`terraform/modules/aws-config/main.tf\` | New \`aws_config_configuration_aggregator\`, \`aws_iam_role.config_aggregator\`, and \`aws_config_organization_conformance_pack\` resources (all count-gated on opt-in vars) |
| \`terraform/modules/aws-config/variables.tf\` | 6 new optional inputs for aggregator + conformance pack (\`enable_organization_aggregator\`, \`organization_aggregator_name\`, \`enable_organization_conformance_pack\`, \`organization_conformance_pack_name\`, \`baseline_conformance_pack_template_body\`, \`baseline_conformance_pack_template_s3_uri\`) |
| \`terraform/modules/config-org/\` | NEW thin wrapper module exposing the canonical qbiq-ai/infra name. 1:1 pass-through to \`aws-config\` for every input/output |

## Why a wrapper, not a rename?

Same logic as #161 (cloudtrail-org wrapper, merged in #193). Renaming \`aws-config\` would force state moves and break BDD compliance tests. The wrapper gives the canonical \`config-org\` name without churn.

## Verification (local)

\`\`\`
$ terraform fmt -recursive -check terraform/modules/aws-config terraform/modules/config-org
(clean)

$ terraform -chdir=terraform/modules/aws-config init -backend=false && terraform -chdir=terraform/modules/aws-config validate
Success! The configuration is valid.
(Pre-existing deprecation warning in aws-config: \`data.aws_region.current.name\` -> \`.region\`. Tracked separately.)

$ terraform -chdir=terraform/modules/aws-config test
Success! 3 passed, 0 failed.

$ terraform -chdir=terraform/modules/config-org init -backend=false && terraform -chdir=terraform/modules/config-org validate
Success! The configuration is valid.

$ tflint --chdir=terraform/modules/aws-config --config $PWD/.tflint.hcl
(clean)

$ tflint --chdir=terraform/modules/config-org --config $PWD/.tflint.hcl
(clean)
\`\`\`

## Cost summary

- AWS Config recorder: ~$0.003 per configuration item recorded. At ~1000 items/account/month that's ~\$3/account/month.
- Config aggregator (in security account): free.
- Conformance pack: $2/month per Config rule per region. The AWS-published "Operational Best Practices for AWS Foundational Security Best Practices" pack adds ~30 rules; ~\$60/month total in the account where it's deployed.
- Total uplift over the existing aws-config module: ~\$60/month, primarily from the conformance pack rules.

## Security review notes

- Aggregator IAM role uses the AWS-managed \`AWSConfigRoleForOrganizations\` policy — least-privilege for org aggregation.
- All new resources are count-gated on opt-in vars; default behaviour is unchanged for existing callers.
- The conformance pack template is loaded from caller-controlled S3 URI or inline body — caller is responsible for vetting the YAML.
- No wildcards introduced. No secrets.

## Rollback plan

Revert the PR. \`terragrunt apply\` after revert removes:
- The aggregator (no impact on recorders)
- The IAM role (no impact)
- The conformance pack (Config rules deployed by it are removed; CIS managed rules in the existing module remain)

The recorder and delivery channel are untouched.

## Dependencies

- Requires #159 (state backend) — merged in #189.
- Requires Config admin to be delegated to the security account before the aggregator can list cross-account resources. Provision via \`aws_organizations_delegated_administrator\` (separate ticket — placeholder until real account IDs land).
- Independent of #167, #166.

## Out of scope (follow-ups)

- Per-account terragrunt fan-out (one config-org unit per account in their region).
- Wiring the AWS-published conformance pack URI into the live terragrunt unit (currently the module accepts the URI; the unit is unchanged in this PR).
- Fixing the pre-existing \`data.aws_region.current.name\` deprecation in \`aws-config\` — separate small fix.