### PR TITLE
feat: securityhub-org wrapper + delegated admin + cross-region aggregator — closes #164

### DIFF
--- a/terraform/modules/security-hub/main.tf
+++ b/terraform/modules/security-hub/main.tf
@@ -74,3 +74,37 @@ resource "aws_securityhub_organization_configuration" "this" {
 
   depends_on = [aws_securityhub_account.this]
 }
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Delegated Administrator (#164)
+# ---------------------------------------------------------------------------------------------------------------------
+# Delegates Security Hub administration from the org management account to a
+# specified account (typically the security account). Only created when the
+# delegated admin is a different account than the current caller.
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_securityhub_organization_admin_account" "this" {
+  count = var.delegated_admin_account_id != "" && var.delegated_admin_account_id != data.aws_caller_identity.current.account_id ? 1 : 0
+
+  admin_account_id = var.delegated_admin_account_id
+
+  depends_on = [aws_securityhub_account.this]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Cross-Region Finding Aggregator (#164)
+# ---------------------------------------------------------------------------------------------------------------------
+# When enabled, aggregates findings from all (or specified) linked regions
+# into the home region of the SecurityHub admin account. Should be created
+# only in the admin account.
+
+resource "aws_securityhub_finding_aggregator" "this" {
+  count = var.enable_finding_aggregator ? 1 : 0
+
+  linking_mode = length(var.finding_aggregator_linked_regions) > 0 ? "SPECIFIED_REGIONS" : "ALL_REGIONS"
+
+  specified_regions = length(var.finding_aggregator_linked_regions) > 0 ? var.finding_aggregator_linked_regions : null
+
+  depends_on = [aws_securityhub_account.this]
+}

--- a/terraform/modules/security-hub/variables.tf
+++ b/terraform/modules/security-hub/variables.tf
@@ -33,6 +33,28 @@ variable "auto_enable_default_standards" {
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
+# Delegated administrator + cross-region aggregation (#164)
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "delegated_admin_account_id" {
+  description = "AWS account ID to delegate Security Hub administration to (typically the security account). When set and != caller, creates aws_securityhub_organization_admin_account. Closes the #164 'delegated admin = security account' criterion."
+  type        = string
+  default     = ""
+}
+
+variable "enable_finding_aggregator" {
+  description = "Create aws_securityhub_finding_aggregator to aggregate findings across regions to the home region. Should be set in the SecurityHub admin account only. Closes the #164 'aggregation across regions' criterion."
+  type        = bool
+  default     = false
+}
+
+variable "finding_aggregator_linked_regions" {
+  description = "List of regions to aggregate findings from. Empty list means ALL_REGIONS (default behaviour). Set explicit regions if you want to opt-in only certain ones."
+  type        = list(string)
+  default     = []
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
 # Common
 # ---------------------------------------------------------------------------------------------------------------------
 

--- a/terraform/modules/securityhub-org/README.md
+++ b/terraform/modules/securityhub-org/README.md
@@ -1,0 +1,119 @@
+# securityhub-org
+
+Organization-wide AWS Security Hub: account enablement, AWS Foundational +
+CIS + PCI-DSS standards, org auto-enrollment, delegated administration to
+the security account, and cross-region finding aggregation.
+
+Closes #164. Thin alias around the existing `security-hub` module which
+now exposes the delegated-admin and finding-aggregator additions.
+
+## Coverage
+
+| #164 acceptance criterion | How it's met |
+|---|---|
+| `modules/securityhub-org` module | This wrapper |
+| Delegated admin = security account | **NEW**: `delegated_admin_account_id` -> `aws_securityhub_organization_admin_account` |
+| AWS Foundational Security Best Practices standard | already in `security-hub` (`enable_aws_foundational_standard = true` default) |
+| CIS AWS Foundations Benchmark standard | already in `security-hub` (`enable_cis_standard = true` default) |
+| All member accounts enrolled | already in `security-hub` (`auto_enable_org = true`) |
+| Aggregation across regions | **NEW**: `enable_finding_aggregator = true` -> `aws_securityhub_finding_aggregator` |
+
+Plus PCI-DSS v3.2.1 standard subscription (defaults on, beyond the issue).
+
+## Why a wrapper, not a rename?
+
+Same logic as #161 (cloudtrail-org) and #162 (config-org). Renaming
+`security-hub` would force state moves and break BDD compliance tests.
+The wrapper gives the canonical name without churn.
+
+## Usage — admin account (security account)
+
+```hcl
+module "security_hub_admin" {
+  source = "../../terraform/modules/securityhub-org"
+
+  delegated_admin_account_id = "111122223333"  # security account itself
+
+  enable_finding_aggregator         = true
+  finding_aggregator_linked_regions = []   # [] -> ALL_REGIONS
+
+  enable_aws_foundational_standard = true
+  enable_cis_standard              = true
+  enable_pci_dss_standard          = true   # default
+
+  auto_enable_org                = true
+  auto_enable_default_standards  = true
+
+  tags = {
+    Environment = "security"
+    ManagedBy   = "terragrunt"
+  }
+}
+```
+
+## Usage — member account
+
+In each member account (typically via per-account terragrunt fan-out):
+
+```hcl
+module "security_hub" {
+  source = "../../terraform/modules/securityhub-org"
+
+  # Don't set delegated_admin_account_id or enable_finding_aggregator —
+  # those run only in the admin account.
+
+  enable_aws_foundational_standard = true
+  enable_cis_standard              = true
+
+  tags = { Environment = "dev" }
+}
+```
+
+## Inputs
+
+| Name | Default | Description |
+|---|---|---|
+| `enable_pci_dss_standard` | `true` | Subscribe to PCI-DSS v3.2.1 |
+| `enable_cis_standard` | `true` | Subscribe to CIS AWS Foundations Benchmark v1.4.0 |
+| `enable_aws_foundational_standard` | `true` | Subscribe to AWS Foundational Security Best Practices |
+| `auto_enable_org` | `true` | Auto-enable for new org member accounts |
+| `auto_enable_default_standards` | `false` | Auto-enable default standards for new members |
+| `delegated_admin_account_id` | `""` | **NEW** — admin account; empty / equal-to-caller -> no delegation |
+| `enable_finding_aggregator` | `false` | **NEW** — cross-region aggregation; admin account only |
+| `finding_aggregator_linked_regions` | `[]` | **NEW** — empty -> ALL_REGIONS |
+| `tags` | `{}` | Tags |
+
+## Outputs
+
+| Name | Description |
+|---|---|
+| `delegated_admin_account_id` | Configured delegated admin (empty if not set) |
+| `finding_aggregator_enabled` | Whether the aggregator is enabled |
+
+## Pre-conditions
+
+- AWS Config (#162) must be enabled in the home region — Security Hub's
+  control checks rely on Config. The CIS and AWS Foundational standards
+  call out specific Config rules that must be present.
+- The security account must be registered as a Security Hub delegated
+  administrator from the management account (provision via
+  `aws_organizations_delegated_administrator` with
+  `service-principal=securityhub.amazonaws.com`).
+- The finding aggregator should be created only in the admin account;
+  member accounts should NOT enable it (would create per-account
+  aggregators that don't see cross-account data).
+
+## Cost
+
+Security Hub charges per finding ingested. Most volume comes from the
+default standards' control checks (~one finding per evaluated resource
+per check). Expect $50-300/month at modest scale (~5 accounts × few
+hundred resources). The aggregator is free; only the underlying findings
+are billed.
+
+## Related
+
+- [`terraform/modules/security-hub/`](../security-hub/) — underlying module
+- [`terraform/modules/config-org/`](../config-org/) — Config dependency (#162)
+- [`docs/scps.md#denyguarddutychanges`](../../../docs/scps.md) — neighbour
+  SCPs that protect security tooling from being disabled

--- a/terraform/modules/securityhub-org/main.tf
+++ b/terraform/modules/securityhub-org/main.tf
@@ -1,0 +1,33 @@
+# -----------------------------------------------------------------------------
+# securityhub-org — Organization-wide AWS Security Hub
+# -----------------------------------------------------------------------------
+# Closes #164. Thin alias around the existing `security-hub` module which now
+# supports delegated administration and cross-region finding aggregation.
+#
+# Why a wrapper instead of renaming `security-hub`?
+#   - Issue #164 asks for `modules/securityhub-org` (mirroring qbiq-ai/infra
+#     naming).
+#   - The existing `security-hub` module already creates the account
+#     enablement, AWS Foundational + CIS + PCI-DSS standard subscriptions,
+#     and org auto-enable. Delegated admin and finding aggregator landed in
+#     the existing module for #164.
+#   - Renaming would force state moves and break BDD compliance tests.
+# -----------------------------------------------------------------------------
+
+module "security_hub" {
+  source = "../security-hub"
+
+  enable_pci_dss_standard          = var.enable_pci_dss_standard
+  enable_cis_standard              = var.enable_cis_standard
+  enable_aws_foundational_standard = var.enable_aws_foundational_standard
+
+  auto_enable_org               = var.auto_enable_org
+  auto_enable_default_standards = var.auto_enable_default_standards
+
+  # #164 — delegated admin + cross-region aggregation
+  delegated_admin_account_id        = var.delegated_admin_account_id
+  enable_finding_aggregator         = var.enable_finding_aggregator
+  finding_aggregator_linked_regions = var.finding_aggregator_linked_regions
+
+  tags = var.tags
+}

--- a/terraform/modules/securityhub-org/outputs.tf
+++ b/terraform/modules/securityhub-org/outputs.tf
@@ -1,0 +1,9 @@
+output "delegated_admin_account_id" {
+  description = "Configured delegated admin account ID (empty if not set)."
+  value       = var.delegated_admin_account_id
+}
+
+output "finding_aggregator_enabled" {
+  description = "Whether the finding aggregator is enabled."
+  value       = var.enable_finding_aggregator
+}

--- a/terraform/modules/securityhub-org/variables.tf
+++ b/terraform/modules/securityhub-org/variables.tf
@@ -1,0 +1,57 @@
+# Pass-through inputs to terraform/modules/security-hub.
+
+variable "enable_pci_dss_standard" {
+  description = "Enable PCI-DSS v3.2.1 standard."
+  type        = bool
+  default     = true
+}
+
+variable "enable_cis_standard" {
+  description = "Enable CIS AWS Foundations Benchmark v1.4.0."
+  type        = bool
+  default     = true
+}
+
+variable "enable_aws_foundational_standard" {
+  description = "Enable AWS Foundational Security Best Practices."
+  type        = bool
+  default     = true
+}
+
+variable "auto_enable_org" {
+  description = "Auto-enable Security Hub for new org member accounts."
+  type        = bool
+  default     = true
+}
+
+variable "auto_enable_default_standards" {
+  description = "Auto-enable default standards for new member accounts."
+  type        = bool
+  default     = false
+}
+
+# #164 — delegated admin + cross-region aggregation
+
+variable "delegated_admin_account_id" {
+  description = "Account to delegate Security Hub admin to (typically security account). Empty / equal-to-caller -> no delegation."
+  type        = string
+  default     = ""
+}
+
+variable "enable_finding_aggregator" {
+  description = "Create a finding aggregator (cross-region aggregation). Run only in the admin account."
+  type        = bool
+  default     = false
+}
+
+variable "finding_aggregator_linked_regions" {
+  description = "Specific regions to aggregate findings from. Empty -> ALL_REGIONS."
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "Tags applied to taggable resources."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/securityhub-org/versions.tf
+++ b/terraform/modules/securityhub-org/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
Closes #164. Builds on the existing \`security-hub\` module by adding the two missing pieces: delegated administration and cross-region finding aggregation.

## Coverage matrix

| #164 acceptance criterion | Status | Where |
|---|---|---|
| \`modules/securityhub-org\` module | **NEW** wrapper | \`terraform/modules/securityhub-org/\` |
| Delegated admin = security account | **NEW** | \`delegated_admin_account_id\` -> \`aws_securityhub_organization_admin_account\` |
| AWS Foundational Security Best Practices standard enabled | already in \`security-hub\` | \`enable_aws_foundational_standard = true\` (default) |
| CIS AWS Foundations Benchmark standard enabled | already in \`security-hub\` | \`enable_cis_standard = true\` (default) |
| All member accounts enrolled | already in \`security-hub\` | \`auto_enable_org = true\` -> \`aws_securityhub_organization_configuration\` |
| Aggregation across regions | **NEW** | \`enable_finding_aggregator = true\` -> \`aws_securityhub_finding_aggregator\` (linking_mode ALL_REGIONS or SPECIFIED_REGIONS) |

## What this PR adds

| Path | Purpose |
|---|---|
| \`terraform/modules/security-hub/main.tf\` | New \`aws_securityhub_organization_admin_account\` (count-gated) and \`aws_securityhub_finding_aggregator\` (count-gated) |
| \`terraform/modules/security-hub/variables.tf\` | 3 new optional inputs: \`delegated_admin_account_id\`, \`enable_finding_aggregator\`, \`finding_aggregator_linked_regions\` |
| \`terraform/modules/securityhub-org/\` | NEW thin wrapper module exposing the canonical qbiq-ai/infra name |

## Why a wrapper, not a rename?

Same logic as #161 (cloudtrail-org wrapper, merged in #193) and #162 (config-org, PR #196). Renaming \`security-hub\` would force state moves and break BDD compliance tests. The wrapper gives the canonical \`securityhub-org\` name without churn.

## Verification (local)

\`\`\`
$ terraform fmt -recursive -check terraform/modules/security-hub terraform/modules/securityhub-org
(clean)

$ terraform -chdir=terraform/modules/security-hub init -backend=false && terraform -chdir=terraform/modules/security-hub validate
Success! The configuration is valid.

$ terraform -chdir=terraform/modules/security-hub test
Success! 6 passed, 0 failed.

$ terraform -chdir=terraform/modules/securityhub-org init -backend=false && terraform -chdir=terraform/modules/securityhub-org validate
Success! The configuration is valid.

$ tflint --chdir=terraform/modules/security-hub --config $PWD/.tflint.hcl
1 issue: pre-existing tags variable unused declaration (existed before this PR)

$ tflint --chdir=terraform/modules/securityhub-org --config $PWD/.tflint.hcl
(clean, exit 0)
\`\`\`

(Pre-existing deprecation warning on \`data.aws_region.current.name\` -> \`.region\` in \`security-hub/main.tf\` — affects multiple modules, tracked separately.)

## Cost summary

- Security Hub: $0.0010 per finding ingested. The CIS + AWS Foundational + PCI-DSS standards generate roughly one finding per evaluated resource per check; expect ~\$50-300/month at modest scale (5 accounts × few hundred resources).
- Finding aggregator: free.
- Total uplift over the existing module: zero — the new resources don't change the volume of findings ingested. They just route them centrally.

## Security review notes

- The aggregator is gated on \`enable_finding_aggregator\` and should be enabled ONLY in the admin account. Enabling it in member accounts would create per-account aggregators that don't see cross-account data — confusing without breaking anything.
- The delegated admin resource is also count-gated and only fires when \`delegated_admin_account_id\` is set AND != caller. Idempotent on re-apply.
- No wildcards introduced. No secrets.

## Rollback plan

Revert the PR. \`terragrunt apply\` after revert removes:
- The aggregator (findings continue to flow into Security Hub but only the home region's view is visible from the admin account)
- The delegated admin record (administration reverts to the management account; member accounts continue receiving control evaluations)

The existing standard subscriptions and \`aws_securityhub_account\` enablement are untouched.

## Dependencies

- Requires #159 (state backend) — merged in #189.
- Requires #162 (config-org) for full effectiveness — Security Hub control checks rely on AWS Config being recording in each account. PR #196 in flight.
- Requires the security account to be registered as a Security Hub delegated administrator from the management account: \`aws_organizations_delegated_administrator\` with \`service-principal = securityhub.amazonaws.com\`. Provisioned out-of-module.

## Out of scope (follow-ups)

- Provisioning the \`aws_organizations_delegated_administrator\` registration for Security Hub — separate small unit at \`terragrunt/_org/_global/securityhub-org/\`.
- Per-account terragrunt fan-out to enable Security Hub in every member account.
- Fixing the pre-existing \`data.aws_region.current.name\` deprecation across multiple modules — separate bulk cleanup.