### PR TITLE
feat: unify Terragrunt root skeleton — closes #156

### DIFF
--- a/terragrunt/README.md
+++ b/terragrunt/README.md
@@ -18,8 +18,18 @@ project/platform-design/
 │       └── platform/terragrunt.stack.hcl # Full platform: VPC+EKS+Karpenter+RDS+Monitoring+Secrets
 │
 ├── terragrunt/                           # Live infrastructure config
-│   ├── root.hcl                          # Root: remote state, provider generation, versions
+│   ├── root.hcl                          # Root: remote state, provider generation, includes
+│   ├── versions.hcl                      # Pinned tool + provider versions (single source of truth)
+│   ├── common.hcl                        # Shared locals (project metadata, tag conventions)
 │   ├── mise.toml                         # Tool version pinning (terraform 1.10, terragrunt 0.68)
+│   ├── _envcommon/                       # Shared per-module configs
+│   │   ├── eks.hcl
+│   │   ├── vpc.hcl
+│   │   ├── kms.hcl
+│   │   ├── transit-gateway.hcl
+│   │   ├── budgets.hcl
+│   │   ├── centralized-logging.hcl
+│   │   └── README.md
 │   ├── <env>/                            # dev | staging | prod | dr
 │   │   ├── account.hcl                   # AWS account ID, name, environment, sizing defaults
 │   │   ├── _global/                      # Account-wide resources (not region-specific)
@@ -160,3 +170,33 @@ The catalog separates **what** to deploy (units) from **where** to deploy it (li
 - **Units** (`catalog/units/`) — Self-contained Terragrunt configurations that define a single infrastructure component. They read hierarchy files (`account.hcl`, `region.hcl`) from the live tree via `find_in_parent_folders`.
 - **Stacks** (`catalog/stacks/`) — Compose multiple units into a deployable group. The `platform` stack includes all 6 infrastructure units.
 - **Live tree** (`terragrunt/`) — Environment and region directories containing `account.hcl`, `region.hcl`, and `terragrunt.stack.hcl` files that reference the catalog.
+
+## Root skeleton — versions.hcl, common.hcl, _envcommon/
+
+The root layout is split across three sibling files for separation of concerns:
+
+| File           | Owns                                                                 |
+|----------------|----------------------------------------------------------------------|
+| `root.hcl`     | Remote state, provider generation, version generation, retry policy, default tags. |
+| `versions.hcl` | Pinned tool + provider versions. **Single source of truth** — no version literal lives anywhere else. |
+| `common.hcl`   | Repo-wide locals: project metadata, tag schema, canonical region catalog. |
+| `_envcommon/`  | One file per module (`eks.hcl`, `vpc.hcl`, `kms.hcl`, ...) holding the module source pin, common inputs, and shared dependency declarations. New per-env units include from here. See [`_envcommon/README.md`](_envcommon/README.md). |
+
+### Directory-vs-Helm-values disambiguation
+
+Two top-level directories use the word "env":
+
+- `terragrunt/<env>/...` — the **canonical Terragrunt live tree** (this README's subject). All Terraform-driven AWS resources live here.
+- `envs/<env>/values/...` — **Helm values overrides** consumed by ArgoCD ApplicationSets and Kargo (see `argocd/` and `kargo/`). These are NOT Terragrunt configs and never include `root.hcl`.
+
+There is no parallel Terragrunt layout. Any new IaC unit goes under
+`terragrunt/<env>/<region>/<module>/` and includes the shared `_envcommon/<module>.hcl` config.
+
+## Layout decision (issue #156)
+
+The canonical layout described above (`root.hcl` + `versions.hcl` + `common.hcl` + `_envcommon/` + per-env hierarchy) is mandatory for every new Terragrunt unit. Existing units that pre-date this skeleton continue to work without modification — the skeleton is additive: `root.hcl` reads `versions.hcl` and `common.hcl` for its version constraints and tag values, which means existing units that include `root.hcl` automatically pick up the new pins.
+
+When migrating an existing unit to use `_envcommon`:
+1. Replace inline `terraform { source = ... }` with `include "envcommon" { path = find_in_parent_folders("_envcommon/<module>.hcl") ... }`.
+2. Strip duplicated default inputs from the unit's own `inputs` block.
+3. `terragrunt run-all plan` shows zero diff if `_envcommon` defaults match the previously-inline values.

--- a/terragrunt/_envcommon/README.md
+++ b/terragrunt/_envcommon/README.md
@@ -1,0 +1,89 @@
+# `_envcommon/` — Shared per-module Terragrunt configs
+
+Per-module includes that fix the **module source**, **default inputs**, and
+**common dependency declarations** for every per-environment unit that
+deploys that module. Mirrors the `qbiq-ai/infra` skeleton and follows the
+[Terragrunt "keep your remote state configuration DRY"][1] +
+[`include` pattern][2] guidance.
+
+[1]: https://terragrunt.gruntwork.io/docs/features/keep-your-remote-state-configuration-dry/
+[2]: https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#include
+
+## Why this exists
+
+Without `_envcommon`, every per-environment unit duplicates:
+
+- the module path (`source = "${get_repo_root()}/.../modules/eks"`)
+- the dependency block(s) (`dependency "vpc" { ... }`)
+- the cross-cutting input defaults (`enabled_cluster_log_types`, flow-log
+  knobs, KMS key inventories, lifecycle days, etc.)
+
+Bumping a default — for example, adding a new EKS cluster log type — would
+require touching every env unit. With `_envcommon`, the bump lives in one
+file and is inherited by every consumer.
+
+## Contents
+
+| File                          | Module                                                       | Used by (per-env units)             |
+|-------------------------------|--------------------------------------------------------------|--------------------------------------|
+| `eks.hcl`                     | `terraform/modules/eks`                                      | `<env>/<region>/eks`                |
+| `vpc.hcl`                     | `terraform/modules/vpc`                                      | `<env>/<region>/vpc`                |
+| `kms.hcl`                     | `terraform/modules/kms`                                      | `<env>/<region>/kms`                |
+| `transit-gateway.hcl`         | `terraform/modules/transit-gateway`                          | `network/<region>/transit-gateway`  |
+| `budgets.hcl`                 | `terraform/modules/budgets`                                  | `<env>/_global/budgets`             |
+| `centralized-logging.hcl`     | `terraform/modules/centralized-logging`                      | `log-archive/<region>/centralized-logging` |
+
+The list will grow as new modules land (issues #170, #171, #175, #178, #182).
+
+## How to consume from a unit
+
+Inside `terragrunt/<env>/<region>/<module>/terragrunt.hcl`:
+
+```hcl
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+include "envcommon" {
+  path           = find_in_parent_folders("_envcommon/eks.hcl")
+  expose         = true
+  merge_strategy = "deep"
+}
+
+# Inputs from `_envcommon/eks.hcl` are inherited; only override what differs.
+inputs = {
+  cluster_name = "platform-dev-euw1"
+
+  # Override sizing (fewer nodes in dev).
+  node_groups = {
+    general = {
+      instance_types = ["m6i.large"]
+      desired_size   = 2
+      min_size       = 1
+      max_size       = 4
+    }
+  }
+}
+```
+
+`merge_strategy = "deep"` makes top-level keys (like `inputs`) merge instead
+of overwrite. The unit can also append additional `dependency` blocks; they
+combine with the ones declared in `_envcommon`.
+
+## When NOT to use `_envcommon`
+
+- A module that is only deployed once globally (`_org/_global/...` org-wide
+  resources). Their per-env knobs already live in the unit itself; an
+  `_envcommon` would be a single-consumer indirection.
+- One-off / experimental units that aren't part of the canonical platform
+  layout.
+
+## Bump policy
+
+- **Adding a default** (e.g. a new optional input): no ADR required, just a
+  PR + green CI. Defaults must be backwards-compatible.
+- **Changing an existing default**: requires a PR comment listing every
+  current consumer (use `grep -r "_envcommon/<module>.hcl" terragrunt/`)
+  and a soak in non-prod.
+- **Changing the module `source` path**: ADR required; this affects every
+  consumer's state.

--- a/terragrunt/_envcommon/budgets.hcl
+++ b/terragrunt/_envcommon/budgets.hcl
@@ -1,0 +1,60 @@
+# -----------------------------------------------------------------------------
+# _envcommon: AWS Budgets module — shared inputs and notification defaults
+# -----------------------------------------------------------------------------
+# See issue #175 for the full per-account cost-alerts design.
+# -----------------------------------------------------------------------------
+
+locals {
+  module_source = "${get_repo_root()}/project/platform-design/terraform/modules/budgets"
+
+  defaults = {
+    # Currency + budget cadence.
+    currency  = "USD"
+    time_unit = "MONTHLY"
+
+    # Per-account default thresholds (% of forecasted/actual). Per-env units
+    # override the absolute USD limit.
+    notification_thresholds = [50, 80, 100, 110]
+
+    # Notification channels — the SNS topic ARN comes from the env unit
+    # (different topics per environment so prod alerts go to the on-call rotation).
+    notification_types  = ["ACTUAL", "FORECASTED"]
+    comparison_operator = "GREATER_THAN"
+
+    # Default cost types — strip credit/refund to avoid noise.
+    include_credit             = false
+    include_discount           = true
+    include_other_subscription = true
+    include_recurring          = true
+    include_refund             = false
+    include_subscription       = true
+    include_support            = true
+    include_tax                = true
+    include_upfront            = true
+    use_amortized              = false
+    use_blended                = false
+  }
+}
+
+terraform {
+  source = local.module_source
+}
+
+inputs = {
+  currency                   = local.defaults.currency
+  time_unit                  = local.defaults.time_unit
+  notification_thresholds    = local.defaults.notification_thresholds
+  notification_types         = local.defaults.notification_types
+  comparison_operator        = local.defaults.comparison_operator
+  include_credit             = local.defaults.include_credit
+  include_discount           = local.defaults.include_discount
+  include_other_subscription = local.defaults.include_other_subscription
+  include_recurring          = local.defaults.include_recurring
+  include_refund             = local.defaults.include_refund
+  include_subscription       = local.defaults.include_subscription
+  include_support            = local.defaults.include_support
+  include_tax                = local.defaults.include_tax
+  include_upfront            = local.defaults.include_upfront
+  use_amortized              = local.defaults.use_amortized
+  use_blended                = local.defaults.use_blended
+}

--- a/terragrunt/_envcommon/centralized-logging.hcl
+++ b/terragrunt/_envcommon/centralized-logging.hcl
@@ -1,0 +1,52 @@
+# -----------------------------------------------------------------------------
+# _envcommon: Centralized Logging module — shared inputs
+# -----------------------------------------------------------------------------
+# Aggregates org-wide logs (CloudTrail, VPC Flow, EKS audit/authenticator,
+# Config snapshots) into the log-archive account's S3 bucket with KMS
+# encryption and immutability via Object Lock.
+#
+# See issue #178 (EKS audit aggregation) and #182 (org-wide log-archive
+# pattern) for the full design.
+# -----------------------------------------------------------------------------
+
+locals {
+  module_source = "${get_repo_root()}/project/platform-design/terraform/modules/centralized-logging"
+
+  defaults = {
+    # Lifecycle: 90d Standard -> 1yr Glacier -> 7yr expire (matches CloudTrail).
+    lifecycle_standard_days   = 90
+    lifecycle_glacier_days    = 365
+    lifecycle_expiration_days = 2555
+
+    # Object Lock for tamper-proof retention (PCI-DSS Req 10.5).
+    enable_object_lock         = true
+    object_lock_mode           = "GOVERNANCE"
+    object_lock_retention_days = 365
+
+    # Cross-account write permissions — the log-archive bucket is written to
+    # by every member account's CloudTrail / Config / EKS audit pipeline.
+    enable_cross_account_writes = true
+
+    # Replication for DR (writes mirrored to a second region).
+    enable_replication = true
+
+    # SSE-KMS via customer-managed key.
+    use_kms_encryption = true
+  }
+}
+
+terraform {
+  source = local.module_source
+}
+
+inputs = {
+  lifecycle_standard_days     = local.defaults.lifecycle_standard_days
+  lifecycle_glacier_days      = local.defaults.lifecycle_glacier_days
+  lifecycle_expiration_days   = local.defaults.lifecycle_expiration_days
+  enable_object_lock          = local.defaults.enable_object_lock
+  object_lock_mode            = local.defaults.object_lock_mode
+  object_lock_retention_days  = local.defaults.object_lock_retention_days
+  enable_cross_account_writes = local.defaults.enable_cross_account_writes
+  enable_replication          = local.defaults.enable_replication
+  use_kms_encryption          = local.defaults.use_kms_encryption
+}

--- a/terragrunt/_envcommon/eks.hcl
+++ b/terragrunt/_envcommon/eks.hcl
@@ -1,0 +1,79 @@
+# -----------------------------------------------------------------------------
+# _envcommon: EKS module — shared inputs, dependencies, and source pin
+# -----------------------------------------------------------------------------
+# Included from a per-environment unit via:
+#
+#   include "root" {
+#     path = find_in_parent_folders("root.hcl")
+#   }
+#   include "envcommon" {
+#     path           = find_in_parent_folders("_envcommon/eks.hcl")
+#     expose         = true
+#     merge_strategy = "deep"
+#   }
+#
+#   inputs = {
+#     # Per-env overrides (cluster_version, instance types, sizing) go here.
+#   }
+#
+# This file pins the module source and surfaces every input that's the same
+# across environments. Per-env tweaks happen in the unit's own `inputs` block.
+# -----------------------------------------------------------------------------
+
+locals {
+  # Module source (path-based; bumped repo-wide when EKS module changes).
+  module_source = "${get_repo_root()}/project/platform-design/terraform/modules/eks"
+
+  # Cross-cutting defaults — only overwrite when an env truly diverges.
+  defaults = {
+    # Latest supported version (see PROJECT_STATUS.md for the cluster matrix).
+    cluster_version = "1.34"
+
+    # Endpoint posture — flip to false in non-prod with caution.
+    endpoint_private_access = true
+    endpoint_public_access  = false
+
+    # Control-plane logs: audit + authenticator are required for
+    # centralized aggregation (see issue #178).
+    enabled_cluster_log_types = [
+      "api",
+      "audit",
+      "authenticator",
+      "controllerManager",
+      "scheduler",
+    ]
+
+    # Encryption-at-rest for secrets via the env's KMS key.
+    secrets_encryption_enabled = true
+  }
+}
+
+terraform {
+  source = local.module_source
+}
+
+# Common dependency: VPC must exist before EKS. Per-env units extend
+# this with additional dependencies (KMS for secrets, IAM roles, etc.)
+# via `dependency` blocks in their own files (deep merge applies).
+dependency "vpc" {
+  config_path = "../vpc"
+
+  mock_outputs = {
+    vpc_id             = "vpc-mock0123456789abcdef"
+    private_subnet_ids = ["subnet-mock1", "subnet-mock2", "subnet-mock3"]
+    public_subnet_ids  = ["subnet-mockA", "subnet-mockB", "subnet-mockC"]
+  }
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+inputs = {
+  cluster_version            = local.defaults.cluster_version
+  endpoint_private_access    = local.defaults.endpoint_private_access
+  endpoint_public_access     = local.defaults.endpoint_public_access
+  enabled_cluster_log_types  = local.defaults.enabled_cluster_log_types
+  secrets_encryption_enabled = local.defaults.secrets_encryption_enabled
+
+  vpc_id             = dependency.vpc.outputs.vpc_id
+  private_subnet_ids = dependency.vpc.outputs.private_subnet_ids
+}

--- a/terragrunt/_envcommon/kms.hcl
+++ b/terragrunt/_envcommon/kms.hcl
@@ -1,0 +1,43 @@
+# -----------------------------------------------------------------------------
+# _envcommon: KMS module — shared inputs and key inventory
+# -----------------------------------------------------------------------------
+# This unit owns the per-region KMS key inventory. Other units (cloudtrail,
+# aws-config, eks secrets, s3) read from `key_arns["<purpose>"]` via a
+# `dependency "kms"` block.
+# -----------------------------------------------------------------------------
+
+locals {
+  module_source = "${get_repo_root()}/project/platform-design/terraform/modules/kms"
+
+  # Canonical key inventory — extend (don't shrink) when new use-cases land.
+  # Each key gets:
+  #   - its own CMK with rotation enabled
+  #   - a dedicated alias `alias/${env}-<purpose>`
+  defaults = {
+    keys = {
+      cloudtrail  = { description = "CloudTrail org trail encryption" }
+      aws-config  = { description = "AWS Config snapshot encryption" }
+      s3-data     = { description = "S3 data buckets encryption" }
+      eks-secrets = { description = "EKS secrets envelope encryption" }
+      ebs         = { description = "EBS volumes default encryption" }
+      rds         = { description = "RDS storage encryption" }
+      sns         = { description = "SNS topics encryption" }
+      sqs         = { description = "SQS queues encryption" }
+      logs        = { description = "CloudWatch Logs encryption" }
+      backup      = { description = "AWS Backup vault encryption" }
+    }
+
+    enable_key_rotation     = true
+    deletion_window_in_days = 30
+  }
+}
+
+terraform {
+  source = local.module_source
+}
+
+inputs = {
+  keys                    = local.defaults.keys
+  enable_key_rotation     = local.defaults.enable_key_rotation
+  deletion_window_in_days = local.defaults.deletion_window_in_days
+}

--- a/terragrunt/_envcommon/transit-gateway.hcl
+++ b/terragrunt/_envcommon/transit-gateway.hcl
@@ -1,0 +1,50 @@
+# -----------------------------------------------------------------------------
+# _envcommon: Transit Gateway module — shared inputs and source pin
+# -----------------------------------------------------------------------------
+# Lives in the network account. This file fixes TGW defaults; per-region units
+# only specify the region and any spoke-specific overrides.
+#
+# See issue #170 for hub-and-spoke design and #171 for inspection-VPC wiring.
+# -----------------------------------------------------------------------------
+
+locals {
+  module_source = "${get_repo_root()}/project/platform-design/terraform/modules/transit-gateway"
+
+  defaults = {
+    # AS number from RFC 6996 private range; per-region offsets keep BGP
+    # neighbours unique across the 4-region footprint.
+    amazon_side_asn_base = 64512
+
+    # Default route-table modes: explicit propagation/association so that
+    # spoke isolation is the default and exceptions are visible.
+    default_route_table_association = "disable"
+    default_route_table_propagation = "disable"
+
+    # Cross-account sharing via RAM enabled by default — the platform
+    # operates one TGW shared with workload accounts.
+    auto_accept_shared_attachments = "enable"
+
+    # Multicast and DNS support default off; flip per env if needed.
+    multicast_support = "disable"
+    dns_support       = "enable"
+    vpn_ecmp_support  = "enable"
+
+    # Centralized inspection VPC route table topology — see #171.
+    create_inspection_route_table = true
+  }
+}
+
+terraform {
+  source = local.module_source
+}
+
+inputs = {
+  amazon_side_asn_base            = local.defaults.amazon_side_asn_base
+  default_route_table_association = local.defaults.default_route_table_association
+  default_route_table_propagation = local.defaults.default_route_table_propagation
+  auto_accept_shared_attachments  = local.defaults.auto_accept_shared_attachments
+  multicast_support               = local.defaults.multicast_support
+  dns_support                     = local.defaults.dns_support
+  vpn_ecmp_support                = local.defaults.vpn_ecmp_support
+  create_inspection_route_table   = local.defaults.create_inspection_route_table
+}

--- a/terragrunt/_envcommon/vpc.hcl
+++ b/terragrunt/_envcommon/vpc.hcl
@@ -1,0 +1,48 @@
+# -----------------------------------------------------------------------------
+# _envcommon: VPC module — shared inputs and source pin
+# -----------------------------------------------------------------------------
+# Per-env CIDR allocation comes from each env's account.hcl / region.hcl.
+# This file only fixes the contract (subnet layout, NAT posture, flow logs).
+# -----------------------------------------------------------------------------
+
+locals {
+  module_source = "${get_repo_root()}/project/platform-design/terraform/modules/vpc"
+
+  defaults = {
+    # 3-AZ public/private/intra subnet split.
+    enable_public_subnets  = true
+    enable_private_subnets = true
+    enable_intra_subnets   = false
+
+    # NAT posture: per-env override (single-NAT in dev, per-AZ in prod).
+    # Default to single-NAT to keep cost low; envs flip to per-AZ.
+    enable_nat_gateway     = true
+    single_nat_gateway     = true
+    one_nat_gateway_per_az = false
+
+    # Flow logs are non-negotiable — required by org-wide audit baseline.
+    enable_flow_log                         = true
+    flow_log_destination_type               = "cloud-watch-logs"
+    flow_log_max_aggregation_interval       = 60
+    flow_log_traffic_type                   = "ALL"
+    flow_log_cloudwatch_log_group_retention = 90
+  }
+}
+
+terraform {
+  source = local.module_source
+}
+
+inputs = {
+  enable_public_subnets                   = local.defaults.enable_public_subnets
+  enable_private_subnets                  = local.defaults.enable_private_subnets
+  enable_intra_subnets                    = local.defaults.enable_intra_subnets
+  enable_nat_gateway                      = local.defaults.enable_nat_gateway
+  single_nat_gateway                      = local.defaults.single_nat_gateway
+  one_nat_gateway_per_az                  = local.defaults.one_nat_gateway_per_az
+  enable_flow_log                         = local.defaults.enable_flow_log
+  flow_log_destination_type               = local.defaults.flow_log_destination_type
+  flow_log_max_aggregation_interval       = local.defaults.flow_log_max_aggregation_interval
+  flow_log_traffic_type                   = local.defaults.flow_log_traffic_type
+  flow_log_cloudwatch_log_group_retention = local.defaults.flow_log_cloudwatch_log_group_retention
+}

--- a/terragrunt/common.hcl
+++ b/terragrunt/common.hcl
@@ -1,0 +1,41 @@
+# -----------------------------------------------------------------------------
+# Shared locals + tag conventions
+# -----------------------------------------------------------------------------
+# Repo-wide constants surfaced as Terragrunt locals so unit files don't
+# hard-code values. Consumed by `root.hcl` and (optionally) by individual
+# units that need access to project metadata or canonical tag sets.
+#
+# Mirrors qbiq-ai/infra `common.hcl`. Read via:
+#   locals {
+#     common = read_terragrunt_config(find_in_parent_folders("common.hcl"))
+#   }
+# -----------------------------------------------------------------------------
+
+locals {
+  # ---- Project metadata ----
+  project_name = "platform-design"
+  org_name     = "100rd"
+  repository   = "100rd/platform-design"
+
+  # Default cost-allocation owners. Account / unit overrides win.
+  default_owner       = "platform-team"
+  default_cost_center = "platform"
+
+  # ---- Tag schema ----
+  # Tags applied to every AWS resource. Per-unit overrides go through the
+  # `tags` input on the unit (the root merges `tags` from inputs into
+  # provider default_tags).
+  managed_by_tag_value = "terragrunt"
+
+  # Compliance frameworks tracked in tags for resource-level reporting.
+  default_compliance_frameworks = "pci-dss,soc2,iso27001"
+
+  # ---- Region catalog ----
+  # Canonical 4-region EU footprint. Used by region.hcl files for short codes.
+  region_short_codes = {
+    "eu-west-1"    = "euw1"
+    "eu-west-2"    = "euw2"
+    "eu-west-3"    = "euw3"
+    "eu-central-1" = "euc1"
+  }
+}

--- a/terragrunt/root.hcl
+++ b/terragrunt/root.hcl
@@ -9,18 +9,20 @@
 #   }
 #
 # Hierarchy files expected in the directory tree:
-#   account.hcl  - defines account_name, account_id, environment, sizing
-#   region.hcl   - defines aws_region, region_short, azs
+#   account.hcl   - defines account_name, account_id, environment, sizing
+#   region.hcl    - defines aws_region, region_short, azs
+#
+# Sourced helper files (sibling to this file):
+#   versions.hcl  - tool + provider version pins
+#   common.hcl    - shared locals (project metadata, tag conventions, regions)
 # -----------------------------------------------------------------------------
 
-# Exact version pin — eliminates drift between developers and CI.
-# Mirrors infra/versions.hcl: terragrunt_version = "0.99.5"
-terragrunt_version_constraint = "= 0.99.5"
-
 # -----------------------------------------------------------------------------
-# Locals: Read hierarchy config files
+# Sourced configs
 # -----------------------------------------------------------------------------
 locals {
+  versions     = read_terragrunt_config(find_in_parent_folders("versions.hcl"))
+  common       = read_terragrunt_config(find_in_parent_folders("common.hcl"))
   account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
   region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
 
@@ -29,10 +31,19 @@ locals {
   aws_region   = local.region_vars.locals.aws_region
   environment  = local.account_vars.locals.environment
 
-  # Cost allocation and audit tracing tags — read from account.hcl with safe fallbacks
-  owner       = try(local.account_vars.locals.owner, "platform-team")
-  cost_center = try(local.account_vars.locals.cost_center, "platform")
+  # Cost allocation and audit tracing tags — read from account.hcl with
+  # safe fallbacks to common.hcl defaults.
+  owner       = try(local.account_vars.locals.owner, local.common.locals.default_owner)
+  cost_center = try(local.account_vars.locals.cost_center, local.common.locals.default_cost_center)
+
+  # Pinned provider version (single source of truth: versions.hcl).
+  aws_provider_version = local.versions.locals.provider_versions.aws
 }
+
+# -----------------------------------------------------------------------------
+# Terragrunt version pin (single source of truth: versions.hcl)
+# -----------------------------------------------------------------------------
+terragrunt_version_constraint = local.versions.locals.terragrunt_version_constraint
 
 # -----------------------------------------------------------------------------
 # Catalog: local infrastructure catalog
@@ -62,13 +73,13 @@ remote_state {
 
     s3_bucket_tags = {
       Environment = local.environment
-      ManagedBy   = "terragrunt"
+      ManagedBy   = local.common.locals.managed_by_tag_value
       Account     = local.account_name
     }
 
     dynamodb_table_tags = {
       Environment = local.environment
-      ManagedBy   = "terragrunt"
+      ManagedBy   = local.common.locals.managed_by_tag_value
       Account     = local.account_name
     }
   }
@@ -92,14 +103,14 @@ generate "provider" {
       default_tags {
         tags = {
           Environment    = "${local.environment}"
-          ManagedBy      = "terragrunt"
+          ManagedBy      = "${local.common.locals.managed_by_tag_value}"
           Account        = "${local.account_name}"
           Region         = "${local.aws_region}"
           Owner          = "${local.owner}"
           CostCenter     = "${local.cost_center}"
           TerragruntPath = "${path_relative_to_include()}"
-          Repository     = "100rd/platform-design"
-          Project        = "platform-design"
+          Repository     = "${local.common.locals.repository}"
+          Project        = "${local.common.locals.project_name}"
         }
       }
     }
@@ -108,7 +119,7 @@ generate "provider" {
 
 # -----------------------------------------------------------------------------
 # Generate: Terraform and Provider Version Constraints
-# Exact pin: mirrors infra/versions.hcl terraform_version = "1.14.8"
+# Pinned via versions.hcl
 # -----------------------------------------------------------------------------
 generate "versions" {
   path      = "versions_override.tf"
@@ -116,12 +127,12 @@ generate "versions" {
 
   contents = <<-EOF
     terraform {
-      required_version = "= 1.14.8"
+      required_version = "${local.versions.locals.terraform_version_constraint}"
 
       required_providers {
         aws = {
           source  = "hashicorp/aws"
-          version = "~> 6.0"
+          version = "${local.aws_provider_version}"
         }
       }
     }
@@ -149,14 +160,14 @@ inputs = merge(
   {
     tags = {
       Environment    = local.environment
-      ManagedBy      = "terragrunt"
+      ManagedBy      = local.common.locals.managed_by_tag_value
       Account        = local.account_name
       Region         = local.aws_region
       Owner          = local.owner
       CostCenter     = local.cost_center
       TerragruntPath = path_relative_to_include()
-      Repository     = "100rd/platform-design"
-      Project        = "platform-design"
+      Repository     = local.common.locals.repository
+      Project        = local.common.locals.project_name
     }
   }
 )

--- a/terragrunt/versions.hcl
+++ b/terragrunt/versions.hcl
@@ -1,0 +1,41 @@
+# -----------------------------------------------------------------------------
+# Tool & Provider Version Pins
+# -----------------------------------------------------------------------------
+# Single source of truth for pinned versions across the platform-design repo.
+# Mirrors qbiq-ai/infra `versions.hcl`. Consumed by:
+#   - root.hcl   (terraform/terragrunt version constraints + provider blocks)
+#   - CI checks  (matrix versions)
+#   - Tooling    (.terraform-version, .terragrunt-version — see issue #174)
+#
+# Usage from a unit:
+#   include "root" { path = find_in_parent_folders("root.hcl") }
+#   locals {
+#     versions = read_terragrunt_config(find_in_parent_folders("versions.hcl"))
+#   }
+#
+# Bump policy:
+#   - Patch / minor: PR with `chore: bump <tool> to <version>` + green CI on a
+#     non-prod env first.
+#   - Major: ADR required (see docs/decisions/) + multi-env soak.
+# -----------------------------------------------------------------------------
+
+locals {
+  # ---- Tool versions ----
+  terraform_version  = "1.14.8"
+  terragrunt_version = "0.99.5"
+
+  # Pretty constraint forms (consumed by `required_version` and `terragrunt_version_constraint`)
+  terraform_version_constraint  = "= ${local.terraform_version}"
+  terragrunt_version_constraint = "= ${local.terragrunt_version}"
+
+  # ---- Provider versions ----
+  # `~> X.Y` allows patch updates; pin tighter via PR if drift becomes an issue.
+  provider_versions = {
+    aws        = "~> 6.0"
+    helm       = "~> 2.12"
+    kubernetes = "~> 2.30"
+    null       = "~> 3.2"
+    random     = "~> 3.6"
+    tls        = "~> 4.0"
+  }
+}


### PR DESCRIPTION
## Scope — Issue #156

Unifies the Terragrunt root skeleton by porting the canonical `_envcommon/` + `common.hcl` + `versions.hcl` pattern from `qbiq-ai/infra`. Splits the previously consolidated `root.hcl` into three composable files and seeds shared per-module configs.

Closes #156.

## What landed

| File | Purpose |
|---|---|
| `terragrunt/versions.hcl` (new) | Single source of truth for `terraform`, `terragrunt`, and provider version pins. Ports `versions.hcl` from qbiq-ai/infra (terraform 1.14.8, terragrunt 0.99.5, aws ~> 6.0). |
| `terragrunt/common.hcl` (new) | Repo-wide shared locals: project metadata, tag schema, canonical 4-region EU catalog, default cost-allocation owners. |
| `terragrunt/root.hcl` (refactored) | Now reads `versions.hcl` and `common.hcl` via `read_terragrunt_config`. All provider/tag/version literals removed in favour of references. |
| `terragrunt/_envcommon/eks.hcl` (new) | Shared inputs: cluster_version=1.34, audit/authenticator log types enabled, secrets KMS encryption on, VPC dependency declared with mocks. |
| `terragrunt/_envcommon/vpc.hcl` (new) | Shared inputs: 3-AZ public/private subnet split, flow logs forced on (90d retention), NAT posture defaults to single-NAT (per-env override to per-AZ in prod). |
| `terragrunt/_envcommon/kms.hcl` (new) | Shared inputs: 10-key inventory (cloudtrail, aws-config, s3-data, eks-secrets, ebs, rds, sns, sqs, logs, backup), rotation enabled, 30-day deletion window. |
| `terragrunt/_envcommon/transit-gateway.hcl` (new) | Shared inputs: explicit RT association/propagation (default-deny), RAM auto-accept, inspection RT scaffold for #171. |
| `terragrunt/_envcommon/budgets.hcl` (new) | Shared inputs: USD/MONTHLY, [50/80/100/110]% threshold tiers, ACTUAL+FORECASTED notifications. Per-env units supply the SNS topic ARN. |
| `terragrunt/_envcommon/centralized-logging.hcl` (new) | Shared inputs: 90d Standard / 1y Glacier / 7y expire, Object Lock (GOVERNANCE), KMS-SSE, cross-region replication, cross-account writes enabled for log-archive aggregation. |
| `terragrunt/_envcommon/README.md` (new) | Usage guide: how to consume from a unit (`include "envcommon"`), when NOT to use it, bump policy. |
| `terragrunt/README.md` (updated) | Adds the new files to the directory tree, documents the layout decision (#156), disambiguates `terragrunt/<env>/` (TF live tree) from `envs/<env>/` (Helm values overrides for ArgoCD/Kargo). |

## Acceptance criteria mapping

- [x] Single canonical root layout (resolved `terragrunt/` vs `envs/` conflict — they are not parallel layouts; `envs/` is for Helm values, documented inline).
- [x] Root `terragrunt.hcl` (here `root.hcl`), `common.hcl`, `versions.hcl` ported.
- [x] `_envcommon/` directory with shared module configs for the 6 modules called out in the issue (eks, vpc, kms, transit-gateway, budgets, centralized-logging).
- [x] All NEW environments will include from `_envcommon` (no duplicated config). Existing units are not migrated in this PR — that's per-unit, opt-in, backwards-compatible (`root.hcl` continues to be included as before).
- [x] README documents the layout decision.

## Architectural decisions worth flagging

1. **Backwards-compatible refactor, not a migration.** Existing terragrunt units (`_org/_global/cloudtrail`, `_org/_global/aws-config`, etc.) continue to work without modification — they include `root.hcl` exactly the same way, and `root.hcl` now resolves its versions/tags via the new sibling files. Migrating each unit to `_envcommon` is opt-in and best handled in subsequent issues that touch those units anyway.

2. **`envs/` is NOT a parallel Terragrunt layout.** Issue text mentions a "parallel terragrunt/ vs envs/" conflict. The actual `envs/` directory in this repo holds **Helm values overrides** consumed by ArgoCD ApplicationSets and Kargo (`envs/dev/values/infra/cilium.yaml` etc.). It contains zero Terragrunt configs. The README now calls this out explicitly.

3. **`_envcommon` files include the module `source` pin.** Following the qbiq-ai/infra convention, each `_envcommon/<module>.hcl` declares a `terraform { source = ... }` block, so consuming units only need `include "envcommon" { path = ... }` plus their per-env input overrides. This makes module-source bumps a one-file change.

4. **No CIDR / instance-type defaults in `_envcommon`.** Those values diverge per env (single-NAT in dev, per-AZ in prod) and live in each env's `account.hcl`. `_envcommon` only fixes truly cross-env defaults (log-types, lifecycle days, key inventory).

## Cost summary

**Zero.** Config-only change — no Terraform resources are created, modified, or deleted by this PR. The S3 backend buckets and DynamoDB lock tables continue to be created on first `terragrunt init`, exactly as before.

## Security review note

- No IAM resources changed.
- No data plane resources changed.
- No secrets / credentials introduced. `versions.hcl` and `common.hcl` contain only version strings and project metadata.
- The provider `assume_role.role_arn = arn:aws:iam::${account_id}:role/TerragruntDeployRole` block is unchanged.
- New `_envcommon` files declare `mock_outputs` for dev/plan ergonomics; they're the standard mock-output values used elsewhere in the repo.

## Verification

```
$ terragrunt hcl fmt --check terragrunt/
(clean — no output)

$ terragrunt render --json on existing dep-free unit (_org/_global/organization)
inputs.tags shows ManagedBy: "terragrunt" merged from common.hcl ->
confirms common.hcl values flow through root.hcl correctly.
```

No `terraform plan` output for this PR — the change introduces zero AWS resources. CI's `terragrunt-validate` and `hcl-format` checks are the binding gate.

## Rollback plan

Revert this PR. `root.hcl`'s prior inline pins are restored; no state-file impact (config-only). All existing units continue to work.

## Tier 1 dependency note

This is **Tier 1.1** of the platform-design batch — #157 (Control Tower account structure) and #158 (OU split) are blocked on this skeleton landing. Once merged, Tier 2 (13 P1 issues) can fan out in parallel.