### PR TITLE
feat: TGW hub-and-spoke + RAM share + dev spoke — closes #170

### DIFF
--- a/terraform/modules/transit-gateway/README.md
+++ b/terraform/modules/transit-gateway/README.md
@@ -1,0 +1,66 @@
+# Module: `transit-gateway`
+
+Hub-and-spoke Transit Gateway for the network account. Creates the TGW,
+segmented route tables (prod / nonprod / shared / optional inspection),
+optional blackhole isolation routes, and an optional RAM share to spread
+TGW use to workload accounts.
+
+Closes part of issue #170.
+
+## Resources
+
+| Resource | When created |
+|---|---|
+| `aws_ec2_transit_gateway.this` | always |
+| `aws_ec2_transit_gateway_route_table.this[*]` | per entry in `var.route_tables` (default: prod, nonprod, shared) |
+| `aws_ec2_transit_gateway_route.blackhole_cross_env[*]` | per entry in `var.blackhole_cidrs` |
+| `aws_ram_resource_share.tgw[0]` | when `length(var.ram_principals) > 0` |
+| `aws_ram_resource_association.tgw[0]` | when share exists — associates TGW ARN |
+| `aws_ram_principal_association.tgw[*]` | one per principal in `var.ram_principals` |
+
+## Inputs (most-used)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `name` | (required) | Prefix for resource names. Use `<account>-<region>`. |
+| `amazon_side_asn` | `64512` | RFC-6996 private ASN for BGP. Use a per-region offset for multi-region. |
+| `route_tables` | `{prod, nonprod, shared}` | Map of route-table-name -> empty object. Add `inspection` when #171 lands. |
+| `blackhole_cidrs` | `{}` | Map of route-table-name -> CIDR for explicit isolation. |
+| `ram_principals` | `[]` | List of account IDs or OU/Org ARNs to RAM-share the TGW with. Empty disables sharing. |
+
+## Default posture
+
+- `default_route_table_association = "disable"` and
+  `default_route_table_propagation = "disable"` — every attachment
+  picks its RT explicitly. No leakage.
+- `auto_accept_shared_attachments = "enable"` — workload accounts can
+  create attachments without round-tripping through the network team.
+- `multicast_support` off by default; flip on per-region if needed.
+- `vpn_ecmp_support = "enable"` for HA VPN.
+- `dns_support = "enable"` so cross-account Route53 resolution works.
+
+## Spoke attachment pattern
+
+Workload accounts use the sibling `tgw-attachment` module. Example unit
+at `terragrunt/dev/eu-west-1/tgw-attachment/terragrunt.hcl` reads the
+TGW ID + route-table ID from this unit's outputs, attaches the local
+VPC, and adds a `/8` route in the VPC's private subnets pointing back
+at the TGW.
+
+## Outputs
+
+- `transit_gateway_id`, `transit_gateway_arn`, `transit_gateway_owner_id`
+- `route_table_ids` — map keyed by RT name
+- `ram_resource_share_arn` — `null` when `ram_principals` is empty
+
+## Cost
+
+Transit Gateway: \$0.05/attachment-hour + \$0.02/GB processed. With 4
+spoke VPCs attached at all hours = ~\$144/month attachment cost; data
+processing scales with traffic.
+
+## Rollback
+
+`terraform destroy` against the consuming unit. Order: destroy spoke
+attachments first (otherwise TGW won't release), then the TGW unit.
+The RAM share unwinds with the TGW.

--- a/terraform/modules/transit-gateway/main.tf
+++ b/terraform/modules/transit-gateway/main.tf
@@ -47,3 +47,35 @@ resource "aws_ec2_transit_gateway_route" "blackhole_cross_env" {
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.this[each.key].id
   blackhole                      = true
 }
+
+# ---------------------------------------------------------------------------------------------------------------------
+# RAM Share — share the TGW with workload accounts so they can attach VPCs.
+# ---------------------------------------------------------------------------------------------------------------------
+# Issue #170. The share is created only when at least one principal is supplied.
+# Account-level principals (12-digit account IDs) and OU/Org ARNs are both
+# accepted as RAM principals — the consuming Terragrunt unit decides which.
+
+resource "aws_ram_resource_share" "tgw" {
+  count = length(var.ram_principals) > 0 ? 1 : 0
+
+  name                      = "${var.name}-tgw-share"
+  allow_external_principals = false # Stay within the org. Flip to true only for vendor / cross-org integrations.
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-tgw-share"
+  })
+}
+
+resource "aws_ram_resource_association" "tgw" {
+  count = length(var.ram_principals) > 0 ? 1 : 0
+
+  resource_arn       = aws_ec2_transit_gateway.this.arn
+  resource_share_arn = aws_ram_resource_share.tgw[0].arn
+}
+
+resource "aws_ram_principal_association" "tgw" {
+  for_each = toset(var.ram_principals)
+
+  principal          = each.value
+  resource_share_arn = aws_ram_resource_share.tgw[0].arn
+}

--- a/terraform/modules/transit-gateway/outputs.tf
+++ b/terraform/modules/transit-gateway/outputs.tf
@@ -17,3 +17,8 @@ output "transit_gateway_owner_id" {
   description = "The AWS account ID of the TGW owner"
   value       = aws_ec2_transit_gateway.this.owner_id
 }
+
+output "ram_resource_share_arn" {
+  description = "ARN of the RAM resource share created for cross-account TGW access (null when ram_principals is empty)."
+  value       = length(aws_ram_resource_share.tgw) > 0 ? aws_ram_resource_share.tgw[0].arn : null
+}

--- a/terraform/modules/transit-gateway/variables.tf
+++ b/terraform/modules/transit-gateway/variables.tf
@@ -31,6 +31,12 @@ variable "blackhole_cidrs" {
   default     = {}
 }
 
+variable "ram_principals" {
+  description = "List of AWS RAM principals to share the TGW with — accept either 12-digit account IDs or OU / Organization ARNs (e.g. 'arn:aws:organizations::000000000000:ou/o-xxx/ou-xxx'). Empty list disables the RAM share entirely. Issue #170."
+  type        = list(string)
+  default     = []
+}
+
 variable "tags" {
   description = "Tags to apply to resources"
   type        = map(string)

--- a/terragrunt/dev/eu-west-1/tgw-attachment/terragrunt.hcl
+++ b/terragrunt/dev/eu-west-1/tgw-attachment/terragrunt.hcl
@@ -1,0 +1,79 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Transit Gateway VPC Attachment — Dev Account, eu-west-1
+# ---------------------------------------------------------------------------------------------------------------------
+# Attaches the dev VPC to the network-account TGW (shared via RAM by
+# `terragrunt/network/eu-west-1/transit-gateway`).  Associates with the
+# `nonprod` route table for env isolation.
+#
+# Issue #170 acceptance criterion: "at least one spoke attached and validated."
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/tgw-attachment"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  account_name = local.account_vars.locals.account_name
+  aws_region   = local.region_vars.locals.aws_region
+  environment  = local.account_vars.locals.environment
+}
+
+# Pull the TGW ID + nonprod route-table ID from the network-account unit.
+# Cross-account state-read works because the network account's state
+# bucket (tfstate-network-eu-west-1) is read-only-shared with workload
+# accounts via the bucket policy provisioned in #160.
+dependency "tgw" {
+  config_path = "../../../network/eu-west-1/transit-gateway"
+
+  mock_outputs = {
+    transit_gateway_id = "tgw-mock0123456789abcdef"
+    route_table_ids = {
+      prod    = "tgw-rtb-mock-prod"
+      nonprod = "tgw-rtb-mock-nonprod"
+      shared  = "tgw-rtb-mock-shared"
+    }
+  }
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+# Pull the local VPC ID + private subnet IDs from the platform stack's
+# VPC unit. Lives at terragrunt/dev/eu-west-1/platform/vpc by convention.
+dependency "vpc" {
+  config_path = "../platform/vpc"
+
+  mock_outputs = {
+    vpc_id             = "vpc-mock0123456789abcdef"
+    private_subnet_ids = ["subnet-mock1", "subnet-mock2", "subnet-mock3"]
+    private_route_table_ids = {
+      "private-1" = "rtb-mock1"
+      "private-2" = "rtb-mock2"
+      "private-3" = "rtb-mock3"
+    }
+  }
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+inputs = {
+  name               = "${local.account_name}-${local.aws_region}"
+  enabled            = local.account_vars.locals.enable_tgw_attachment
+  transit_gateway_id = dependency.tgw.outputs.transit_gateway_id
+  vpc_id             = dependency.vpc.outputs.vpc_id
+  subnet_ids         = dependency.vpc.outputs.private_subnet_ids
+  # Dev attaches to the nonprod RT.
+  route_table_id      = dependency.tgw.outputs.route_table_ids["nonprod"]
+  vpc_route_table_ids = dependency.vpc.outputs.private_route_table_ids
+  # /8 covers the entire RFC-1918 internal range; spokes still need
+  # specific routes to reach each other (set in the TGW route tables).
+  tgw_destination_cidr = "10.0.0.0/8"
+
+  tags = {
+    Environment = local.environment
+    ManagedBy   = "terragrunt"
+    Component   = "tgw-attachment"
+  }
+}

--- a/terragrunt/network/eu-west-1/transit-gateway/terragrunt.hcl
+++ b/terragrunt/network/eu-west-1/transit-gateway/terragrunt.hcl
@@ -1,0 +1,63 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Transit Gateway — Network Account, eu-west-1
+# ---------------------------------------------------------------------------------------------------------------------
+# Hub for inter-VPC and inter-account connectivity. RAM-shares to all
+# workload accounts so they can attach VPCs from their own units.
+#
+# Issue #170. Composes with #171 (inspection VPC) — that issue adds an
+# 'inspection' route table.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/transit-gateway"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  account_name = local.account_vars.locals.account_name
+  aws_region   = local.region_vars.locals.aws_region
+  environment  = local.account_vars.locals.environment
+}
+
+inputs = {
+  name = "${local.account_name}-${local.aws_region}"
+
+  amazon_side_asn = 64512
+
+  # Three segmented route tables enforce env isolation:
+  #   prod    — only Prod VPCs attach here. Default propagation off.
+  #   nonprod — Dev + Staging VPCs attach here.
+  #   shared  — Shared services (ECR, Route53 PHZs) and the inspection VPC.
+  # Cross-env reachability requires explicit per-CIDR routes from one RT
+  # back to another; default is no leakage.
+  route_tables = {
+    prod    = {}
+    nonprod = {}
+    shared  = {}
+  }
+
+  # Blackhole CIDRs prevent accidental traffic flow across env boundaries
+  # even if a route is ever added by mistake.
+  blackhole_cidrs = {}
+
+  # RAM share to every workload + shared-services account. Member
+  # account IDs come from _org/account.hcl member_accounts; we list
+  # them inline here for explicitness and easier auditability.
+  ram_principals = [
+    "111111111111", # dev
+    "222222222222", # staging
+    "333333333333", # prod
+    "444444444444", # dr
+    "777777777777", # security
+    "888888888888", # log-archive
+    "999999999999", # shared
+  ]
+
+  tags = {
+    Environment = local.environment
+    ManagedBy   = "terragrunt"
+    Component   = "transit-gateway"
+  }
+}


### PR DESCRIPTION
## Scope — Issue #170

Closes the remaining acceptance criteria for hub-and-spoke TGW: RAM share, live network-account unit, validated dev spoke.

Closes #170.

## What landed

### Module changes
- `terraform/modules/transit-gateway/main.tf` — adds 3 RAM resources gated on non-empty `ram_principals`: `aws_ram_resource_share` (org-internal only), `aws_ram_resource_association`, per-principal `aws_ram_principal_association`.
- `terraform/modules/transit-gateway/variables.tf` — new `ram_principals` input.
- `terraform/modules/transit-gateway/outputs.tf` — new `ram_resource_share_arn` output (null when share disabled).
- `terraform/modules/transit-gateway/README.md` — full module doc.

### Live units
- `terragrunt/network/eu-west-1/transit-gateway/terragrunt.hcl` (new) — TGW + 3 route tables + RAM share to 7 accounts.
- `terragrunt/dev/eu-west-1/tgw-attachment/terragrunt.hcl` (new) — first spoke. Cross-account state read pulls TGW ID; associates with `nonprod` RT; /8 route in private subnets.

## Acceptance criteria
- [x] `modules/transit-gateway` (pre-existing + RAM share added + README)
- [x] `modules/tgw-attachment` (pre-existing)
- [x] Route tables segmented (prod, nonprod, shared)
- [x] **RAM share to other accounts** — 3 RAM resources, 7 principals
- [x] **At least one spoke attached and validated** — dev/eu-west-1

## Cost
~\$36/month per always-on attachment (\$0.05/hour). 1 attachment now (dev); full 4-spoke fleet at ~\$144/month plus data processing at \$0.02/GB.

## Rollback
Revert PR. Apply-from-main order: spoke attachment first, then network-account TGW.