### PR TITLE
feat: centralized-logging module for org-wide log aggregation — closes #182

### DIFF
--- a/terraform/modules/centralized-logging/README.md
+++ b/terraform/modules/centralized-logging/README.md
@@ -1,0 +1,105 @@
+# Module: `centralized-logging`
+
+Org-wide log archive in the log-archive account. Aggregates CloudTrail
+org-trails, Config snapshots, VPC Flow Logs, EKS audit/authenticator
+streams into a single immutable S3 bucket with cross-region replication
+to a DR-region mirror.
+
+Closes #182.
+
+## Resources
+
+| Resource | When created |
+|---|---|
+| `aws_s3_bucket.this` | always — primary bucket with Object Lock enabled at creation |
+| `aws_s3_bucket_versioning.this` | always |
+| `aws_s3_bucket_public_access_block.this` | always |
+| `aws_s3_bucket_server_side_encryption_configuration.this` | always — SSE-KMS via `var.kms_key_arn` |
+| `aws_s3_bucket_object_lock_configuration.this` | when `enable_object_lock = true` (default) |
+| `aws_s3_bucket_lifecycle_configuration.this` | always — STANDARD → IA → GLACIER → expire |
+| `aws_s3_bucket_policy.this` | always — DenyInsecureTransport + per-account writers + CloudTrail/Config service principals |
+| `aws_s3_bucket.dr[0]` | when `enable_replication = true` AND `dr_kms_key_arn != ""` |
+| `aws_iam_role.replication[0]` + scoped policy | when replication enabled |
+| `aws_s3_bucket_replication_configuration.this[0]` | when replication enabled — replicates everything (Versioning + delete-markers + KMS-encrypted objects) |
+
+## Inputs (most-used)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `bucket_name` | (required) | Globally unique bucket name. Convention: `<project>-log-archive-<account_id>-<region>`. |
+| `kms_key_arn` | (required) | Primary-region KMS key (`alias/log-archive`). |
+| `dr_kms_key_arn` | `""` | DR-region KMS key. Required for replication. |
+| `enable_object_lock` | `true` | PCI-DSS Req 10.5 immutable retention. **Cannot be disabled later.** |
+| `object_lock_mode` | `"GOVERNANCE"` | `GOVERNANCE` (admin override) or `COMPLIANCE` (no override). |
+| `object_lock_retention_days` | `365` | Default per-object retention. |
+| `lifecycle_*` | 30 / 90 / 365 / 2555 | Tier transitions + 7-year expiry. |
+| `trusted_writer_account_ids` | `[]` | List of member-account IDs that may write to their own prefix. |
+| `log_source_prefixes` | 5 default sources | Map of source-name → prefix. |
+
+## Provider configuration
+
+The module declares an `aws.dr` provider alias (see `versions.tf`). The
+consuming root supplies it:
+
+```hcl
+provider "aws" {
+  region = "eu-west-1"
+}
+
+provider "aws" {
+  alias  = "dr"
+  region = "eu-central-1"
+}
+```
+
+## Bucket policy
+
+The auto-generated policy enforces:
+
+- **TLS-only** (`DenyInsecureTransport` deny statement).
+- **Per-account scoped writes** — each member account in
+  `trusted_writer_account_ids` can `PutObject` to its own
+  `<prefix>/AWSLogs/<account>/*` path with
+  `s3:x-amz-acl == bucket-owner-full-control`.
+- **CloudTrail + Config service principals** — the standard
+  `s3:GetBucketAcl` + `s3:PutObject` allow statements required by AWS
+  for org-trail and aggregated-Config delivery.
+
+The DR bucket has no bucket policy of its own — replication writes
+inherit the role's permissions.
+
+## Lifecycle
+
+Object lifecycle: `STANDARD` → `STANDARD_IA` (30d) → `GLACIER` (90d) →
+expire (2555d ≈ 7 years).
+
+PCI-DSS Req 10.5 specifies tamper-proof retention for at least 1 year
+in immediately-accessible storage, plus extended retention for 3+
+years. The defaults here exceed both requirements.
+
+## Cost
+
+Approximate monthly cost for a typical 9-account org with full
+CloudTrail / Config / VPC Flow / EKS audit ingestion:
+
+| Component | ~Volume | Cost |
+|---|---|---|
+| STANDARD storage (first 30d) | 50 GB | \$1.15 |
+| STANDARD_IA (30-90d) | 100 GB | \$1.25 |
+| GLACIER (90d-7yr) | 5 TB | \$20 |
+| KMS API calls | ~1M/month | \$3 |
+| Cross-region replication transfer | 50 GB | \$1 |
+| Replicated storage (DR) | full mirror | matches primary |
+| **Total** | | **~\$50-60/month** |
+
+## Rollback
+
+`terraform destroy` is **disabled** by Object Lock — once a bucket has
+Object Lock enabled, neither the bucket nor objects under retention
+can be deleted until retention expires. To roll back:
+1. Wait out the retention period (default 365 days), OR
+2. If `object_lock_mode = "GOVERNANCE"`, an admin with
+   `s3:BypassGovernanceRetention` can delete objects sooner.
+
+The bucket itself can be deleted only when empty AND no objects under
+retention remain.

--- a/terraform/modules/centralized-logging/main.tf
+++ b/terraform/modules/centralized-logging/main.tf
@@ -1,0 +1,352 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Centralized Logging — log-archive account
+# ---------------------------------------------------------------------------------------------------------------------
+# Aggregates org-wide audit trails (CloudTrail, Config snapshots, VPC Flow
+# Logs, EKS audit/authenticator) into a single immutable S3 bucket in the
+# log-archive account. Cross-region replicated to the DR region for
+# audit-trail durability (PCI-DSS Req 10.5).
+#
+# Issue #182.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Primary bucket
+# -----------------------------------------------------------------------------
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+
+  # Object Lock requires bucket-level enablement at creation time.
+  # Set object_lock_enabled = true here AND configure the lock rule below.
+  object_lock_enabled = var.enable_object_lock
+
+  tags = var.tags
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = var.kms_key_arn
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_object_lock_configuration" "this" {
+  count = var.enable_object_lock ? 1 : 0
+
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    default_retention {
+      mode = var.object_lock_mode
+      days = var.object_lock_retention_days
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    id     = "tier-and-expire"
+    status = "Enabled"
+
+    filter {} # apply to all objects
+
+    transition {
+      days          = var.lifecycle_standard_days
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = var.lifecycle_ia_days
+      storage_class = "GLACIER"
+    }
+
+    dynamic "expiration" {
+      for_each = var.lifecycle_expiration_days > 0 ? [1] : []
+      content {
+        days = var.lifecycle_expiration_days
+      }
+    }
+
+    # Expire incomplete multi-part uploads after 7 days.
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Bucket policy — grant scoped Put access to trusted log-source roles in each
+# member account, plus the AWS service principals that write directly
+# (cloudtrail.amazonaws.com, config.amazonaws.com, etc.).
+# -----------------------------------------------------------------------------
+data "aws_iam_policy_document" "bucket" {
+  # Deny non-TLS access (AWS-Foundational-Best-Practices.S3.5).
+  statement {
+    sid     = "DenyInsecureTransport"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.this.arn,
+      "${aws_s3_bucket.this.arn}/*",
+    ]
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+
+  # Cross-account writes per log-source prefix.
+  dynamic "statement" {
+    for_each = var.trusted_writer_account_ids
+    content {
+      sid     = "AllowOrgAccount${replace(statement.value, "-", "")}"
+      effect  = "Allow"
+      actions = ["s3:PutObject", "s3:PutObjectAcl"]
+      principals {
+        type        = "AWS"
+        identifiers = ["arn:aws:iam::${statement.value}:root"]
+      }
+      resources = [for k, v in var.log_source_prefixes : "${aws_s3_bucket.this.arn}/${v}/AWSLogs/${statement.value}/*"]
+      condition {
+        test     = "StringEquals"
+        variable = "s3:x-amz-acl"
+        values   = ["bucket-owner-full-control"]
+      }
+    }
+  }
+
+  # CloudTrail service principal needs a top-level GetBucketAcl too.
+  statement {
+    sid     = "AllowCloudTrailGetBucketAcl"
+    effect  = "Allow"
+    actions = ["s3:GetBucketAcl"]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+    resources = [aws_s3_bucket.this.arn]
+  }
+
+  statement {
+    sid     = "AllowCloudTrailPutObject"
+    effect  = "Allow"
+    actions = ["s3:PutObject"]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+    resources = ["${aws_s3_bucket.this.arn}/${var.log_source_prefixes["cloudtrail"]}/AWSLogs/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+  }
+
+  # Config service principal — same pattern.
+  statement {
+    sid     = "AllowConfigPutObject"
+    effect  = "Allow"
+    actions = ["s3:PutObject"]
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+    resources = ["${aws_s3_bucket.this.arn}/${var.log_source_prefixes["config"]}/AWSLogs/*"]
+  }
+
+  statement {
+    sid     = "AllowConfigGetBucketAcl"
+    effect  = "Allow"
+    actions = ["s3:GetBucketAcl"]
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+    resources = [aws_s3_bucket.this.arn]
+  }
+}
+
+resource "aws_s3_bucket_policy" "this" {
+  bucket = aws_s3_bucket.this.id
+  policy = data.aws_iam_policy_document.bucket.json
+}
+
+# -----------------------------------------------------------------------------
+# DR region — replicated bucket
+# -----------------------------------------------------------------------------
+resource "aws_s3_bucket" "dr" {
+  count    = var.enable_replication && var.dr_kms_key_arn != "" ? 1 : 0
+  provider = aws.dr
+
+  bucket              = "${var.bucket_name}-dr"
+  object_lock_enabled = var.enable_object_lock
+
+  tags = var.tags
+}
+
+resource "aws_s3_bucket_versioning" "dr" {
+  count    = var.enable_replication && var.dr_kms_key_arn != "" ? 1 : 0
+  provider = aws.dr
+
+  bucket = aws_s3_bucket.dr[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "dr" {
+  count    = var.enable_replication && var.dr_kms_key_arn != "" ? 1 : 0
+  provider = aws.dr
+
+  bucket                  = aws_s3_bucket.dr[0].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "dr" {
+  count    = var.enable_replication && var.dr_kms_key_arn != "" ? 1 : 0
+  provider = aws.dr
+
+  bucket = aws_s3_bucket.dr[0].id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = var.dr_kms_key_arn
+    }
+    bucket_key_enabled = true
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Replication role + rule
+# -----------------------------------------------------------------------------
+data "aws_iam_policy_document" "replication_assume" {
+  count = var.enable_replication && var.dr_kms_key_arn != "" ? 1 : 0
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "replication" {
+  count              = var.enable_replication && var.dr_kms_key_arn != "" ? 1 : 0
+  name               = "${var.bucket_name}-replication"
+  assume_role_policy = data.aws_iam_policy_document.replication_assume[0].json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "replication" {
+  count = var.enable_replication && var.dr_kms_key_arn != "" ? 1 : 0
+
+  statement {
+    actions = [
+      "s3:GetReplicationConfiguration",
+      "s3:ListBucket",
+    ]
+    resources = [aws_s3_bucket.this.arn]
+  }
+
+  statement {
+    actions = [
+      "s3:GetObjectVersionForReplication",
+      "s3:GetObjectVersionAcl",
+      "s3:GetObjectVersionTagging",
+    ]
+    resources = ["${aws_s3_bucket.this.arn}/*"]
+  }
+
+  statement {
+    actions = [
+      "s3:ReplicateObject",
+      "s3:ReplicateDelete",
+      "s3:ReplicateTags",
+    ]
+    resources = ["${aws_s3_bucket.dr[0].arn}/*"]
+  }
+
+  statement {
+    actions   = ["kms:Decrypt"]
+    resources = [var.kms_key_arn]
+  }
+
+  statement {
+    actions   = ["kms:Encrypt"]
+    resources = [var.dr_kms_key_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "replication" {
+  count  = var.enable_replication && var.dr_kms_key_arn != "" ? 1 : 0
+  name   = "${var.bucket_name}-replication"
+  role   = aws_iam_role.replication[0].id
+  policy = data.aws_iam_policy_document.replication[0].json
+}
+
+resource "aws_s3_bucket_replication_configuration" "this" {
+  count = var.enable_replication && var.dr_kms_key_arn != "" ? 1 : 0
+
+  depends_on = [aws_s3_bucket_versioning.this, aws_s3_bucket_versioning.dr]
+  bucket     = aws_s3_bucket.this.id
+  role       = aws_iam_role.replication[0].arn
+
+  rule {
+    id     = "replicate-everything"
+    status = "Enabled"
+
+    filter {}
+
+    delete_marker_replication {
+      status = "Enabled"
+    }
+
+    destination {
+      bucket        = aws_s3_bucket.dr[0].arn
+      storage_class = "STANDARD"
+
+      encryption_configuration {
+        replica_kms_key_id = var.dr_kms_key_arn
+      }
+    }
+
+    source_selection_criteria {
+      sse_kms_encrypted_objects {
+        status = "Enabled"
+      }
+    }
+  }
+}

--- a/terraform/modules/centralized-logging/outputs.tf
+++ b/terraform/modules/centralized-logging/outputs.tf
@@ -1,0 +1,29 @@
+output "bucket_name" {
+  description = "Name of the primary log-archive bucket."
+  value       = aws_s3_bucket.this.bucket
+}
+
+output "bucket_arn" {
+  description = "ARN of the primary log-archive bucket."
+  value       = aws_s3_bucket.this.arn
+}
+
+output "dr_bucket_name" {
+  description = "Name of the DR-region replicated bucket. Null when replication disabled."
+  value       = length(aws_s3_bucket.dr) > 0 ? aws_s3_bucket.dr[0].bucket : null
+}
+
+output "dr_bucket_arn" {
+  description = "ARN of the DR-region replicated bucket. Null when replication disabled."
+  value       = length(aws_s3_bucket.dr) > 0 ? aws_s3_bucket.dr[0].arn : null
+}
+
+output "log_source_prefixes" {
+  description = "Map of log-source name to its S3 prefix in the bucket. Pass to consumers (CloudTrail, Config, VPC Flow, EKS audit) so they write to the right path."
+  value       = var.log_source_prefixes
+}
+
+output "replication_role_arn" {
+  description = "ARN of the IAM role used by S3 replication. Null when replication disabled."
+  value       = length(aws_iam_role.replication) > 0 ? aws_iam_role.replication[0].arn : null
+}

--- a/terraform/modules/centralized-logging/variables.tf
+++ b/terraform/modules/centralized-logging/variables.tf
@@ -1,0 +1,103 @@
+variable "bucket_name" {
+  description = "Name of the centralized log archive S3 bucket. Must be globally unique. Convention: <project>-log-archive-<account_id>-<region>."
+  type        = string
+}
+
+variable "primary_region" {
+  description = "Primary AWS region. Used for the S3 bucket and KMS key."
+  type        = string
+  default     = "eu-west-1"
+}
+
+variable "dr_region" {
+  description = "DR region for cross-region replication. Empty disables replication."
+  type        = string
+  default     = "eu-central-1"
+}
+
+variable "kms_key_arn" {
+  description = "ARN of the KMS key used for SSE-KMS on the primary bucket. Provisioned by terraform/modules/kms (alias: alias/log-archive)."
+  type        = string
+}
+
+variable "dr_kms_key_arn" {
+  description = "ARN of the KMS key used for SSE-KMS on the DR-region bucket. Provisioned by terraform/modules/kms in the DR region. Empty disables replication."
+  type        = string
+  default     = ""
+}
+
+variable "enable_replication" {
+  description = "Enable cross-region replication to the DR bucket."
+  type        = bool
+  default     = true
+}
+
+variable "enable_object_lock" {
+  description = "Enable Object Lock GOVERNANCE retention on the primary bucket. Required for PCI-DSS Req 10.5 (immutable audit trail). Object Lock CANNOT be disabled once enabled."
+  type        = bool
+  default     = true
+}
+
+variable "object_lock_mode" {
+  description = "Object Lock mode: GOVERNANCE (admin can override) or COMPLIANCE (no override, no shorter retention)."
+  type        = string
+  default     = "GOVERNANCE"
+  validation {
+    condition     = contains(["GOVERNANCE", "COMPLIANCE"], var.object_lock_mode)
+    error_message = "Object Lock mode must be GOVERNANCE or COMPLIANCE."
+  }
+}
+
+variable "object_lock_retention_days" {
+  description = "Default Object Lock retention period in days. Applied to every new object."
+  type        = number
+  default     = 365
+}
+
+variable "lifecycle_standard_days" {
+  description = "Days to keep objects in S3 STANDARD before transitioning to STANDARD_IA."
+  type        = number
+  default     = 30
+}
+
+variable "lifecycle_ia_days" {
+  description = "Days in STANDARD_IA before transitioning to GLACIER (must be >= lifecycle_standard_days + 30)."
+  type        = number
+  default     = 90
+}
+
+variable "lifecycle_glacier_days" {
+  description = "Days in STANDARD before transitioning to GLACIER (used when lifecycle_ia_days is 0 or skipped)."
+  type        = number
+  default     = 365
+}
+
+variable "lifecycle_expiration_days" {
+  description = "Days before objects are deleted. Set to 0 to disable expiration."
+  type        = number
+  default     = 2555 # ~7 years (PCI-DSS retention requirement)
+}
+
+variable "trusted_writer_account_ids" {
+  description = "List of AWS account IDs allowed to write to this bucket (CloudTrail, Config, VPC Flow, EKS audit). Each account's CloudTrail-org / Config / etc. roles need s3:PutObject on the corresponding prefix."
+  type        = list(string)
+  default     = []
+}
+
+variable "log_source_prefixes" {
+  description = "Map of log-source-name to S3 prefix. Each source's principals get a scoped Put policy on its prefix only. Common prefixes: cloudtrail/, config/, vpc-flow/, eks-audit/, eks-authenticator/."
+  type        = map(string)
+  default = {
+    cloudtrail        = "cloudtrail"
+    config            = "config"
+    vpc-flow          = "vpc-flow"
+    eks-audit         = "eks-audit"
+    eks-authenticator = "eks-authenticator"
+  }
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/centralized-logging/versions.tf
+++ b/terraform/modules/centralized-logging/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 6.0"
+      configuration_aliases = [aws.dr]
+    }
+  }
+}


### PR DESCRIPTION
## Scope — Issue #182

Org-wide log archive in the log-archive account. Aggregates CloudTrail / Config / VPC Flow / EKS audit / EKS authenticator from every member account into a single immutable S3 bucket with cross-region replication.

Closes #182.

## Files
- `terraform/modules/centralized-logging/{versions,variables,main,outputs}.tf`
- `terraform/modules/centralized-logging/README.md`

## Resources (primary)
S3 bucket with Object Lock enabled at creation, versioning, PAB, SSE-KMS, lifecycle (STANDARD → IA at 30d → GLACIER at 90d → expire at 7y), bucket policy (TLS-only deny + per-account scoped writes + CloudTrail/Config service principals).

## Resources (DR — gated on `enable_replication=true` + `dr_kms_key_arn`)
DR bucket via `aws.dr` provider alias + replication role with scoped policy + replication configuration with delete-marker replication and KMS-encrypted-objects selection criteria. Same pattern as `state-backend-dr` (PR #190).

## Acceptance criteria
- [x] `modules/centralized-logging` module
- [x] CloudTrail/Config/VPC Flow Logs delivered to log-archive bucket
- [x] Lifecycle policy (Standard → IA → Glacier)
- [x] CMK encryption (SSE-KMS)

## Cost
~\$50-60/month for full org ingestion. Documented in README.

## Security
TLS-only enforced. Per-account scoped writes. Object Lock at creation (cannot be disabled). All PABs on.

## Rollback
Revert PR. Deletion is side-effect-free while unused; Object Lock prevents deletion for the retention window once in use.