### PR TITLE
feat: add 4 missing Control Tower accounts — closes #157

### DIFF
--- a/terragrunt/README.md
+++ b/terragrunt/README.md
@@ -30,8 +30,9 @@ project/platform-design/
 │   │   ├── budgets.hcl
 │   │   ├── centralized-logging.hcl
 │   │   └── README.md
-│   ├── <env>/                            # dev | staging | prod | dr
-│   │   ├── account.hcl                   # AWS account ID, name, environment, sizing defaults
+│   ├── <account>/                        # _org | security | log-archive | network | shared
+│   │   │                                 # | dev | staging | prod | dr | third-party
+│   │   ├── account.hcl                   # AWS account_id, email, org_ou, sizing defaults
 │   │   ├── _global/                      # Account-wide resources (not region-specific)
 │   │   │   └── iam/terragrunt.hcl        # IAM roles, policies, cross-account access
 │   │   └── <region>/                     # eu-west-1 | eu-west-2 | eu-west-3 | eu-central-1
@@ -42,14 +43,32 @@ project/platform-design/
 └── terraform/modules/                    # Custom Terraform modules (referenced by catalog units)
 ```
 
-## Environments
+## Accounts
 
-| Environment | AWS Account  | Purpose                      |
-|-------------|-------------|------------------------------|
-| dev         | 111111111111 | Development and experimentation |
-| staging     | 222222222222 | Pre-production validation    |
-| prod        | 333333333333 | Production workloads         |
-| dr          | 444444444444 | Disaster recovery            |
+The Control Tower landing zone (issue #157) defines nine accounts. Each top-level
+folder under `terragrunt/` corresponds to one AWS account and carries `account.hcl`
++ `eu-west-1/region.hcl`. OU placement is defined in #158.
+
+| Folder         | AWS Account  | OU              | Purpose                                            |
+|----------------|--------------|-----------------|----------------------------------------------------|
+| `_org/`        | 000000000000 | Root            | Organization management account (Control Tower hub) |
+| `security/`    | 777777777777 | Security        | Delegated admin: GuardDuty, SecurityHub, Detective, Inspector, Macie |
+| `log-archive/` | 888888888888 | Security        | Centralized log bucket (CloudTrail, Config, VPC Flow, EKS audit)     |
+| `network/`     | 555555555555 | Infrastructure  | Transit Gateway hub, Route53 resolver, inspection VPC                |
+| `shared/`      | 999999999999 | Infrastructure  | Shared services: ECR, Route53 private zones, ACM authority           |
+| `dev/`         | 111111111111 | Non-Production  | Development workloads                                                |
+| `staging/`     | 222222222222 | Non-Production  | Pre-production validation (canonical name: `stage`)                  |
+| `prod/`        | 333333333333 | Production      | Production workloads                                                 |
+| `dr/`          | 444444444444 | Production      | Disaster recovery for prod                                           |
+| `third-party/` | 121212121212 | Security        | Vendor IAM principals (Datadog, Vanta, Snyk) — narrow cross-org trust |
+
+**Account.hcl shape**: every per-account file declares `account_name`, `account_id`,
+`email`, `org_ou`, `environment`, `owner`, `cost_center`. Sizing knobs (NAT posture,
+EKS node groups, RDS class, etc.) live in workload accounts only.
+
+> Note: this repo originally used `staging/` for pre-prod; Control Tower / source
+> reference call it `stage`. We keep `staging/` for backwards compatibility — it
+> satisfies the `stage` slot in the canonical 9-account structure.
 
 ## Regions
 

--- a/terragrunt/_org/account.hcl
+++ b/terragrunt/_org/account.hcl
@@ -3,6 +3,7 @@ locals {
   account_id     = "000000000000" # TODO: Replace with actual AWS management account ID
   aws_account_id = "000000000000"
   environment    = "management"
+  email          = "aws+management@example.com"
 
   # Cost allocation and audit tracing
   owner       = "platform-team"

--- a/terragrunt/dev/account.hcl
+++ b/terragrunt/dev/account.hcl
@@ -3,6 +3,7 @@ locals {
   account_id     = "111111111111" # TODO: Replace with actual AWS account ID
   aws_account_id = "111111111111" # Alias for reference compatibility
   environment    = "dev"
+  email          = "aws+dev@example.com"
 
   # Cost allocation and audit tracing
   owner       = "platform-team"

--- a/terragrunt/dr/account.hcl
+++ b/terragrunt/dr/account.hcl
@@ -3,6 +3,7 @@ locals {
   account_id     = "444444444444" # TODO: Replace with actual AWS account ID
   aws_account_id = "444444444444" # Alias for reference compatibility
   environment    = "dr"
+  email          = "aws+dr@example.com"
 
   # Cost allocation and audit tracing
   owner       = "platform-team"

--- a/terragrunt/log-archive/account.hcl
+++ b/terragrunt/log-archive/account.hcl
@@ -1,0 +1,28 @@
+locals {
+  account_name   = "log-archive"
+  account_id     = "888888888888" # TODO: Replace with actual AWS log-archive account ID
+  aws_account_id = "888888888888"
+  environment    = "log-archive"
+
+  # Cost allocation and audit tracing
+  owner       = "platform-team"
+  cost_center = "platform-log-archive"
+
+  # Organization context
+  org_account_type   = "log-archive"
+  org_ou             = "Security"
+  management_account = "000000000000"
+
+  email = "aws+log-archive@example.com"
+
+  # Centralized log-archive bucket lives here. Other accounts ship CloudTrail,
+  # Config snapshots, VPC Flow Logs, EKS audit/authenticator (see #178, #182)
+  # to this bucket via cross-account write policies.
+  primary_region = "eu-west-1"
+
+  # Object Lock + KMS + replication enforced via _envcommon/centralized-logging.hcl.
+  log_archive_bucket_name = "platform-log-archive-888888888888-eu-west-1"
+
+  enable_eks = false
+  enable_rds = false
+}

--- a/terragrunt/log-archive/eu-west-1/region.hcl
+++ b/terragrunt/log-archive/eu-west-1/region.hcl
@@ -1,0 +1,5 @@
+locals {
+  aws_region   = "eu-west-1"
+  region_short = "euw1"
+  azs          = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+}

--- a/terragrunt/network/account.hcl
+++ b/terragrunt/network/account.hcl
@@ -3,6 +3,7 @@ locals {
   account_id     = "555555555555" # TODO: Replace with actual AWS network account ID
   aws_account_id = "555555555555"
   environment    = "network"
+  email          = "aws+network@example.com"
 
   # Cost allocation and audit tracing
   owner       = "platform-team"

--- a/terragrunt/prod/account.hcl
+++ b/terragrunt/prod/account.hcl
@@ -3,6 +3,7 @@ locals {
   account_id     = "333333333333" # TODO: Replace with actual AWS account ID
   aws_account_id = "333333333333" # Alias for reference compatibility
   environment    = "prod"
+  email          = "aws+prod@example.com"
 
   # Cost allocation and audit tracing
   owner       = "platform-team"

--- a/terragrunt/security/account.hcl
+++ b/terragrunt/security/account.hcl
@@ -1,0 +1,29 @@
+locals {
+  account_name   = "security"
+  account_id     = "777777777777" # TODO: Replace with actual AWS security account ID
+  aws_account_id = "777777777777"
+  environment    = "security"
+
+  # Cost allocation and audit tracing
+  owner       = "platform-team"
+  cost_center = "platform-security"
+
+  # Organization context
+  org_account_type   = "security"
+  org_ou             = "Security"
+  management_account = "000000000000"
+
+  # Email used at account-vending time. Maps to AWS-account root email.
+  email = "aws+security@example.com"
+
+  # Security tooling delegated-admin in this account:
+  #   - GuardDuty (delegated from management)
+  #   - SecurityHub (delegated from management)
+  #   - Detective, Inspector, Macie (when enabled)
+  # Cross-region aggregation home region:
+  primary_region = "eu-west-1"
+
+  # Sizing — security tooling is light on infra: no EKS, no RDS by default.
+  enable_eks = false
+  enable_rds = false
+}

--- a/terragrunt/security/eu-west-1/region.hcl
+++ b/terragrunt/security/eu-west-1/region.hcl
@@ -1,0 +1,5 @@
+locals {
+  aws_region   = "eu-west-1"
+  region_short = "euw1"
+  azs          = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+}

--- a/terragrunt/shared/account.hcl
+++ b/terragrunt/shared/account.hcl
@@ -1,0 +1,28 @@
+locals {
+  account_name   = "shared"
+  account_id     = "999999999999" # TODO: Replace with actual AWS shared-services account ID
+  aws_account_id = "999999999999"
+  environment    = "shared"
+
+  # Cost allocation and audit tracing
+  owner       = "platform-team"
+  cost_center = "platform-shared"
+
+  # Organization context
+  org_account_type   = "shared-services"
+  org_ou             = "Infrastructure"
+  management_account = "000000000000"
+
+  email = "aws+shared@example.com"
+
+  # Shared services hosted here:
+  #   - ECR registry (replicated to workload regions)
+  #   - Route53 private hosted zones (delegated to spokes via association)
+  #   - ACM certificate central authority (where DNS-01 challenge anchors)
+  #   - Service Catalog portfolios for self-service vending
+  primary_region = "eu-west-1"
+
+  # Lightweight footprint — no EKS, optional small RDS for tooling state.
+  enable_eks = false
+  enable_rds = false
+}

--- a/terragrunt/shared/eu-west-1/region.hcl
+++ b/terragrunt/shared/eu-west-1/region.hcl
@@ -1,0 +1,5 @@
+locals {
+  aws_region   = "eu-west-1"
+  region_short = "euw1"
+  azs          = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+}

--- a/terragrunt/staging/account.hcl
+++ b/terragrunt/staging/account.hcl
@@ -3,6 +3,7 @@ locals {
   account_id     = "222222222222" # TODO: Replace with actual AWS account ID
   aws_account_id = "222222222222" # Alias for reference compatibility
   environment    = "staging"
+  email          = "aws+staging@example.com"
 
   # Cost allocation and audit tracing
   owner       = "platform-team"

--- a/terragrunt/third-party/account.hcl
+++ b/terragrunt/third-party/account.hcl
@@ -1,0 +1,26 @@
+locals {
+  account_name   = "third-party"
+  account_id     = "121212121212" # TODO: Replace with actual AWS third-party-integrations account ID
+  aws_account_id = "121212121212"
+  environment    = "third-party"
+
+  # Cost allocation and audit tracing
+  owner       = "platform-team"
+  cost_center = "platform-third-party"
+
+  # Organization context. Lives in a dedicated OU so SCPs can grant
+  # narrow cross-org trust to vendor IAM principals (Datadog, Vanta,
+  # Snyk, etc.) without polluting workload accounts.
+  org_account_type   = "third-party-integrations"
+  org_ou             = "Security"
+  management_account = "000000000000"
+
+  email = "aws+third-party@example.com"
+
+  primary_region = "eu-west-1"
+
+  # No EKS / RDS — this account holds IAM roles + cross-account audit
+  # exports only.
+  enable_eks = false
+  enable_rds = false
+}

--- a/terragrunt/third-party/eu-west-1/region.hcl
+++ b/terragrunt/third-party/eu-west-1/region.hcl
@@ -1,0 +1,5 @@
+locals {
+  aws_region   = "eu-west-1"
+  region_short = "euw1"
+  azs          = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+}


### PR DESCRIPTION
## Scope — Issue #157

Brings the platform-design account structure to the canonical 9-account Control Tower landing zone shape from `qbiq-ai/infra`.

Closes #157.

## What landed

| Folder | OU | Status | Purpose |
|---|---|---|---|
| `terragrunt/_org/` | Root | pre-existing | Organization management account |
| `terragrunt/security/` | Security | **NEW** | GuardDuty/SecurityHub/Detective/Inspector/Macie delegated admin |
| `terragrunt/log-archive/` | Security | **NEW** | Centralized log bucket (#178, #182 will write here) |
| `terragrunt/network/` | Infrastructure | pre-existing | TGW hub, Route53 resolver, inspection VPC |
| `terragrunt/shared/` | Infrastructure | **NEW** | Shared services (ECR, Route53 PHZs, ACM, Service Catalog) |
| `terragrunt/dev/` | Non-Production | pre-existing | Development workloads |
| `terragrunt/staging/` | Non-Production | pre-existing | Pre-production validation (covers canonical `stage`) |
| `terragrunt/prod/` | Production | pre-existing | Production workloads |
| `terragrunt/dr/` | Production | pre-existing | DR for prod (extra account beyond the canonical 9) |
| `terragrunt/third-party/` | Security | **NEW** | Vendor IAM principals (Datadog, Vanta, Snyk) |

Each new folder ships with:
- `account.hcl` — `account_name`, `account_id`, `email`, `org_ou`, `org_account_type`, `environment`, `owner`, `cost_center`, plus account-class-specific knobs.
- `eu-west-1/region.hcl` — `aws_region`, `region_short`, `azs`.

## Acceptance criteria

- [x] All 9 account folders created (5 pre-existing + 4 new).
- [x] Each has `account.hcl` with `account_id`, `email`, `org_ou`.
- [x] Each has `eu-west-1/region.hcl`.
- [x] Folder layout aligns with Control Tower expectations.

## Architectural decisions

1. **`staging/` covers the canonical `stage` slot.** Source repo names this account `stage`. This repo has been using `staging/` since before the Control Tower refactor, and several already-merged units (`_org/_global/sso`, SCPs, IAM baseline) reference `org_ou = \"NonProd\"` directly with paths under `staging/`. Renaming would force a state migration on those units. The README explicitly documents `staging == stage` for clarity.

2. **`dr/` retained as an extra account.** Not part of the canonical 9 from the source repo, but it pre-existed and is referenced by the SSO permission-set assignments merged in PR #191. Removing it would break those assignments.

3. **Placeholder account IDs.** The new accounts use synthetic 12-digit IDs (777..., 888..., 999..., 121212...) flagged with `# TODO: Replace with actual AWS account ID`. Real IDs land when AFT (#168) is wired and accounts are vended.

4. **`email` field added to all existing `account.hcl` files.** The acceptance criterion calls out `account_id, email, org_ou` per account; the previous batch's accounts had `account_id` and `org_ou` but not `email`. Backfilled with `aws+<env>@example.com` placeholders consistent with what `_org/account.hcl`'s `member_accounts` map already used.

## Cost summary

**Zero.** Config-only — no AWS resources. The new account IDs are placeholders; nothing is provisioned in any of those accounts by this PR.

## Security review note

- No IAM/data-plane changes.
- No secrets / credentials introduced.
- Placeholder account IDs are clearly marked TODO; real IDs land when AFT (#168) vends the accounts.
- The four new accounts deliberately have `enable_eks = false` and `enable_rds = false` defaults — they're not workload accounts.

## Verification

```
$ terragrunt hcl fmt --check terragrunt/
(clean — no output)

$ git diff --stat HEAD~1..HEAD
15 files changed, 166 insertions(+), 10 deletions(-)
```

8 new files (4 × account.hcl + 4 × region.hcl), 6 existing `account.hcl` updates (added `email` field), 1 README update.

## Rollback plan

Revert this PR. The 4 new account folders are deleted; existing accounts revert to not having an `email` field (no functional impact — `email` is consumed only by AFT, which isn't wired yet). No state-file impact.

## Tier 1 dependency note

This is **Tier 1.2**. Tier 1.3 (#158 — OU split) blocks on this; Tier 2 (13 P1 issues) blocks on #158. No tier-2 PRs are opened until #158 lands.