### PR TITLE
docs(adr): backfill architecture + CI/CD ADRs from infra/argocd source-of-truth

### DIFF
--- a/docs/adrs/0003-cilium-over-aws-vpc-cni.md
+++ b/docs/adrs/0003-cilium-over-aws-vpc-cni.md
@@ -1,0 +1,100 @@
+# ADR-0003: Cilium over aws-vpc-cni as the EKS CNI
+
+- Status: **Accepted** — decision is *adopted (live in source estate)*
+- Date: 2026-06-03
+- Authors: platform-team
+- Related issues: (ported)
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+The transaction-analytics platform runs all AWS control-plane workloads on EKS
+(GitOps orchestration, the LiteLLM/inference gateway front-end, public APIs).
+These clusters need a CNI plugin. The EKS default `aws-vpc-cni` allocates
+ENI-attached IPs from the VPC, which caps pod density per node and leaves
+network-policy enforcement to security-groups-for-pods rather than a first-class
+policy layer. We evaluated three options:
+
+1. **aws-vpc-cni** (default) — tight VPC integration but limited pod density and
+   coarse policy model.
+2. **Calico** — mature network policies but iptables-based at scale.
+3. **Cilium** — eBPF-based with advanced observability and security.
+
+Pod-to-pod encryption matters here: the control plane carries scoring requests
+and references to client data, so data-in-transit protection is a baseline
+requirement rather than a nice-to-have.
+
+## Decision
+
+Use **Cilium** as the CNI for all EKS clusters in the platform.
+
+A reviewer can check conformance by confirming new clusters ship Cilium (not
+`aws-vpc-cni`) and that network policy is expressed as `CiliumNetworkPolicy` /
+`CiliumClusterwideNetworkPolicy` rather than security-groups-for-pods.
+
+## Alternatives considered
+
+### Alternative A: aws-vpc-cni (EKS default)
+Keep the managed default add-on.
+Rejected because: ENI IP allocation caps pod density per node and the policy
+model relies on security-groups-for-pods, which is coarser and harder to audit
+than L3/L4/L7 Cilium policies. No native pod-to-pod encryption without sidecars.
+
+### Alternative B: Calico
+Mature, widely deployed network-policy CNI.
+Rejected because: iptables-based dataplane adds per-packet overhead at the
+connection rates the platform sees, and it lacks the built-in flow observability
+(Hubble) and transparent WireGuard encryption Cilium provides.
+
+### Alternative C: Status quo
+At time of decision the clusters were greenfield, so "status quo" is the EKS
+default (Alternative A) — same rejection.
+
+## Consequences
+
+### Positive
+- eBPF kernel-level packet processing avoids iptables overhead (~20–30% better
+  latency observed on service-mesh-style workloads in source-estate benchmarks).
+- Transparent WireGuard pod-to-pod encryption satisfies data-in-transit
+  requirements without per-pod sidecars.
+- L3/L4/L7 DNS-aware policies via `CiliumNetworkPolicy` are more expressive than
+  vanilla `NetworkPolicy`.
+- Hubble gives flow logs, service maps, and HTTP-level metrics from eBPF — no
+  extra agent. This pairs with the platform's existing Prometheus/Grafana stack.
+- Overlay mode is not bounded by ENI IP allocation, so pod density per node is
+  higher.
+- ClusterMesh enables cross-cluster connectivity (relevant for the multi-region
+  control plane) without bolt-on infrastructure.
+
+### Negative
+- Team must learn Cilium-specific CRDs.
+- Cannot use `aws-vpc-cni` security-groups-for-pods — policy moves entirely to
+  Cilium.
+- Cilium operator adds management/upgrade overhead, maintained separately from
+  EKS managed add-ons.
+
+### Risks
+- Kernel-version dependency (5.10+). Mitigated by AL2023 node AMIs, which satisfy
+  it.
+- Cilium upgrade path is decoupled from EKS add-on lifecycle. Mitigated by
+  pinning the Cilium chart version in GitOps and gating upgrades behind a runbook.
+
+## Implementation notes
+
+- Cilium is installed via Helm (GitOps-managed), CNI add-on disabled on the
+  cluster module.
+- Network policy authored as `CiliumNetworkPolicy`; default-deny baseline per
+  namespace.
+- Locks in alongside ADR-0009 (Cilium Gateway API ingress), which reuses the same
+  Cilium install.
+
+## References
+
+- Cilium docs: <https://docs.cilium.io/>
+- Ported from `qbiq-ai/infra` ADR-001 (Cilium over aws-vpc-cni)
+- Related: ADR-0009 (Cilium Gateway API ingress)
+
+---
+*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0003-cilium-over-aws-vpc-cni.md
+++ b/docs/adrs/0003-cilium-over-aws-vpc-cni.md
@@ -92,9 +92,9 @@ default (Alternative A) — same rejection.
 ## References
 
 - Cilium docs: <https://docs.cilium.io/>
-- Ported from `qbiq-ai/infra` ADR-001 (Cilium over aws-vpc-cni)
+- Ported from `infra` ADR-001 (Cilium over aws-vpc-cni)
 - Related: ADR-0009 (Cilium Gateway API ingress)
 
 ---
-*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+*Ported from infra@572b54d (and argocd@c364c6c) during the 2026-06
 platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0004-terragrunt-over-plain-terraform.md
+++ b/docs/adrs/0004-terragrunt-over-plain-terraform.md
@@ -1,0 +1,89 @@
+# ADR-0004: Terragrunt over plain Terraform for multi-account orchestration
+
+- Status: **Accepted** — decision is *adopted (live in source estate)*
+- Date: 2026-06-03
+- Authors: platform-team
+- Related issues: (ported)
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+The platform spans many AWS accounts (per ADR-0001's OU split: production,
+non-production, deployments, sandbox, plus security/network/shared) across four
+EU regions. Managing that estate needs a strategy for DRY configuration,
+consistent provider/backend wiring, and multi-account orchestration. This repo
+already standardised on Terraform-only state bootstrap (ADR-0002); the question
+is what orchestration layer sits on top. We evaluated:
+
+1. **Plain Terraform** with workspaces.
+2. **Terragrunt** as a thin Terraform wrapper.
+3. **CDK for Terraform (CDKTF)** in TypeScript/Python.
+
+## Decision
+
+Use **Terragrunt** as the Terraform orchestration layer. A reviewer can check
+conformance by confirming new infrastructure is expressed as a `terragrunt.hcl`
+unit composing an `_envcommon/` definition, not a standalone root module with a
+hand-written `backend` block.
+
+## Alternatives considered
+
+### Alternative A: Plain Terraform with workspaces
+Use Terraform workspaces to separate accounts/environments.
+Rejected because: workspaces share one backend/state-key namespace and one
+provider block, which does not map cleanly onto an account-per-isolation model.
+Backend and `default_tags` config would be copy-pasted per module, drifting over
+time.
+
+### Alternative B: CDKTF
+Generate Terraform from a general-purpose language.
+Rejected because: introduces a new language and a code-generation step the team
+does not currently run. Existing expertise is Terraform/HCL; the marginal power
+of a real language does not pay for the onboarding and debugging cost here.
+
+### Alternative C: Status quo
+Hand-wired Terraform root modules per account.
+Rejected because: that is the duplication problem Terragrunt's `_envcommon/`
+pattern exists to eliminate; it does not scale to the account/region count above.
+
+## Consequences
+
+### Positive
+- `_envcommon/` patterns eliminate duplication: one module definition serves
+  dev/stage/prod via account-specific `account.hcl` / `region.hcl` inputs.
+- Automatic S3 backend config via `remote_state` — no per-module backend blocks
+  (and consistent with the ADR-0002 bootstrap'd backend).
+- `generate "provider"` produces consistent provider configs with `default_tags`
+  across every deployment (drives the cost-allocation tags ADR-0001 relies on).
+- `dependency` blocks give cross-module references without hardcoded outputs.
+- `terragrunt run-all` plans/applies across accounts with dependency ordering.
+- Adds a thin HCL layer rather than a new language.
+
+### Negative
+- Learning curve for Terragrunt-specific HCL patterns.
+- Debugging is harder (generated files, nested configs).
+- CI must install both Terraform and Terragrunt.
+
+### Risks
+- Terragrunt version upgrades can introduce breaking changes. Mitigated by
+  pinning the Terragrunt version in CI and in the `.mise`/tool-version manifest.
+- Some Terraform tooling (e.g. Terraform Cloud) has limited Terragrunt support.
+  Accepted — the platform does not depend on those integrations.
+
+## Implementation notes
+
+- Module bodies live under `terraform/modules/`; orchestration under
+  `_envcommon/` + `<account>/<region>/<unit>/terragrunt.hcl`.
+- Backend block is generated, pointing at the ADR-0002 bootstrap S3 bucket.
+- CI installs pinned Terraform + Terragrunt and runs `terragrunt run-all plan`.
+
+## References
+
+- Terragrunt docs: <https://terragrunt.gruntwork.io/>
+- Ported from `qbiq-ai/infra` ADR-002 (Terragrunt over plain Terraform)
+- Related: ADR-0001 (OU split), ADR-0002 (Terraform-only state backend)
+
+---
+*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0004-terragrunt-over-plain-terraform.md
+++ b/docs/adrs/0004-terragrunt-over-plain-terraform.md
@@ -81,9 +81,9 @@ pattern exists to eliminate; it does not scale to the account/region count above
 ## References
 
 - Terragrunt docs: <https://terragrunt.gruntwork.io/>
-- Ported from `qbiq-ai/infra` ADR-002 (Terragrunt over plain Terraform)
+- Ported from `infra` ADR-002 (Terragrunt over plain Terraform)
 - Related: ADR-0001 (OU split), ADR-0002 (Terraform-only state backend)
 
 ---
-*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+*Ported from infra@572b54d (and argocd@c364c6c) during the 2026-06
 platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0005-hub-spoke-transit-gateway.md
+++ b/docs/adrs/0005-hub-spoke-transit-gateway.md
@@ -1,0 +1,91 @@
+# ADR-0005: Hub-and-spoke connectivity via AWS Transit Gateway
+
+- Status: **Accepted** — decision is *adopted (live in source estate)*
+- Date: 2026-06-03
+- Authors: platform-team
+- Related issues: (ported)
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+With many AWS accounts (ADR-0001) each containing one or more VPCs, the platform
+needs an inter-VPC connectivity strategy that scales and supports segmentation —
+production data-plane traffic must never have a route to sandbox/dev. Options
+evaluated:
+
+1. **VPC peering** — point-to-point connections.
+2. **AWS Transit Gateway (TGW)** — hub-and-spoke.
+3. **AWS Cloud WAN** — managed global network.
+
+The platform is anchored in `eu-west-1` for the primary control plane (with
+additional EU regions for the multi-region tier), so a single-region-optimised
+topology is acceptable for v1.
+
+## Decision
+
+Use **AWS Transit Gateway** in a hub-and-spoke topology, owned and managed from
+the **Network account**. Inter-VPC routing is expressed through custom TGW route
+tables (no default association/propagation), so reachability is an explicit
+allow-list.
+
+A reviewer can check conformance by confirming new VPC attachments go through the
+TGW (not a new peering connection) and are associated with an explicit custom
+route table.
+
+## Alternatives considered
+
+### Alternative A: VPC peering mesh
+Peer every VPC that needs to talk to every other.
+Rejected because: peering is non-transitive and grows as N·(N-1)/2 — unmanageable
+at the platform's account count, and segmentation (prod ↛ sandbox) becomes a
+per-pair bookkeeping exercise instead of a route-table policy.
+
+### Alternative B: AWS Cloud WAN
+Managed global network with policy-based segmentation.
+Rejected because: Cloud WAN's value is multi-region global routing; for a
+single-region-anchored estate it is more expensive than TGW with no offsetting
+benefit. Revisit if the estate becomes genuinely global-mesh.
+
+### Alternative C: Status quo
+At decision time the estate was greenfield — "status quo" is no shared
+connectivity, which does not meet the requirement.
+
+## Consequences
+
+### Positive
+- Scales to thousands of attachments; no peering combinatorics.
+- Centralised routing and a single point for future traffic inspection (a
+  centralised inspection VPC with AWS Network Firewall — see ADR-0013).
+- Custom TGW route tables provide network segmentation: production route tables
+  never contain a route to sandbox/dev attachments.
+- Hub VPC in the Shared account offers centralised endpoints (DNS, ECR, S3
+  gateway) reachable from all spokes.
+- More cost-effective than Cloud WAN for the platform's single-region anchor.
+
+### Negative
+- TGW hourly charge per attachment (~$36/month per VPC attachment).
+- Data-processing charges for inter-VPC traffic through the TGW.
+- Route-table management grows more complex as account count grows.
+
+### Risks
+- TGW as a single point of failure. Mitigated by TGW's multi-AZ design.
+- Cross-region connectivity needs a second TGW with peering. Tracked as a
+  future-consideration for the multi-region tier, not v1.
+
+## Implementation notes
+
+- `modules/transit-gateway` + `modules/tgw-routing` + `modules/tgw-attachment`
+  (attachments inert by default until routes are added).
+- Owned by the Network account; route tables are custom, least-privilege.
+- The detailed cross-estate / VPN segmentation model layered on this is ADR-0013.
+
+## References
+
+- AWS Transit Gateway: <https://docs.aws.amazon.com/vpc/latest/tgw/>
+- Ported from `qbiq-ai/infra` ADR-003 (Hub-and-spoke via Transit Gateway)
+- Related: ADR-0001 (OU split), ADR-0013 (inter-VPC access security model)
+
+---
+*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0005-hub-spoke-transit-gateway.md
+++ b/docs/adrs/0005-hub-spoke-transit-gateway.md
@@ -83,9 +83,9 @@ connectivity, which does not meet the requirement.
 ## References
 
 - AWS Transit Gateway: <https://docs.aws.amazon.com/vpc/latest/tgw/>
-- Ported from `qbiq-ai/infra` ADR-003 (Hub-and-spoke via Transit Gateway)
+- Ported from `infra` ADR-003 (Hub-and-spoke via Transit Gateway)
 - Related: ADR-0001 (OU split), ADR-0013 (inter-VPC access security model)
 
 ---
-*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+*Ported from infra@572b54d (and argocd@c364c6c) during the 2026-06
 platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0006-argocd-for-gitops.md
+++ b/docs/adrs/0006-argocd-for-gitops.md
@@ -1,0 +1,92 @@
+# ADR-0006: ArgoCD for GitOps delivery of Kubernetes workloads
+
+- Status: **Accepted** — decision is *adopted (live in source estate)*
+- Date: 2026-06-03
+- Authors: platform-team
+- Related issues: (ported)
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+The platform's AWS control-plane workloads (GitOps orchestration, observability
+stack, the LiteLLM/inference gateway front-end, public APIs) are deployed to EKS.
+The edge tier's agent rollout is also promotion-driven from Git. We need a GitOps
+tool that continuously reconciles desired state from Git and self-heals drift.
+Options:
+
+1. **ArgoCD** — declarative GitOps with a UI.
+2. **Flux** — CNCF GitOps toolkit.
+3. **Terraform-only** — manage K8s resources via Terraform.
+
+## Decision
+
+Use **ArgoCD** for all Kubernetes workload delivery, in an app-of-apps layout
+(`bootstrap/root-app` → ApplicationSets per cluster-role/infra/observability/
+workloads). A reviewer can check conformance by confirming new workloads are
+delivered as ArgoCD `Application`/`ApplicationSet` definitions rather than
+`kubectl apply` or Terraform-managed manifests.
+
+## Alternatives considered
+
+### Alternative A: Flux v2
+Controller-based CNCF GitOps toolkit.
+Rejected because: no built-in UI, and the controller-per-concern model is more
+complex for teams newer to GitOps. ArgoCD's dashboard is load-bearing for
+developer self-service across multiple product domains.
+
+### Alternative B: Terraform-only
+Render and apply Kubernetes manifests from Terraform.
+Rejected because: Terraform is not designed for continuous reconciliation. Drift
+detection and self-healing require a watch loop, which ArgoCD provides and
+Terraform does not.
+
+### Alternative C: Status quo
+Greenfield — "status quo" is no continuous delivery (manual `kubectl`), which
+fails the self-healing / auditability requirement.
+
+## Consequences
+
+### Positive
+- The web UI gives immediate visibility into sync status, diffs, and history —
+  essential for self-service across the platform's product teams.
+- `ApplicationSet` templating drives multi-environment, multi-cluster delivery
+  from one definition (see ADR-0012 for the cluster-selector label scheme).
+- Sync waves and hooks order deployments (CRDs before workloads, migrations
+  before apps) without external orchestration.
+- Project/application RBAC integrates with SSO; teams manage their own apps
+  without cluster-admin.
+- Large ecosystem (notifications, image updater, Argo Rollouts integration — see
+  ADR-0014).
+
+### Negative
+- Another component to operate and upgrade on-cluster.
+- CRD-management complexity (ArgoCD's own CRDs plus application CRDs).
+- Secrets are handled out-of-band via External Secrets Operator (ADR-0008) —
+  ArgoCD does not natively manage encrypted secrets in Git.
+- Resource overhead: argocd-server, repo-server, application-controller pods.
+
+### Risks
+- Teams must learn ArgoCD concepts (sync policies, health checks). Mitigated by
+  the app-of-apps convention and reference values charts.
+
+## Implementation notes
+
+- App-of-apps via `bootstrap/root-app`; ApplicationSets for cluster-roles, infra,
+  observability, and workloads.
+- Secrets via ESO `ClusterSecretStore` (ADR-0008); progressive delivery via Argo
+  Rollouts (ADR-0014).
+- CI integrates by opening PRs into the GitOps repo that bump image tag/digest
+  (ADR-0015).
+
+## References
+
+- ArgoCD docs: <https://argo-cd.readthedocs.io/>
+- Ported from `qbiq-ai/infra` ADR-004 (ArgoCD for GitOps) and `qbiq-ai/argocd`
+  app-of-apps layout
+- Related: ADR-0008 (ESO), ADR-0012 (cluster-role labels), ADR-0014 (Argo
+  Rollouts), ADR-0015 (reusable CI pipelines)
+
+---
+*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0006-argocd-for-gitops.md
+++ b/docs/adrs/0006-argocd-for-gitops.md
@@ -82,11 +82,11 @@ fails the self-healing / auditability requirement.
 ## References
 
 - ArgoCD docs: <https://argo-cd.readthedocs.io/>
-- Ported from `qbiq-ai/infra` ADR-004 (ArgoCD for GitOps) and `qbiq-ai/argocd`
+- Ported from `infra` ADR-004 (ArgoCD for GitOps) and `argocd`
   app-of-apps layout
 - Related: ADR-0008 (ESO), ADR-0012 (cluster-role labels), ADR-0014 (Argo
   Rollouts), ADR-0015 (reusable CI pipelines)
 
 ---
-*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+*Ported from infra@572b54d (and argocd@c364c6c) during the 2026-06
 platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0007-karpenter-over-cluster-autoscaler.md
+++ b/docs/adrs/0007-karpenter-over-cluster-autoscaler.md
@@ -69,9 +69,9 @@ right-sizes nor controls cost for bursty workloads.
 ## References
 
 - Karpenter docs: <https://karpenter.sh/>
-- Ported from `qbiq-ai/infra` ADR-005 (Karpenter over Cluster Autoscaler)
+- Ported from `infra` ADR-005 (Karpenter over Cluster Autoscaler)
 - Related: ADR-0003 (Cilium CNI), ADR-0006 (ArgoCD)
 
 ---
-*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+*Ported from infra@572b54d (and argocd@c364c6c) during the 2026-06
 platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0007-karpenter-over-cluster-autoscaler.md
+++ b/docs/adrs/0007-karpenter-over-cluster-autoscaler.md
@@ -1,0 +1,77 @@
+# ADR-0007: Karpenter over Cluster Autoscaler for EKS node provisioning
+
+- Status: **Accepted** — decision is *adopted (live in source estate)*
+- Date: 2026-06-03
+- Authors: platform-team
+- Related issues: (ported)
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+The platform's EKS clusters carry bursty, heterogeneous workloads: steady GitOps
+and observability components alongside spiky inference-gateway and template-mining
+support jobs. Node scaling must right-size capacity quickly and cheaply, with a
+preference for Graviton/arm64 and spot where workloads tolerate it. Options:
+
+1. **Cluster Autoscaler (CAS)** — scales predefined node groups based on pending
+   pods.
+2. **Karpenter** — provisions nodes directly from pod requirements.
+
+## Decision
+
+Use **Karpenter** for all EKS node scaling, with capacity shaped by `NodePool`
+and `EC2NodeClass` CRDs. A reviewer can check conformance by confirming capacity
+is expressed as Karpenter `NodePool`/`EC2NodeClass` rather than managed node
+groups + CAS.
+
+## Alternatives considered
+
+### Alternative A: Cluster Autoscaler
+Scale predefined ASG-backed node groups.
+Rejected because: CAS scales fixed node-group shapes, frequently over-provisioning
+nodes that don't match actual pod requests; scale-up rides ASG latency; and
+scale-down only removes empty nodes (no active consolidation).
+
+### Alternative B: Status quo
+Greenfield — "status quo" is no autoscaling (static node groups), which neither
+right-sizes nor controls cost for bursty workloads.
+
+## Consequences
+
+### Positive
+- Bin-packing: Karpenter provisions right-sized instances from actual pod
+  requests, across a broad instance set, prioritising spot where allowed — good
+  fit for spiky inference-support workloads.
+- Speed: provisions nodes in under ~60s via direct EC2 API calls.
+- Consolidation actively bin-packs and terminates underutilised nodes.
+- Disruption budgets handle rolling updates and spot interruptions gracefully.
+- AWS-native EKS integration; `EC2NodeClass` simplifies AMI/subnet/SG selection
+  (and makes Graviton/arm64 defaults easy).
+
+### Negative
+- EKS-specific (not portable to other K8s platforms).
+- Must author `NodePool` / `EC2NodeClass` CRDs (learning curve).
+- Manages its own node lifecycle — cannot use ASG lifecycle hooks / warm pools.
+
+### Risks
+- Spot interruption handling is built-in but requires proper pod-disruption
+  budgets on workloads. Mitigated by shipping default PDBs in the reference chart.
+- Karpenter is younger than CAS. Mitigated by pinning to the stable v1 API and
+  GitOps-gated upgrades.
+
+## Implementation notes
+
+- Karpenter installed via Helm (GitOps); `NodePool` favours Graviton + spot for
+  tolerant workloads, on-demand for stateful/critical pods.
+- Consolidation enabled; disruption budgets tuned per workload class.
+
+## References
+
+- Karpenter docs: <https://karpenter.sh/>
+- Ported from `qbiq-ai/infra` ADR-005 (Karpenter over Cluster Autoscaler)
+- Related: ADR-0003 (Cilium CNI), ADR-0006 (ArgoCD)
+
+---
+*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0008-external-secrets-operator.md
+++ b/docs/adrs/0008-external-secrets-operator.md
@@ -79,10 +79,10 @@ and manual creation does not fit the GitOps model.
 ## References
 
 - ESO docs: <https://external-secrets.io/>
-- Ported from `qbiq-ai/infra` ADR-006 (ESO over native secrets) and `qbiq-ai/argocd`
+- Ported from `infra` ADR-006 (ESO over native secrets) and `argocd`
   `ClusterSecretStore` usage
 - Related: ADR-0006 (ArgoCD GitOps)
 
 ---
-*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+*Ported from infra@572b54d (and argocd@c364c6c) during the 2026-06
 platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0008-external-secrets-operator.md
+++ b/docs/adrs/0008-external-secrets-operator.md
@@ -1,0 +1,88 @@
+# ADR-0008: External Secrets Operator over native K8s secrets
+
+- Status: **Accepted** — decision is *adopted (live in source estate)*
+- Date: 2026-06-03
+- Authors: platform-team
+- Related issues: (ported)
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+Platform workloads need secrets — database credentials, upstream model-provider
+API keys for the inference gateway, object-store and observability tokens,
+certificates. GitOps (ADR-0006) explicitly does not put plaintext secrets in Git.
+Options for managing secrets:
+
+1. **Native K8s Secrets** — base64 in etcd, created out-of-band.
+2. **Sealed Secrets (Bitnami)** — encrypted secrets committed to Git.
+3. **External Secrets Operator (ESO)** — sync from an external provider.
+4. **HashiCorp Vault** — with injector sidecar.
+
+## Decision
+
+Use **External Secrets Operator (ESO)** with **AWS Secrets Manager** as the
+backend, authenticated via IRSA, exposed through a `ClusterSecretStore`. A
+reviewer can check conformance by confirming workloads consume `ExternalSecret`
+manifests (synced from Secrets Manager) rather than hand-created `Secret`
+objects or Git-committed sealed secrets.
+
+## Alternatives considered
+
+### Alternative A: HashiCorp Vault
+Self-managed secrets engine with an injector sidecar.
+Rejected because: Vault adds significant operational burden (HA, unseal, backup)
+the platform does not want to run. AWS Secrets Manager is a managed service with
+no infrastructure to operate, and the estate is already AWS-native.
+
+### Alternative B: Sealed Secrets
+Encrypt secrets and commit them to Git.
+Rejected because: requires managing the controller's encryption key and
+re-encrypting on every rotation, and does not integrate with AWS-native secret
+storage or rotation. Rotation becomes a Git operation rather than an AWS one.
+
+### Alternative C: Status quo (native K8s Secrets)
+Create secrets manually in each cluster.
+Rejected because: no single source of truth, no automatic rotation propagation,
+and manual creation does not fit the GitOps model.
+
+## Consequences
+
+### Positive
+- Single source of truth: secrets live in AWS Secrets Manager, managed by
+  Terraform/Terragrunt (ADR-0004). No secrets in Git, no manual K8s creation.
+- Automatic rotation: ESO polls on an interval; rotated AWS secrets propagate to
+  K8s automatically.
+- IRSA auth — no static credentials.
+- Multi-cluster: one set of Secrets Manager secrets serves dev/stage/prod via a
+  `ClusterSecretStore` mapped to account-specific IAM roles.
+- Audit trail: secret access logged in CloudTrail (Secrets Manager API) and K8s
+  audit logs.
+
+### Negative
+- Dependency on AWS Secrets Manager (vendor lock-in for secret storage).
+- Another CRD/controller to operate.
+- Sync-interval latency vs. real-time reads.
+- Must author `ExternalSecret` manifests per workload.
+
+### Risks
+- Secrets Manager cost grows with secret count ($0.40/secret/month + API charges).
+  Accepted — small relative to the platform's spend; mitigated by consolidating
+  related keys per secret where safe.
+
+## Implementation notes
+
+- ESO installed via Helm (GitOps); `ClusterSecretStore` per account, IRSA-bound.
+- Secrets provisioned in Secrets Manager by Terragrunt; workloads reference them
+  by `ExternalSecret`.
+
+## References
+
+- ESO docs: <https://external-secrets.io/>
+- Ported from `qbiq-ai/infra` ADR-006 (ESO over native secrets) and `qbiq-ai/argocd`
+  `ClusterSecretStore` usage
+- Related: ADR-0006 (ArgoCD GitOps)
+
+---
+*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0009-cilium-gateway-api-ingress.md
+++ b/docs/adrs/0009-cilium-gateway-api-ingress.md
@@ -1,0 +1,93 @@
+# ADR-0009: Cilium Gateway API as the cluster ingress controller
+
+- Status: **Accepted** — decision is *adopted (live in source estate)*
+- Date: 2026-06-03
+- Authors: platform-team
+- Related issues: (ported)
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+The shared EKS cluster needs an ingress solution for workloads delivered via
+ArgoCD (ADR-0006) — the observability surfaces (Grafana), the inference-gateway
+front-end, and platform tooling. The cluster already runs Cilium as its CNI
+(ADR-0003), which supports the Kubernetes Gateway API natively. Three options
+were evaluated:
+
+1. **AWS Load Balancer Controller (ALB Ingress)** — tight ALB integration but
+   per-Ingress ALB provisioning; cost scales with service count.
+2. **NGINX Ingress Controller** — widely adopted, but a separate Deployment and
+   extra attack surface.
+3. **Cilium Gateway API** — built into the existing Cilium CNI, uses the
+   Kubernetes Gateway API standard, no additional Deployment.
+
+Gateway API v1.x graduated `GatewayClass`/`HTTPRoute` to stable, and Cilium
+exposes it via `gatewayAPI.enabled`.
+
+## Decision
+
+Enable **Cilium Gateway API** (`gatewayAPI.enabled = true`) as the ingress
+controller for the shared cluster. Workloads expose themselves with `Gateway` +
+`HTTPRoute` objects. A reviewer can check conformance by confirming new ingress
+is authored as Gateway API resources, not `Ingress` objects or per-service ALBs.
+
+## Alternatives considered
+
+### Alternative A: AWS Load Balancer Controller (ALB Ingress)
+Provision an ALB per Ingress.
+Rejected because: cost scales linearly with the number of exposed services, and
+it is a separate controller to operate. Gateway API on the existing Cilium has no
+such per-service cost.
+
+### Alternative B: NGINX Ingress Controller
+Run NGINX as a separate ingress Deployment.
+Rejected because: it is an additional component and attack surface, and locks the
+platform into the legacy `Ingress` API just as the ecosystem migrates to Gateway
+API.
+
+### Alternative C: Status quo (no ingress / direct LoadBalancer Services)
+Expose each service with its own `Service type=LoadBalancer`.
+Rejected because: it multiplies load balancers and offers no shared routing,
+TLS termination, or host/path policy layer.
+
+## Consequences
+
+### Positive
+- No additional component: Cilium already runs as a DaemonSet; enabling Gateway
+  API adds a watch loop in the existing operator — zero extra pods.
+- Cost: load balancers are provisioned per `Gateway`, not per `Ingress`.
+- Standards alignment: Gateway API is the upstream replacement for `Ingress`;
+  adopting now avoids a future migration.
+- Hubble observability: Gateway API traffic is visible in Hubble flow logs (ties
+  back to ADR-0003's observability story).
+
+### Negative
+- Gateway API CRDs (`gateway.networking.k8s.io`) must be installed before the
+  Cilium Helm release; ordering handled via ArgoCD `dependencies` /
+  sync-waves.
+- Team learns `GatewayClass`/`Gateway`/`HTTPRoute` instead of `Ingress`.
+- Not all NGINX `Ingress` annotations are supported; annotation-heavy configs
+  must be ported to `HTTPRoute` filters.
+
+### Risks
+- An environment without the CRDs installed would fail the Cilium upgrade.
+  Mitigated by a default-off module flag (`enable_gateway_api = false`) preserving
+  backward compatibility, and a runbook pinning the CRD install manifest.
+
+## Implementation notes
+
+- CRDs installed ahead of the Cilium chart (sync-wave / `dependencies`).
+- `Gateway` objects own the load balancers; `HTTPRoute` objects own host/path
+  routing. The Argo Rollouts canary plugin (ADR-0014) manipulates `HTTPRoute`
+  backend weights.
+
+## References
+
+- Kubernetes Gateway API: <https://gateway-api.sigs.k8s.io/>
+- Ported from `qbiq-ai/infra` ADR-008 and `qbiq-ai/argocd` Gateway API usage
+- Related: ADR-0003 (Cilium CNI), ADR-0014 (Argo Rollouts canary)
+
+---
+*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0009-cilium-gateway-api-ingress.md
+++ b/docs/adrs/0009-cilium-gateway-api-ingress.md
@@ -85,9 +85,9 @@ TLS termination, or host/path policy layer.
 ## References
 
 - Kubernetes Gateway API: <https://gateway-api.sigs.k8s.io/>
-- Ported from `qbiq-ai/infra` ADR-008 and `qbiq-ai/argocd` Gateway API usage
+- Ported from `infra` ADR-008 and `argocd` Gateway API usage
 - Related: ADR-0003 (Cilium CNI), ADR-0014 (Argo Rollouts canary)
 
 ---
-*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+*Ported from infra@572b54d (and argocd@c364c6c) during the 2026-06
 platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0010-eks-public-endpoint-cidr-allowlist.md
+++ b/docs/adrs/0010-eks-public-endpoint-cidr-allowlist.md
@@ -88,10 +88,10 @@ cannot be tightened without a module change. Externalising it is the whole point
 ## References
 
 - EKS endpoint access: <https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html>
-- Ported from `qbiq-ai/infra` ADR-009 (EKS public endpoint + parameterised CIDR)
+- Ported from `infra` ADR-009 (EKS public endpoint + parameterised CIDR)
 - Related: ADR-0003 (Cilium CNI), ADR-0001 (OU split / tier separation)
 
 ---
-*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+*Ported from infra@572b54d (and argocd@c364c6c) during the 2026-06
 platform-design sync. Decision status in the source estate: adopted (live) for
 the shared/non-prod cluster; narrow prod allow-list is a design-target.*

--- a/docs/adrs/0010-eks-public-endpoint-cidr-allowlist.md
+++ b/docs/adrs/0010-eks-public-endpoint-cidr-allowlist.md
@@ -1,0 +1,97 @@
+# ADR-0010: EKS public API endpoint with a parameterised CIDR allow-list
+
+- Status: **Accepted** — decision is *adopted (live in source estate)*
+- Date: 2026-06-03
+- Authors: platform-team
+- Related issues: (ported)
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+The EKS control-plane endpoint configuration determines how operators, CI
+runners, and deployers reach the Kubernetes API server. For the platform's
+non-production / shared cluster, CI (GitHub Actions runners with dynamic IPs)
+needs `kubectl` and `terragrunt` access to the API. Three models exist:
+
+1. **Private only** — API reachable only inside the VPC; all external callers
+   need a bastion/VPN. Highest security, highest friction.
+2. **Public only** — API reachable from any IP; simplest, largest attack surface.
+3. **Public + private, CIDR-restricted** — reachable privately from the VPC and
+   publicly from an explicit CIDR allow-list. Balances access and security.
+
+The previous EKS unit left `cluster_endpoint_public_access_cidrs` unset, which
+AWS interprets as `0.0.0.0/0` (implicitly wide open). The goal is to make the
+allow-list a first-class, tightenable Terraform variable.
+
+## Decision
+
+Set `cluster_endpoint_public_access = true`,
+`cluster_endpoint_private_access = true`, and introduce
+`cluster_endpoint_public_access_cidrs` as an explicit input variable. For the
+shared/non-prod cluster it is currently `["0.0.0.0/0"]` — a known, documented
+risk that preserves current CI behaviour while making the allow-list explicit and
+parameterised.
+
+A reviewer can check conformance by confirming the EKS unit sets the CIDR list
+explicitly (never relies on the implicit `0.0.0.0/0` default) and keeps private
+access enabled.
+
+## Alternatives considered
+
+### Alternative A: Private-only endpoint
+Lock the API to the VPC.
+Rejected because: GitHub Actions runners use dynamic IPs; reaching a private-only
+endpoint requires a NAT gateway with an Elastic IP (cost + complexity) or a
+bastion/VPN for every CI job. For a non-production preview cluster the friction
+outweighs the benefit.
+
+### Alternative B: Public-only endpoint
+Drop private access.
+Rejected because: it forces in-cluster components (Cilium operator, kube-system)
+to traverse the public endpoint and removes the internal-path mitigation. Private
+access must stay on.
+
+### Alternative C: Status quo (implicit `0.0.0.0/0`)
+Leave the CIDR variable unset.
+Rejected because: the implicit wide-open default is invisible in review and
+cannot be tightened without a module change. Externalising it is the whole point.
+
+## Consequences
+
+### Positive
+- The CIDR list is a first-class `terragrunt.hcl` input — tightenable later (e.g.
+  to GitHub Actions IP ranges via `api.github.com/meta`) without a module change.
+- Private access retained: in-cluster components always use the internal
+  endpoint, bounding the blast radius of a public-CIDR breach.
+
+### Negative
+- The explicit `["0.0.0.0/0"]` on the shared cluster is a documented, accepted
+  risk for the non-production tier.
+
+### Risks
+- Tightening the CIDR later must be validated against every CI pipeline that
+  calls `kubectl`/`terragrunt plan` against the cluster, or those jobs break.
+  Mitigated by tracking the tightening as a follow-up once runner-IP stability is
+  confirmed.
+- **Production-tier note:** production/data-plane clusters should NOT inherit the
+  `0.0.0.0/0` value. The variable exists precisely so prod can ship a narrow
+  allow-list (or private-only). This is a *design-target* for the prod tier.
+
+## Implementation notes
+
+- `cluster_endpoint_public_access_cidrs` plumbed through `_envcommon` → the EKS
+  `terragrunt.hcl` unit.
+- Shared/non-prod: `["0.0.0.0/0"]` (documented). Prod: narrow allow-list /
+  private — to be set when the prod cluster lands.
+
+## References
+
+- EKS endpoint access: <https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html>
+- Ported from `qbiq-ai/infra` ADR-009 (EKS public endpoint + parameterised CIDR)
+- Related: ADR-0003 (Cilium CNI), ADR-0001 (OU split / tier separation)
+
+---
+*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+platform-design sync. Decision status in the source estate: adopted (live) for
+the shared/non-prod cluster; narrow prod allow-list is a design-target.*

--- a/docs/adrs/0011-break-glass-iam-destroy-protection.md
+++ b/docs/adrs/0011-break-glass-iam-destroy-protection.md
@@ -1,0 +1,90 @@
+# ADR-0011: Break-glass IAM user destroy protection
+
+- Status: **Accepted** — decision is *adopted (live in source estate)*
+- Date: 2026-06-03
+- Authors: platform-team
+- Related issues: (ported)
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+Each member account has a `break-glass-<account>` IAM user created by the
+`modules/break-glass-user` module. It is the last-resort emergency access path
+when AWS SSO / Identity Center is unavailable (control-plane outage,
+mis-configured permission set, accidental SSO org detachment).
+
+The module set `force_destroy = false` on `aws_iam_user.this`, which is **not**
+equivalent to `lifecycle { prevent_destroy = true }`:
+
+- `force_destroy = false`: Terraform fails *at apply* if it tries to delete the
+  user while attached policies exist — but the deletion can still be **planned**.
+- `lifecycle { prevent_destroy = true }`: Terraform errors *at plan time* if any
+  configuration produces a destroy action — before any API call.
+
+A `terraform destroy` or a stray `moved` block could silently plan deletion of a
+break-glass user with only `force_destroy = false` in place.
+
+## Decision
+
+Add `lifecycle { prevent_destroy = true }` to `aws_iam_user.this` in
+`modules/break-glass-user/main.tf`, in addition to `force_destroy = false`. A
+reviewer can check conformance by confirming the break-glass user resource
+carries both guards.
+
+## Alternatives considered
+
+### Alternative A: Rely on `force_destroy = false` alone
+Keep the existing single guard.
+Rejected because: it only blocks at apply, after the destroy is already planned —
+it does not prevent a destroy plan from being produced, and the protection
+depends on attached policies still existing.
+
+### Alternative B: Out-of-band protection (SCP / resource tag + manual review)
+Protect the user via an SCP denying `iam:DeleteUser` on the principal.
+Rejected because: it adds cross-account policy surface for a guarantee Terraform
+can make locally and declaratively. (An SCP could complement this later, but is
+not the primary control.)
+
+### Alternative C: Status quo
+Leave it as-is.
+Rejected because: emergency-access continuity is too important to leave to a
+guard that only triggers at apply time.
+
+## Consequences
+
+### Positive
+- Plan-time protection: the resource cannot appear in any destroy plan regardless
+  of trigger (targeted destroy, full destroy, accidental `moved`).
+- Defence in depth: two independent layers stop accidental deletion.
+- Emergency-access continuity preserved during incidents.
+- Intentional removals remain possible via a deliberate, reviewed commit removing
+  the lifecycle block.
+
+### Negative
+- `terraform destroy` on an account with a break-glass user always fails for
+  `aws_iam_user.this` until the lifecycle block is removed — intentional and
+  expected.
+
+### Risks
+- Operators who must deliberately delete a break-glass user must (1) PR removing
+  the lifecycle block, (2) get it reviewed/merged, (3) apply. This is the desired
+  friction, not a bug.
+- CI pipelines running `terraform destroy` for ephemeral environments are
+  unaffected — the break-glass module is only used in long-lived account stacks.
+
+## Implementation notes
+
+- `modules/break-glass-user/main.tf`: add `lifecycle { prevent_destroy = true }`
+  on `aws_iam_user.this`; keep `force_destroy = false`.
+- Pairs with the break-glass operating procedure in `docs/break-glass-procedure.md`.
+
+## References
+
+- Terraform `prevent_destroy`: <https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle>
+- Ported from `qbiq-ai/infra` ADR-010 (break-glass non-delete protection)
+- Related: ADR-0001 (OU split / SCP guardrails)
+
+---
+*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0011-break-glass-iam-destroy-protection.md
+++ b/docs/adrs/0011-break-glass-iam-destroy-protection.md
@@ -82,9 +82,9 @@ guard that only triggers at apply time.
 ## References
 
 - Terraform `prevent_destroy`: <https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle>
-- Ported from `qbiq-ai/infra` ADR-010 (break-glass non-delete protection)
+- Ported from `infra` ADR-010 (break-glass non-delete protection)
 - Related: ADR-0001 (OU split / SCP guardrails)
 
 ---
-*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+*Ported from infra@572b54d (and argocd@c364c6c) during the 2026-06
 platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0012-cluster-role-label-scheme-for-appsets.md
+++ b/docs/adrs/0012-cluster-role-label-scheme-for-appsets.md
@@ -78,10 +78,10 @@ bug this ADR fixes.
 ## References
 
 - ArgoCD ApplicationSet cluster generator: <https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/>
-- Ported from `qbiq-ai/infra` ADR-011 (cluster_role label scheme) and the
-  `qbiq-ai/argocd` ApplicationSet selectors
+- Ported from `infra` ADR-011 (cluster_role label scheme) and the
+  `argocd` ApplicationSet selectors
 - Related: ADR-0006 (ArgoCD GitOps)
 
 ---
-*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+*Ported from infra@572b54d (and argocd@c364c6c) during the 2026-06
 platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0012-cluster-role-label-scheme-for-appsets.md
+++ b/docs/adrs/0012-cluster-role-label-scheme-for-appsets.md
@@ -1,0 +1,87 @@
+# ADR-0012: `cluster_role` label scheme for ArgoCD ApplicationSet selectors
+
+- Status: **Accepted** — decision is *adopted (live in source estate)*
+- Date: 2026-06-03
+- Authors: platform-team
+- Related issues: (ported)
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+ArgoCD ApplicationSets (ADR-0006) use a cluster-selector matrix to decide which
+clusters receive which Applications. The selector filters on labels of the ArgoCD
+cluster secret, which are populated by the `modules/argocd-bootstrap` module via
+its `cluster_labels` input.
+
+The GitOps repo's ApplicationSet manifests target the platform/shared cluster
+with `cluster_role: "platform"`. The bootstrap module originally labelled the
+shared cluster secret `cluster_role: "shared"`. The mismatch caused AppSets to
+produce **zero** Applications for the shared cluster — workloads never deployed.
+
+Two fixes were possible: change the AppSet selectors in the GitOps repo, or
+change the cluster label in the infra repo.
+
+## Decision
+
+Set `cluster_labels.cluster_role = "platform"` (not `"shared"`) in the shared
+cluster's `argocd-bootstrap` unit. The `cluster_role` label is a **cluster
+identity claim** (`platform` / `app` / `data`), distinct from the account name,
+which is conveyed by a separate `env` label (`env = "shared"`).
+
+A reviewer can check conformance by confirming the cluster-role label value
+matches the AppSet selector convention (`platform`), and that `env` carries the
+account name separately.
+
+## Alternatives considered
+
+### Alternative A: Change AppSet selectors from `platform` to `shared`
+Update the GitOps repo's ApplicationSets instead.
+Rejected because: the AppSet selector is the consumed contract across multiple
+teams; `platform` is the established convention. Changing it requires coordinated
+updates to every AppSet and inverts the established label semantics.
+
+### Alternative B: Add a second label rather than changing `cluster_role`
+Leave `cluster_role = "shared"` and add `cluster_role_alias = "platform"`.
+Rejected because: it leaves two competing identity labels and invites future
+drift; the selector contract should resolve to one canonical value.
+
+### Alternative C: Status quo
+Leave the mismatch.
+Rejected because: it means zero Applications deploy to the shared cluster — the
+bug this ADR fixes.
+
+## Consequences
+
+### Positive
+- AppSets filtering on `cluster_role: "platform"` deploy to the shared cluster.
+- Minimal blast radius: one Helm value in one Terragrunt unit; the cluster secret
+  is updated in place on next apply, no Application resources destroyed.
+- `env = "shared"` retained for account-level filtering by other AppSets.
+
+### Negative
+- The intentional mismatch between account name ("shared") and cluster-role label
+  ("platform") must be documented (here) so nobody "fixes" it back.
+
+### Risks
+- After apply, verify AppSet dry-run output to ensure no unintended Applications
+  are triggered by the now-matching selector.
+- Future "platform"-role clusters must also use `cluster_role = "platform"` to be
+  included in the same AppSet matrix row.
+
+## Implementation notes
+
+- `shared/eu-west-1/argocd-bootstrap/terragrunt.hcl`: `cluster_labels.cluster_role
+  = "platform"`, `env = "shared"`.
+- Do **not** revert `cluster_role` to `"shared"`.
+
+## References
+
+- ArgoCD ApplicationSet cluster generator: <https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/>
+- Ported from `qbiq-ai/infra` ADR-011 (cluster_role label scheme) and the
+  `qbiq-ai/argocd` ApplicationSet selectors
+- Related: ADR-0006 (ArgoCD GitOps)
+
+---
+*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0013-inter-vpc-access-security-model.md
+++ b/docs/adrs/0013-inter-vpc-access-security-model.md
@@ -167,11 +167,11 @@ transitive path to prod is possible. The model must precede enabling routing.
 ## References
 
 - AWS TGW appliance-mode / Network Firewall: <https://docs.aws.amazon.com/network-firewall/latest/developerguide/>
-- Ported from `qbiq-ai/infra` ADR-012 (inter-VPC access security model)
+- Ported from `infra` ADR-012 (inter-VPC access security model)
 - Related: ADR-0005 (hub-spoke TGW), ADR-0001 (OU split)
 
 ---
-*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+*Ported from infra@572b54d (and argocd@c364c6c) during the 2026-06
 platform-design sync. Decision status in the source estate: in-repo enforcement
 adopted (live); legacy-side return routes and prod NACL backstop are
 cross-account design-targets.*

--- a/docs/adrs/0013-inter-vpc-access-security-model.md
+++ b/docs/adrs/0013-inter-vpc-access-security-model.md
@@ -1,0 +1,177 @@
+# ADR-0013: Inter-VPC access security model (TGW segmentation + cross-estate VPN join)
+
+- Status: **Accepted** — decision is *adopted (live in source estate)*; the
+  legacy-side return routes and the prod NACL backstop are tracked as
+  cross-account follow-ups (see *Consequences*), so those sub-parts are
+  *design-target*. Builds on ADR-0005 (hub-spoke TGW).
+- Date: 2026-06-03
+- Authors: platform-team, security
+- Related issues: (ported)
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+The platform is merging two network estates and adding a VPN that spans both, so
+the inter-VPC security model must guarantee that production data-plane VPCs stay
+isolated from dev/standard even with a cross-estate VPN in play. (Account IDs and
+specific CIDRs from the source estate are intentionally omitted here; the
+platform-design mock uses representative ranges.)
+
+1. **Legacy estate** — internally a flat **VPC peering mesh** (admin / dev-EKS /
+   prod / analytics-prod VPCs). The legacy VPN server runs in the admin VPC in
+   NAT/masquerade mode, so its client pool is SNAT'd and not visible at the AWS
+   routing layer. The legacy admin/prod/dev VPCs are **already attached** to the
+   hub TGW, but the attachments are **inert** — there are zero custom TGW route
+   tables, so no traffic flows through the TGW yet.
+
+2. **New estate** (this repo) — **hub-and-spoke TGW** (ADR-0005) in the Network
+   account, with planned spoke/shared/prod VPC ranges. `modules/tgw-routing`
+   implements **custom, least-privilege** TGW route tables (no default
+   association/propagation); `modules/tgw-attachment` creates **inert**
+   attachments until topology is approved.
+
+3. **The join point** — a **new VPN server** in the network account, linked to
+   the legacy estate **via the Transit Gateway** (the legacy admin VPC is already
+   a TGW attachment). **No new VPC peering is created** — this avoids a redundant
+   second routing mechanism and matches ADR-0005 ("no direct VPC peering between
+   workload accounts"). The security control therefore shifts entirely to the
+   least-privilege custom TGW route tables. The VPN is the one component that can
+   route across both estates, so it is the highest-leverage place to enforce
+   segmentation.
+
+Without an explicit model, the VPN + the legacy flat peering could create a
+transitive path letting a dev/standard client reach production — exactly what
+ADR-0005's segmentation promise forbids.
+
+## Decision
+
+Adopt a **defense-in-depth, least-privilege, deny-by-default** inter-VPC model
+with four enforcement layers, applied to the new TGW estate and to the TGW join
+with the legacy estate. A reviewer can check conformance by confirming every
+attachment is associated with an explicit custom route table and that no route
+table grants a dev/standard source a path into prod.
+
+### Layer 1 — TGW route-table segmentation (primary control)
+- **No default route-table association or propagation.** Every attachment is
+  associated with an **explicit custom route table** containing **only** the
+  destinations that role may reach. Production route tables **never** contain a
+  route to sandbox/dev attachments.
+- **VPN segmentation:** the VPN attachment's route table lists only the spokes
+  VPN clients may reach; spokes get a return route to the VPN pool **only** where
+  allowed. The VPN is **not** given `0.0.0.0/0` into the mesh.
+- **Legacy reachability via TGW:** routes to the legacy admin/analytics ranges are
+  added on the VPN route table via the legacy admin-VPC's existing attachment. The
+  **return** routes on the legacy side are owned by legacy-ops (out-of-repo; see
+  Consequences).
+
+### Layer 2 — Security groups (instance/ENI control)
+- Default-deny; explicit ingress only; prefer **SG references** for intra-estate
+  east-west AWS sources.
+- **VPN host SG:** the data-plane source is the **NLB** (target group
+  `target_type = ip`, `preserve_client_ip = false`), **never `0.0.0.0/0` on the
+  host**. The only world-facing surface is internet→NLB. UI restricted to admin
+  networks over VPN/TGW; **no public UI**; **no SSH** (SSM only).
+- DB SGs accept only the specific app/EKS SG/CIDR that the TGW route table also
+  permits — SGs and TGW routes must **agree** (two independent layers).
+
+### Layer 3 — Network ACLs (subnet backstop)
+- Stateless subnet-level deny for traffic that should never appear. Prod subnets
+  NACL-deny the **standard VPN sub-pool** while allowing the **ops sub-pool**, as
+  a backstop behind the TGW allow-list. (Prod-account VPC unit; cross-account
+  follow-up — *design-target*.)
+
+### Layer 4 — Centralized inspection (future)
+- `modules/inspection-vpc` already exists (AWS Network Firewall, TGW
+  appliance-mode attachment, ALERT+FLOW logging). **Future:** route inter-segment
+  / egress traffic through it for DPI + logging. Not enabled in v1.
+
+### VPN client trust segmentation (resolved)
+- The VPN pool is **sub-divided by trust level**:
+  - **ops sub-pool** → full access: new prod, shared, network, and all legacy
+    ranges.
+  - **standard sub-pool** → **only** the shared range.
+- **Only the ops sub-pool** is routed/propagated to production. The standard
+  sub-pool has **no** prod route and no legacy route.
+- **Negative test is an acceptance requirement:** a non-ops VPN client **must
+  NOT** reach prod (verified end-to-end).
+
+### Legacy ↔ new join rules (the critical seam)
+- Link = **Transit Gateway** (legacy admin VPC already attached); **no new VPC
+  peering.** The join carries **narrow, explicit routes** both ways (no broad
+  supernets): new prod advertised **only to the ops segment**, not to legacy dev;
+  legacy reachable from the new VPN per the allow-list (ops → all legacy;
+  standard → none).
+- **No transitive prod exposure:** deny-by-default TGW route tables mean a
+  legacy/standard client cannot hop into prod unless an explicit allow-list entry
+  permits it. The VPN allow-list is the single reviewed place this is decided.
+
+### Detective controls
+- **VPC Flow Logs** (KMS-encrypted) on the network VPC, **GuardDuty** on the
+  network account, and **CloudWatch alarms** on the VPN host (EC2 auto-recovery +
+  a `NetworkOut` anomaly-detection band). Required for v1.
+
+### DNS boundary (supporting)
+- The internal shared zone is a **PRIVATE** Route53 zone resolvable only inside
+  associated VPCs; VPN clients resolve it via the network-VPC association + DNS
+  push. The internal namespace does not leak publicly (the public apex lives
+  outside AWS DNS and is untouched).
+
+## Alternatives considered
+
+### Alternative A: New VPC peering for the legacy join
+Add a parallel VPC peering between the new network VPC and the legacy admin VPC.
+Rejected because: the legacy admin VPC is already a TGW attachment; a second
+routing mechanism duplicates control surface and contradicts ADR-0005. One
+least-privilege control surface (the admin-VPC route table) is preferable.
+
+### Alternative B: One flat VPN pool with broad routes
+Give the whole VPN pool reachability to all estates.
+Rejected because: it removes the prod-isolation guarantee — a standard client
+could transit to prod. Trust sub-pools are the cheapest auditable fix.
+
+### Alternative C: Status quo (inert attachments, no model)
+Leave the TGW attachments inert and add no explicit model.
+Rejected because: as soon as the VPN + legacy peering are live, an unmodelled
+transitive path to prod is possible. The model must precede enabling routing.
+
+## Consequences
+
+### Positive
+- Production stays isolated from dev/standard even with a cross-estate VPN.
+- Auditable: every cross-segment flow is an explicit TGW route + SG (+ future
+  firewall rule); trust sub-pools make "who can reach prod" a one-line answer.
+- Incremental: the inspection VPC can be switched on later with no redesign.
+
+### Negative
+- More route-table / SG / NACL bookkeeping as accounts grow.
+- The VPN allow-list + ops sub-pool membership must be change-controlled.
+- The legacy flat peering mesh stays less granular than the TGW side until legacy
+  VPCs are migrated onto the TGW (future).
+
+### Risks / sequencing gate
+- `enable_vpn_routing = true` must be flipped **only after** (1) the network VPC +
+  attachment are applied and (2) the **prod NACL deny** backstop is in place —
+  otherwise the standard sub-pool transiently reaches prod via the TGW. Default is
+  `false`.
+
+## Implementation notes
+
+- Reuses `tgw-routing`, `tgw-attachment` (inert-by-default), `inspection-vpc`.
+- Out-of-repo / cross-account follow-ups (*design-target*): legacy-side return
+  routes (owned by legacy-ops), the prod NACL backstop (prod-account VPC unit),
+  VPN-host egress tightening (`0.0.0.0/0:443` → VPC endpoints), enabling the
+  inspection VPC for east-west, and migrating legacy peering VPCs fully onto the
+  hub TGW.
+
+## References
+
+- AWS TGW appliance-mode / Network Firewall: <https://docs.aws.amazon.com/network-firewall/latest/developerguide/>
+- Ported from `qbiq-ai/infra` ADR-012 (inter-VPC access security model)
+- Related: ADR-0005 (hub-spoke TGW), ADR-0001 (OU split)
+
+---
+*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+platform-design sync. Decision status in the source estate: in-repo enforcement
+adopted (live); legacy-side return routes and prod NACL backstop are
+cross-account design-targets.*

--- a/docs/adrs/0014-argo-rollouts-canary-progressive-delivery.md
+++ b/docs/adrs/0014-argo-rollouts-canary-progressive-delivery.md
@@ -28,7 +28,7 @@ and ships a Prometheus stack — the prerequisites for metric-gated canary.
 ## Decision
 
 Use **Argo Rollouts** with a **canary** strategy for production workloads via the
-shared `qbiq-app` Helm chart. Traffic is shifted by the **Gateway API plugin**
+shared `app` Helm chart. Traffic is shifted by the **Gateway API plugin**
 (`argoproj-labs/gatewayAPI`) adjusting `HTTPRoute` backend weights between a
 stable and a canary Service; each weight step is gated by an inline **Analysis**
 (Prometheus `error-rate` and `latency-p95` queries against the canary Service
@@ -85,7 +85,7 @@ Same as Alternative A — rejected for the same reasons.
 
 ## Implementation notes
 
-- Shared chart `qbiq-app` templates: `rollout.yaml` (canary steps +
+- Shared chart `app` templates: `rollout.yaml` (canary steps +
   `trafficRouting.plugins.argoproj-labs/gatewayAPI`), `analysistemplate.yaml`
   (`error-rate`, `latency-p95`), `service-canary.yaml`, `httproute.yaml`.
 - Canary weights and analysis parameters are chart values per workload; analysis
@@ -95,9 +95,9 @@ Same as Alternative A — rejected for the same reasons.
 
 - Argo Rollouts: <https://argo-rollouts.readthedocs.io/>
 - Gateway API plugin: <https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi>
-- Ported from `qbiq-ai/argocd` (`charts/qbiq-app` rollout + analysistemplate)
+- Ported from `argocd` (`charts/app` rollout + analysistemplate)
 - Related: ADR-0006 (ArgoCD), ADR-0009 (Cilium Gateway API)
 
 ---
-*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+*Ported from infra@572b54d (and argocd@c364c6c) during the 2026-06
 platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0014-argo-rollouts-canary-progressive-delivery.md
+++ b/docs/adrs/0014-argo-rollouts-canary-progressive-delivery.md
@@ -1,0 +1,103 @@
+# ADR-0014: Argo Rollouts canary with Gateway API traffic-routing and analysis
+
+- Status: **Accepted** — decision is *adopted (live in source estate)*
+- Date: 2026-06-03
+- Authors: platform-team
+- Related issues: (ported)
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+Platform workloads on EKS (the inference-gateway front-end, render/document
+services, public APIs) need a deployment strategy that limits the blast radius of
+a bad release. A plain Kubernetes `Deployment` rolling update shifts all traffic
+to new pods as they become Ready, with no metric-gated pause — a regression in
+error rate or p95 latency is only caught after it is already serving production
+traffic. Options:
+
+1. **Plain `Deployment` rolling update** — simple, but no progressive traffic
+   shift and no automated metric gate.
+2. **Argo Rollouts canary** — weighted traffic shift with analysis-gated steps,
+   integrated with ArgoCD (ADR-0006).
+3. **Manual blue/green via two Services** — operator-driven, error-prone.
+
+The platform already runs ArgoCD (ADR-0006) and Cilium Gateway API (ADR-0009),
+and ships a Prometheus stack — the prerequisites for metric-gated canary.
+
+## Decision
+
+Use **Argo Rollouts** with a **canary** strategy for production workloads via the
+shared `qbiq-app` Helm chart. Traffic is shifted by the **Gateway API plugin**
+(`argoproj-labs/gatewayAPI`) adjusting `HTTPRoute` backend weights between a
+stable and a canary Service; each weight step is gated by an inline **Analysis**
+(Prometheus `error-rate` and `latency-p95` queries against the canary Service
+only).
+
+A reviewer can check conformance by confirming production workloads are authored
+as `Rollout` objects with a canary strategy + `AnalysisTemplate`, not bare
+`Deployment` rolling updates.
+
+## Alternatives considered
+
+### Alternative A: Plain Deployment rolling update
+Use Kubernetes-native rolling updates.
+Rejected because: no weighted traffic control and no automated metric gate — a
+latency or error-rate regression is served to 100% of traffic before anyone
+notices. Unacceptable for the latency-sensitive scoring/gateway path.
+
+### Alternative B: Manual blue/green
+Stand up a second Service and cut over manually.
+Rejected because: it is operator-driven and error-prone, with no automated
+abort-on-bad-metrics. Argo Rollouts encodes the same idea declaratively with
+analysis gating.
+
+### Alternative C: Status quo (Deployment)
+Same as Alternative A — rejected for the same reasons.
+
+## Consequences
+
+### Positive
+- Weighted canary: `canaryService` receives a controlled fraction while
+  `stableService` keeps the rest; the Gateway API plugin (ADR-0009) drains
+  connections gracefully on each shift.
+- Metric-gated steps: inline `AnalysisTemplate` checks Prometheus `error-rate`
+  and `latency-p95` (against the canary Service only) before advancing.
+- Graceful abort: on analysis failure the canary ReplicaSet stays alive for
+  `abortScaleDownDelaySeconds` so in-flight requests complete, then rolls back.
+- Reuses the existing ArgoCD + Gateway API + Prometheus stack — no new platform
+  dependency.
+
+### Negative
+- Workloads are authored as `Rollout` CRDs, not `Deployment` (chart abstracts
+  most of this).
+- Requires a canary Service and `HTTPRoute` wiring per workload (provided by the
+  shared chart).
+- Analysis queries must be tuned per workload (interval, count, `failureLimit`,
+  success conditions) or canaries either stall or pass bad releases.
+
+### Risks
+- A mis-specified Prometheus query (e.g. counting stable traffic) would gate on
+  the wrong signal. Mitigated by the chart passing the canary Service name into
+  the analysis args so queries target only canary traffic.
+- Rollouts controller is another component to operate. Mitigated by GitOps-managed
+  install and pinning.
+
+## Implementation notes
+
+- Shared chart `qbiq-app` templates: `rollout.yaml` (canary steps +
+  `trafficRouting.plugins.argoproj-labs/gatewayAPI`), `analysistemplate.yaml`
+  (`error-rate`, `latency-p95`), `service-canary.yaml`, `httproute.yaml`.
+- Canary weights and analysis parameters are chart values per workload; analysis
+  is opt-in via `rollout.analysis.enabled`.
+
+## References
+
+- Argo Rollouts: <https://argo-rollouts.readthedocs.io/>
+- Gateway API plugin: <https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi>
+- Ported from `qbiq-ai/argocd` (`charts/qbiq-app` rollout + analysistemplate)
+- Related: ADR-0006 (ArgoCD), ADR-0009 (Cilium Gateway API)
+
+---
+*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+platform-design sync. Decision status in the source estate: adopted (live).*

--- a/docs/adrs/0015-reusable-ci-pipelines.md
+++ b/docs/adrs/0015-reusable-ci-pipelines.md
@@ -111,10 +111,10 @@ are needed.
 
 - GitHub reusable workflows: <https://docs.github.com/actions/using-workflows/reusing-workflows>
 - GitHub OIDC → AWS: <https://docs.github.com/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services>
-- Ported from `qbiq-ai/infra` CI/CD ADR-001 (reusable pipelines)
+- Ported from `infra` CI/CD ADR-001 (reusable pipelines)
 - Related: ADR-0004 (Terragrunt), ADR-0006 (ArgoCD), ADR-0016 (Tier 1 hardening)
 
 ---
-*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+*Ported from infra@572b54d (and argocd@c364c6c) during the 2026-06
 platform-design sync. Decision status in the source estate: Proposed / rolling
 out (design-target); the seed OIDC+ECR+Trivy build workflow is live.*

--- a/docs/adrs/0015-reusable-ci-pipelines.md
+++ b/docs/adrs/0015-reusable-ci-pipelines.md
@@ -1,0 +1,120 @@
+# ADR-0015: Reusable CI/CD pipelines for the platform organisation
+
+- Status: **Proposed** — decision is a *design-target* (the reusable-pipeline
+  platform is being rolled out; source estate has the seed `build-and-push`
+  workflow live)
+- Date: 2026-06-03
+- Authors: platform-team, security
+- Related issues: (ported)
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+Workloads across the platform organisation are converging onto the shared EKS
+clusters (Graviton, `eu-west-1`). Each repository today carries its own ad-hoc
+GitHub Actions YAML — variable in quality, hard to audit, and prone to drift on
+patch-version pinning, scan thresholds, and OIDC role wiring. A central, versioned
+set of building blocks lets us:
+
+- Roll out security-policy changes (image-scan threshold, SBOM format, base-image
+  scan) once and have all callers pick them up via a `@v1` floating tag.
+- Eliminate per-repo IAM role sprawl by using **one** OIDC-federated role for ECR
+  push, trust-scoped to the whole org.
+- Standardise the GitOps deploy contract (PR into the GitOps repo) so the
+  platform team has a single integration point with ArgoCD (ADR-0006).
+
+The platform already has a proven OIDC + ECR + Trivy build workflow as the seed;
+this ADR formalises and generalises it.
+
+## Decision
+
+Ship a **two-layer reuse model**: atomic **composite actions** and full
+**reusable workflows** (`workflow_call`). Standardise on **one central
+OIDC-federated IAM role** for ECR push (org-scoped trust, ECR resource policy
+scoped to the platform's repository namespace), **multi-arch builds**
+(`linux/arm64,linux/amd64` — Graviton default), a **GitOps deploy contract** that
+opens a PR into the GitOps repo (auto-merge on non-prod, manual review on prod),
+**SHA-pinned** third-party actions, and **semver** releases with a floating major
+tag.
+
+A reviewer can check conformance by confirming caller repos consume the reusable
+workflows via `uses: <org>/infra/.github/workflows/reusable-*.yml@v1` rather than
+hand-rolled pipelines, and that third-party `uses:` are SHA-pinned.
+
+## Alternatives considered
+
+### Alternative A: Per-repo bespoke pipelines (status quo)
+Each repo keeps its own GitHub Actions YAML.
+Rejected because: that is exactly the drift/audit problem — policy changes require
+N copy-paste edits, and per-repo OIDC roles proliferate.
+
+### Alternative B: Composite actions only (no reusable workflows)
+Ship atomic building blocks but let each repo assemble its own pipeline.
+Rejected because: it standardises steps but not the *pipeline shape*, so the
+deploy contract and gating order still drift. The two-layer model lets callers mix
+(use a reusable workflow wholesale, or compose atomic actions for custom paths).
+
+### Alternative C: Reusable workflows only (no composite actions)
+Ship only `workflow_call` pipelines.
+Rejected because: repos that need one atomic step (just ECR login, or just a tag
+bump) inside a custom workflow would have no building block to reuse. Both layers
+are needed.
+
+## Consequences
+
+### Positive
+- Single place to change security policy; callers float on `@v1`.
+- One OIDC role for ECR push (org-scoped trust, namespace-scoped ECR policy; no
+  IAM, no STS, no cross-account).
+- Multi-arch images built once (`docker/build-push-action` + QEMU + gha cache).
+- Single GitOps integration point: a deploy action opens a PR bumping image
+  tag/digest in the GitOps repo (auto-merge on dev/stage, manual on prod).
+- SHA-pinned, Renovate/Dependabot-maintained third-party actions.
+
+### Negative
+- The infra repo becomes a shared dependency with strict semver discipline —
+  a breaking change in `@v1` would break all callers (mitigated below).
+- arm64 QEMU emulation is ~2–3× slower than native; accepted for v1 since gha
+  cache eliminates warm rebuilds and build counts are low.
+
+### Risks
+- **Wildcard org trust** on the OIDC role — any org repo can assume it. Mitigated
+  by scoping the ECR resource policy to the platform's repository namespace only
+  (no IAM/STS/cross-account), mandatory branch protection on callers, and a
+  follow-up CloudTrail alarm on unusual ECR push patterns.
+- **Compromised third-party action** could push a malicious image. Mitigated by
+  SHA-pinning + Dependabot review, plus Trivy failing CRITICAL/HIGH before push
+  and an SBOM attached to every image (signing is ADR-0016).
+- **Breaking change in the `@v1` floating tag** breaks all callers. Mitigated by
+  strict semver: breaking changes ship as `v2`; a smoke workflow gates the `v1`
+  advance.
+- **GitOps bot-token leak.** Mitigated by a fine-scoped token (`contents:write` on
+  the GitOps repo only), rotated quarterly, never logged.
+
+## Implementation notes
+
+- Composite actions: `aws-oidc-login`, `ecr-login`, `docker-build-multiarch`,
+  `trivy-scan`, `syft-sbom`, `argocd-tag-bump`, `python-ci`, `node-ci`.
+- Reusable workflows: `reusable-build-and-push`, `reusable-python-ci`,
+  `reusable-node-ci`, `reusable-deploy-via-argocd`, `reusable-full-release`, plus
+  a path-filtered smoke workflow.
+- Terraform: `modules/github-oidc-central-ecr` (central role + ECR push policy,
+  reusing the existing OIDC provider via a `data` lookup) + Terragrunt unit
+  (ADR-0004).
+- `values_path` for the GitOps deploy is a **required** input — no implicit layout
+  convention.
+- Tier 1 supply-chain hardening (dep scan, secrets, SAST, signing, manifest
+  validation, smoke) layers on top — see ADR-0016.
+
+## References
+
+- GitHub reusable workflows: <https://docs.github.com/actions/using-workflows/reusing-workflows>
+- GitHub OIDC → AWS: <https://docs.github.com/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services>
+- Ported from `qbiq-ai/infra` CI/CD ADR-001 (reusable pipelines)
+- Related: ADR-0004 (Terragrunt), ADR-0006 (ArgoCD), ADR-0016 (Tier 1 hardening)
+
+---
+*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+platform-design sync. Decision status in the source estate: Proposed / rolling
+out (design-target); the seed OIDC+ECR+Trivy build workflow is live.*

--- a/docs/adrs/0016-tier1-supply-chain-hardening.md
+++ b/docs/adrs/0016-tier1-supply-chain-hardening.md
@@ -1,0 +1,124 @@
+# ADR-0016: Tier 1 CI/CD hardening — dep scan, secrets, SAST, signing, manifest validation, smoke
+
+- Status: **Proposed** — decision is a *design-target* (extends ADR-0015; rolling
+  out)
+- Date: 2026-06-03
+- Authors: platform-team, security
+- Related issues: (ported)
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+ADR-0015 delivers the baseline: lint/test → multi-arch build → Trivy image scan →
+SBOM → ECR push → GitOps PR. That gets every microservice to *shippable*. Tier 1
+takes them from shippable to **production-grade** by adding the six controls that
+catch the next class of supply-chain and configuration risk:
+
+1. Application-dependency vulnerabilities (Trivy image scan only covers
+   OS/system libs).
+2. Hard-coded secrets in source.
+3. Static application security (SAST) findings.
+4. Image provenance signing.
+5. Helm/Kustomize manifest validation before ArgoCD touches them.
+6. Post-deploy smoke verification.
+
+## Decision
+
+Add six atomic composite actions (matching ADR-0015's form factor) and wire them
+additively into the existing reusable workflows, with **zero new long-lived
+secrets** (signing uses keyless OIDC; SARIF uploads use the built-in
+`GITHUB_TOKEN`). Tool choices:
+
+- **Dependency scan:** `pip-audit` (Python); `npm audit` + `osv-scanner` (Node).
+  Gate on HIGH/CRITICAL; per-repo `.audit-ignore` allow-list.
+- **Secrets scan:** `gitleaks`, SARIF to GitHub Security; fail on any finding.
+- **SAST:** CodeQL (`security-and-quality`), SARIF to Code Scanning;
+  merge-blocking left to branch protection.
+- **Image signing:** `cosign` keyless via GitHub OIDC (Fulcio + Rekor); sign by
+  **digest**, attach the SBOM as a signed attestation.
+- **Manifest validation:** `helm lint` → `kubeconform -strict` → `conftest`
+  (OPA/Rego) — a reusable workflow callable from the GitOps repo's CI.
+- **Post-deploy smoke:** `argocd app wait --health --sync` then an HTTP probe;
+  opt-in via an optional `smoke_url` input.
+
+A reviewer can check conformance by confirming the full-release workflow runs
+`secrets-scan` and `sast-codeql` as upstream gates feeding `build`, that
+`cosign-sign` runs after push (by digest), and that GitOps manifest changes pass
+`reusable-manifest-validate`.
+
+## Alternatives considered
+
+### Alternative A: Stop at the ADR-0015 baseline
+Ship only image scanning + SBOM.
+Rejected because: Trivy image scan covers OS libs only — application-dependency
+CVEs, leaked secrets, SAST findings, provenance, and manifest defects all go
+uncaught. That is "shippable", not "production-grade".
+
+### Alternative B: KMS-backed signing keys instead of keyless cosign
+Sign images with a managed KMS key.
+Rejected because: KMS key sprawl + rotation burden + another IAM scope. Keyless
+cosign binds the signature to a specific repo+workflow OIDC identity and the
+public transparency log is an **audit advantage**, not a leak (repo names are not
+secrets).
+
+### Alternative C: semgrep instead of CodeQL for SAST
+Use semgrep's free ruleset.
+Rejected as the default because: CodeQL is natively integrated (SARIF → Security
+tab) and the org already has Advanced Security. semgrep remains a fallback if
+CodeQL minutes become a problem.
+
+## Consequences
+
+### Positive
+- Catches app-dependency CVEs, leaked secrets, SAST findings, unsigned images, and
+  bad manifests before they reach production.
+- No new long-lived secrets — keyless signing + `GITHUB_TOKEN` SARIF uploads.
+- Unified findings surface (Trivy + CodeQL + gitleaks all in GitHub Security).
+- Manifest validation runs in the GitOps repo's CI, so bad values files are caught
+  before ArgoCD (ADR-0006) syncs them.
+
+### Negative
+- ~4–7 min added per build on top of the ADR-0015 baseline (SAST is the long
+  pole). Acceptable for production-grade pipelines; SAST can move to a scheduled
+  scan if minutes blow up at scale.
+- More moving parts (six new actions + two new reusable workflows).
+
+### Risks
+- `.audit-ignore` becoming a dumping ground. Mitigated by requiring an expiry-date
+  comment per entry and a quarterly review.
+- gitleaks false positives blocking PRs. Mitigated by a repo-local `.gitleaks.toml`
+  allow-list and finding-level dismissal in Code Scanning.
+- conftest policies too strict. Mitigated by shipping them **advisory** in v1
+  (`fail-on-policy-violations: false`), promoted to a gate once manifests
+  stabilise.
+- Sigstore Fulcio/Rekor outage blocking releases. Mitigated by an `advisory` input
+  that makes signing best-effort during incidents.
+
+## Implementation notes
+
+- Composite actions: `python-dep-scan`, `node-dep-scan`, `secrets-scan`,
+  `sast-codeql`, `cosign-sign`, `manifest-validate`, `argocd-wait-sync-and-smoke`.
+- Reusable workflows: `reusable-secrets-scan`, `reusable-manifest-validate`
+  (callable from the GitOps repo); standalone in-repo `secrets-scan` +
+  `smoke-tier1`.
+- Gating order in `reusable-full-release`: `secrets-scan` + `sast-codeql` run
+  parallel to language CI, both feeding `build`; dep-scan layered inside the
+  language CI workflows; `cosign-sign` inside build-and-push after push; smoke
+  inside deploy.
+- All new third-party `uses:` SHA-pinned with the Renovate-comment convention
+  from ADR-0015.
+
+## References
+
+- cosign / Sigstore keyless: <https://docs.sigstore.dev/cosign/signing/overview/>
+- kubeconform: <https://github.com/yannh/kubeconform>; conftest:
+  <https://www.conftest.dev/>
+- Ported from `qbiq-ai/infra` CI/CD ADR-002 (Tier 1 hardening)
+- Related: ADR-0015 (reusable CI pipelines), ADR-0006 (ArgoCD), ADR-0014 (Argo
+  Rollouts canary)
+
+---
+*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+platform-design sync. Decision status in the source estate: Proposed / rolling
+out (design-target).*

--- a/docs/adrs/0016-tier1-supply-chain-hardening.md
+++ b/docs/adrs/0016-tier1-supply-chain-hardening.md
@@ -114,11 +114,11 @@ CodeQL minutes become a problem.
 - cosign / Sigstore keyless: <https://docs.sigstore.dev/cosign/signing/overview/>
 - kubeconform: <https://github.com/yannh/kubeconform>; conftest:
   <https://www.conftest.dev/>
-- Ported from `qbiq-ai/infra` CI/CD ADR-002 (Tier 1 hardening)
+- Ported from `infra` CI/CD ADR-002 (Tier 1 hardening)
 - Related: ADR-0015 (reusable CI pipelines), ADR-0006 (ArgoCD), ADR-0014 (Argo
   Rollouts canary)
 
 ---
-*Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
+*Ported from infra@572b54d (and argocd@c364c6c) during the 2026-06
 platform-design sync. Decision status in the source estate: Proposed / rolling
 out (design-target).*

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,50 @@
+# Architecture Decision Records
+
+This directory holds the platform-design Architecture Decision Records (ADRs).
+Each ADR follows [`0000-template.md`](0000-template.md): Context → Decision →
+Alternatives considered → Consequences → Implementation notes → References.
+
+ADRs 0001–0002 are native to platform-design. ADRs 0003–0016 were **ported during
+the 2026-06 platform-design sync** from the source-of-truth estate
+(`qbiq-ai/infra@572b54d` and `qbiq-ai/argocd@c364c6c`), with wording adapted to
+this transaction-analytics platform. Each ported ADR carries a provenance footer
+and is marked **adopted** (live in the source estate) or **design-target**
+(proposed / rolling out).
+
+## Index
+
+| ADR | Title | Status | Provenance |
+|-----|-------|--------|------------|
+| [0001](0001-ou-split.md) | OU split — Prod / Non-Prod / Deployments / Suspended / Sandbox | Accepted | native |
+| [0002](0002-tf-only-state-backend.md) | Terraform-only state backend bootstrap | Accepted | native |
+| [0003](0003-cilium-over-aws-vpc-cni.md) | Cilium over aws-vpc-cni as the EKS CNI | Accepted | ported · adopted |
+| [0004](0004-terragrunt-over-plain-terraform.md) | Terragrunt over plain Terraform for multi-account orchestration | Accepted | ported · adopted |
+| [0005](0005-hub-spoke-transit-gateway.md) | Hub-and-spoke connectivity via AWS Transit Gateway | Accepted | ported · adopted |
+| [0006](0006-argocd-for-gitops.md) | ArgoCD for GitOps delivery of Kubernetes workloads | Accepted | ported · adopted |
+| [0007](0007-karpenter-over-cluster-autoscaler.md) | Karpenter over Cluster Autoscaler for EKS node provisioning | Accepted | ported · adopted |
+| [0008](0008-external-secrets-operator.md) | External Secrets Operator over native K8s secrets | Accepted | ported · adopted |
+| [0009](0009-cilium-gateway-api-ingress.md) | Cilium Gateway API as the cluster ingress controller | Accepted | ported · adopted |
+| [0010](0010-eks-public-endpoint-cidr-allowlist.md) | EKS public API endpoint with a parameterised CIDR allow-list | Accepted | ported · adopted (prod allow-list is a design-target) |
+| [0011](0011-break-glass-iam-destroy-protection.md) | Break-glass IAM user destroy protection | Accepted | ported · adopted |
+| [0012](0012-cluster-role-label-scheme-for-appsets.md) | `cluster_role` label scheme for ArgoCD ApplicationSet selectors | Accepted | ported · adopted |
+| [0013](0013-inter-vpc-access-security-model.md) | Inter-VPC access security model (TGW segmentation + cross-estate VPN join) | Accepted | ported · adopted (legacy-side routes + prod NACL backstop are design-targets) |
+| [0014](0014-argo-rollouts-canary-progressive-delivery.md) | Argo Rollouts canary with Gateway API traffic-routing and analysis | Accepted | ported · adopted |
+| [0015](0015-reusable-ci-pipelines.md) | Reusable CI/CD pipelines for the platform organisation | Proposed | ported · design-target |
+| [0016](0016-tier1-supply-chain-hardening.md) | Tier 1 CI/CD hardening — dep scan, secrets, SAST, signing, manifest validation, smoke | Proposed | ported · design-target |
+
+## Notes on the sync
+
+- **Multi-account strategy** (source `qbiq-ai/infra` ADR-007) is **not** a
+  separate ADR here: it overlaps [ADR-0001](0001-ou-split.md) (the OU split). The
+  account/OU rationale (blast-radius isolation, per-account cost allocation,
+  OU-level SCP guardrails, Control Tower vending, separate Security/Log Archive
+  and Network/Shared accounts) is folded into ADR-0001 rather than duplicated.
+- Source numbering does not map 1:1 onto target numbering: ported ADRs were
+  renumbered sequentially from 0003 with clearer kebab titles, and the two CI/CD
+  ADRs land last as 0015–0016.
+
+## Conventions
+
+- Filenames: `NNNN-kebab-title.md`, zero-padded to four digits.
+- New ADRs continue from the highest existing number; never renumber a merged ADR.
+- A superseded ADR keeps its file and links forward via `Superseded by: ADR-NNNN`.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -6,7 +6,7 @@ Alternatives considered → Consequences → Implementation notes → References
 
 ADRs 0001–0002 are native to platform-design. ADRs 0003–0016 were **ported during
 the 2026-06 platform-design sync** from the source-of-truth estate
-(`qbiq-ai/infra@572b54d` and `qbiq-ai/argocd@c364c6c`), with wording adapted to
+(`infra@572b54d` and `argocd@c364c6c`), with wording adapted to
 this transaction-analytics platform. Each ported ADR carries a provenance footer
 and is marked **adopted** (live in the source estate) or **design-target**
 (proposed / rolling out).
@@ -34,7 +34,7 @@ and is marked **adopted** (live in the source estate) or **design-target**
 
 ## Notes on the sync
 
-- **Multi-account strategy** (source `qbiq-ai/infra` ADR-007) is **not** a
+- **Multi-account strategy** (source `infra` ADR-007) is **not** a
   separate ADR here: it overlaps [ADR-0001](0001-ou-split.md) (the OU split). The
   account/OU rationale (blast-radius isolation, per-account cost allocation,
   OU-level SCP guardrails, Control Tower vending, separate Security/Log Archive


### PR DESCRIPTION
## What

Part of the **2026-06 platform-design sync**. Ports the real, deployed
architecture decisions from the source-of-truth estate
(`qbiq-ai/infra@572b54d` and `qbiq-ai/argocd@c364c6c`) into platform-design's
ADR catalog — **12 infra architecture ADRs + 2 CI/CD ADRs** — adapted to this
transaction-analytics platform's context and numbered **0003–0016**. The
existing native ADRs **0001 (OU split)** and **0002 (state backend)** are
preserved and not duplicated.

## ADRs added

| ADR | Title | Status |
|-----|-------|--------|
| 0003 | Cilium over aws-vpc-cni as the EKS CNI | Accepted · adopted |
| 0004 | Terragrunt over plain Terraform | Accepted · adopted |
| 0005 | Hub-and-spoke connectivity via AWS Transit Gateway | Accepted · adopted |
| 0006 | ArgoCD for GitOps delivery | Accepted · adopted |
| 0007 | Karpenter over Cluster Autoscaler | Accepted · adopted |
| 0008 | External Secrets Operator over native K8s secrets | Accepted · adopted |
| 0009 | Cilium Gateway API as ingress controller | Accepted · adopted |
| 0010 | EKS public endpoint with parameterised CIDR allow-list | Accepted · adopted (prod allow-list = design-target) |
| 0011 | Break-glass IAM user destroy protection | Accepted · adopted |
| 0012 | `cluster_role` label scheme for ArgoCD AppSet selectors | Accepted · adopted |
| 0013 | Inter-VPC access security model (TGW segmentation + cross-estate VPN join) | Accepted · adopted (legacy-side routes + prod NACL backstop = design-targets) |
| 0014 | Argo Rollouts canary w/ Gateway API traffic-routing + analysis | Accepted · adopted |
| 0015 | Reusable CI/CD pipelines for the platform org | Proposed · design-target |
| 0016 | Tier 1 CI/CD hardening (dep scan, secrets, SAST, signing, manifest validation, smoke) | Proposed · design-target |

Plus a new **`docs/adrs/README.md`** index listing every ADR with status and
provenance.

## Notes

- **Provenance per file:** every ported ADR ends with a one-line footer —
  *"Ported from qbiq-ai/infra@572b54d (and argocd@c364c6c) during the 2026-06
  platform-design sync."* — and is marked **adopted (live in source estate)**
  vs **design-target** (the two CI/CD ADRs and a few sub-parts).
- **Dedup:** source `infra` ADR-007 (multi-account strategy) overlaps the
  existing **0001 (OU split)**, so it is folded in as a short note in the index
  rather than duplicated.
- **Adapted wording:** rationale reuses the real technical reasoning but is
  reframed for the transaction-analytics platform; infra-specific account IDs /
  CIDRs are intentionally omitted.
- All files are under `docs/adrs/`; nothing else is touched.

## Test plan

- [x] Each ADR mirrors the existing `0000-template.md` structure/frontmatter.
- [x] Sequential numbering 0003→0016; existing 0001/0002 untouched.
- [x] README index links resolve to the right files.
- [ ] Reviewer sanity-check that adapted rationale reads correctly for the
      platform-design context.