### PR TITLE
feat(helm): Argo Rollouts canary + Gateway API progressive delivery in generic app chart

### DIFF
--- a/helm/app/Chart.yaml
+++ b/helm/app/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: app
-description: Cloud-native application chart with 12-factor support
-version: 0.3.0
+description: Cloud-native application chart with 12-factor support and optional Argo Rollouts canary (Gateway API trafficRouting)
+version: 0.4.0
 appVersion: "1.0"
 type: application

--- a/helm/app/README.md
+++ b/helm/app/README.md
@@ -4,15 +4,58 @@ This Helm chart deploys a generic application container with optional Nginx ingr
 
 ## Features
 
-- Deployment and Service resources.
+- Deployment **or** Argo Rollouts canary (`rollout.enabled` toggle) — mutually exclusive workload kinds sharing one pod spec.
+- Service resource, plus an optional weighted **canary Service** for progressive delivery.
 - Optional Ingress resource supporting multiple ingress classes (e.g., `nginx`, `internal-nginx`).
+- Optional Gateway API `HTTPRoute` for internal ingress and canary traffic shifting.
 - Optional ExternalSecret resource to fetch secrets from AWS Secrets Manager via External Secrets Operator.
+
+## Workload kind: Deployment vs Argo Rollouts canary
+
+By default (`rollout.enabled: false`) the chart renders a plain `Deployment` — this
+is backward compatible, so existing releases are unaffected.
+
+Set `rollout.enabled: true` to render an **Argo Rollouts canary `Rollout`** instead
+of the Deployment (the two are mutually exclusive). The Rollout:
+
+- Splits traffic between a **stable Service** (`<fullname>`, 100% under steady
+  state) and a **canary Service** (`<fullname>-canary`, the weighted fraction).
+- Shifts traffic with the Gateway API plugin (`argoproj-labs/gatewayAPI`), which
+  rewrites the `HTTPRoute` backendRef weights — Cilium drains connections on each
+  shift. Requires `httpRoute.enabled: true`.
+- Progresses through a weight ladder (default `10 → 30 → 50 → 100`) with an
+  `AnalysisTemplate` gate between each step.
+- Aborts gracefully via `abortScaleDownDelaySeconds`, keeping the canary
+  ReplicaSet alive briefly so in-flight requests drain.
+
+The container/pod definition is shared between Deployment and Rollout via the
+`app.podSpec` helper, so the two kinds never diverge.
+
+### Analysis gate (AnalysisTemplate)
+
+When `rollout.analysis.enabled: true` (default), each canary step is gated on two
+Prometheus metrics, scoped to the canary Service:
+
+- **5xx error-rate** must stay `< 1%` (`rollout.analysis.errorRate`).
+- **p95 latency** must stay `< 500ms` (`rollout.analysis.latencyP95`).
+
+Disable it (`rollout.analysis.enabled: false`) for pure workers with no HTTP
+metrics.
+
+> **Where Kargo fits:** Kargo remains the planned promotion layer *above* this
+> chart — it promotes verified artifacts between environments. This chart's
+> `rollout` block governs the in-cluster canary once a version lands in an
+> environment.
 
 ## Values
 
 Key settings in `values.yaml`:
 
 - `image.repository` – container image to deploy.
+- `rollout.enabled` – switch from Deployment to an Argo Rollouts canary Rollout.
+- `rollout.canary.weights` – progressive weight ladder for the canary.
+- `rollout.analysis.enabled` – toggle the Prometheus metric gate between steps.
+- `httpRoute.enabled` – enable the Gateway API HTTPRoute (required for canary traffic shifting).
 - `ingress.enabled` – enable ingress.
 - `ingress.className` – default ingress class.
 - `ingress.extraClasses` – additional ingress classes to create separate ingress objects.
@@ -20,3 +63,11 @@ Key settings in `values.yaml`:
 - `externalSecrets.secretStoreRef` – reference to a `SecretStore` or `ClusterSecretStore` configured for AWS.
 
 Consult the `values.yaml` file for the full list of configuration options.
+
+## Provenance
+
+The progressive-delivery machinery (`rollout.yaml`, `service-canary.yaml`,
+`analysistemplate.yaml`, `httproute.yaml`, the `app.podSpec` shared helper, and
+the `rollout` / `httpRoute` values blocks) was **ported from
+`qbiq-ai/argocd@c364c6c` `charts/qbiq-app`, 2026-06 sync**, adapted to this
+chart's `app.*` helper templates and naming conventions.

--- a/helm/app/README.md
+++ b/helm/app/README.md
@@ -69,5 +69,5 @@ Consult the `values.yaml` file for the full list of configuration options.
 The progressive-delivery machinery (`rollout.yaml`, `service-canary.yaml`,
 `analysistemplate.yaml`, `httproute.yaml`, the `app.podSpec` shared helper, and
 the `rollout` / `httpRoute` values blocks) was **ported from
-`qbiq-ai/argocd@c364c6c` `charts/qbiq-app`, 2026-06 sync**, adapted to this
+`argocd@c364c6c` `charts/app`, 2026-06 sync**, adapted to this
 chart's `app.*` helper templates and naming conventions.

--- a/helm/app/templates/_helpers.tpl
+++ b/helm/app/templates/_helpers.tpl
@@ -37,3 +37,125 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- default "default" .Values.serviceAccount.name -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Shared pod spec — rendered as the body of `template.spec:` for BOTH the
+Deployment and the Argo Rollouts Rollout so the container/pod definition never
+diverges between the two workload kinds. Include with `nindent 6`.
+*/}}
+{{- define "app.podSpec" -}}
+serviceAccountName: {{ include "app.serviceAccountName" . }}
+terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
+{{- with .Values.podSecurityContext }}
+securityContext:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.initContainers }}
+initContainers:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+containers:
+  - name: {{ .Chart.Name }}
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+    imagePullPolicy: {{ .Values.image.pullPolicy }}
+    {{- with .Values.containerSecurityContext }}
+    securityContext:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    ports:
+      - name: http
+        containerPort: {{ .Values.containerPort }}
+        protocol: TCP
+    {{- with .Values.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- if .Values.probes.liveness.enabled }}
+    livenessProbe:
+      httpGet:
+        path: {{ .Values.probes.liveness.httpGet.path }}
+        port: {{ .Values.probes.liveness.httpGet.port }}
+      initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+      periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+      timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+      failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+    {{- end }}
+    {{- if .Values.probes.readiness.enabled }}
+    readinessProbe:
+      httpGet:
+        path: {{ .Values.probes.readiness.httpGet.path }}
+        port: {{ .Values.probes.readiness.httpGet.port }}
+      initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+      periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+      timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+      failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+    {{- end }}
+    {{- if .Values.probes.startup.enabled }}
+    startupProbe:
+      httpGet:
+        path: {{ .Values.probes.startup.httpGet.path }}
+        port: {{ .Values.probes.startup.httpGet.port }}
+      initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+      periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+      timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+      failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+    {{- end }}
+    {{- with .Values.lifecycle }}
+    lifecycle:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- if or .Values.externalSecrets.enabled .Values.envFrom }}
+    envFrom:
+      {{- if .Values.externalSecrets.enabled }}
+      - secretRef:
+          name: {{ include "app.fullname" . }}-secrets
+      {{- end }}
+      {{- with .Values.envFrom }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- end }}
+    {{- with .Values.env }}
+    env:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- with .Values.topologySpreadConstraints }}
+topologySpreadConstraints:
+  {{- range . }}
+  - maxSkew: {{ .maxSkew }}
+    topologyKey: {{ .topologyKey }}
+    whenUnsatisfiable: {{ .whenUnsatisfiable }}
+    labelSelector:
+      matchLabels:
+        {{- include "app.selectorLabels" $ | nindent 8 }}
+  {{- end }}
+{{- end }}
+{{- with .Values.affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.tolerations }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Pod template metadata (labels + annotations) shared by Deployment and Rollout.
+Include with `nindent 6` under `template:`.
+*/}}
+{{- define "app.podTemplateMeta" -}}
+metadata:
+  labels:
+    {{- include "app.selectorLabels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.podAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/helm/app/templates/analysistemplate.yaml
+++ b/helm/app/templates/analysistemplate.yaml
@@ -9,7 +9,7 @@
   both scoped to the canary Service so stable traffic is not counted. Queries are
   parametrised on {{`{{args.service}}`}} (the canary Service, injected per-step).
 
-  Ported from qbiq-ai/argocd@c364c6c charts/qbiq-app (2026-06 sync), adapted to
+  Ported from argocd@c364c6c charts/app (2026-06 sync), adapted to
   platform-design's app.* helpers.
 */}}
 {{- if and .Values.rollout.enabled .Values.rollout.analysis.enabled }}

--- a/helm/app/templates/analysistemplate.yaml
+++ b/helm/app/templates/analysistemplate.yaml
@@ -1,0 +1,47 @@
+---
+{{- /*
+  AnalysisTemplate — the metric gate between canary steps. Referenced by the
+  inline analysis steps in templates/rollout.yaml (templateName = app.fullname).
+  Renders only when rollout.enabled AND rollout.analysis.enabled, so pure workers
+  (no HTTP metrics) can disable it via rollout.analysis.enabled=false.
+
+  Two metrics gate each promotion: 5xx error-rate (<1%) and p95 latency (<500ms),
+  both scoped to the canary Service so stable traffic is not counted. Queries are
+  parametrised on {{`{{args.service}}`}} (the canary Service, injected per-step).
+
+  Ported from qbiq-ai/argocd@c364c6c charts/qbiq-app (2026-06 sync), adapted to
+  platform-design's app.* helpers.
+*/}}
+{{- if and .Values.rollout.enabled .Values.rollout.analysis.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  args:
+    # The canary Service name is passed by the inline analysis step in the Rollout.
+    - name: service          # canary Service, injected per-step
+  metrics:
+    - name: error-rate
+      interval: {{ .Values.rollout.analysis.interval | default "30s" }}
+      count: {{ .Values.rollout.analysis.count | default 5 }}
+      failureLimit: {{ .Values.rollout.analysis.failureLimit | default 1 }}
+      successCondition: {{ .Values.rollout.analysis.errorRate.successCondition | quote }}
+      provider:
+        prometheus:
+          address: {{ .Values.rollout.analysis.prometheusAddress | quote }}
+          query: |
+            {{- .Values.rollout.analysis.errorRate.query | nindent 12 }}
+    - name: latency-p95
+      interval: {{ .Values.rollout.analysis.interval | default "30s" }}
+      count: {{ .Values.rollout.analysis.count | default 5 }}
+      failureLimit: {{ .Values.rollout.analysis.failureLimit | default 1 }}
+      successCondition: {{ .Values.rollout.analysis.latencyP95.successCondition | quote }}
+      provider:
+        prometheus:
+          address: {{ .Values.rollout.analysis.prometheusAddress | quote }}
+          query: |
+            {{- .Values.rollout.analysis.latencyP95.query | nindent 12 }}
+{{- end }}

--- a/helm/app/templates/deployment.yaml
+++ b/helm/app/templates/deployment.yaml
@@ -1,4 +1,13 @@
 ---
+{{- /*
+  Deployment is the default workload kind. It is mutually exclusive with the
+  Argo Rollouts Rollout (templates/rollout.yaml): when rollout.enabled=true this
+  Deployment is suppressed and a Rollout takes over. Default rollout.enabled is
+  false, so existing releases keep getting a plain Deployment (backward compat).
+  The pod spec is rendered from the shared `app.podSpec` helper so the container
+  definition never diverges between Deployment and Rollout.
+*/}}
+{{- if not .Values.rollout.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -6,7 +15,7 @@ metadata:
   labels:
     {{- include "app.labels" . | nindent 4 }}
     {{- with .Values.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
@@ -16,111 +25,7 @@ spec:
     matchLabels:
       {{- include "app.selectorLabels" . | nindent 6 }}
   template:
-    metadata:
-      labels:
-        {{- include "app.selectorLabels" . | nindent 8 }}
-        {{- with .Values.labels }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-      {{- with .Values.podAnnotations }}
-      annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+    {{- include "app.podTemplateMeta" . | nindent 4 }}
     spec:
-      serviceAccountName: {{ include "app.serviceAccountName" . }}
-      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
-      {{- with .Values.podSecurityContext }}
-      securityContext:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.initContainers }}
-      initContainers:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      containers:
-        - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.containerSecurityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          ports:
-            - name: http
-              containerPort: {{ .Values.containerPort }}
-              protocol: TCP
-          {{- with .Values.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- if .Values.probes.liveness.enabled }}
-          livenessProbe:
-            httpGet:
-              path: {{ .Values.probes.liveness.httpGet.path }}
-              port: {{ .Values.probes.liveness.httpGet.port }}
-            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
-            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
-            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
-            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
-          {{- end }}
-          {{- if .Values.probes.readiness.enabled }}
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.probes.readiness.httpGet.path }}
-              port: {{ .Values.probes.readiness.httpGet.port }}
-            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
-            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
-            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
-            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
-          {{- end }}
-          {{- if .Values.probes.startup.enabled }}
-          startupProbe:
-            httpGet:
-              path: {{ .Values.probes.startup.httpGet.path }}
-              port: {{ .Values.probes.startup.httpGet.port }}
-            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
-            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
-            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
-            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
-          {{- end }}
-          {{- with .Values.lifecycle }}
-          lifecycle:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- if or .Values.externalSecrets.enabled .Values.envFrom }}
-          envFrom:
-            {{- if .Values.externalSecrets.enabled }}
-            - secretRef:
-                name: {{ include "app.fullname" . }}-secrets
-            {{- end }}
-            {{- with .Values.envFrom }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- end }}
-          {{- with .Values.env }}
-          env:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-      {{- with .Values.topologySpreadConstraints }}
-      topologySpreadConstraints:
-        {{- range . }}
-        - maxSkew: {{ .maxSkew }}
-          topologyKey: {{ .topologyKey }}
-          whenUnsatisfiable: {{ .whenUnsatisfiable }}
-          labelSelector:
-            matchLabels:
-              {{- include "app.selectorLabels" $ | nindent 14 }}
-        {{- end }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "app.podSpec" . | nindent 6 }}
+{{- end }}

--- a/helm/app/templates/httproute.yaml
+++ b/helm/app/templates/httproute.yaml
@@ -7,7 +7,7 @@
   should ignore this path via ignoreDifferences on the Application). Without a
   Rollout, a single backendRef points at the stable Service.
 
-  Ported from qbiq-ai/argocd@c364c6c charts/qbiq-app (2026-06 sync), adapted to
+  Ported from argocd@c364c6c charts/app (2026-06 sync), adapted to
   platform-design's app.* helpers.
 */}}
 {{- if .Values.httpRoute.enabled }}

--- a/helm/app/templates/httproute.yaml
+++ b/helm/app/templates/httproute.yaml
@@ -1,0 +1,59 @@
+---
+{{- /*
+  Internal ingress via Gateway API (Cilium Gateway). Off by default. When the
+  Rollout is active, BOTH the stable and canary Services are listed as
+  backendRefs so the argoproj-labs/gatewayAPI plugin can shift weights between
+  them during a canary; Argo Rollouts owns those weights at runtime (ArgoCD
+  should ignore this path via ignoreDifferences on the Application). Without a
+  Rollout, a single backendRef points at the stable Service.
+
+  Ported from qbiq-ai/argocd@c364c6c charts/qbiq-app (2026-06 sync), adapted to
+  platform-design's app.* helpers.
+*/}}
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ .Values.httpRoute.gateway.name }}
+      namespace: {{ .Values.httpRoute.gateway.namespace }}
+      sectionName: {{ .Values.httpRoute.gateway.sectionName }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ .Values.httpRoute.path | default "/" | quote }}
+      backendRefs:
+        {{- if .Values.rollout.enabled }}
+        # Both backendRefs must be present so the Gateway API plugin can adjust
+        # weights. Argo Rollouts owns these weights at runtime — configure ArgoCD
+        # to ignore this path via ignoreDifferences in the Application.
+        # Initial weights: stable=100, canary=0 (plugin sets them on rollout start).
+        - group: ""
+          kind: Service
+          name: {{ include "app.fullname" . }}
+          port: {{ .Values.service.port }}
+          weight: 100
+        - group: ""
+          kind: Service
+          name: {{ include "app.fullname" . }}-canary
+          port: {{ .Values.service.port }}
+          weight: 0
+        {{- else }}
+        - group: ""
+          kind: Service
+          name: {{ include "app.fullname" . }}
+          port: {{ .Values.service.port }}
+          weight: 1
+        {{- end }}
+{{- end }}

--- a/helm/app/templates/rollout.yaml
+++ b/helm/app/templates/rollout.yaml
@@ -1,0 +1,71 @@
+---
+{{- /*
+  app.canarySteps: builds the canary steps list.
+  For each weight in rollout.canary.weights: setWeight(w), then an inline analysis
+  step (when rollout.analysis.enabled). A final setWeight: 100 is appended.
+  If rollout.canary.customSteps is non-empty it is rendered verbatim instead —
+  use it for non-standard ladders (e.g. workers without analysis gates).
+
+  Ported from qbiq-ai/argocd@c364c6c charts/qbiq-app (2026-06 sync), adapted to
+  platform-design's app.* helper templates and naming conventions.
+*/}}
+{{- define "app.canarySteps" -}}
+{{- if .Values.rollout.canary.customSteps }}
+{{- toYaml .Values.rollout.canary.customSteps }}
+{{- else }}
+{{- $fullname := include "app.fullname" . -}}
+{{- $analysisEnabled := .Values.rollout.analysis.enabled -}}
+{{- range .Values.rollout.canary.weights }}
+- setWeight: {{ . }}
+{{- if $analysisEnabled }}
+- analysis:
+    templates:
+      - templateName: {{ $fullname }}
+    args:
+      - name: service
+        value: {{ $fullname }}-canary
+{{- end }}
+{{- end }}
+- setWeight: 100
+{{- end }}
+{{- end }}
+{{- if .Values.rollout.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "app.selectorLabels" . | nindent 6 }}
+  template:
+    {{- include "app.podTemplateMeta" . | nindent 4 }}
+    spec:
+      {{- include "app.podSpec" . | nindent 6 }}
+  strategy:
+    canary:
+      # stableService receives 100% of production traffic; canaryService
+      # receives the weighted fraction while the canary ReplicaSet is live.
+      # The Gateway API plugin (argoproj-labs/gatewayAPI) adjusts the HTTPRoute
+      # backendRef weights — Envoy/Cilium drains connections on each shift.
+      stableService: {{ include "app.fullname" . }}
+      canaryService: {{ include "app.fullname" . }}-canary
+      # Graceful abort: if analysis fails, the canary ReplicaSet stays alive for
+      # this many seconds after abort so in-flight requests complete.
+      abortScaleDownDelaySeconds: {{ .Values.rollout.abortScaleDownDelaySeconds }}
+      trafficRouting:
+        plugins:
+          argoproj-labs/gatewayAPI:
+            httpRoute: {{ include "app.fullname" . }}
+            namespace: {{ .Release.Namespace }}
+      steps:
+        {{- include "app.canarySteps" . | trim | nindent 8 }}
+{{- end }}

--- a/helm/app/templates/rollout.yaml
+++ b/helm/app/templates/rollout.yaml
@@ -6,7 +6,7 @@
   If rollout.canary.customSteps is non-empty it is rendered verbatim instead —
   use it for non-standard ladders (e.g. workers without analysis gates).
 
-  Ported from qbiq-ai/argocd@c364c6c charts/qbiq-app (2026-06 sync), adapted to
+  Ported from argocd@c364c6c charts/app (2026-06 sync), adapted to
   platform-design's app.* helper templates and naming conventions.
 */}}
 {{- define "app.canarySteps" -}}

--- a/helm/app/templates/service-canary.yaml
+++ b/helm/app/templates/service-canary.yaml
@@ -1,0 +1,28 @@
+---
+{{- /*
+  Canary Service for Gateway API canary trafficRouting: Argo Rollouts points it
+  at the canary ReplicaSet. The Gateway API plugin (argoproj-labs/gatewayAPI)
+  adjusts its backendRef weight in the HTTPRoute; do not set a weight here.
+  Only rendered alongside the Rollout (rollout.enabled=true). Mirrors the stable
+  Service (templates/service.yaml) but is intentionally cluster-local (no Cilium
+  global / ClusterMesh annotations — canary traffic stays in-cluster).
+
+  Ported from qbiq-ai/argocd@c364c6c charts/qbiq-app (2026-06 sync).
+*/}}
+{{- if .Values.rollout.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "app.fullname" . }}-canary
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "app.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/app/templates/service-canary.yaml
+++ b/helm/app/templates/service-canary.yaml
@@ -7,7 +7,7 @@
   Service (templates/service.yaml) but is intentionally cluster-local (no Cilium
   global / ClusterMesh annotations — canary traffic stays in-cluster).
 
-  Ported from qbiq-ai/argocd@c364c6c charts/qbiq-app (2026-06 sync).
+  Ported from argocd@c364c6c charts/app (2026-06 sync).
 */}}
 {{- if .Values.rollout.enabled }}
 apiVersion: v1

--- a/helm/app/values.yaml
+++ b/helm/app/values.yaml
@@ -106,7 +106,7 @@ service:
   shared: false
 
 # --- Progressive delivery (Argo Rollouts canary) -----------------------------
-# Ported from qbiq-ai/argocd@c364c6c charts/qbiq-app (2026-06 sync).
+# Ported from argocd@c364c6c charts/app (2026-06 sync).
 #
 # rollout.enabled=false → a plain Deployment (templates/deployment.yaml).
 # rollout.enabled=true  → an Argo Rollouts canary Rollout replaces the

--- a/helm/app/values.yaml
+++ b/helm/app/values.yaml
@@ -105,6 +105,74 @@ service:
   # Shared: when true, load-balances across local AND remote pods simultaneously
   shared: false
 
+# --- Progressive delivery (Argo Rollouts canary) -----------------------------
+# Ported from qbiq-ai/argocd@c364c6c charts/qbiq-app (2026-06 sync).
+#
+# rollout.enabled=false → a plain Deployment (templates/deployment.yaml).
+# rollout.enabled=true  → an Argo Rollouts canary Rollout replaces the
+#   Deployment. The Rollout uses a stableService (this app's Service, behind the
+#   HTTPRoute at 100%) plus a canaryService (the weighted fraction). The Gateway
+#   API plugin (argoproj-labs/gatewayAPI) shifts the HTTPRoute backendRef weights
+#   as the canary progresses; Cilium drains connections on each weight shift.
+#
+# Default is OFF for backward compatibility — existing releases keep their
+# Deployment unchanged. Kargo remains the planned promotion layer ABOVE this:
+# Kargo promotes verified artifacts between environments; this rollout block
+# governs the in-cluster canary once a new version lands in an environment.
+rollout:
+  enabled: false
+  # Seconds the canary ReplicaSet stays alive after an abort so in-flight
+  # requests (up to the app's own request timeout) drain before SIGKILL.
+  abortScaleDownDelaySeconds: 30
+  canary:
+    # Progressive weight ladder. List of integer weights; the template inserts
+    # an analysis gate between each weight (when analysis.enabled=true) and a
+    # final setWeight: 100. Default ladder: 10 → 30 → 50 → 100.
+    weights: [10, 30, 50]
+    # Full override: when non-empty, `weights` is ignored and these steps are
+    # rendered verbatim. Use for non-standard ladders (e.g. workers with no
+    # analysis gates).
+    customSteps: []
+  # Metric gate (Argo Rollouts AnalysisTemplate). ON by default for any app that
+  # uses the canary rollout. Only renders when rollout.enabled too, so pure
+  # workers with no HTTP metrics are unaffected. Set analysis.enabled: false for
+  # workers that expose no flask_http_request_* / latency metrics.
+  analysis:
+    enabled: true
+    # kube-prometheus-stack Service in the observability namespace. Adjust to the
+    # actual release-prefixed Service name for this platform.
+    prometheusAddress: "http://kube-prometheus-stack-prometheus.observability.svc:9090"
+    interval: 30s
+    count: 5
+    failureLimit: 1
+    # Queries are parametrised — {{args.service}} is the canary Service so stable
+    # traffic is not counted. Tune the label selectors to the real scrape labels.
+    errorRate:
+      successCondition: "result[0] < 0.01"   # <1% 5xx
+      query: |
+        sum(rate(flask_http_request_total{service="{{args.service}}",status=~"5.."}[1m]))
+        /
+        sum(rate(flask_http_request_total{service="{{args.service}}"}[1m]))
+    latencyP95:
+      successCondition: "result[0] < 0.5"     # p95 < 500ms
+      query: |
+        histogram_quantile(0.95,
+          sum(rate(flask_http_request_duration_seconds_bucket{service="{{args.service}}"}[1m])) by (le))
+
+# --- Internal ingress via Gateway API (Cilium) -------------------------------
+# Off by default. Required when rollout.enabled=true (the Gateway API plugin
+# shifts traffic by rewriting this HTTPRoute's backendRef weights). When the
+# Rollout is active, both the stable and canary Services are listed as
+# backendRefs. This is independent of the legacy `ingress` (Nginx/ALB) block.
+httpRoute:
+  enabled: false
+  gateway:
+    name: gw-internal
+    namespace: kube-system
+    sectionName: http
+  path: /
+  hostnames: []
+
 # --- Ingress ---
 ingress:
   enabled: false


### PR DESCRIPTION
## Summary

Ports the real progressive-delivery pattern from **qbiq-ai/argocd@c364c6c**'s `charts/qbiq-app` into platform-design's generic `helm/app` chart.

Adds four new templates plus a values toggle:

- `templates/rollout.yaml` — Argo Rollouts **canary** `Rollout`, gated by `.Values.rollout.enabled`. stable/canary Services, `abortScaleDownDelaySeconds` graceful abort, Gateway API trafficRouting via the `argoproj-labs/gatewayAPI` plugin, and a progressive weight ladder (default `10 → 30 → 50 → 100`) with an analysis gate between each step.
- `templates/service-canary.yaml` — weighted canary `Service` (`<fullname>-canary`), rendered only with the Rollout.
- `templates/analysistemplate.yaml` — `AnalysisTemplate` gating each canary step on Prometheus metrics: **5xx error-rate < 1%** and **p95 latency < 500ms**, scoped to the canary Service.
- `templates/httproute.yaml` — Gateway API `HTTPRoute` (Cilium gateway) whose backendRef weights the rollout plugin shifts at runtime.

## Behavior

- **Replaces the Deployment when `rollout.enabled=true`.** `deployment.yaml` is wrapped in `{{- if not .Values.rollout.enabled }}` so the Deployment and Rollout are mutually exclusive — exactly like the source chart.
- **Backward compatible:** `rollout.enabled` defaults to **false**, so existing releases keep rendering a plain Deployment, unchanged.
- The pod/container spec is extracted into a shared `app.podSpec` helper (`_helpers.tpl`) used by both the Deployment and the Rollout, so the two workload kinds never diverge.
- `values.yaml` gains a documented `rollout:` block (enabled, `canary.weights`/`customSteps`, `trafficRouting` gatewayAPI httpRoute ref, `analysis` toggle + metric thresholds) plus an `httpRoute:` block, matching the source defaults. `README.md` documents the new canary mode with a provenance note.
- Analysis is **on by default**; disable (`rollout.analysis.enabled=false`) for workers with no HTTP metrics.

> **Note:** platform-design's **Kargo** layer is preserved as the planned promotion layer *above* this chart. Kargo promotes verified artifacts between environments; this `rollout` block governs the in-cluster canary once a version lands in an environment.

## Validation

- `helm lint helm/app` → 0 failures.
- `helm template helm/app` (default) → renders a `Deployment`, no Rollout/canary/HTTPRoute.
- `helm template helm/app --set rollout.enabled=true --set httpRoute.enabled=true` → renders `Rollout` (no Deployment) + canary `Service` + `AnalysisTemplate` + `HTTPRoute`; verified steps ladder, analysis gates, and backendRef weights (stable 100 / canary 0).
- Edge cases checked: `analysis.enabled=false` (no analysis steps/template), `autoscaling.enabled=true` (replicas omitted from Rollout), `canary.customSteps` verbatim override, and full YAML parse of all rendered docs in both modes.

Touches only files under `helm/app/`.

## Test plan

- [ ] CI / chart-testing (`ct lint` / `helm lint`) passes.
- [ ] Render against a real env overlay (`envs/<env>/values/<app>.yaml`) with `rollout.enabled=true`.
- [ ] Confirm the Argo Rollouts controller + `argoproj-labs/gatewayAPI` plugin are installed in target clusters before enabling per app.