### PR TITLE
chore(creme): switch hello-world HelmRelease to image digest

### DIFF
--- a/apps/direct/hello-world/README.md
+++ b/apps/direct/hello-world/README.md
@@ -1,0 +1,21 @@
+# hello-world (Creme-ala-creme)
+
+GitOps deployment manifest for the `hello-world` application owned by
+[`100rd/Creme-ala-creme`](https://github.com/100rd/Creme-ala-creme).
+
+## Update flow
+
+1. A push to `main` in `Creme-ala-creme` builds the image, pushes it,
+   and captures the resulting `sha256:...` digest.
+2. The `gitops-pr` job in that repo opens a PR here updating
+   `helmrelease.yaml`:
+   - `spec.values.image.repository` ← canonical ECR URL
+   - `spec.values.image.digest`     ← new sha256 digest
+   - `spec.values.image.tag`        ← cleared (digest wins)
+3. A human reviewer (or branch protection auto-merge) merges that PR.
+4. Flux reconciles the HelmRelease and rolls out the new digest.
+
+## Rollback
+
+Revert the PR that introduced the digest you want to back out. Flux
+reconciles the older digest on the next interval.

--- a/apps/direct/hello-world/helmrelease.yaml
+++ b/apps/direct/hello-world/helmrelease.yaml
@@ -1,0 +1,63 @@
+# hello-world (Creme-ala-creme) HelmRelease.
+#
+# This HelmRelease is the GitOps target updated by the
+# `gitops-pr` job in `100rd/Creme-ala-creme/.github/workflows/ci.yml`.
+# When the Creme-ala-creme `main` branch builds and pushes a new image,
+# its CI captures the resulting `sha256:...` digest and opens a PR
+# against this file with the new `image.digest` value (and clears
+# `image.tag` so the digest wins).
+#
+# Why digest, not tag:
+#   - tags are mutable; an attacker (or a CI race) can repoint
+#     `:latest` or even `:sha-<commit>` to a different image.
+#   - digests are content-addressed and are the only image reference
+#     that can be safely audited end-to-end.
+#
+# To roll back, simply revert the PR that bumped the digest.
+
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: hello-world
+  namespace: hello-world
+spec:
+  releaseName: hello-world
+  targetNamespace: hello-world
+  interval: 5m
+
+  # The chart lives in the Creme-ala-creme repo so that the chart and
+  # the app version stay in lock-step. Point a GitRepository at it.
+  chart:
+    spec:
+      chart: hello-world/helm/hello-world
+      sourceRef:
+        kind: GitRepository
+        name: creme-ala-creme
+        namespace: flux-system
+      interval: 1m
+
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+
+  upgrade:
+    remediation:
+      retries: 3
+
+  values:
+    replicaCount: 2
+    image:
+      # `repository` and `digest` are bumped by the GitOps PR opened by
+      # Creme-ala-creme CI on every main-branch push. `tag` is kept as
+      # an empty string so the chart's helper picks `digest` over `tag`.
+      repository: 000000000000.dkr.ecr.eu-central-1.amazonaws.com/hello-world
+      digest: ""
+      tag: ""
+      pullPolicy: IfNotPresent
+    containerPort: 8080
+    service:
+      type: ClusterIP
+      port: 80
+    ingress:
+      enabled: false


### PR DESCRIPTION
## Summary

Adds a Flux `HelmRelease` for the Creme-ala-creme hello-world app pinned by sha256 digest instead of a mutable tag.

- `apps/direct/hello-world/helmrelease.yaml` — HelmRelease pointing at the chart in `100rd/Creme-ala-creme`; `image.digest` takes precedence over `image.tag` (which is left empty)
- `apps/direct/hello-world/README.md` — documents the GitOps update flow

## Why

Tags are mutable; an attacker or CI race can repoint `:latest` (or even `:sha-<commit>`) to a different image. Digests are content-addressed and the only image reference that can be audited end-to-end.

## Update flow (after merge)

1. A push to `main` in `Creme-ala-creme` builds the image and captures the resulting `sha256:...` digest.
2. The new `gitops-pr` job in `100rd/Creme-ala-creme/.github/workflows/ci.yml` opens a PR here updating `spec.values.image.digest` (and clearing `image.tag` so digest wins).
3. A reviewer merges; Flux reconciles the new digest.

## Test plan

- [x] `apps/direct/hello-world/helmrelease.yaml` parses as valid YAML
- [x] Chart digest precedence verified via `helm template` in the Creme repo (renders `repository@digest`)
- [x] CI step that opens this PR uses `peter-evans/create-pull-request@5e914681...` (v7.0.5), pinned by SHA
- [ ] After merge: CI on Creme-ala-creme `main` opens an automated follow-up PR bumping the digest

## Companion PR

Creme-ala-creme: `feat: delivery hardening - immutable digest, alerts/runbooks, ephemeral envs` (linked from this PR's body once both are open).