### PR TITLE
feat: add rabbitmq-cluster app and env overrides for dual-cluster EKS topology

### DIFF
--- a/apps/infra/rabbitmq-cluster/Chart.yaml
+++ b/apps/infra/rabbitmq-cluster/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: rabbitmq-cluster
+description: Provisions the RabbitMQ cluster instance and associated vhosts, users, and permissions
+type: application
+version: 1.0.0
+appVersion: "1.0.0"

--- a/apps/infra/rabbitmq-cluster/templates/rabbitmq-cluster.yaml
+++ b/apps/infra/rabbitmq-cluster/templates/rabbitmq-cluster.yaml
@@ -1,0 +1,23 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: qbiq-rabbitmq
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.rabbitmq.replicas }}
+  rabbitmq:
+    additionalPlugins:
+      - rabbitmq_management
+      - rabbitmq_prometheus
+      - rabbitmq_shovel
+      - rabbitmq_shovel_management
+  persistence:
+    storageClassName: {{ .Values.rabbitmq.storageClassName }}
+    storage: {{ .Values.rabbitmq.storageSize }}
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: "2"
+      memory: 2Gi

--- a/apps/infra/rabbitmq-cluster/templates/rabbitmq-topology.yaml
+++ b/apps/infra/rabbitmq-cluster/templates/rabbitmq-topology.yaml
@@ -1,0 +1,84 @@
+{{- if eq .Values.environment "production" }}
+{{- range $env := list "prod" "ops" "env2" "env3" }}
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Vhost
+metadata:
+  name: {{ $env }}-vhost
+  namespace: {{ $.Release.Namespace }}
+spec:
+  name: /{{ $env }}
+  rabbitmqClusterReference:
+    name: qbiq-rabbitmq
+
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: User
+metadata:
+  name: {{ $env }}-user
+  namespace: {{ $.Release.Namespace }}
+spec:
+  tags: []
+  rabbitmqClusterReference:
+    name: qbiq-rabbitmq
+  importCredentialsSecret:
+    name: rabbitmq-{{ $env }}-credentials
+
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Permission
+metadata:
+  name: {{ $env }}-permission
+  namespace: {{ $.Release.Namespace }}
+spec:
+  vhost: /{{ $env }}
+  user: {{ $env }}-user
+  permissions:
+    configure: ".*"
+    write: ".*"
+    read: ".*"
+  rabbitmqClusterReference:
+    name: qbiq-rabbitmq
+{{- end }}
+{{- else }}
+# Default vhost for shared/dev/preview environments
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Vhost
+metadata:
+  name: preview-vhost
+  namespace: {{ .Release.Namespace }}
+spec:
+  name: /preview
+  rabbitmqClusterReference:
+    name: qbiq-rabbitmq
+
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: User
+metadata:
+  name: preview-user
+  namespace: {{ .Release.Namespace }}
+spec:
+  tags: []
+  rabbitmqClusterReference:
+    name: qbiq-rabbitmq
+  importCredentialsSecret:
+    name: rabbitmq-preview-credentials
+
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Permission
+metadata:
+  name: preview-permission
+  namespace: {{ .Release.Namespace }}
+spec:
+  vhost: /preview
+  user: preview-user
+  permissions:
+    configure: ".*"
+    write: ".*"
+    read: ".*"
+  rabbitmqClusterReference:
+    name: qbiq-rabbitmq
+{{- end }}

--- a/apps/infra/rabbitmq-cluster/values.yaml
+++ b/apps/infra/rabbitmq-cluster/values.yaml
@@ -1,0 +1,7 @@
+# Default values for rabbitmq-cluster.
+# Overridden per environment under envs/<env>/values/infra/rabbitmq-cluster.yaml.
+
+rabbitmq:
+  replicas: 1
+  storageSize: 10Gi
+  storageClassName: gp3

--- a/envs/production/values/infra/rabbitmq-cluster.yaml
+++ b/envs/production/values/infra/rabbitmq-cluster.yaml
@@ -1,0 +1,5 @@
+environment: "production"
+rabbitmq:
+  replicas: 3
+  storageSize: 20Gi
+  storageClassName: gp3

--- a/envs/production/values/infra/rabbitmq-operator.yaml
+++ b/envs/production/values/infra/rabbitmq-operator.yaml
@@ -1,0 +1,19 @@
+rabbitmq-cluster-operator:
+  clusterOperator:
+    replicaCount: 2
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+  msgTopologyOperator:
+    replicaCount: 2
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi

--- a/envs/shared/values/infra/rabbitmq-cluster.yaml
+++ b/envs/shared/values/infra/rabbitmq-cluster.yaml
@@ -1,0 +1,5 @@
+environment: "shared"
+rabbitmq:
+  replicas: 1
+  storageSize: 5Gi
+  storageClassName: gp3

--- a/envs/shared/values/infra/rabbitmq-operator.yaml
+++ b/envs/shared/values/infra/rabbitmq-operator.yaml
@@ -1,0 +1,19 @@
+rabbitmq-cluster-operator:
+  clusterOperator:
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 300m
+        memory: 256Mi
+  msgTopologyOperator:
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi


### PR DESCRIPTION
## Summary
This PR adds the Kubernetes/ArgoCD resources for running **RabbitMQ inside the EKS cluster** via the RabbitMQ Cluster Operator.

## Changes
- Added `apps/infra/rabbitmq-cluster/` Helm chart and templates for the cluster and dynamic topology management.
- Provisioned environment-specific value overrides in `envs/shared/values/infra/` and `envs/production/values/infra/` with topology and resource limits.
- Set up virtual hosts (`/prod`, `/ops`, etc.) to align with our simplified environment separation in the EKS clusters.

## Linked Issues
Supersedes #178.