### PR TITLE
feat(observability): YACE CloudWatch exporter + real dashboards + Grafana OAuth/Alertmanager via ESO

### DIFF
--- a/apps/infra/observability/grafana-dashboards/README.md
+++ b/apps/infra/observability/grafana-dashboards/README.md
@@ -422,6 +422,26 @@ kubectl get configmaps -n observability -l grafana_dashboard=1 -o yaml > dashboa
 kubectl apply -f dashboards-backup.yaml
 ```
 
+## Provenance
+
+The following dashboards were **ported from `qbiq-ai/argocd@c364c6c`
+`apps/observability`, 2026-06 sync**:
+
+- **`kubernetes-overview.json`** (uid `k8s-cluster-overview`) - node & pod
+  CPU/memory from node-exporter and kube-state-metrics.
+- **`aws-infra-overview.json`** (uid `aws-infra-overview`) - AWS infrastructure
+  fed by the YACE CloudWatch exporter (`yace` chart): EKS node CPU/mem, NLB
+  healthy/unhealthy hosts + active/new flows + processed bytes, S3 bucket
+  size/object count, EBS burst balance/IOPS. The ACM certificate-expiry row from
+  the source dashboard is intentionally omitted because the YACE config drops the
+  `AWS/CertificateManager` job (internal CA, not ACM).
+- **`argocd-platform-overview.json`** (uid `argocd-platform-overview`) - ArgoCD
+  app health/sync, application-controller reconciliation queue/duration,
+  repo-server git-fetch/RPC, and component CPU/memory.
+
+These are inlined into `templates/configmap-dashboards.yaml` as `data` keys,
+matching the existing dashboards in this chart.
+
 ## Resources
 
 - [Grafana Documentation](https://grafana.com/docs/)

--- a/apps/infra/observability/grafana-dashboards/README.md
+++ b/apps/infra/observability/grafana-dashboards/README.md
@@ -424,7 +424,7 @@ kubectl apply -f dashboards-backup.yaml
 
 ## Provenance
 
-The following dashboards were **ported from `qbiq-ai/argocd@c364c6c`
+The following dashboards were **ported from `argocd@c364c6c`
 `apps/observability`, 2026-06 sync**:
 
 - **`kubernetes-overview.json`** (uid `k8s-cluster-overview`) - node & pod

--- a/apps/infra/observability/grafana-dashboards/dashboards/argocd-platform-overview.json
+++ b/apps/infra/observability/grafana-dashboards/dashboards/argocd-platform-overview.json
@@ -1,0 +1,643 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": {
+    "list": []
+  },
+  "description": "ArgoCD operational dashboard — app health, sync status, controller queue, repo-server, reconciliation performance",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "title": "Application Health & Sync",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "0"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Apps Healthy",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(argocd_app_info{health_status=\"Healthy\"})",
+          "legendFormat": "Healthy",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Apps Degraded",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(argocd_app_info{health_status=\"Degraded\"})",
+          "legendFormat": "Degraded",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Apps Out of Sync",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(argocd_app_info{sync_status!=\"Synced\"})",
+          "legendFormat": "OutOfSync",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "App Health by Status",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (health_status) (argocd_app_info)",
+          "legendFormat": "{{ health_status }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "App Sync Status",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (sync_status) (argocd_app_info)",
+          "legendFormat": "{{ sync_status }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 101,
+      "title": "Application Controller",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Reconciliation Queue Depth",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (queue) (workqueue_depth{job=~\"argocd-application-controller\"})",
+          "legendFormat": "{{ queue }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "p99"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Reconciliation Duration p99",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(argocd_app_reconcile_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(argocd_app_reconcile_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 102,
+      "title": "Repo Server",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Git Fetch Duration p99",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, repo) (rate(argocd_git_fetch_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{ repo }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Repo Server RPC Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (grpc_method) (rate(grpc_server_handled_total{job=~\"argocd-repo-server\"}[5m]))",
+          "legendFormat": "{{ grpc_method }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 103,
+      "title": "Resource Usage",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Memory Usage — ArgoCD Components",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"argocd\", container!=\"\"})",
+          "legendFormat": "{{ pod }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "cores"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "CPU Usage — ArgoCD Components",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"argocd\", container!=\"\"}[5m]))",
+          "legendFormat": "{{ pod }}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": [
+    "argocd",
+    "gitops",
+    "platform"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource",
+        "label": "Prometheus"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "ArgoCD — Platform Overview",
+  "uid": "argocd-platform-overview",
+  "version": 1
+}

--- a/apps/infra/observability/grafana-dashboards/dashboards/aws-infra-overview.json
+++ b/apps/infra/observability/grafana-dashboards/dashboards/aws-infra-overview.json
@@ -1,0 +1,634 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": {
+    "list": []
+  },
+  "description": "AWS infrastructure overview driven by YACE CloudWatch exporter metrics - EKS, NLB, S3, EBS",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "title": "EKS",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Failed Nodes",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "max(aws_eks_cluster_failed_node_count_maximum)",
+          "legendFormat": "Failed Nodes",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percentunit",
+          "max": 1,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "EKS Node CPU Utilization",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "aws_eks_node_cpu_utilization_average / 100",
+          "legendFormat": "{{ dimension_ClusterName }} / {{ dimension_NodeName }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percentunit",
+          "max": 1,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "EKS Node Memory Utilization",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "aws_eks_node_memory_utilization_average / 100",
+          "legendFormat": "{{ dimension_ClusterName }} / {{ dimension_NodeName }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 101,
+      "title": "Network Load Balancer",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "NLB Healthy / Unhealthy Hosts",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "aws_networkelb_healthy_host_count_minimum",
+          "legendFormat": "Healthy: {{ dimension_LoadBalancer }}",
+          "refId": "A"
+        },
+        {
+          "expr": "aws_networkelb_un_healthy_host_count_maximum",
+          "legendFormat": "Unhealthy: {{ dimension_LoadBalancer }}",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "NLB Active Flows",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "aws_networkelb_active_flow_count_average",
+          "legendFormat": "{{ dimension_LoadBalancer }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "NLB Processed Bytes",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "aws_networkelb_processed_bytes_sum",
+          "legendFormat": "{{ dimension_LoadBalancer }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "NLB New Flows / Period",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "aws_networkelb_new_flow_count_sum",
+          "legendFormat": "{{ dimension_LoadBalancer }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 102,
+      "title": "S3",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "S3 Bucket Size",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "aws_s3_bucket_size_bytes_average",
+          "legendFormat": "{{ dimension_BucketName }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "S3 Object Count",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "aws_s3_number_of_objects_average",
+          "legendFormat": "{{ dimension_BucketName }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 103,
+      "title": "EBS",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 30
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "asc"
+        }
+      },
+      "title": "EBS Burst Balance (alert if < 10%)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "aws_ebs_burst_balance_minimum",
+          "legendFormat": "{{ dimension_VolumeId }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "iops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "EBS Volume IOPS (Read + Write)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "aws_ebs_volume_read_ops_sum",
+          "legendFormat": "Read: {{ dimension_VolumeId }}",
+          "refId": "A"
+        },
+        {
+          "expr": "aws_ebs_volume_write_ops_sum",
+          "legendFormat": "Write: {{ dimension_VolumeId }}",
+          "refId": "B"
+        }
+      ]
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 38,
+  "tags": [
+    "aws",
+    "cloudwatch",
+    "yace",
+    "eks",
+    "nlb",
+    "s3",
+    "ebs"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource",
+        "label": "Prometheus"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "AWS Infrastructure Overview (YACE)",
+  "uid": "aws-infra-overview",
+  "version": 1
+}

--- a/apps/infra/observability/grafana-dashboards/dashboards/kubernetes-overview.json
+++ b/apps/infra/observability/grafana-dashboards/dashboards/kubernetes-overview.json
@@ -1,0 +1,728 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": {
+    "list": []
+  },
+  "description": "Kubernetes cluster overview — node and pod CPU/memory from node-exporter and kube-state-metrics",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "title": "Cluster Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Nodes Total",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "count(kube_node_info)",
+          "legendFormat": "Nodes",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Nodes Not Ready",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "count(kube_node_status_condition{condition=\"Ready\",status!=\"true\"})",
+          "legendFormat": "NotReady",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Pods Running",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(kube_pod_status_phase{phase=\"Running\"})",
+          "legendFormat": "Running",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Pods Pending",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(kube_pod_status_phase{phase=\"Pending\"})",
+          "legendFormat": "Pending",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Pods Failed",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(kube_pod_status_phase{phase=\"Failed\"})",
+          "legendFormat": "Failed",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 101,
+      "title": "Node Resources",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percentunit",
+          "max": 1,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Node CPU Utilization",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "1 - avg by (node) (rate(node_cpu_seconds_total{mode=\"idle\", job=\"node-exporter\"}[5m]))",
+          "legendFormat": "{{ node }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percentunit",
+          "max": 1,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Node Memory Utilization",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "1 - (node_memory_MemAvailable_bytes{job=\"node-exporter\"} / node_memory_MemTotal_bytes{job=\"node-exporter\"})",
+          "legendFormat": "{{ instance }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 102,
+      "title": "Pod Resources (Top Namespace Consumers)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "cores"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "CPU Usage by Namespace",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (namespace) (rate(container_cpu_usage_seconds_total{container!=\"\", container!=\"POD\"}[5m]))",
+          "legendFormat": "{{ namespace }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Memory Usage by Namespace",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (namespace) (container_memory_working_set_bytes{container!=\"\", container!=\"POD\"})",
+          "legendFormat": "{{ namespace }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 103,
+      "title": "Resource Requests vs Limits vs Actual",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percentunit",
+          "max": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Node CPU Request Commitment",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (node) (kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\"}) / sum by (node) (kube_node_status_allocatable{resource=\"cpu\", unit=\"core\"})",
+          "legendFormat": "{{ node }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "percentunit",
+          "max": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "Node Memory Request Commitment",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (node) (kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\"}) / sum by (node) (kube_node_status_allocatable{resource=\"memory\", unit=\"byte\"})",
+          "legendFormat": "{{ node }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 104,
+      "title": "PersistentVolume Capacity",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.7
+              },
+              {
+                "color": "red",
+                "value": 0.85
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "title": "PVC Used Capacity %",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "1 - (kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes)",
+          "legendFormat": "{{ namespace }}/{{ persistentvolumeclaim }}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": [
+    "kubernetes",
+    "cluster",
+    "nodes",
+    "pods"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource",
+        "label": "Prometheus"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "Kubernetes Cluster Overview",
+  "uid": "k8s-cluster-overview",
+  "version": 1
+}

--- a/apps/infra/observability/grafana-dashboards/templates/configmap-ported-dashboards.yaml
+++ b/apps/infra/observability/grafana-dashboards/templates/configmap-ported-dashboards.yaml
@@ -1,5 +1,5 @@
 {{/*
-Ported Grafana dashboards (qbiq-ai/argocd@c364c6c apps/observability, 2026-06 sync).
+Ported Grafana dashboards (argocd@c364c6c apps/observability, 2026-06 sync).
 
 These dashboards are loaded with .Files.Get, which returns the raw file bytes
 WITHOUT running them through the Go template engine. This means Grafana

--- a/apps/infra/observability/grafana-dashboards/templates/configmap-ported-dashboards.yaml
+++ b/apps/infra/observability/grafana-dashboards/templates/configmap-ported-dashboards.yaml
@@ -1,0 +1,36 @@
+{{/*
+Ported Grafana dashboards (qbiq-ai/argocd@c364c6c apps/observability, 2026-06 sync).
+
+These dashboards are loaded with .Files.Get, which returns the raw file bytes
+WITHOUT running them through the Go template engine. This means Grafana
+legend-format strings like {{ node }} or {{ dimension_LoadBalancer }} are
+preserved verbatim and never mis-interpreted as Helm template actions (which is
+why these dashboards live under dashboards/ and are NOT inlined into a template
+like the legacy configmap-dashboards.yaml).
+
+The dashboards/ directory is a Helm "files" directory (not templates/), so Helm
+never auto-renders its contents. .Files.Glob finds every *.json inside it;
+.Files.Get pulls the raw content; indent 4 aligns the multi-line JSON block under
+the YAML data key.
+
+Adding a new ported dashboard = drop a new *.json into dashboards/ and push.
+No changes to this template file are needed.
+*/}}
+{{- range $path, $_ := .Files.Glob "dashboards/*.json" }}
+{{- $name := base $path | trimSuffix ".json" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-{{ $name }}
+  namespace: {{ $.Values.grafanaNamespace }}
+  labels:
+    {{- range $key, $val := $.Values.dashboardLabels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+data:
+  {{ base $path }}: |-
+{{ $.Files.Get $path | indent 4 }}
+{{- end }}

--- a/apps/infra/observability/grafana-dashboards/values.yaml
+++ b/apps/infra/observability/grafana-dashboards/values.yaml
@@ -26,7 +26,7 @@ dashboards:
     enabled: true
   argocdInventory:
     enabled: true
-  # Ported from qbiq-ai/argocd@c364c6c apps/observability, 2026-06 sync.
+  # Ported from argocd@c364c6c apps/observability, 2026-06 sync.
   kubernetesOverview:
     enabled: true
   awsInfraOverview:

--- a/apps/infra/observability/grafana-dashboards/values.yaml
+++ b/apps/infra/observability/grafana-dashboards/values.yaml
@@ -26,6 +26,13 @@ dashboards:
     enabled: true
   argocdInventory:
     enabled: true
+  # Ported from qbiq-ai/argocd@c364c6c apps/observability, 2026-06 sync.
+  kubernetesOverview:
+    enabled: true
+  awsInfraOverview:
+    enabled: true
+  argocdPlatformOverview:
+    enabled: true
 
 datasources:
   prometheus:

--- a/apps/infra/observability/prometheus-stack/README.md
+++ b/apps/infra/observability/prometheus-stack/README.md
@@ -762,7 +762,7 @@ admin, **Grafana Google OAuth**, Alertmanager Slack, and Alertmanager PagerDuty.
 
 #### Grafana Google OAuth + Alertmanager Slack via ESO
 
-**Ported from `qbiq-ai/argocd@c364c6c` `apps/observability`, 2026-06 sync.**
+**Ported from `argocd@c364c6c` `apps/observability`, 2026-06 sync.**
 
 - **Grafana Google OAuth** - the `grafana-oauth-credentials` ExternalSecret pulls
   `client_id` / `client_secret` from AWS Secrets Manager

--- a/apps/infra/observability/prometheus-stack/README.md
+++ b/apps/infra/observability/prometheus-stack/README.md
@@ -756,6 +756,37 @@ spec:
       property: admin-password
 ```
 
+This chart ships `templates/external-secrets.yaml`, which declares an
+`aws-secrets-manager` `ClusterSecretStore` plus `ExternalSecret`s for Grafana
+admin, **Grafana Google OAuth**, Alertmanager Slack, and Alertmanager PagerDuty.
+
+#### Grafana Google OAuth + Alertmanager Slack via ESO
+
+**Ported from `qbiq-ai/argocd@c364c6c` `apps/observability`, 2026-06 sync.**
+
+- **Grafana Google OAuth** - the `grafana-oauth-credentials` ExternalSecret pulls
+  `client_id` / `client_secret` from AWS Secrets Manager
+  (`platform/observability/grafana-oauth`) and exposes them as the env vars
+  `GF_AUTH_GENERIC_OAUTH_CLIENT_ID` / `GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET`. They
+  are injected into Grafana via `grafana.envFromSecret` and consumed by the
+  `grafana.ini` `auth.generic_oauth` block, which is **domain-restricted**
+  (`allowed_domains`) with an admin allow-list in `role_attribute_path`. Override
+  `allowed_domains`, the admin list, and `server.root_url` per environment.
+  Local-admin break-glass stays enabled (`oauth_auto_login: false`).
+- **Alertmanager Slack** - the `alertmanager-slack-secret` ExternalSecret pulls
+  the webhook URL from `platform/observability/alertmanager`. It is mounted into
+  the Alertmanager pods via `alertmanagerSpec.secrets` and read by the receiver
+  config through `slack_api_url_file`. No plaintext webhooks in Git.
+
+Populate the backing secrets (synthetic shapes shown):
+
+```bash
+aws secretsmanager put-secret-value --secret-id platform/observability/grafana-oauth \
+  --secret-string '{"client_id":"<id>","client_secret":"<secret>"}'
+aws secretsmanager put-secret-value --secret-id platform/observability/alertmanager \
+  --secret-string '{"slack-webhook-url":"https://hooks.slack.com/services/T.../B.../..."}'
+```
+
 ## Upgrade Guide
 
 ### Backup Before Upgrade

--- a/apps/infra/observability/prometheus-stack/templates/external-secrets.yaml
+++ b/apps/infra/observability/prometheus-stack/templates/external-secrets.yaml
@@ -40,6 +40,44 @@ spec:
         key: platform/observability/grafana
         property: admin-password
 ---
+# Grafana Google OAuth Credentials
+# Ported from qbiq-ai/argocd@c364c6c apps/observability, 2026-06 sync.
+#
+# Source: AWS Secrets Manager platform/observability/grafana-oauth
+# Shape:  {"client_id":"<id>","client_secret":"<secret>"}
+# Consumer: Grafana envFromSecret -> env vars
+#   GF_AUTH_GENERIC_OAUTH_CLIENT_ID / GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
+#   referenced by grafana.ini auth.generic_oauth (see values.yaml).
+#
+# Operator: create an OAuth 2.0 Client in the Google Cloud Console and register
+# the redirect URI <grafana-root-url>/login/generic_oauth, then populate the
+# secret:
+#   aws secretsmanager put-secret-value \
+#     --secret-id platform/observability/grafana-oauth \
+#     --secret-string '{"client_id":"<id>","client_secret":"<secret>"}'
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-oauth-credentials
+  namespace: {{ .Release.Namespace }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-secrets-manager
+  target:
+    name: grafana-oauth-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: GF_AUTH_GENERIC_OAUTH_CLIENT_ID
+      remoteRef:
+        key: platform/observability/grafana-oauth
+        property: client_id
+    - secretKey: GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
+      remoteRef:
+        key: platform/observability/grafana-oauth
+        property: client_secret
+---
 # Alertmanager Slack Webhook
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret

--- a/apps/infra/observability/prometheus-stack/templates/external-secrets.yaml
+++ b/apps/infra/observability/prometheus-stack/templates/external-secrets.yaml
@@ -41,7 +41,7 @@ spec:
         property: admin-password
 ---
 # Grafana Google OAuth Credentials
-# Ported from qbiq-ai/argocd@c364c6c apps/observability, 2026-06 sync.
+# Ported from argocd@c364c6c apps/observability, 2026-06 sync.
 #
 # Source: AWS Secrets Manager platform/observability/grafana-oauth
 # Shape:  {"client_id":"<id>","client_secret":"<secret>"}

--- a/apps/infra/observability/prometheus-stack/values.yaml
+++ b/apps/infra/observability/prometheus-stack/values.yaml
@@ -239,11 +239,18 @@ kube-prometheus-stack:
     replicas: 1  # Stateless, can scale horizontally if needed
 
     # Admin credentials (use External Secrets in production)
-    # Admin password injected via ExternalSecret (see external-secrets/grafana-secrets.yaml)
+    # Admin password injected via ExternalSecret (see templates/external-secrets.yaml)
     admin:
       existingSecret: grafana-admin-credentials
       userKey: admin-user
       passwordKey: admin-password
+
+    # Google OAuth client credentials injected from the ESO ExternalSecret
+    # 'grafana-oauth-credentials' (templates/external-secrets.yaml) as the env
+    # vars GF_AUTH_GENERIC_OAUTH_CLIENT_ID / GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET,
+    # referenced below in grafana.ini auth.generic_oauth.
+    # Ported from qbiq-ai/argocd@c364c6c apps/observability, 2026-06 sync.
+    envFromSecret: grafana-oauth-credentials
 
     # Persistence disabled - dashboards as code via ConfigMaps
     persistence:
@@ -450,22 +457,45 @@ kube-prometheus-stack:
         x_content_type_options: true
         x_xss_protection: true
 
-      # Auth (example: OAuth with AWS Cognito)
-      # auth:
-      #   disable_login_form: false
-      #   oauth_auto_login: true
+      # --------------------------------------------------------------------
+      # Google OAuth (Google Workspace SSO), domain-restricted.
+      # Ported from qbiq-ai/argocd@c364c6c apps/observability, 2026-06 sync.
       #
-      # auth.generic_oauth:
-      #   enabled: true
-      #   name: AWS Cognito
-      #   allow_sign_up: true
-      #   client_id: $__file{/etc/secrets/oauth-client-id}
-      #   client_secret: $__file{/etc/secrets/oauth-client-secret}
-      #   scopes: openid profile email
-      #   auth_url: https://your-domain.auth.us-east-1.amazoncognito.com/oauth2/authorize
-      #   token_url: https://your-domain.auth.us-east-1.amazoncognito.com/oauth2/token
-      #   api_url: https://your-domain.auth.us-east-1.amazoncognito.com/oauth2/userInfo
-      #   role_attribute_path: "contains(cognito:groups[*], 'Admins') && 'Admin' || 'Viewer'"
+      # Client credentials come from the ESO ExternalSecret
+      # 'grafana-oauth-credentials' (templates/external-secrets.yaml), injected
+      # as env vars via grafana.envFromSecret above. No plaintext secrets here.
+      #
+      # Local admin break-glass stays available at /login (oauth_auto_login is
+      # OFF) so an OAuth misconfiguration cannot lock everyone out. Flip
+      # oauth_auto_login to true only after OAuth is verified end-to-end.
+      auth:
+        disable_login_form: false
+        oauth_auto_login: false
+
+      auth.generic_oauth:
+        enabled: true
+        name: Google
+        allow_sign_up: true
+        # Injected from the ESO secret as env vars (see grafana.envFromSecret).
+        client_id: "${GF_AUTH_GENERIC_OAUTH_CLIENT_ID}"
+        client_secret: "${GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET}"
+        scopes: "openid email profile"
+        auth_url: "https://accounts.google.com/o/oauth2/v2/auth"
+        token_url: "https://oauth2.googleapis.com/token"
+        api_url: "https://openidconnect.googleapis.com/v1/userinfo"
+        use_pkce: true
+        use_refresh_token: true
+        # Restrict login to a single Google Workspace domain. Override per
+        # environment (values-<env>.yaml) to match the org's domain.
+        allowed_domains: "example.com"
+        # Role mapping: grant Admin to an explicit allow-list of emails, Viewer
+        # to everyone else in the allowed domain. Extend the contains() list to
+        # add admins; override per environment.
+        role_attribute_path: >-
+          contains(['admin@example.com'], email) && 'Admin' || 'Viewer'
+        # redirect_uri is derived from root_url; set explicitly per environment
+        # if the external hostname differs from server.root_url.
+        redirect_uri: ""
 
       # Logging
       log:
@@ -490,6 +520,15 @@ kube-prometheus-stack:
     alertmanagerSpec:
       # HA Configuration - 3 replicas for quorum
       replicas: 3
+
+      # Mount the ESO-sourced K8s Secrets into the Alertmanager pods at
+      # /etc/alertmanager/secrets/<name>/ so the receiver config can read the
+      # Slack webhook URL (and PagerDuty service key) via *_file directives
+      # below. These Secrets are created by templates/external-secrets.yaml.
+      # Ported from qbiq-ai/argocd@c364c6c apps/observability, 2026-06 sync.
+      secrets:
+        - alertmanager-slack-secret
+        - alertmanager-pagerduty-secret
 
       # Resource limits
       resources:

--- a/apps/infra/observability/prometheus-stack/values.yaml
+++ b/apps/infra/observability/prometheus-stack/values.yaml
@@ -249,7 +249,7 @@ kube-prometheus-stack:
     # 'grafana-oauth-credentials' (templates/external-secrets.yaml) as the env
     # vars GF_AUTH_GENERIC_OAUTH_CLIENT_ID / GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET,
     # referenced below in grafana.ini auth.generic_oauth.
-    # Ported from qbiq-ai/argocd@c364c6c apps/observability, 2026-06 sync.
+    # Ported from argocd@c364c6c apps/observability, 2026-06 sync.
     envFromSecret: grafana-oauth-credentials
 
     # Persistence disabled - dashboards as code via ConfigMaps
@@ -459,7 +459,7 @@ kube-prometheus-stack:
 
       # --------------------------------------------------------------------
       # Google OAuth (Google Workspace SSO), domain-restricted.
-      # Ported from qbiq-ai/argocd@c364c6c apps/observability, 2026-06 sync.
+      # Ported from argocd@c364c6c apps/observability, 2026-06 sync.
       #
       # Client credentials come from the ESO ExternalSecret
       # 'grafana-oauth-credentials' (templates/external-secrets.yaml), injected
@@ -525,7 +525,7 @@ kube-prometheus-stack:
       # /etc/alertmanager/secrets/<name>/ so the receiver config can read the
       # Slack webhook URL (and PagerDuty service key) via *_file directives
       # below. These Secrets are created by templates/external-secrets.yaml.
-      # Ported from qbiq-ai/argocd@c364c6c apps/observability, 2026-06 sync.
+      # Ported from argocd@c364c6c apps/observability, 2026-06 sync.
       secrets:
         - alertmanager-slack-secret
         - alertmanager-pagerduty-secret

--- a/apps/infra/observability/yace/Chart.yaml
+++ b/apps/infra/observability/yace/Chart.yaml
@@ -1,0 +1,40 @@
+apiVersion: v2
+name: yace
+description: >
+  YACE (Yet Another CloudWatch Exporter) - polls AWS CloudWatch metrics and
+  exposes them in Prometheus format. Deployed to the observability namespace on
+  clusters where AWS IRSA is available. Feeds the "AWS Infrastructure Overview"
+  Grafana dashboard (NetworkELB / ApplicationELB / S3 / EBS).
+type: application
+version: 0.1.0
+appVersion: "v0.61.2"
+
+keywords:
+  - cloudwatch
+  - aws
+  - yace
+  - exporter
+  - observability
+  - metrics
+
+maintainers:
+  - name: Platform Team
+    email: platform@example.com
+
+# yet-another-cloudwatch-exporter - the canonical YACE chart published by the
+# upstream project at nerdswords/helm-charts. prometheus-community does NOT host
+# YACE (only the unrelated, older prometheus-cloudwatch-exporter), so the chart
+# must be pulled from the project's own Helm repo.
+# Chart 0.38.0 ships YACE app v0.61.2 - supports discovery jobs, decoupled
+# scraping, IRSA, and ARM64 multi-arch images.
+dependencies:
+  - name: yet-another-cloudwatch-exporter
+    version: "0.38.0"
+    repository: https://nerdswords.github.io/helm-charts
+    condition: yet-another-cloudwatch-exporter.enabled
+
+annotations:
+  category: observability
+  licenses: Apache-2.0
+  # Ported from qbiq-ai/argocd@c364c6c apps/observability/yace, 2026-06 sync.
+  "platform.example.com/provenance": "qbiq-ai/argocd@c364c6c"

--- a/apps/infra/observability/yace/Chart.yaml
+++ b/apps/infra/observability/yace/Chart.yaml
@@ -36,5 +36,5 @@ dependencies:
 annotations:
   category: observability
   licenses: Apache-2.0
-  # Ported from qbiq-ai/argocd@c364c6c apps/observability/yace, 2026-06 sync.
-  "platform.example.com/provenance": "qbiq-ai/argocd@c364c6c"
+  # Ported from argocd@c364c6c apps/observability/yace, 2026-06 sync.
+  "platform.example.com/provenance": "argocd@c364c6c"

--- a/apps/infra/observability/yace/README.md
+++ b/apps/infra/observability/yace/README.md
@@ -50,7 +50,7 @@ period regardless of the 60s Prometheus scrape interval.
 
 ## Provenance
 
-Ported from `qbiq-ai/argocd@c364c6c` `apps/observability/yace`, 2026-06 sync.
+Ported from `argocd@c364c6c` `apps/observability/yace`, 2026-06 sync.
 Adapted to platform-design conventions: placeholder IRSA role/account (no
 hardcoded org identifiers), region `eu-central-1` to match the prometheus-stack
 ClusterSecretStore default.

--- a/apps/infra/observability/yace/README.md
+++ b/apps/infra/observability/yace/README.md
@@ -1,0 +1,56 @@
+# YACE - Yet Another CloudWatch Exporter
+
+Wrapper chart for [`yet-another-cloudwatch-exporter`](https://github.com/nerdswords/yet-another-cloudwatch-exporter)
+(nerdswords chart `0.38.0`, YACE app `v0.61.2`). YACE polls AWS CloudWatch and
+re-exposes the metrics in Prometheus format so the prometheus-stack can scrape
+them via a ServiceMonitor. It feeds the **AWS Infrastructure Overview** Grafana
+dashboard (`grafana-dashboards` chart).
+
+## Discovery jobs
+
+Four CloudWatch discovery jobs are configured (period/length `300`, delay `120`
+for the 5-min-resolution jobs):
+
+| Namespace             | Key metrics                                                           |
+|-----------------------|-----------------------------------------------------------------------|
+| `AWS/NetworkELB`      | HealthyHostCount, UnHealthyHostCount, ActiveFlowCount, NewFlowCount, ProcessedBytes |
+| `AWS/ApplicationELB`  | HealthyHostCount, UnHealthyHostCount, RequestCount, TargetResponseTime (p99), HTTPCode_Target_5XX_Count |
+| `AWS/S3`              | BucketSizeBytes, NumberOfObjects (24h resolution)                     |
+| `AWS/EBS`             | BurstBalance, VolumeReadOps, VolumeWriteOps, VolumeQueueLength        |
+
+Deliberately **dropped** (see provenance commits #58/#59 in the source repo):
+
+- **`AWS/EKS`** - not a YACE-supported discovery service in v0.61.2; EKS
+  node/pod CPU & memory are already collected in-cluster by node-exporter and
+  kube-state-metrics, so CloudWatch EKS metrics would be redundant.
+- **`AWS/CertificateManager` (ACM)** - this platform uses an internal CA
+  (cert-manager private issuer), not ACM, so there are no certs to discover.
+
+## IRSA
+
+The ServiceAccount `yace` (namespace `observability`) is annotated with a
+**placeholder** IAM role ARN:
+
+```
+arn:aws:iam::<AWS_ACCOUNT_ID>:role/platform-observability-yace
+```
+
+Replace `<AWS_ACCOUNT_ID>` and, if needed, the role name with the IRSA role that
+grants CloudWatch read access (`cloudwatch:GetMetricData`,
+`cloudwatch:ListMetrics`, `tag:GetResources`, `apigateway:GET`, etc.). The role's
+trust policy must allow `sub = system:serviceaccount:observability:yace`. Until
+the role exists, YACE starts but CloudWatch calls fail with
+`AccessDeniedException` - non-fatal (metrics absent, no crashloop).
+
+## Cost control
+
+CloudWatch `GetMetricData` is billed per 1000 metrics requested. Discovery jobs
+cache results for the `period` window, so YACE makes ~1 CloudWatch call per
+period regardless of the 60s Prometheus scrape interval.
+
+## Provenance
+
+Ported from `qbiq-ai/argocd@c364c6c` `apps/observability/yace`, 2026-06 sync.
+Adapted to platform-design conventions: placeholder IRSA role/account (no
+hardcoded org identifiers), region `eu-central-1` to match the prometheus-stack
+ClusterSecretStore default.

--- a/apps/infra/observability/yace/templates/networkpolicy.yaml
+++ b/apps/infra/observability/yace/templates/networkpolicy.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.networkPolicy.enabled }}
+---
+# Network Policy: YACE CloudWatch exporter
+# Egress: AWS APIs (CloudWatch / STS / tagging over HTTPS) + DNS.
+# Ingress: Prometheus scrape of the YACE metrics port (5000 in the upstream
+#          chart's Service).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: yace
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: yet-another-cloudwatch-exporter
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: cloudwatch-exporter
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: yet-another-cloudwatch-exporter
+
+  policyTypes:
+    - Ingress
+    - Egress
+
+  ingress:
+    # Allow Prometheus to scrape the exporter.
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - protocol: TCP
+          port: 5000
+
+  egress:
+    # Allow access to AWS service endpoints (CloudWatch, STS, tagging) over HTTPS.
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 443
+
+    # Allow DNS resolution.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+{{- end }}

--- a/apps/infra/observability/yace/values.yaml
+++ b/apps/infra/observability/yace/values.yaml
@@ -1,0 +1,164 @@
+# YACE (Yet Another CloudWatch Exporter) - shared defaults.
+# Ported from qbiq-ai/argocd@c364c6c apps/observability/yace (2026-06 sync) and
+# adapted to platform-design conventions (placeholder IRSA role/account, no
+# hardcoded org identifiers; eu-central-1 to match the prometheus-stack
+# ClusterSecretStore default region).
+#
+# IRSA dependency: the ServiceAccount below references an IAM role
+# (<PLACEHOLDER>) that must be created out-of-band (e.g. infra
+# modules/observability-irsa) with a trust policy on:
+#   sub = system:serviceaccount:observability:yace
+# Until that role exists, YACE starts but CloudWatch calls fail with
+# AccessDeniedException - non-fatal (metrics absent, no crashloop).
+#
+# Chart = nerdswords/yet-another-cloudwatch-exporter 0.38.0 (YACE app v0.61.2).
+# The chart renders `.Values.config` through `tpl` and expects a STRING - the
+# YACE config below is therefore a YAML block scalar (config: |-), NOT a mapping.
+#
+# Cost control: CloudWatch GetMetricData is billed per 1000 metrics requested.
+# Discovery jobs use period/length 300 (5-min resolution) with delay 120, so
+# YACE makes ~1 CW call per period window regardless of the 60s Prometheus
+# scrape interval (YACE caches results for the period).
+#
+# ARM64/Graviton: YACE 0.61.x ships a multi-arch manifest - no image override.
+
+yet-another-cloudwatch-exporter:
+  enabled: true
+
+  # ---- AWS region -------------------------------------------------------
+  # Override per-environment (values-<env>.yaml) where clusters live in a
+  # different region.
+  aws:
+    region: eu-central-1
+
+  # ---- Service account (IRSA) ------------------------------------------
+  # The role ARN is a PLACEHOLDER. Replace <AWS_ACCOUNT_ID> and the role name
+  # with the IRSA role provisioned for CloudWatch read access, or inject it
+  # per-environment via values-<env>.yaml / ApplicationSet generator.
+  # Trust policy on that role: sub = system:serviceaccount:observability:yace
+  serviceAccount:
+    create: true
+    name: yace
+    annotations:
+      eks.amazonaws.com/role-arn: "arn:aws:iam::<AWS_ACCOUNT_ID>:role/platform-observability-yace"
+
+  # ---- Resources --------------------------------------------------------
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+
+  # ---- Node affinity (Graviton / ARM64) ---------------------------------
+  nodeSelector:
+    kubernetes.io/arch: arm64
+
+  # ---- ServiceMonitor ---------------------------------------------------
+  # The prometheus-stack discovers ServiceMonitors carrying the
+  # `prometheus: kube-prometheus` label (serviceMonitorSelector). The upstream
+  # YACE chart lets us attach extra labels so the operator selects this monitor.
+  serviceMonitor:
+    enabled: true
+    interval: 60s
+    scrapeTimeout: 30s
+    additionalLabels:
+      prometheus: kube-prometheus
+
+  # ---- YACE configuration (STRING - rendered via tpl by the chart) ------
+  # period: 300  - 5-minute CloudWatch resolution
+  # length: 300  - fetch last 5 minutes per poll
+  # delay:  120  - start 2 minutes in the past (CloudWatch propagation lag)
+  # Metrics are scoped to key operational signals only, to bound CW API cost.
+  config: |-
+    apiVersion: v1alpha1
+    sts-region: eu-central-1
+    discovery:
+      jobs:
+        # NOTE: AWS/EKS is intentionally absent - YACE v0.61.2 does not support
+        # it as a discovery service (not in its known-services list). EKS
+        # cluster/node/pod CPU/memory are already collected in-cluster by the
+        # prometheus-stack (node-exporter, kube-state-metrics, kubelet), so
+        # CloudWatch AWS/EKS metrics would be redundant anyway.
+
+        # Network Load Balancer
+        - type: AWS/NetworkELB
+          regions: [eu-central-1]
+          roles: []
+          period: 300
+          length: 300
+          delay: 120
+          metrics:
+            - name: HealthyHostCount
+              statistics: [Minimum]
+            - name: UnHealthyHostCount
+              statistics: [Maximum]
+            - name: ActiveFlowCount
+              statistics: [Average]
+            - name: NewFlowCount
+              statistics: [Sum]
+            - name: ProcessedBytes
+              statistics: [Sum]
+
+        # Application Load Balancer
+        - type: AWS/ApplicationELB
+          regions: [eu-central-1]
+          roles: []
+          period: 300
+          length: 300
+          delay: 120
+          metrics:
+            - name: HealthyHostCount
+              statistics: [Minimum]
+            - name: UnHealthyHostCount
+              statistics: [Maximum]
+            - name: RequestCount
+              statistics: [Sum]
+            - name: TargetResponseTime
+              statistics: [Average, p99]
+            - name: HTTPCode_Target_5XX_Count
+              statistics: [Sum]
+
+        # S3 (24h resolution - daily aggregation)
+        - type: AWS/S3
+          regions: [eu-central-1]
+          roles: []
+          period: 86400
+          length: 86400
+          delay: 7200
+          metrics:
+            - name: BucketSizeBytes
+              statistics: [Average]
+            - name: NumberOfObjects
+              statistics: [Average]
+          dimensionNameRequirements: [BucketName, StorageType]
+
+        # EBS
+        - type: AWS/EBS
+          regions: [eu-central-1]
+          roles: []
+          period: 300
+          length: 300
+          delay: 120
+          metrics:
+            - name: BurstBalance
+              statistics: [Minimum]
+            - name: VolumeReadOps
+              statistics: [Sum]
+            - name: VolumeWriteOps
+              statistics: [Sum]
+            - name: VolumeQueueLength
+              statistics: [Average]
+
+        # NOTE: AWS/CertificateManager intentionally omitted - this platform uses
+        # an internal CA (cert-manager private issuer), not ACM, so there are no
+        # ACM certs to discover and YACE would log "No tagged resources" every
+        # scrape. Re-add a CertificateManager job if ACM certs are introduced.
+
+# ----------------------------------------------------------------------------
+# Wrapper-chart values (consumed by templates/ in THIS chart, not the subchart).
+# ----------------------------------------------------------------------------
+networkPolicy:
+  # NetworkPolicy restricting YACE egress to AWS APIs + DNS and ingress to
+  # Prometheus scrape. Disable on clusters without a CNI that enforces policy.
+  enabled: true

--- a/apps/infra/observability/yace/values.yaml
+++ b/apps/infra/observability/yace/values.yaml
@@ -1,5 +1,5 @@
 # YACE (Yet Another CloudWatch Exporter) - shared defaults.
-# Ported from qbiq-ai/argocd@c364c6c apps/observability/yace (2026-06 sync) and
+# Ported from argocd@c364c6c apps/observability/yace (2026-06 sync) and
 # adapted to platform-design conventions (placeholder IRSA role/account, no
 # hardcoded org identifiers; eu-central-1 to match the prometheus-stack
 # ClusterSecretStore default region).


### PR DESCRIPTION
## What

Ports observability components that exist in the live `qbiq-ai/argocd` estate but were missing from platform-design. Provenance: **ported from `qbiq-ai/argocd@c364c6c` `apps/observability`, 2026-06 sync**.

### 1. YACE - Yet Another CloudWatch Exporter (new chart `apps/infra/observability/yace/`)
- Wraps `nerdswords/yet-another-cloudwatch-exporter` chart `0.38.0` (YACE app `v0.61.2`).
- 4 discovery jobs: **AWS/NetworkELB, AWS/ApplicationELB, AWS/S3, AWS/EBS** (5-min resolution; S3 daily). `AWS/EKS` and `AWS/CertificateManager` (ACM) intentionally dropped - EKS metrics are already in-cluster via node-exporter/kube-state-metrics, and this platform uses an internal CA, not ACM.
- IRSA ServiceAccount annotation is a **placeholder** (`arn:aws:iam::<AWS_ACCOUNT_ID>:role/platform-observability-yace`), adapted to platform-design conventions (no hardcoded org identifiers). ServiceMonitor enabled via the subchart with the `prometheus: kube-prometheus` selector label; NetworkPolicy follows the sibling charts' conventions.

### 2. Three Grafana dashboards (`grafana-dashboards` chart)
Added under `dashboards/` and loaded via a new `.Files.Get` template (`configmap-ported-dashboards.yaml`) - the raw-bytes pattern that keeps Grafana `{{ legend }}` strings from being parsed as Helm actions:
- **kubernetes-overview** - node & pod CPU/mem from node-exporter + kube-state-metrics.
- **aws-infra-overview** - fed by YACE: EKS node CPU/mem, NLB healthy/unhealthy + active/new flows + processed bytes, S3 size/object count, EBS burst balance/IOPS. (ACM row dropped to match the YACE config.)
- **argocd-platform-overview** - app health/sync, controller reconciliation queue/duration, repo-server git-fetch/RPC, component CPU/mem.

All three are valid Grafana JSON, carry the `grafana_dashboard: "1"` sidecar label, and render to ConfigMaps in the `observability` namespace.

### 3. Grafana OAuth + Alertmanager Slack via ExternalSecrets (`prometheus-stack` chart)
- Extended `templates/external-secrets.yaml` with a `grafana-oauth-credentials` ExternalSecret (ESO `aws-secrets-manager` ClusterSecretStore) exposing `GF_AUTH_GENERIC_OAUTH_CLIENT_ID/SECRET` from `platform/observability/grafana-oauth`.
- Wired Grafana Google OAuth in `grafana.ini` (`auth.generic_oauth`), **domain-restricted** via `allowed_domains` with an admin allow-list in `role_attribute_path`; credentials injected through `grafana.envFromSecret`. Local-admin break-glass stays on (`oauth_auto_login: false`).
- Mounted the ESO-sourced Slack (and PagerDuty) secrets into Alertmanager via `alertmanagerSpec.secrets` so the existing `slack_api_url_file` receiver config resolves. No plaintext secrets in Git.

## Preserved
Existing **Tempo / OTel Collector / Pyroscope** kept as design-ahead. **Thanos** objstore + servicemonitors already present on `main` - untouched.

## Test plan
- `helm template` renders the new `external-secrets.yaml` (ClusterSecretStore + 4 ExternalSecrets incl. `grafana-oauth-credentials`) and the YACE NetworkPolicy cleanly.
- The 3 ported dashboards render to 3 ConfigMaps with valid embedded JSON (validated via `json.loads`) and the sidecar label.
- All touched values/Chart YAML parse.
- Scope: only files under `apps/infra/observability/`. No ADR/docs files added.
- [ ] Two **pre-existing** chart-level Helm parse errors remain on `main` and are out of scope here: `grafana-dashboards/templates/configmap-dashboards.yaml:350` and `prometheus-stack/templates/servicemonitors/karpenter-servicemonitor.yaml:119` (both are inline `{{ }}` strings parsed by Helm). The new dashboards deliberately avoid this by using the `.Files.Get` pattern.