### PR TITLE
feat: make Slack notifications conditional — closes #180

### DIFF
--- a/.github/workflows/terragrunt-apply.yml
+++ b/.github/workflows/terragrunt-apply.yml
@@ -36,6 +36,10 @@ permissions:
 env:
   TF_VERSION: "1.14.8"
   TG_VERSION: "0.99.5"
+  # Slack webhook is OPTIONAL. Steps that notify Slack are gated on this
+  # being non-empty so fork PRs and forks of this repo without the secret
+  # don't fail the workflow. Issue #180.
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -140,7 +144,9 @@ jobs:
         run: terragrunt apply -no-color -auto-approve tfplan
 
       - name: Notify Slack on failure
-        if: failure()
+        # Skip Slack notification when webhook secret is not configured
+        # (e.g. forks, scratch repos). Issue #180.
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -167,8 +173,15 @@ jobs:
     needs: apply
     if: success()
     runs-on: ubuntu-latest
+    env:
+      # Re-export here so step-level `if: env.SLACK_WEBHOOK_URL != ''` can
+      # gate the notification — secrets are not directly accessible in `if`.
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
       - name: Notify Slack on success
+        # Skip when webhook secret is not configured (forks, scratch repos).
+        # Issue #180.
+        if: env.SLACK_WEBHOOK_URL != ''
         uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Scope — Issue #180

Gates the two Slack notification steps in `terragrunt-apply.yml` so fork PRs without the `SLACK_WEBHOOK_URL` secret don't fail.

Closes #180.

## Pattern applied

Re-export the secret at env scope so step-level `if:` expressions can read it (secrets are not directly accessible in `if`):

```yaml
env:
  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
...
- name: Notify Slack on failure
  if: failure() && env.SLACK_WEBHOOK_URL != ''
  uses: slackapi/slack-github-action@v2.1.0
```

## Steps gated

- `Notify Slack on failure` (in `apply` job, on `failure()`)
- `Notify Slack on success` (in `notify-success` job)

`terragrunt-apply.yml` is the only workflow that touches Slack today.

## Acceptance criteria
- [x] All Slack-notify steps gated with `if: env.SLACK_WEBHOOK_URL != ''`.
- [x] Fork PRs no longer fail on missing secret.
- [ ] Tested with a fork PR — gating uses the well-known idiom; not exercised from an actual fork in this PR.

## Cost / Security
Zero cost. No secret exposure (env-export only changes step-level visibility for `if` expressions; webhook value still masked in logs).

## Rollback
Revert PR.