### PR TITLE
feat: add github-branch-protection module — closes #177

### DIFF
--- a/terraform/modules/github-branch-protection/README.md
+++ b/terraform/modules/github-branch-protection/README.md
@@ -1,0 +1,80 @@
+# Module: `github-branch-protection`
+
+GitHub branch-protection rule managed as Terraform. One rule per repo /
+branch-pattern. Closes #177.
+
+## Why IaC for this
+
+Branch protection rules are a critical control plane: they decide who can
+push to `main`, what checks must pass, whether admins can bypass, etc. A
+console-clicked rule is invisible to the audit trail and easy to drift
+silently (someone disables a check during a hotfix and forgets). IaC
+makes the rule reviewable, diff-able, and atomic-rollback-able.
+
+## Inputs
+
+The full list lives in `variables.tf`. Defaults are tuned for a
+canonical "protect main on a CI-first repo":
+
+- `enforce_admins = true` — admins can't bypass.
+- `allows_deletions = false`, `allows_force_pushes = false`.
+- `require_conversation_resolution = true`.
+- `dismiss_stale_reviews = true`, `required_approving_review_count = 1`.
+- `strict_status_checks = true` (branch must be up-to-date).
+- `bypass_pull_request_actor_ids = []` (no bypassers).
+- `push_restrictions_actor_ids = []` (no direct pushes for anyone).
+
+The most-tweaked input is `required_status_checks` — list the workflow
+job names that must pass.
+
+## Bypass list management
+
+Each entry in `bypass_pull_request_actor_ids` and
+`push_restrictions_actor_ids` is a GitHub **node ID** (base64-ish string
+like `MDQ6VXNlcjEyMzQ1`), not a login. Lookup tools:
+
+```bash
+# User node ID
+gh api graphql -f query='query{user(login:"<login>"){id}}'
+# Team node ID
+gh api graphql -f query='query{organization(login:"<org>"){team(slug:"<team>"){id}}}'
+```
+
+Document EVERY entry inline in the consuming Terragrunt unit's input map
+— bypass is a security-sensitive privilege.
+
+## Provider
+
+The module declares `integrations/github ~> 6.0`. The provider's `owner`
+is configured at the provider level (in the consuming root or via
+`GITHUB_TOKEN` / `GITHUB_OWNER` env vars).
+
+## Required status checks for this repo
+
+Standard set for `100rd/platform-design::main`:
+
+```hcl
+required_status_checks = [
+  "HCL Format Check",
+  "Validate Catalog Units",
+  "Detect Terragrunt roots",
+  "Detect changed modules",
+  "gitleaks",
+  "kubeconform",
+  "OPA Policy Status",
+  "Plan Status",
+]
+```
+
+Per-PR matrix checks (`OPA <module>`, `Plan <module>`) are excluded
+because their names vary by changed-module set; the umbrella `OPA Policy
+Status` and `Plan Status` jobs aggregate the matrix into a stable name.
+
+## Cost
+
+Zero — GitHub branch protection is free.
+
+## Rollback
+
+`terraform destroy` against the consuming unit removes the rule, returning
+the branch to "no protection".

--- a/terraform/modules/github-branch-protection/main.tf
+++ b/terraform/modules/github-branch-protection/main.tf
@@ -1,0 +1,61 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GitHub Branch Protection
+# ---------------------------------------------------------------------------------------------------------------------
+# Manages a single branch-protection rule for a single repository / branch
+# pattern. Designed to be invoked per-repo from a Terragrunt unit so each
+# repo gets its own state and bypass list. Issue #177.
+#
+# Permissions required on the GitHub PAT / app token used by the provider:
+#   - Repo Admin (or org-level Admin)
+#   - For org-level apps: 'Branch protection rules' read+write.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "github_branch_protection" "this" {
+  repository_id = var.repository
+  pattern       = var.branch_pattern
+
+  enforce_admins   = var.enforce_admins
+  allows_deletions = var.allows_deletions
+  # Force-pushes are blocked when allows_force_pushes = false; the field
+  # name is somewhat counter-intuitive, but matches the API.
+  allows_force_pushes             = var.allows_force_pushes
+  require_conversation_resolution = var.require_conversation_resolution
+  require_signed_commits          = var.require_signed_commits
+  lock_branch                     = var.lock_branch
+
+  # Required status checks block — only included when at least one check
+  # is listed (empty list disables the gate cleanly).
+  dynamic "required_status_checks" {
+    for_each = length(var.required_status_checks) > 0 ? [1] : []
+    content {
+      strict   = var.strict_status_checks
+      contexts = var.required_status_checks
+    }
+  }
+
+  # Required PR review block — only included when at least one approval
+  # is required (count = 0 disables reviews).
+  dynamic "required_pull_request_reviews" {
+    for_each = var.required_approving_review_count > 0 ? [1] : []
+    content {
+      required_approving_review_count = var.required_approving_review_count
+      dismiss_stale_reviews           = var.dismiss_stale_reviews
+      require_code_owner_reviews      = var.require_code_owner_reviews
+      require_last_push_approval      = var.require_last_push_approval
+
+      # Bypass list — empty by default. Add Dependabot or platform-team
+      # actor IDs as needed; each entry is a node ID (not a login).
+      pull_request_bypassers = var.bypass_pull_request_actor_ids
+    }
+  }
+
+  # Push restrictions — empty list disables direct pushes for everyone
+  # (only the merge UI / merge_pull_request mutation can land changes).
+  dynamic "restrict_pushes" {
+    for_each = length(var.push_restrictions_actor_ids) > 0 ? [1] : []
+    content {
+      blocks_creations = var.restrict_pushes_blocks_creations
+      push_allowances  = var.push_restrictions_actor_ids
+    }
+  }
+}

--- a/terraform/modules/github-branch-protection/outputs.tf
+++ b/terraform/modules/github-branch-protection/outputs.tf
@@ -1,0 +1,14 @@
+output "branch_protection_id" {
+  description = "GitHub node ID of the branch protection rule."
+  value       = github_branch_protection.this.id
+}
+
+output "repository" {
+  description = "Repository the rule applies to."
+  value       = var.repository
+}
+
+output "branch_pattern" {
+  description = "Branch pattern the rule protects."
+  value       = var.branch_pattern
+}

--- a/terraform/modules/github-branch-protection/variables.tf
+++ b/terraform/modules/github-branch-protection/variables.tf
@@ -1,0 +1,104 @@
+variable "repository" {
+  description = "Repository name (without owner). The provider's `owner` is configured at the provider level."
+  type        = string
+}
+
+variable "branch_pattern" {
+  description = "Branch name or pattern (regex) to protect. Default 'main' protects the canonical default branch."
+  type        = string
+  default     = "main"
+}
+
+variable "required_status_checks" {
+  description = "Required status check names (workflow job names). Empty list disables the required-checks gate. Strict (require branch up-to-date) is configurable separately."
+  type        = list(string)
+  default     = []
+}
+
+variable "strict_status_checks" {
+  description = "Require branch to be up-to-date with base before merging. Recommended for monorepos to keep plans deterministic."
+  type        = bool
+  default     = true
+}
+
+variable "required_approving_review_count" {
+  description = "Number of approving reviews required to merge. 0 disables required reviews; 1 is the typical baseline; 2 for prod-affecting branches."
+  type        = number
+  default     = 1
+  validation {
+    condition     = var.required_approving_review_count >= 0 && var.required_approving_review_count <= 6
+    error_message = "GitHub allows 0-6 required approving reviews."
+  }
+}
+
+variable "dismiss_stale_reviews" {
+  description = "Dismiss stale approvals when new commits are pushed. Strongly recommended."
+  type        = bool
+  default     = true
+}
+
+variable "require_code_owner_reviews" {
+  description = "Require review from CODEOWNERS for paths that match. Requires a CODEOWNERS file in the repo."
+  type        = bool
+  default     = false
+}
+
+variable "require_last_push_approval" {
+  description = "Require an explicit approval AFTER the most recent push (the 'last-push approval' control)."
+  type        = bool
+  default     = false
+}
+
+variable "enforce_admins" {
+  description = "Apply branch protection to admins (admins cannot bypass). Recommended on for prod repos."
+  type        = bool
+  default     = true
+}
+
+variable "allows_deletions" {
+  description = "Allow the protected branch to be deleted. Should be false for main."
+  type        = bool
+  default     = false
+}
+
+variable "allows_force_pushes" {
+  description = "Allow force-pushes. Should be false for main."
+  type        = bool
+  default     = false
+}
+
+variable "require_conversation_resolution" {
+  description = "Require all conversations on the PR to be resolved before merge."
+  type        = bool
+  default     = true
+}
+
+variable "require_signed_commits" {
+  description = "Require signed commits. Recommended on for compliance-sensitive repos but disabled by default to ease developer onboarding."
+  type        = bool
+  default     = false
+}
+
+variable "lock_branch" {
+  description = "Lock the branch (read-only). Use only for archived branches."
+  type        = bool
+  default     = false
+}
+
+variable "bypass_pull_request_actor_ids" {
+  description = "Node IDs of users / teams / apps allowed to bypass the pull-request requirement (e.g., Dependabot). Use sparingly and document each entry."
+  type        = list(string)
+  default     = []
+}
+
+variable "push_restrictions_actor_ids" {
+  description = "Node IDs of users / teams allowed to push directly to the branch. Empty list disables direct pushes for everyone."
+  type        = list(string)
+  default     = []
+}
+
+variable "restrict_pushes_blocks_creations" {
+  description = "If push_restrictions are set, also block branch CREATIONS by non-listed actors."
+  type        = bool
+  default     = true
+}

--- a/terraform/modules/github-branch-protection/versions.tf
+++ b/terraform/modules/github-branch-protection/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## Scope — Issue #177

GitHub branch protection managed as a Terraform module. One rule per repo / branch-pattern. Closes #177.

## Files
- `terraform/modules/github-branch-protection/{versions,variables,main,outputs,README}.tf`
- 16 inputs covering required-checks, review counts, stale-dismissal, CODEOWNERS, last-push approval, enforce-admins, deletions/force-push lockdown, conversation-resolution, signed commits, branch lock, bypass and push-restriction actor lists.
- Dynamic blocks gate optional features so disabling each is a clean no-op.

## Default posture
Industry-baseline "protect main on a CI-first repo": `enforce_admins=true`, no force-pushes, no deletions, conversation resolution required, 1 approving review, dismiss stale reviews on push, strict status checks.

## Acceptance criteria
- [x] `modules/github-branch-protection` module
- [x] Required status checks defined (set documented in README)
- [x] Required reviews count defined (validated 0-6)
- [ ] Applied to main branch of relevant repos — deferred to a follow-up. Needs a GitHub provider config (token + owner) which is separate from the AWS provider in `root.hcl`. Recommendation: land alongside #173 so GitHub token storage is decided once.
- [x] Bypass list documented (README section with node-ID lookup commands)

## Cost / Security
Zero cost. No secrets in code. Token comes from consumer environment (`GITHUB_TOKEN` or explicit provider block).

## Rollback
Revert PR. Module is unused (no consumer); deletion is side-effect-free.