### PR TITLE
feat: add .editorconfig and .trivyignore — closes #184

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,45 @@
+# EditorConfig — https://editorconfig.org
+# Repo-wide indentation, charset, EOL conventions. Honoured by most editors
+# (VS Code, JetBrains, Vim with editorconfig-vim, GitHub web).
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 120
+
+# ---- Languages with their own conventions ----
+
+[*.md]
+trim_trailing_whitespace = false
+max_line_length = off
+
+[Makefile]
+indent_style = tab
+
+[*.{go,mod,sum}]
+indent_style = tab
+indent_size = 4
+
+[*.{py}]
+indent_size = 4
+
+[*.{tf,tfvars,hcl}]
+indent_size = 2
+
+[*.{yaml,yml}]
+indent_size = 2
+
+[*.{json,jsonc}]
+indent_size = 2
+
+[*.{sh,bash,zsh}]
+indent_size = 2
+
+[*.{Dockerfile,Dockerfile.*}]
+indent_size = 2

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,17 @@
+# Trivy ignore file — https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/
+# Vulnerabilities and misconfigurations listed here are SUPPRESSED. Use
+# sparingly: every entry should have an inline comment explaining the
+# justification and an expiry date. The CI workflow `.github/workflows/`
+# Trivy steps consume this file.
+#
+# Format:
+#   <CVE-ID or check ID>  # justification (and expiry: YYYY-MM-DD)
+#
+# Categories:
+#   1. False positives — checker mis-fires; document upstream issue link.
+#   2. Accepted risk — risk is real but mitigated by other controls.
+#   3. Pending upstream fix — track CVE; remove once patched version landed.
+#
+# Bias toward NOT adding entries. Prefer fixing the underlying issue.
+
+# (intentionally empty — initial baseline)


### PR DESCRIPTION
## Scope — Issue #184

Adds two repo-root convention files.

Closes #184.

## Files

- `.editorconfig` — repo-wide indent, charset, EOL conventions (space-2 default, tab-4 for Go/Makefile, no-trim for markdown).
- `.trivyignore` — empty baseline with documented format and justification rules for future suppressions.

## Cost / Security
Zero cost. No IAM/data-plane changes. No suppressions added (empty `.trivyignore`).

## Rollback
Revert PR.