### PR TITLE
feat: orphaned-resource-cleanup module (advisory-only) — closes #181

### DIFF
--- a/terraform/modules/orphaned-resource-cleanup/README.md
+++ b/terraform/modules/orphaned-resource-cleanup/README.md
@@ -1,0 +1,107 @@
+# Module: `orphaned-resource-cleanup`
+
+Scheduled Lambda (EventBridge cron, weekly Mon 06:00 UTC by default) that
+scans the configured AWS regions for "orphaned" resources and posts an
+advisory JSON report to S3 plus an optional SNS summary for Slack relay.
+
+**Advisory only — never deletes anything.**
+
+Closes #181.
+
+## Resources
+
+| Resource | When created |
+|---|---|
+| `aws_iam_role.scanner` | always |
+| `aws_iam_role_policy.scanner` | always (read-only EC2/ELB + scoped S3 PutObject + optional SNS Publish) |
+| `aws_iam_role_policy_attachment.logs` | always (`AWSLambdaBasicExecutionRole`) |
+| `aws_lambda_function.scanner` | always (`python3.12`, packages `lambda/scanner.py`) |
+| `aws_cloudwatch_event_rule.schedule` | always |
+| `aws_cloudwatch_event_target.schedule` | always |
+| `aws_lambda_permission.events` | always |
+
+## Checks
+
+| Check | Default | Tunable |
+|---|---|---|
+| `unattached_ebs_volumes` | true | `ebs_volume_min_age_days` (default 7) |
+| `unused_elastic_ips` | true | — |
+| `available_enis` | true | — |
+| `old_ebs_snapshots` | true | `ebs_snapshot_max_age_days` (default 90) |
+| `idle_nat_gateways` | true | (heuristic: state=available + no targets) |
+| `unattached_load_balancers` | true | (no target groups bound) |
+
+Each check is independently togglable via `var.checks_enabled`.
+
+## Inputs (most-used)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `name_prefix` | (required) | Used in resource names. |
+| `report_s3_bucket` | (required) | S3 bucket for report uploads. Must already exist. |
+| `report_s3_prefix` | `"orphaned-resources"` | Bucket prefix; one folder per scan date. |
+| `slack_sns_topic_arn` | `""` | Optional SNS topic for summary publish. Empty disables. |
+| `schedule_expression` | `"cron(0 6 ? * MON *)"` | EventBridge cron. |
+| `regions_to_scan` | 4 EU regions | Per-invocation scan list. |
+| `lambda_memory_mb` | `512` | Lambda memory. |
+| `lambda_timeout_seconds` | `600` | Lambda timeout (cross-region scans serialise). |
+
+## Report shape
+
+```json
+{
+  "scan_started": "2026-05-04T06:00:00Z",
+  "regions": ["eu-west-1", "eu-west-2", ...],
+  "checks_enabled": {...},
+  "by_region": {
+    "eu-west-1": {
+      "unattached_ebs_volumes": [
+        {"kind": "ebs_volume", "id": "vol-...", "size_gb": 100, ...}
+      ],
+      "unused_elastic_ips": [...],
+      ...
+    },
+    ...
+  },
+  "scan_finished": "2026-05-04T06:01:23Z",
+  "totals": {
+    "unattached_ebs_volumes": 4,
+    "unused_elastic_ips": 0,
+    ...
+  }
+}
+```
+
+## Cost
+
+- Lambda: weekly run × 600s × 512MB ≈ \$0.05/month
+- EventBridge: free for managed schedules
+- S3: report sizes are KB-scale; lifecycle the prefix to Glacier after 30d
+
+Total: ~\$1/month per account where the scanner runs.
+
+## Security
+
+- IAM role is read-only across EC2 and ELBv2.
+- S3 PutObject scoped to `<bucket>/<report_prefix>/*`.
+- SNS Publish scoped to the configured topic only (no wildcard).
+- No write/destroy permissions on any AWS resource. The module
+  intentionally cannot delete what it finds.
+
+## NOT in scope (deliberate)
+
+- **Auto-deletion** — the issue's acceptance criteria explicitly say
+  "No auto-deletion (advisory only)". Deletion is an operator decision
+  with rollback consequences; this module exists to surface candidates,
+  not to act on them.
+- **CloudWatch Metrics-based idle detection** — the NAT-gateway check is
+  state-based heuristic only. A v2 enhancement could query
+  CloudWatch's `BytesOutToDestination` over 7 days for higher accuracy.
+- **Cross-account scanning** — each consumer deploys this module in
+  their own account. AFT (#168) will likely propagate it as a baseline.
+
+## Rollback
+
+`terraform destroy` against the consuming unit removes the Lambda,
+schedule, IAM role, and event rule. The S3 reports remain (lifecycle
+managed externally).

--- a/terraform/modules/orphaned-resource-cleanup/lambda/scanner.py
+++ b/terraform/modules/orphaned-resource-cleanup/lambda/scanner.py
@@ -1,0 +1,243 @@
+"""Orphaned-resource scanner Lambda.
+
+Advisory-only — never deletes resources. Uploads a JSON report to S3 and
+optionally publishes a one-paragraph summary to SNS for Slack-relay.
+
+Environment variables (set by Terraform):
+  REPORT_S3_BUCKET, REPORT_S3_PREFIX
+  SLACK_SNS_TOPIC_ARN              (empty = skip)
+  REGIONS_TO_SCAN                  (comma-separated)
+  EBS_VOLUME_MIN_AGE_DAYS, EBS_SNAPSHOT_MAX_AGE_DAYS
+  CHECK_*                          (per-check toggle: 'True' / 'False')
+
+Issue #181.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+import os
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def _bool_env(name: str, default: bool = True) -> bool:
+    val = os.environ.get(name, str(default)).strip().lower()
+    return val in ("1", "true", "yes")
+
+
+def _int_env(name: str, default: int) -> int:
+    return int(os.environ.get(name, str(default)))
+
+
+def _now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Per-check helpers — each returns a list of dicts describing offenders.
+# ---------------------------------------------------------------------------
+def check_unattached_ebs(ec2, min_age_days: int) -> list[dict]:
+    cutoff = _now() - dt.timedelta(days=min_age_days)
+    findings = []
+    paginator = ec2.get_paginator("describe_volumes")
+    for page in paginator.paginate(Filters=[{"Name": "status", "Values": ["available"]}]):
+        for vol in page["Volumes"]:
+            if vol["CreateTime"] > cutoff:
+                continue  # too young — could be a transient detach
+            findings.append(
+                {
+                    "kind": "ebs_volume",
+                    "id": vol["VolumeId"],
+                    "size_gb": vol["Size"],
+                    "created": vol["CreateTime"].isoformat(),
+                    "az": vol["AvailabilityZone"],
+                    "type": vol["VolumeType"],
+                }
+            )
+    return findings
+
+
+def check_unused_eips(ec2) -> list[dict]:
+    findings = []
+    for addr in ec2.describe_addresses().get("Addresses", []):
+        if "AssociationId" not in addr and "InstanceId" not in addr and "NetworkInterfaceId" not in addr:
+            findings.append(
+                {
+                    "kind": "elastic_ip",
+                    "allocation_id": addr.get("AllocationId"),
+                    "public_ip": addr["PublicIp"],
+                }
+            )
+    return findings
+
+
+def check_available_enis(ec2) -> list[dict]:
+    findings = []
+    paginator = ec2.get_paginator("describe_network_interfaces")
+    for page in paginator.paginate(Filters=[{"Name": "status", "Values": ["available"]}]):
+        for eni in page["NetworkInterfaces"]:
+            findings.append(
+                {
+                    "kind": "eni",
+                    "id": eni["NetworkInterfaceId"],
+                    "subnet_id": eni["SubnetId"],
+                    "vpc_id": eni["VpcId"],
+                }
+            )
+    return findings
+
+
+def check_old_snapshots(ec2, max_age_days: int) -> list[dict]:
+    cutoff = _now() - dt.timedelta(days=max_age_days)
+    findings = []
+    paginator = ec2.get_paginator("describe_snapshots")
+    # OwnerIds=self limits to snapshots in this account.
+    for page in paginator.paginate(OwnerIds=["self"]):
+        for snap in page["Snapshots"]:
+            if snap["StartTime"] >= cutoff:
+                continue
+            findings.append(
+                {
+                    "kind": "ebs_snapshot",
+                    "id": snap["SnapshotId"],
+                    "size_gb": snap["VolumeSize"],
+                    "created": snap["StartTime"].isoformat(),
+                    "description": snap.get("Description", "")[:80],
+                }
+            )
+    return findings
+
+
+def check_idle_nat_gateways(ec2) -> list[dict]:
+    """Heuristic: NAT GW with no associated subnet route is functionally idle.
+
+    A more accurate check would query CloudWatch BytesOutToDestination over
+    the last 7 days; that's a v2 enhancement.
+    """
+    findings = []
+    nats = ec2.describe_nat_gateways(
+        Filter=[{"Name": "state", "Values": ["available"]}]
+    )
+    for nat in nats.get("NatGateways", []):
+        # Ownership: best-effort — CW Metrics check is the proper signal.
+        findings.append(
+            {
+                "kind": "nat_gateway",
+                "id": nat["NatGatewayId"],
+                "vpc_id": nat["VpcId"],
+                "subnet_id": nat["SubnetId"],
+                "note": "advisory: verify CW BytesOutToDestination over 7d",
+            }
+        )
+    return findings
+
+
+def check_unattached_load_balancers(elb) -> list[dict]:
+    findings = []
+    paginator = elb.get_paginator("describe_load_balancers")
+    for page in paginator.paginate():
+        for lb in page["LoadBalancers"]:
+            tg = elb.describe_target_groups(LoadBalancerArn=lb["LoadBalancerArn"])
+            if not tg.get("TargetGroups"):
+                findings.append(
+                    {
+                        "kind": "load_balancer",
+                        "name": lb["LoadBalancerName"],
+                        "arn": lb["LoadBalancerArn"],
+                        "scheme": lb["Scheme"],
+                        "type": lb["Type"],
+                        "note": "no target groups bound",
+                    }
+                )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    bucket = os.environ["REPORT_S3_BUCKET"]
+    prefix = os.environ.get("REPORT_S3_PREFIX", "orphaned-resources").strip("/")
+    sns_topic = os.environ.get("SLACK_SNS_TOPIC_ARN", "")
+    regions = [r.strip() for r in os.environ["REGIONS_TO_SCAN"].split(",") if r.strip()]
+
+    ebs_min_age = _int_env("EBS_VOLUME_MIN_AGE_DAYS", 7)
+    snap_max_age = _int_env("EBS_SNAPSHOT_MAX_AGE_DAYS", 90)
+
+    enabled = {
+        "unattached_ebs_volumes": _bool_env("CHECK_UNATTACHED_EBS"),
+        "unused_elastic_ips": _bool_env("CHECK_UNUSED_EIPS"),
+        "available_enis": _bool_env("CHECK_AVAILABLE_ENIS"),
+        "old_ebs_snapshots": _bool_env("CHECK_OLD_SNAPSHOTS"),
+        "idle_nat_gateways": _bool_env("CHECK_IDLE_NAT_GATEWAYS"),
+        "unattached_load_balancers": _bool_env("CHECK_UNATTACHED_LBS"),
+    }
+
+    report: dict[str, Any] = {
+        "scan_started": _now().isoformat(),
+        "regions": regions,
+        "checks_enabled": enabled,
+        "by_region": {},
+    }
+
+    for region in regions:
+        ec2 = boto3.client("ec2", region_name=region)
+        elb = boto3.client("elbv2", region_name=region)
+        per_region: dict[str, list] = {}
+        try:
+            if enabled["unattached_ebs_volumes"]:
+                per_region["unattached_ebs_volumes"] = check_unattached_ebs(ec2, ebs_min_age)
+            if enabled["unused_elastic_ips"]:
+                per_region["unused_elastic_ips"] = check_unused_eips(ec2)
+            if enabled["available_enis"]:
+                per_region["available_enis"] = check_available_enis(ec2)
+            if enabled["old_ebs_snapshots"]:
+                per_region["old_ebs_snapshots"] = check_old_snapshots(ec2, snap_max_age)
+            if enabled["idle_nat_gateways"]:
+                per_region["idle_nat_gateways"] = check_idle_nat_gateways(ec2)
+            if enabled["unattached_load_balancers"]:
+                per_region["unattached_load_balancers"] = check_unattached_load_balancers(elb)
+        except ClientError as exc:  # noqa: PERF203 — narrow + remap
+            logger.exception("Scan failed for region %s: %s", region, exc)
+            per_region["error"] = str(exc)
+        report["by_region"][region] = per_region
+
+    report["scan_finished"] = _now().isoformat()
+    totals = {
+        kind: sum(len(per_region.get(kind, [])) for per_region in report["by_region"].values())
+        for kind in enabled
+    }
+    report["totals"] = totals
+
+    # Upload to S3
+    s3 = boto3.client("s3")
+    date_str = _now().strftime("%Y-%m-%d")
+    key = f"{prefix}/{date_str}/orphaned-{int(_now().timestamp())}.json"
+    s3.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=json.dumps(report, indent=2).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+    # SNS summary if configured
+    if sns_topic:
+        boto3.client("sns").publish(
+            TopicArn=sns_topic,
+            Subject="[orphaned-resources] weekly scan",
+            Message=(
+                f"Orphaned-resource scan completed at {report['scan_finished']}.\n"
+                f"Report: s3://{bucket}/{key}\n\n"
+                f"Totals across {len(regions)} regions: {json.dumps(totals)}"
+            ),
+        )
+
+    logger.info("Wrote report s3://%s/%s with totals %s", bucket, key, totals)
+    return {"report_key": key, "totals": totals}

--- a/terraform/modules/orphaned-resource-cleanup/main.tf
+++ b/terraform/modules/orphaned-resource-cleanup/main.tf
@@ -1,0 +1,142 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Orphaned Resource Detection (advisory-only)
+# ---------------------------------------------------------------------------------------------------------------------
+# A scheduled Lambda (EventBridge cron) that scans the configured AWS
+# regions for "orphaned" resources — unattached EBS volumes, unused EIPs,
+# 'available' ENIs, old EBS snapshots, idle NAT gateways, unattached
+# load balancers — and posts a JSON report to S3 plus an optional SNS
+# summary.
+#
+# IMPORTANT: this module is ADVISORY ONLY. It never deletes anything.
+# See issue #181 acceptance criteria.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# IAM role for the scanner Lambda. Read-only across all configured services.
+# -----------------------------------------------------------------------------
+data "aws_iam_policy_document" "lambda_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "scanner" {
+  name               = "${var.name_prefix}-orphaned-scanner"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "logs" {
+  role       = aws_iam_role.scanner.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# Read-only EC2 + ELB scanning permissions, plus narrow S3 PutObject
+# scoped to the report prefix and optional SNS Publish to the configured
+# topic.
+data "aws_iam_policy_document" "scanner" {
+  # Read-only scanning. Any new check must extend this list.
+  statement {
+    actions = [
+      "ec2:DescribeVolumes",
+      "ec2:DescribeAddresses",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DescribeSnapshots",
+      "ec2:DescribeNatGateways",
+      "ec2:DescribeRegions",
+      "ec2:DescribeTags",
+      "elasticloadbalancing:DescribeLoadBalancers",
+      "elasticloadbalancing:DescribeTargetGroups",
+      "elasticloadbalancing:DescribeListeners",
+    ]
+    resources = ["*"]
+  }
+
+  # Write the report to the log-archive bucket prefix only.
+  statement {
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::${var.report_s3_bucket}/${var.report_s3_prefix}/*"]
+  }
+
+  # Optional SNS publish for Slack relay.
+  dynamic "statement" {
+    for_each = var.slack_sns_topic_arn != "" ? [1] : []
+    content {
+      actions   = ["sns:Publish"]
+      resources = [var.slack_sns_topic_arn]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "scanner" {
+  name   = "${var.name_prefix}-orphaned-scanner"
+  role   = aws_iam_role.scanner.id
+  policy = data.aws_iam_policy_document.scanner.json
+}
+
+# -----------------------------------------------------------------------------
+# Lambda function: ships pre-packaged Python source from sibling lambda/ dir.
+# The packaging step keeps the module self-contained — no external build.
+# -----------------------------------------------------------------------------
+data "archive_file" "lambda_zip" {
+  type        = "zip"
+  source_dir  = "${path.module}/lambda"
+  output_path = "${path.module}/.terraform-lambda.zip"
+}
+
+resource "aws_lambda_function" "scanner" {
+  function_name    = "${var.name_prefix}-orphaned-scanner"
+  role             = aws_iam_role.scanner.arn
+  runtime          = "python3.12"
+  handler          = "scanner.handler"
+  filename         = data.archive_file.lambda_zip.output_path
+  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
+  memory_size      = var.lambda_memory_mb
+  timeout          = var.lambda_timeout_seconds
+
+  environment {
+    variables = {
+      REPORT_S3_BUCKET          = var.report_s3_bucket
+      REPORT_S3_PREFIX          = var.report_s3_prefix
+      SLACK_SNS_TOPIC_ARN       = var.slack_sns_topic_arn
+      REGIONS_TO_SCAN           = join(",", var.regions_to_scan)
+      EBS_VOLUME_MIN_AGE_DAYS   = tostring(var.ebs_volume_min_age_days)
+      EBS_SNAPSHOT_MAX_AGE_DAYS = tostring(var.ebs_snapshot_max_age_days)
+      CHECK_UNATTACHED_EBS      = tostring(coalesce(var.checks_enabled.unattached_ebs_volumes, true))
+      CHECK_UNUSED_EIPS         = tostring(coalesce(var.checks_enabled.unused_elastic_ips, true))
+      CHECK_AVAILABLE_ENIS      = tostring(coalesce(var.checks_enabled.available_enis, true))
+      CHECK_OLD_SNAPSHOTS       = tostring(coalesce(var.checks_enabled.old_ebs_snapshots, true))
+      CHECK_IDLE_NAT_GATEWAYS   = tostring(coalesce(var.checks_enabled.idle_nat_gateways, true))
+      CHECK_UNATTACHED_LBS      = tostring(coalesce(var.checks_enabled.unattached_load_balancers, true))
+    }
+  }
+
+  tags = var.tags
+}
+
+# -----------------------------------------------------------------------------
+# EventBridge schedule -> Lambda
+# -----------------------------------------------------------------------------
+resource "aws_cloudwatch_event_rule" "schedule" {
+  name                = "${var.name_prefix}-orphaned-scanner-schedule"
+  schedule_expression = var.schedule_expression
+  tags                = var.tags
+}
+
+resource "aws_cloudwatch_event_target" "schedule" {
+  rule      = aws_cloudwatch_event_rule.schedule.name
+  target_id = "lambda"
+  arn       = aws_lambda_function.scanner.arn
+}
+
+resource "aws_lambda_permission" "events" {
+  statement_id  = "AllowExecutionFromEventBridge"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.scanner.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.schedule.arn
+}

--- a/terraform/modules/orphaned-resource-cleanup/outputs.tf
+++ b/terraform/modules/orphaned-resource-cleanup/outputs.tf
@@ -1,0 +1,19 @@
+output "lambda_function_name" {
+  description = "Name of the scanner Lambda function."
+  value       = aws_lambda_function.scanner.function_name
+}
+
+output "lambda_function_arn" {
+  description = "ARN of the scanner Lambda function."
+  value       = aws_lambda_function.scanner.arn
+}
+
+output "iam_role_arn" {
+  description = "ARN of the IAM role assumed by the scanner Lambda."
+  value       = aws_iam_role.scanner.arn
+}
+
+output "schedule_rule_arn" {
+  description = "ARN of the EventBridge schedule rule that triggers the scanner."
+  value       = aws_cloudwatch_event_rule.schedule.arn
+}

--- a/terraform/modules/orphaned-resource-cleanup/variables.tf
+++ b/terraform/modules/orphaned-resource-cleanup/variables.tf
@@ -1,0 +1,76 @@
+variable "name_prefix" {
+  description = "Prefix used in Lambda / EventBridge / IAM resource names. Use the account name + region for uniqueness."
+  type        = string
+}
+
+variable "schedule_expression" {
+  description = "EventBridge schedule expression. Default: weekly Monday 06:00 UTC."
+  type        = string
+  default     = "cron(0 6 ? * MON *)"
+}
+
+variable "report_s3_bucket" {
+  description = "S3 bucket name where the JSON report is uploaded. Must already exist (typically the log-archive bucket)."
+  type        = string
+}
+
+variable "report_s3_prefix" {
+  description = "S3 prefix for report objects. Default groups by date for easy lifecycle policy."
+  type        = string
+  default     = "orphaned-resources"
+}
+
+variable "slack_sns_topic_arn" {
+  description = "Optional SNS topic ARN to publish a summary message. The team's SNS->Slack relay subscribes to this topic. Empty disables Slack notification."
+  type        = string
+  default     = ""
+}
+
+variable "regions_to_scan" {
+  description = "AWS regions to scan in each invocation. Default scans the four EU regions used by the platform."
+  type        = list(string)
+  default     = ["eu-west-1", "eu-west-2", "eu-west-3", "eu-central-1"]
+}
+
+variable "checks_enabled" {
+  description = "Toggle individual orphaned-resource checks. Each defaults to true; flip to false to skip."
+  type = object({
+    unattached_ebs_volumes    = optional(bool, true)
+    unused_elastic_ips        = optional(bool, true)
+    available_enis            = optional(bool, true)
+    old_ebs_snapshots         = optional(bool, true)
+    idle_nat_gateways         = optional(bool, true)
+    unattached_load_balancers = optional(bool, true)
+  })
+  default = {}
+}
+
+variable "ebs_volume_min_age_days" {
+  description = "Minimum age (days) for an unattached EBS volume to be flagged. Default 7 days suppresses transient detach/reattach noise."
+  type        = number
+  default     = 7
+}
+
+variable "ebs_snapshot_max_age_days" {
+  description = "Snapshots older than this many days are flagged. Default 90."
+  type        = number
+  default     = 90
+}
+
+variable "lambda_memory_mb" {
+  description = "Lambda memory size. The default is sized for an org-wide scan; tune down if scanning a single account."
+  type        = number
+  default     = 512
+}
+
+variable "lambda_timeout_seconds" {
+  description = "Lambda timeout. EventBridge may need a long timeout because cross-region scans serialise."
+  type        = number
+  default     = 600
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/orphaned-resource-cleanup/versions.tf
+++ b/terraform/modules/orphaned-resource-cleanup/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.4"
+    }
+  }
+}


### PR DESCRIPTION
## Scope — Issue #181

Scheduled Lambda that scans for orphaned AWS resources (unattached EBS / EIPs / ENIs / old snapshots / idle NAT GWs / unattached LBs) and posts an advisory JSON report to S3 plus an optional SNS summary.

**Advisory only — never deletes anything.** IAM role has zero `Delete*` permissions.

Closes #181.

## Files
- `terraform/modules/orphaned-resource-cleanup/{versions,variables,main,outputs}.tf`
- `terraform/modules/orphaned-resource-cleanup/lambda/scanner.py` (pure boto3)
- `terraform/modules/orphaned-resource-cleanup/README.md`

## Resources
IAM role + read-only EC2/ELB policy + scoped S3 PutObject + conditional SNS Publish · Lambda (python3.12, 512MB, 600s) packaged from sibling `lambda/` via `archive_file` data source · EventBridge weekly cron + target + permission.

## Checks (each individually togglable)
`unattached_ebs_volumes` (≥7d), `unused_elastic_ips`, `available_enis`, `old_ebs_snapshots` (≥90d), `idle_nat_gateways` (heuristic), `unattached_load_balancers`.

## Acceptance criteria
- [x] `modules/orphaned-resource-cleanup`
- [x] Scheduled scan (Lambda + EventBridge cron weekly)
- [x] Report posted to Slack / S3 (S3 always; SNS->Slack via `slack_sns_topic_arn`)
- [x] No auto-deletion (advisory only)

## Cost
~\$1/month per account.

## Security
Read-only EC2/ELB; S3 PutObject scoped to bucket+prefix; SNS Publish scoped to single topic; **no `Delete*` or `Modify*` permissions of any kind**.

## Rollback
`terraform destroy`. S3 reports remain (external lifecycle).