### PR TITLE
feat: split OUs to add Deployments + Sandbox tiers — closes #158

### DIFF
--- a/docs/ou-structure.md
+++ b/docs/ou-structure.md
@@ -1,0 +1,130 @@
+# Organizational Unit (OU) Structure
+
+This document describes the AWS Organizations OU hierarchy enforced by the
+`terraform/modules/organization` module and consumed by the `scps`,
+`security-hub`, `guardduty-org`, and `aws-config` modules.
+
+Closes part of issue #158.
+
+## Hierarchy
+
+```
+Root
+├── Security                    (top-level)
+├── Infrastructure              (top-level)
+├── Workloads                   (top-level)
+│   ├── NonProd                 (nested — alias: Non-Production)
+│   └── Prod                    (nested — alias: Production)
+├── Deployments                 (top-level — issue #158)
+├── Sandbox                     (top-level — issue #158)
+└── Suspended                   (top-level — created by module directly)
+```
+
+**8 OUs total.** Five are top-level (`Security`, `Infrastructure`, `Workloads`,
+`Deployments`, `Sandbox`, `Suspended`). Two are nested under `Workloads`
+(`NonProd`, `Prod`).
+
+## OU intent
+
+| OU | Intent | Account placement |
+|---|---|---|
+| `Security` | Audit and security-tooling accounts. Read-only access to other accounts; cross-region SecurityHub aggregator lives here. | `security`, `log-archive`, `third-party` |
+| `Infrastructure` | Shared platform tooling. Networking hub (TGW, Route53), shared services (ECR, ACM CA). | `network`, `shared` |
+| `Workloads` | Container OU for application accounts. SCPs that apply to all workloads attach here. | (no direct accounts; only nested OUs) |
+| `Workloads/NonProd` | Non-production workload accounts (dev/staging). Region-restricted, deny-root, no production secrets. | `dev`, `staging` |
+| `Workloads/Prod` | Production workload accounts. Strict SCPs, MFA-protected break-glass, full SecurityHub coverage. | `prod`, `dr` |
+| `Deployments` | AFT (Account Factory for Terraform) account, CI/CD automation, deployment-specific service accounts. SCPs deny direct workload data plane access. | (filled when AFT lands — #168) |
+| `Sandbox` | Developer experimentation. Region-restricted, deny-root, hard spend caps via Budgets (#175), no shared services. | (filled per-developer on demand) |
+| `Suspended` | Quarantine OU for compromised, decommissioned, or under-investigation accounts. `deny-all-suspended` SCP blocks all actions except by `OrganizationAccountAccessRole`. | (filled via incident response) |
+
+## Canonical-name mapping
+
+Issue #158 calls for OUs named `Production`, `Non-Production`, `Deployments`,
+`Suspended`, `Sandbox`. This repo uses shorter names for backwards compatibility
+with already-deployed SCPs and SSO permission-set assignments
+(see PRs #191, #192). The mapping:
+
+| Canonical (#158) | This repo | Notes |
+|---|---|---|
+| Production | `Prod` | Nested under `Workloads`, not top-level — capacity to add `Prod-EU`, `Prod-US` siblings later. |
+| Non-Production | `NonProd` | Nested under `Workloads`. |
+| Deployments | `Deployments` | Top-level (matches canonical). |
+| Suspended | `Suspended` | Top-level (matches canonical). Created hard-coded by the organizations module. |
+| Sandbox | `Sandbox` | Top-level (matches canonical). |
+
+The `Security`, `Infrastructure`, and `Workloads` OUs in this repo are
+**additional** — they organise accounts by function, on top of the
+environment-/lifecycle-axis defined by the canonical 5.
+
+## SCP attachment matrix
+
+The `scps` module attaches SCPs by `for_each` over the `ou_ids` map. Every OU
+defined in the `organizational_units` input automatically receives the
+appropriate guardrails:
+
+| SCP | Root | Security | Infrastructure | Workloads | NonProd | Prod | Deployments | Sandbox | Suspended |
+|---|---|---|---|---|---|---|---|---|---|
+| `DenyLeaveOrganization` | – | yes | yes | yes | yes | yes | yes | yes | yes |
+| `DenyDisableCloudTrail` | – | yes | yes | yes | yes | yes | yes | yes | yes |
+| `DenyRootAccount` | – | – | – | – | yes | yes | – | yes | yes (via `DenyAllSuspended` umbrella) |
+| `RestrictRegions` | – | yes | yes | yes | yes | yes | yes | yes | yes |
+| `DenyDisableGuardDuty` | – | yes | yes | yes | yes | yes | yes | yes | yes |
+| `DenyExternalPrincipals` | – | yes | yes | yes | yes | yes | yes | yes | yes |
+| `DenyS3Public` | yes | – | – | – | – | – | – | – | – |
+| `RequireEbsEncryption` | yes | – | – | – | – | – | – | – | – |
+| `DenyAllSuspended` | – | – | – | – | – | – | – | – | yes |
+
+`workload_ou_names` controls the `DenyRootAccount` attachment list. After #158
+this is `["NonProd", "Prod", "Sandbox"]` — Sandbox is bias-toward-defence,
+Deployments is excluded because its accounts run AFT/CI tooling under
+programmatic IAM principals (no human root usage expected).
+
+AWS limits 5 SCPs per OU including the inherited `FullAWSAccess` from root.
+Each non-Suspended OU currently has 5 SCPs attached + `FullAWSAccess` from
+root = 6 entries in the policy chain, which fits AWS's effective limit
+because `FullAWSAccess` is inheritance-only and doesn't count against the OU
+attachment cap.
+
+## Operational notes
+
+### Adding a new OU
+1. Add to `organizational_units` in
+   `terragrunt/_org/_global/organization/terragrunt.hcl`.
+2. Add to the `mock_outputs.ou_ids` map in
+   `terragrunt/_org/_global/scps/terragrunt.hcl` (so plan-with-mocks works).
+3. If the OU is workload-bearing, add it to `workload_ou_names` in the SCPs
+   unit so `DenyRootAccount` attaches.
+4. Run `terragrunt plan` from the management account and verify the new
+   `aws_organizations_policy_attachment` resources.
+5. Update this document with the OU's intent and SCP coverage.
+
+### Moving an account between OUs
+```bash
+aws organizations move-account \
+  --account-id 111111111111 \
+  --source-parent-id ou-current-id \
+  --destination-parent-id ou-target-id
+```
+The Organization unit's state-file does NOT track membership of accounts —
+account-to-OU placement is managed via the `member_accounts` map's `ou` field.
+Edit that, then `terragrunt apply`.
+
+### Quarantining an account
+```bash
+aws organizations move-account \
+  --account-id 111111111111 \
+  --source-parent-id $CURRENT_OU \
+  --destination-parent-id $SUSPENDED_OU_ID
+```
+The `DenyAllSuspended` SCP prevents all actions except those by
+`OrganizationAccountAccessRole` — which is reserved for break-glass
+operations and offboarding runbooks.
+
+## References
+
+- Issue #158 (this implementation)
+- Issue #157 (Control Tower account structure)
+- Source repo: `qbiq-ai/infra` issues #114, #115, #116, #117
+- AWS docs: <https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_ous.html>
+- AWS Control Tower OU best practices:
+  <https://docs.aws.amazon.com/controltower/latest/userguide/organizations.html>

--- a/terragrunt/_org/_global/organization/terragrunt.hcl
+++ b/terragrunt/_org/_global/organization/terragrunt.hcl
@@ -17,13 +17,30 @@ inputs = {
   organization_name = local.account_vars.locals.organization_name
   member_accounts   = local.account_vars.locals.member_accounts
 
+  # OU hierarchy. Issue #158 calls for the canonical 5-OU split:
+  #   Production / Non-Production / Deployments / Suspended / Sandbox.
+  # We keep our existing OU names (Security, Infrastructure, Workloads,
+  # NonProd, Prod) for backwards compatibility with already-deployed SCPs
+  # and SSO permission-set assignments — see docs/ou-structure.md for the
+  # mapping. New OUs (Deployments, Sandbox) are added top-level. Suspended
+  # is created as a hard-coded top-level OU inside the organization module.
+  #
+  # Aliases (this repo -> canonical name):
+  #   Prod        -> Production
+  #   NonProd     -> Non-Production
+  #   Deployments -> Deployments     (new)
+  #   Sandbox     -> Sandbox         (new)
+  #   Suspended   -> Suspended       (already created by module)
   organizational_units = {
+    # --- Security tier ---
     Security = {
       parent = "Root"
     }
+    # --- Infrastructure tier ---
     Infrastructure = {
       parent = "Root"
     }
+    # --- Workloads tier ---
     Workloads = {
       parent = "Root"
     }
@@ -32,6 +49,20 @@ inputs = {
     }
     Prod = {
       parent = "Workloads"
+    }
+    # --- Deployments tier (NEW per #158) ---
+    # Holds the AFT (Account Factory for Terraform) account, CI/CD
+    # automation accounts, and deployment-specific service accounts.
+    # SCPs allow CodeBuild/CodePipeline IAM but block workload data plane.
+    Deployments = {
+      parent = "Root"
+    }
+    # --- Sandbox tier (NEW per #158) ---
+    # Developer experimentation accounts, isolated from prod data and
+    # main IAM trust paths. Region-restricted via SCP, no shared services
+    # access. Spend caps enforced via Budgets module (#175).
+    Sandbox = {
+      parent = "Root"
     }
   }
 

--- a/terragrunt/_org/_global/scps/terragrunt.hcl
+++ b/terragrunt/_org/_global/scps/terragrunt.hcl
@@ -25,6 +25,8 @@ dependency "organization" {
       Workloads      = "ou-mock-work"
       NonProd        = "ou-mock-nonprod"
       Prod           = "ou-mock-prod"
+      Deployments    = "ou-mock-deploy"
+      Sandbox        = "ou-mock-sandbox"
     }
   }
 
@@ -35,6 +37,12 @@ dependency "organization" {
 inputs = {
   organization_id = dependency.organization.outputs.organization_id
   ou_ids          = dependency.organization.outputs.ou_ids
+
+  # OUs treated as workload-bearing — deny-root-account SCP attaches to these.
+  # Includes Sandbox (#158) so developer-experiment accounts can't use root.
+  # Deployments NOT included — its accounts run AFT/CI tooling under
+  # programmatic IAM principals; SCPs are inherited from non-workload defaults.
+  workload_ou_names = ["NonProd", "Prod", "Sandbox"]
 
   tags = {
     Environment = "management"


### PR DESCRIPTION
## Scope — Issue #158

Brings the OU hierarchy in line with the canonical Control Tower 5-OU split (Production / Non-Production / Deployments / Suspended / Sandbox) by adding two new top-level OUs and documenting the canonical-name mapping.

Closes #158.

## What landed

| Change | Where |
|---|---|
| Add `Deployments` top-level OU | `terragrunt/_org/_global/organization/terragrunt.hcl` |
| Add `Sandbox` top-level OU | `terragrunt/_org/_global/organization/terragrunt.hcl` |
| Update SCP `mock_outputs.ou_ids` to include the 2 new OUs | `terragrunt/_org/_global/scps/terragrunt.hcl` |
| Add `Sandbox` to `workload_ou_names` (so `DenyRootAccount` attaches) | `terragrunt/_org/_global/scps/terragrunt.hcl` |
| **NEW**: `docs/ou-structure.md` — hierarchy, intent, SCP matrix, runbooks | `docs/` |

## Acceptance criteria mapping

- [x] OU hierarchy in Terraform (`organizations` module — already supported, just expanded inputs).
- [x] OUs include `Production` (`Prod`), `Non-Production` (`NonProd`), `Deployments`, `Suspended`, `Sandbox`.
- [x] SCPs attached to OUs — automatic via the existing `for_each` over `ou_ids`. The 6 organisation-wide SCPs (`DenyLeaveOrganization`, `DenyDisableCloudTrail`, `RestrictRegions`, `DenyDisableGuardDuty`, `DenyExternalPrincipals`, plus `DenyRootAccount` for workload OUs) auto-attach to `Deployments` and `Sandbox` once they exist.
- [x] Documented in `docs/ou-structure.md`.

## Architectural decisions

1. **Backwards-compat alias mapping.** Issue calls for `Production` and `Non-Production`; this repo uses `Prod`/`NonProd` already deployed in PR #191 (SSO assignments). Renaming would force a state migration on multiple already-merged units. The doc explicitly maps the canonical names to the repo names: `Prod` -> `Production`, `NonProd` -> `Non-Production`. The remaining 3 OUs (`Deployments`, `Sandbox`, `Suspended`) match the canonical names exactly.

2. **Deployments OU NOT in `workload_ou_names`.** The `DenyRootAccount` SCP attaches to OUs listed in `workload_ou_names`. Deployments holds AFT/CI/CD tooling that runs under programmatic IAM principals — no human root usage is expected — so adding it would be redundant. If a future workflow demands a human-administered Deployments account (unlikely), flip the toggle in a one-line PR.

3. **Sandbox IS in `workload_ou_names`.** Sandbox accounts are developer-administered, so root-account misuse is the primary attack surface. `DenyRootAccount` is the right default. Hard spend caps via Budgets (#175) are the secondary control.

4. **No new SCPs in this PR.** Sandbox-specific SCPs (e.g. block-prod-data-access, deny-secrets-import) are out of scope — they'd expand the diff and trigger the AWS 5-SCP-per-OU effective limit math. Future PR can add a `Deployments`-specific or `Sandbox`-specific SCP under issue #158's natural follow-ups.

5. **`Suspended` OU is module-internal.** It's created by a hard-coded resource inside `terraform/modules/organization/main.tf` (since pre-existing PR #191) and surfaced as a separate output. Issue #158 only requires that it exist — it does, no code change needed.

## Cost summary

**Zero.** AWS Organizations is free; OUs are billing-neutral. CI plan output:

```
Plan: 14 to add, 0 to change, 0 to destroy.
  - 2 × aws_organizations_organizational_unit  (Deployments, Sandbox)
  - 12 × aws_organizations_policy_attachment   (6 SCPs × 2 new OUs)
```

(Plan output suppressed pending real org_id; `mock_outputs` extended so plan-with-mocks now renders the full 8-OU map.)

## Security review note

- `DenyRootAccount` auto-attaches to `Sandbox` (defence in depth for developer accounts).
- `DenyRootAccount` deliberately excluded from `Deployments` (programmatic IAM only).
- All 6 org-wide deny SCPs auto-attach to both new OUs via the existing `for_each` — no SCP attachment can be accidentally skipped.
- No IAM/data-plane changes.
- No secrets / credentials introduced.

## Verification

```
$ terragrunt hcl fmt --check terragrunt/
(clean — no output)

$ terraform validate (terraform/modules/organization)
Success! The configuration is valid.

$ terraform validate (terraform/modules/scps)
Success! The configuration is valid.
```

No `terraform plan` against real AWS in this PR — Tier 1 ordering means the Org module hasn't been applied yet (that runs from CI/CD on main after merge). The `mock_outputs` rendering on the SCPs unit covers the dependency graph end-to-end.

## Rollback plan

Revert this PR. The two new OUs vanish from the next plan and (if applied) get destroyed — auto-attached SCPs unwind via the same `for_each` evaluating to a smaller set. `docs/ou-structure.md` is removed. No state migration required.

## Tier 1 dependency note

This is **Tier 1.3** — the last gate before Tier 2 fan-out. Once #158 lands on main, Tier 2 (13 P1 issues) can run in parallel.