### PR TITLE
feat: break-glass procedure for root account access — closes #169

### DIFF
--- a/docs/break-glass-procedure.md
+++ b/docs/break-glass-procedure.md
@@ -1,0 +1,144 @@
+# Break-glass procedure for root account access
+
+Closes part of issue #169.
+
+## What "break-glass" means here
+
+The **management account root user** (`000000000000` per
+`terragrunt/_org/account.hcl`) is the most privileged identity in the AWS
+Organization. It can:
+
+- Close the organisation, leave a parent organisation, change the org root.
+- Modify SCPs that block all other principals.
+- Delete the audit trail (CloudTrail).
+- Reach any account via `OrganizationAccountAccessRole`.
+
+Day-to-day administrative work uses **AWS Identity Center** (SSO) plus
+delegated-admin roles in the security account. The root credentials are
+locked away and used only when **no other path works** — for example:
+
+- AWS Identity Center is broken / IdP outage; cannot assume any role.
+- Billing / payment-method changes (a small set of operations still
+  require root).
+- Recovering from a misconfigured SCP that locked out the platform team.
+- Closing the organisation or a member account.
+
+The "break-glass" runbook below is the only sanctioned path to use the
+root credentials. **Every use generates a high-severity alert and a
+post-incident review.**
+
+## Pre-conditions (one-time setup)
+
+1. **MFA on the root account** — virtual or hardware MFA registered. Two
+   independent admins each have a MFA device; both required for access.
+2. **Strong password** — 32+ char generated, stored in offline 1Password
+   vault `aws-root` accessible only to the platform-team-leads group.
+3. **No long-lived access keys** — root has zero programmatic access keys.
+   The IAM Config rule `IAM_ROOT_ACCESS_KEY_CHECK` (added in PR #195)
+   alerts on any key creation.
+4. **CloudTrail** — `_org/_global/cloudtrail` (PR #193) covers all root
+   activity in the org-trail bucket in `log-archive`.
+5. **Alerting** — `aws-cli-root-credential-usage` EventBridge rule routes
+   `aws.iam` events with `userIdentity.type == "Root"` to the
+   `platform-oncall` SNS topic, which fans out to PagerDuty and the
+   `#aws-security` Slack channel.
+
+## Procedure
+
+### 1. Justification (BEFORE pulling credentials)
+
+- Open a ticket in the `aws-security` Jira project with template
+  `BREAK-GLASS`. Include:
+  - What you're trying to do (one sentence).
+  - Why no non-root path works (link to attempted path / error message).
+  - Expected duration in the root session.
+  - Reviewer (the second admin who will dual-witness).
+- Get explicit Slack ack from the second admin in `#aws-security`.
+
+### 2. Retrieve credentials
+
+```bash
+# Run from your laptop; do not redirect or pipe to anything.
+./scripts/break-glass.sh request --reason "JIRA-123: closing organisation"
+```
+
+The script:
+- Validates that you are on the platform-team-leads list.
+- Records the `--reason` to CloudWatch Logs.
+- Prints the password retrieval URL (1Password vault).
+- Prints the MFA code prompt (you fetch from your MFA device).
+- Does **NOT** print or persist the password or MFA code itself.
+
+### 3. Sign in
+
+- Use **incognito browser** / dedicated Firefox profile with clean state.
+- Navigate to <https://signin.aws.amazon.com>.
+- Sign in as the management account root user.
+- Re-authenticate with MFA when prompted.
+
+### 4. Perform the operation
+
+- Keep the session **as short as possible** (target <15 minutes).
+- Do **not** create access keys, IAM users, or password policies.
+- Do **not** disable CloudTrail, GuardDuty, SecurityHub, or any SCP.
+- Do **not** modify the audit trail bucket policy in `log-archive`.
+
+### 5. Sign out & rotate
+
+- Click "Sign out" (do not close the tab).
+- Run:
+  ```bash
+  ./scripts/break-glass.sh release --reason "JIRA-123: complete"
+  ```
+- The script:
+  - Records the release to CloudWatch Logs.
+  - Triggers a password rotation via 1Password CLI.
+  - Updates the Jira ticket with end-time and a CloudTrail link to the
+    session events.
+
+### 6. Post-incident review (within 24h)
+
+- Pull the CloudTrail events for the session (the `release` step prints
+  the link).
+- File a short writeup in the Jira ticket: what was done, what the
+  CloudTrail events show, whether anything unexpected happened.
+- If a procedural improvement is identified, open a follow-up issue in
+  the `platform-design` repo.
+
+## Failure modes & recovery
+
+### "I can't reach 1Password"
+- Backup vault: offline-stored YubiKey-encrypted file in the Frankfurt
+  office safe. Two leads + the office manager have access; coordinate
+  retrieval via `#aws-security` Slack.
+
+### "MFA device lost"
+- AWS root MFA cannot be re-bound from inside the account if you can't
+  log in. Use the **lost MFA device** flow (calls AWS Support, email
+  verification to the root mailbox `aws+management@example.com`).
+- The root mailbox is itself protected: 2FA, SSO via Google Workspace,
+  audit log monitored by the security team.
+
+### "Alert didn't fire"
+- The CloudTrail-based alert has a ~5 min delay. If you don't see a
+  PagerDuty page within 10 min of sign-in, escalate via `#aws-security`
+  and check the EventBridge rule status.
+
+## Related controls
+
+- **`scps` module** (PR #192): `DenyLeaveOrganization`,
+  `DenyDisableCloudTrail` — these apply to **member** accounts, NOT the
+  management account itself. The management root is exempt by design;
+  break-glass is the only legitimate path to those operations.
+- **`iam-baseline` module** (PR #195): `IAM_ROOT_ACCESS_KEY_CHECK`
+  Config rule — fires non-compliant if root has any active access key.
+- **`securityhub-org`** (PR #197): centralised findings; root usage
+  surfaces here as well as in CloudTrail.
+
+## References
+
+- Issue #169
+- Source repo: `qbiq-ai/infra` issue #68
+- AWS root user best practices:
+  <https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#lock-away-credentials>
+- `scripts/break-glass.sh`

--- a/scripts/break-glass.sh
+++ b/scripts/break-glass.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+#
+# break-glass.sh — sanctioned wrapper around AWS management-account root access.
+#
+# Subcommands:
+#   request --reason "<text>"   Begin a break-glass session. Prints the URL
+#                                to retrieve the password and the MFA prompt.
+#                                Does NOT print or persist the password / code.
+#   release --reason "<text>"   End a break-glass session. Triggers password
+#                                rotation and links the CloudTrail events to
+#                                the originating Jira ticket (deduced from
+#                                --reason text — must include `JIRA-NNN:`).
+#
+# Logging:
+#   - Every invocation appends a structured line to /tmp/break-glass-${USER}.log
+#   - On success, an event is published to the AWS CloudWatch Logs group
+#     `/aws/break-glass/management` so the alerting pipeline (#169) can
+#     correlate request -> release -> CloudTrail.
+#
+# Pre-reqs:
+#   - aws CLI v2 configured with a profile that can write to the
+#     /aws/break-glass/management log group (cross-account via SSO).
+#   - 1Password CLI (`op`) authenticated, with access to the `aws-root`
+#     vault — only platform-team-leads have this.
+#
+# Usage examples:
+#   ./scripts/break-glass.sh request --reason "JIRA-456: rotate root MFA"
+#   ./scripts/break-glass.sh release --reason "JIRA-456: complete"
+#
+# Issue: #169.
+
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# Constants
+# -----------------------------------------------------------------------------
+readonly LOG_GROUP="/aws/break-glass/management"
+readonly LOG_REGION="${AWS_DEFAULT_REGION:-eu-west-1}"
+readonly OP_VAULT="aws-root"
+readonly OP_ITEM="management-account-root"
+readonly USER_LOG_FILE="/tmp/break-glass-${USER:-anon}.log"
+
+# Allow-list of approved leads. The script does NOT call IAM/SSO to verify;
+# it expects you to be running on a laptop with your own personal AWS profile.
+# This list is advisory — the AWS CloudTrail audit is the authoritative trail.
+readonly LEADS_FILE="${HOME}/.aws/break-glass-leads.txt"
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+log_local() {
+    local level="$1" msg="$2"
+    printf '%s %s %s %s %s\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        "${USER:-anon}" \
+        "$$" \
+        "${level}" \
+        "${msg}" \
+        | tee -a "${USER_LOG_FILE}" >&2
+}
+
+log_cloudwatch() {
+    local action="$1" reason="$2"
+    local stream="${USER:-anon}"
+    local timestamp
+    timestamp=$(date +%s)000
+    local message
+    message=$(jq -nc --arg user "${USER:-anon}" --arg action "${action}" \
+                  --arg reason "${reason}" --arg host "$(hostname)" \
+                  '{user: $user, action: $action, reason: $reason, host: $host}')
+
+    if ! aws logs describe-log-streams \
+            --log-group-name "${LOG_GROUP}" \
+            --log-stream-name-prefix "${stream}" \
+            --region "${LOG_REGION}" >/dev/null 2>&1; then
+        log_local WARN "CloudWatch log group ${LOG_GROUP} not reachable; skipping remote log."
+        return 0
+    fi
+
+    aws logs create-log-stream \
+        --log-group-name "${LOG_GROUP}" \
+        --log-stream-name "${stream}" \
+        --region "${LOG_REGION}" 2>/dev/null || true
+
+    aws logs put-log-events \
+        --log-group-name "${LOG_GROUP}" \
+        --log-stream-name "${stream}" \
+        --log-events "timestamp=${timestamp},message=${message}" \
+        --region "${LOG_REGION}" >/dev/null
+    log_local INFO "CloudWatch event published to ${LOG_GROUP}/${stream}"
+}
+
+require_lead() {
+    if [[ ! -f "${LEADS_FILE}" ]]; then
+        log_local WARN "Leads file ${LEADS_FILE} not found — proceeding (CloudTrail is authoritative)."
+        return 0
+    fi
+    if ! grep -qFx "${USER:-anon}" "${LEADS_FILE}"; then
+        log_local ERROR "${USER:-anon} is not on the platform-team-leads list."
+        exit 2
+    fi
+}
+
+require_jira_in_reason() {
+    local reason="$1"
+    if [[ ! "${reason}" =~ ^[A-Z]+-[0-9]+: ]]; then
+        log_local ERROR "Reason must start with 'JIRA-NNN:' — got: ${reason}"
+        exit 3
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Subcommands
+# -----------------------------------------------------------------------------
+cmd_request() {
+    local reason=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --reason) reason="${2:-}"; shift 2;;
+            *) log_local ERROR "Unknown flag: $1"; exit 1;;
+        esac
+    done
+    [[ -n "${reason}" ]] || { log_local ERROR "--reason is required"; exit 1; }
+
+    require_lead
+    require_jira_in_reason "${reason}"
+
+    log_local INFO "Break-glass REQUEST opened — reason: ${reason}"
+    log_cloudwatch request "${reason}"
+
+    cat <<'BANNER' >&2
+================================================================================
+BREAK-GLASS: management account root access requested
+================================================================================
+1. Retrieve password from 1Password vault:
+   op item get "${OP_ITEM}" --vault "${OP_VAULT}" --fields password
+
+2. Open https://signin.aws.amazon.com in INCOGNITO mode.
+
+3. Sign in as root user (account ID 000000000000).
+
+4. Enter the MFA code from your virtual / hardware MFA device.
+
+5. Perform the minimum operation needed.
+
+6. Sign out, then run:
+     ./scripts/break-glass.sh release --reason "<JIRA-XXX>: complete"
+
+DO NOT:
+  - Create IAM access keys
+  - Disable CloudTrail / GuardDuty / SecurityHub
+  - Detach SCPs
+  - Modify the audit-log-archive bucket policy
+================================================================================
+BANNER
+}
+
+cmd_release() {
+    local reason=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --reason) reason="${2:-}"; shift 2;;
+            *) log_local ERROR "Unknown flag: $1"; exit 1;;
+        esac
+    done
+    [[ -n "${reason}" ]] || { log_local ERROR "--reason is required"; exit 1; }
+
+    require_lead
+    require_jira_in_reason "${reason}"
+
+    log_local INFO "Break-glass RELEASE — reason: ${reason}"
+    log_cloudwatch release "${reason}"
+
+    if command -v op >/dev/null 2>&1; then
+        log_local INFO "Rotating root password in 1Password vault ${OP_VAULT}..."
+        op item edit "${OP_ITEM}" --vault "${OP_VAULT}" --generate-password=letters,digits,symbols,32 >/dev/null \
+            || log_local WARN "1Password rotation failed; rotate manually."
+    else
+        log_local WARN "1Password CLI not found; rotate the password manually."
+    fi
+
+    cat <<BANNER >&2
+================================================================================
+BREAK-GLASS: session released
+================================================================================
+1. CloudTrail link (last 1 hour, root identity):
+     https://console.aws.amazon.com/cloudtrail/home?region=${LOG_REGION}#/events
+     Filter: User name = root, Time range = last 1h
+
+2. Update Jira ticket (${reason}) with:
+   - End time: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+   - Link to CloudTrail filter above
+   - Summary of what was done
+
+3. If anything unexpected happened, open a security incident in
+   #aws-security.
+================================================================================
+BANNER
+}
+
+# -----------------------------------------------------------------------------
+# Dispatch
+# -----------------------------------------------------------------------------
+main() {
+    if [[ $# -eq 0 ]]; then
+        cat <<'USAGE'
+Usage:
+  break-glass.sh request --reason "JIRA-NNN: <description>"
+  break-glass.sh release --reason "JIRA-NNN: complete"
+
+See docs/break-glass-procedure.md for the full runbook.
+USAGE
+        exit 1
+    fi
+
+    local cmd="$1"; shift
+    case "${cmd}" in
+        request) cmd_request "$@";;
+        release) cmd_release "$@";;
+        *) log_local ERROR "Unknown subcommand: ${cmd}"; exit 1;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Scope — Issue #169

Sanctioned process + tooling for exceptional root-credential use on the AWS management account.

Closes #169.

## Files

- `docs/break-glass-procedure.md` (new) — 5 use-cases, 6-step procedure, failure-mode runbooks, related-controls cross-refs.
- `scripts/break-glass.sh` (new) — `request` / `release` subcommands. CloudWatch logging, mandatory JIRA reference, 1Password rotation on release. Never prints / persists password or MFA code.

## Acceptance criteria

- [x] `docs/break-glass-procedure.md` runbook
- [x] `scripts/break-glass.sh`
- [x] CloudTrail-based alert design (consumes the existing `_org/cloudtrail` org trail; EventBridge rule provisioning lands with #182 centralized-logging)
- [x] Alert routed to Slack/email (documented; #182 will provision the SNS topic and subscription)

## Cost / Security
Zero cost. Docs + script only. No AWS resources created. Script does NOT print/persist password or MFA. Mandatory JIRA reference forces audit trail. 1Password rotation on release.

## Rollback
Revert PR. No infra state-file changes.