### PR TITLE
feat: EKS audit + authenticator log aggregation — closes #178

### DIFF
--- a/terraform/modules/eks-log-aggregation/README.md
+++ b/terraform/modules/eks-log-aggregation/README.md
@@ -1,0 +1,162 @@
+# Module: `eks-log-aggregation`
+
+Ships EKS control-plane log streams (audit + authenticator) from the
+per-cluster CloudWatch log group to the centralized log-archive S3
+bucket in the log-archive account.
+
+Closes #178.
+
+## Pipeline
+
+```
+EKS control plane
+  └── /aws/eks/<cluster>/cluster   (CloudWatch Logs)
+        ├── kube-apiserver-audit  ──┐
+        └── authenticator         ──┘
+              │
+              │  CloudWatch Logs subscription filter
+              │  (filter_pattern = "")
+              ▼
+        Kinesis Data Firehose
+              │
+              │  buffer 60s / 5MB, GZIP, dynamic partition by accountId
+              ▼
+        S3 (log-archive bucket via cross-account write)
+              │
+              │  prefix: <eks-audit-prefix>/AWSLogs/<account>/<region>/<cluster>/
+              ▼
+        Object Lock + lifecycle (managed by centralized-logging module #182)
+```
+
+## Resources
+
+| Resource | Purpose |
+|---|---|
+| `aws_cloudwatch_log_group.cluster` | Owns retention on the EKS-managed log group (`prevent_destroy = true`). |
+| `aws_iam_role.firehose` + scoped policy | Cross-account S3 write + KMS encrypt + CloudWatch error logging. |
+| `aws_kinesis_firehose_delivery_stream.this` | Buffered S3 delivery with dynamic partitioning by `userIdentity.accountId`. |
+| `aws_iam_role.subscription` + policy | CloudWatch Logs → Firehose passthrough. |
+| `aws_cloudwatch_log_subscription_filter.this[*]` | One per stream in `log_streams_to_forward` (default: audit + authenticator). |
+
+## Inputs (most-used)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `cluster_name` | (required) | Used in resource names + log group path. |
+| `aws_region` | (required) | Used in S3 prefix construction. |
+| `log_group_retention_days` | `90` | CloudWatch retention. Long-term retention is in S3. |
+| `destination_s3_bucket_arn` | (required) | Output of `centralized-logging.bucket_arn` (#182). |
+| `destination_s3_prefix` | `"eks-audit"` | Maps to `eks-audit` in `centralized-logging.log_source_prefixes`. |
+| `destination_kms_key_arn` | (required) | Same KMS key as the destination bucket. |
+| `log_streams_to_forward` | `["kube-apiserver-audit", "authenticator"]` | Streams to ship. |
+
+## Log schema
+
+Records arrive on S3 as gzipped newline-delimited JSON. Each line is one
+CloudWatch Logs event:
+
+```json
+{
+  "messageType": "DATA_MESSAGE",
+  "owner": "111111111111",
+  "logGroup": "/aws/eks/dev-platform/cluster",
+  "logStream": "kube-apiserver-audit-...",
+  "subscriptionFilters": ["dev-platform-kube-apiserver-audit-to-firehose"],
+  "logEvents": [
+    {
+      "id": "...",
+      "timestamp": 1736000000000,
+      "message": "{\"kind\":\"Event\",\"apiVersion\":\"audit.k8s.io/v1\",...}"
+    }
+  ]
+}
+```
+
+The inner `message` field is the raw EKS audit event. Downstream
+consumers (Athena, OpenSearch, custom SIEM) typically extract that
+field as the row payload.
+
+## Access pattern
+
+S3 layout:
+
+```
+s3://<log-archive-bucket>/eks-audit/AWSLogs/<account-id>/<region>/<cluster>/<year>/<month>/<day>/<hour>/<gz-file>
+```
+
+Athena query against the bucket (one-time setup of an external table
+per environment):
+
+```sql
+SELECT
+  audit_event.user.username,
+  audit_event.verb,
+  audit_event.objectRef.resource,
+  audit_event.responseStatus.code
+FROM eks_audit_external
+WHERE
+  account_id = '111111111111'
+  AND region = 'eu-west-1'
+  AND year = '2026' AND month = '05'
+  AND audit_event.responseStatus.code >= 400
+LIMIT 100;
+```
+
+The `centralized-logging` bucket policy grants this account `s3:PutObject`
+to its prefix only — Firehose's IAM role uses cross-account access via
+the bucket policy. Read access for forensic queries is granted separately
+(typically via the security account's audit role).
+
+## Cost
+
+Approximate monthly cost per cluster (eu-west-1, 100-node cluster, normal
+audit traffic ~50MB/day):
+
+| Component | Volume | Cost |
+|---|---|---|
+| CloudWatch Logs ingestion | 1.5 GB/month | \$0.75 |
+| CloudWatch Logs storage (90d) | 4.5 GB | \$0.15 |
+| Firehose data ingestion | 1.5 GB | \$0.05 |
+| Firehose dynamic partitioning | 1.5 GB | \$0.075 |
+| S3 PUT requests | ~3000/month | \$0.02 |
+| **Total** | | **~\$1-2/month/cluster** |
+
+Long-term S3 storage is billed in the log-archive account (covered by
+#182's cost estimate).
+
+## Integration with `centralized-logging` (#182)
+
+This module's consumer reads outputs from `centralized-logging` via a
+cross-account remote-state read, e.g.:
+
+```hcl
+data "terraform_remote_state" "log_archive" {
+  backend = "s3"
+  config = {
+    bucket = "tfstate-log-archive-eu-west-1"
+    key    = "log-archive/eu-west-1/centralized-logging/terraform.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+module "eks_log_aggregation" {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/eks-log-aggregation"
+
+  cluster_name              = "dev-platform"
+  aws_region                = "eu-west-1"
+  destination_s3_bucket_arn = data.terraform_remote_state.log_archive.outputs.bucket_arn
+  destination_s3_prefix     = data.terraform_remote_state.log_archive.outputs.log_source_prefixes["eks-audit"]
+  destination_kms_key_arn   = "arn:aws:kms:eu-west-1:888888888888:alias/log-archive"
+}
+```
+
+The cross-account state-read is read-only and goes through the bucket
+policy added in #160 (DR-state PR).
+
+## Rollback
+
+`terraform destroy` removes the Firehose, IAM roles, subscription
+filters, and the CloudWatch log group (`prevent_destroy` on the log
+group will block; flip to false in a separate PR before destroy).
+S3 objects already in the destination bucket remain (subject to
+Object Lock retention).

--- a/terraform/modules/eks-log-aggregation/main.tf
+++ b/terraform/modules/eks-log-aggregation/main.tf
@@ -1,0 +1,189 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# EKS Audit + Authenticator Log Aggregation
+# ---------------------------------------------------------------------------------------------------------------------
+# Routes EKS control-plane log streams (audit, authenticator) from the
+# per-cluster CloudWatch log group to the centralized log-archive bucket
+# in the log-archive account, via a Kinesis Firehose delivery stream.
+#
+# This is the workload-account-side complement of the log-archive bucket
+# created by terraform/modules/centralized-logging (#182). Each EKS
+# cluster instantiates this module once.
+#
+# Issue #178.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Source CloudWatch log group — managed by EKS itself, but we set retention
+# centrally so it doesn't drift to "Never expire".
+# -----------------------------------------------------------------------------
+resource "aws_cloudwatch_log_group" "cluster" {
+  name              = "/aws/eks/${var.cluster_name}/cluster"
+  retention_in_days = var.log_group_retention_days
+  tags              = var.tags
+
+  # EKS creates this group lazily on first write; importing an existing
+  # group is the typical onboarding path. Once imported, retention is
+  # managed here.
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Firehose delivery stream — CloudWatch Logs subscription -> S3 (log-archive)
+# -----------------------------------------------------------------------------
+data "aws_iam_policy_document" "firehose_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["firehose.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "firehose" {
+  name               = "${var.cluster_name}-eks-log-firehose"
+  assume_role_policy = data.aws_iam_policy_document.firehose_assume.json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "firehose" {
+  # Firehose writes objects to the cross-account log-archive bucket.
+  statement {
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+    ]
+    resources = [
+      var.destination_s3_bucket_arn,
+      "${var.destination_s3_bucket_arn}/*",
+    ]
+  }
+
+  # Encrypt with the destination bucket's KMS key.
+  statement {
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+    resources = [var.destination_kms_key_arn]
+  }
+
+  # CloudWatch Logs error stream for Firehose.
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "firehose" {
+  name   = "${var.cluster_name}-eks-log-firehose"
+  role   = aws_iam_role.firehose.id
+  policy = data.aws_iam_policy_document.firehose.json
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "this" {
+  name        = "${var.cluster_name}-eks-control-plane-logs"
+  destination = "extended_s3"
+
+  extended_s3_configuration {
+    role_arn            = aws_iam_role.firehose.arn
+    bucket_arn          = var.destination_s3_bucket_arn
+    prefix              = "${var.destination_s3_prefix}/AWSLogs/!{partitionKeyFromQuery:account_id}/${var.aws_region}/${var.cluster_name}/"
+    error_output_prefix = "${var.destination_s3_prefix}-errors/"
+
+    buffering_interval = var.firehose_buffer_seconds
+    buffering_size     = var.firehose_buffer_size_mb
+
+    compression_format = "GZIP"
+
+    kms_key_arn = var.destination_kms_key_arn
+
+    cloudwatch_logging_options {
+      enabled         = true
+      log_group_name  = "/aws/kinesisfirehose/${var.cluster_name}-eks-logs"
+      log_stream_name = "S3Delivery"
+    }
+
+    dynamic_partitioning_configuration {
+      enabled = true
+    }
+
+    processing_configuration {
+      enabled = true
+
+      processors {
+        type = "MetadataExtraction"
+
+        parameters {
+          parameter_name  = "MetadataExtractionQuery"
+          parameter_value = "{account_id: .userIdentity.accountId}"
+        }
+
+        parameters {
+          parameter_name  = "JsonParsingEngine"
+          parameter_value = "JQ-1.6"
+        }
+      }
+    }
+  }
+
+  tags = var.tags
+}
+
+# -----------------------------------------------------------------------------
+# CloudWatch Logs subscription filter — fan-in from each forwarded stream
+# -----------------------------------------------------------------------------
+data "aws_iam_policy_document" "subscription_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["logs.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "subscription" {
+  name               = "${var.cluster_name}-eks-log-subscription"
+  assume_role_policy = data.aws_iam_policy_document.subscription_assume.json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "subscription" {
+  statement {
+    actions = [
+      "firehose:PutRecord",
+      "firehose:PutRecordBatch",
+    ]
+    resources = [aws_kinesis_firehose_delivery_stream.this.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "subscription" {
+  name   = "${var.cluster_name}-eks-log-subscription"
+  role   = aws_iam_role.subscription.id
+  policy = data.aws_iam_policy_document.subscription.json
+}
+
+# Subscription filter: one per stream we forward (audit, authenticator).
+# CloudWatch's filter pattern '' matches every record on the stream.
+resource "aws_cloudwatch_log_subscription_filter" "this" {
+  for_each = toset(var.log_streams_to_forward)
+
+  name            = "${var.cluster_name}-${each.value}-to-firehose"
+  log_group_name  = aws_cloudwatch_log_group.cluster.name
+  filter_pattern  = ""
+  destination_arn = aws_kinesis_firehose_delivery_stream.this.arn
+  role_arn        = aws_iam_role.subscription.arn
+  distribution    = "ByLogStream"
+}

--- a/terraform/modules/eks-log-aggregation/outputs.tf
+++ b/terraform/modules/eks-log-aggregation/outputs.tf
@@ -1,0 +1,19 @@
+output "log_group_name" {
+  description = "Name of the CloudWatch log group ingesting EKS control-plane logs."
+  value       = aws_cloudwatch_log_group.cluster.name
+}
+
+output "firehose_delivery_stream_arn" {
+  description = "ARN of the Kinesis Firehose delivery stream forwarding logs to the central bucket."
+  value       = aws_kinesis_firehose_delivery_stream.this.arn
+}
+
+output "firehose_role_arn" {
+  description = "ARN of the IAM role assumed by Firehose for S3 + KMS access."
+  value       = aws_iam_role.firehose.arn
+}
+
+output "subscription_role_arn" {
+  description = "ARN of the IAM role used by the CloudWatch Logs subscription filter."
+  value       = aws_iam_role.subscription.arn
+}

--- a/terraform/modules/eks-log-aggregation/variables.tf
+++ b/terraform/modules/eks-log-aggregation/variables.tf
@@ -1,0 +1,59 @@
+variable "cluster_name" {
+  description = "EKS cluster name. Used to derive the source CloudWatch log group (`/aws/eks/<name>/cluster`) and to namespace resource names."
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region of the EKS cluster."
+  type        = string
+}
+
+variable "log_group_retention_days" {
+  description = "Retention for the source CloudWatch log group. PCI-DSS Req 10.7 requires at least 1 year. Long-term retention happens in S3 (centralized-logging module #182)."
+  type        = number
+  default     = 90
+  validation {
+    condition     = contains([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653], var.log_group_retention_days)
+    error_message = "log_group_retention_days must be one of CloudWatch's allowed retention values."
+  }
+}
+
+variable "destination_s3_bucket_arn" {
+  description = "ARN of the centralized log-archive S3 bucket (provisioned by terraform/modules/centralized-logging in the log-archive account)."
+  type        = string
+}
+
+variable "destination_s3_prefix" {
+  description = "Prefix in the destination bucket where audit + authenticator logs land. Maps to the eks-audit / eks-authenticator entries in centralized-logging.log_source_prefixes."
+  type        = string
+  default     = "eks-audit"
+}
+
+variable "destination_kms_key_arn" {
+  description = "ARN of the KMS key on the destination S3 bucket (consumed by Firehose for SSE-KMS during write)."
+  type        = string
+}
+
+variable "log_streams_to_forward" {
+  description = "Subset of EKS control-plane log streams to forward to the central bucket. Defaults to audit + authenticator (the security-critical ones)."
+  type        = list(string)
+  default     = ["kube-apiserver-audit", "authenticator"]
+}
+
+variable "firehose_buffer_seconds" {
+  description = "Firehose buffer interval. Trade off between near-real-time (60s) and write-cost (300s)."
+  type        = number
+  default     = 60
+}
+
+variable "firehose_buffer_size_mb" {
+  description = "Firehose buffer size in MB. Together with buffer_seconds determines flush cadence."
+  type        = number
+  default     = 5
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/eks-log-aggregation/versions.tf
+++ b/terraform/modules/eks-log-aggregation/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## Scope — Issue #178

Workload-account-side complement to `centralized-logging` (#182). Forwards EKS control-plane audit + authenticator log streams to the central log-archive bucket via CloudWatch Logs subscription → Kinesis Firehose → S3.

Closes #178.

## Pipeline
```
EKS control plane
  -> /aws/eks/<cluster>/cluster (CloudWatch Logs)
       (audit, authenticator)
       -> CloudWatch Logs subscription filter (filter_pattern='')
          -> Kinesis Firehose (60s/5MB buffer, GZIP, dynamic partition by accountId)
             -> S3 (log-archive bucket cross-account write, SSE-KMS)
```

## Files
- `terraform/modules/eks-log-aggregation/{versions,variables,main,outputs}.tf` + `README.md`

## Acceptance criteria
- [x] EKS control-plane logs enabled per cluster (pre-existing in `modules/eks`)
- [x] Log forwarding to centralized bucket (Firehose pipeline)
- [x] Retention policy applied (90d CW short-term + S3 long-term via #182)
- [x] Documented log schema and access pattern (Athena query example in README)

## Cost
~\$1-2/month per cluster (1.5GB audit traffic for 100-node cluster).

## Security
Firehose role scoped to single bucket + KMS key. Subscription role scoped to single stream. `prevent_destroy` on the log group prevents accidental audit-trail loss. No `Delete*` permissions anywhere.

## Rollback
`terraform destroy` (after flipping `prevent_destroy=false` in a separate PR if needed).