### PR TITLE
ci: reflect platform-workflows consolidation (Tier-1 hardening, reusable pipelines, cosign signing)

### DIFF
--- a/.github/actions/argocd-tag-bump/action.yml
+++ b/.github/actions/argocd-tag-bump/action.yml
@@ -1,0 +1,184 @@
+# -----------------------------------------------------------------------------
+# argocd-tag-bump
+#
+# Mirrors qbiq-ai/platform-workflows@3bb35df .github/actions/argocd-tag-bump
+# (2026-06 platform-workflows consolidation sync). Adapted to platform-design's
+# argocd config repo (100rd/argocd) and bot identity.
+# -----------------------------------------------------------------------------
+name: "ArgoCD Tag Bump"
+description: "Open a PR in the argocd config repo updating image.tag and image.digest in a values file. Auto-merge labelled for non-prod environments."
+
+inputs:
+  app-name:
+    description: "Application name (used in branch name and PR title)."
+    required: true
+  env:
+    description: "Target environment: dev, stage, or prod."
+    required: true
+  image-tag:
+    description: "New image tag (usually the git SHA)."
+    required: true
+  image-digest:
+    description: "Image content digest (sha256:...). Pinned alongside the tag for supply-chain integrity."
+    required: true
+  values-path:
+    description: "Path to the values file inside the argocd repo. REQUIRED — no default. Caller must specify explicitly. Common patterns: `envs/{env}/values/{app}.yaml` or `workloads/{app}/envs/{env}/values.yaml`. The substrings `{env}` and `{app}` are replaced before checkout."
+    required: true
+  argocd-repo:
+    description: "ArgoCD config repo in `owner/repo` form."
+    required: false
+    default: "100rd/argocd"
+  bot-token:
+    description: "GitHub token with `contents:write` and `pull-requests:write` on the argocd repo. Pass via secrets, never inline."
+    required: true
+  auto-merge:
+    description: "Add `auto-merge` label to the PR. Convention: true for dev/stage, false for prod."
+    required: false
+    default: "true"
+  git-user-name:
+    description: "Git committer name."
+    required: false
+    default: "platform-design-ci[bot]"
+  git-user-email:
+    description: "Git committer email."
+    required: false
+    default: "ci@platform-design.local"
+
+outputs:
+  pr-number:
+    description: "Number of the opened PR."
+    value: ${{ steps.open-pr.outputs.pr-number }}
+  pr-url:
+    description: "URL of the opened PR."
+    value: ${{ steps.open-pr.outputs.pr-url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve target values path
+      id: resolve
+      shell: bash
+      env:
+        VALUES_PATH_TEMPLATE: ${{ inputs.values-path }}
+        APP_NAME: ${{ inputs.app-name }}
+        ENV: ${{ inputs.env }}
+      run: |
+        set -euo pipefail
+        resolved="${VALUES_PATH_TEMPLATE//\{app\}/${APP_NAME}}"
+        resolved="${resolved//\{env\}/${ENV}}"
+        echo "values-path=${resolved}" >> "$GITHUB_OUTPUT"
+        echo "Resolved values path: ${resolved}"
+
+    - name: Checkout argocd repo
+      # actions/checkout v4.2.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        repository: ${{ inputs.argocd-repo }}
+        token: ${{ inputs.bot-token }}
+        path: .argocd-repo
+
+    - name: Install yq
+      shell: bash
+      run: |
+        set -euo pipefail
+        if ! command -v yq >/dev/null 2>&1; then
+          YQ_VERSION="v4.44.3"
+          curl -sSL -o /tmp/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          sudo mv /tmp/yq /usr/local/bin/yq
+          sudo chmod +x /usr/local/bin/yq
+        fi
+        yq --version
+
+    - name: Update image tag and digest
+      shell: bash
+      working-directory: .argocd-repo
+      env:
+        VALUES_PATH: ${{ steps.resolve.outputs.values-path }}
+        IMAGE_TAG: ${{ inputs.image-tag }}
+        IMAGE_DIGEST: ${{ inputs.image-digest }}
+        ARGOCD_REPO: ${{ inputs.argocd-repo }}
+      run: |
+        set -euo pipefail
+        if [ ! -f "${VALUES_PATH}" ]; then
+          echo "::error::Values file not found at ${VALUES_PATH} in ${ARGOCD_REPO}. Check the values-path input."
+          exit 1
+        fi
+        yq -i ".image.tag = strenv(IMAGE_TAG)" "${VALUES_PATH}"
+        yq -i ".image.digest = strenv(IMAGE_DIGEST)" "${VALUES_PATH}"
+        echo "Updated ${VALUES_PATH}:"
+        yq '.image' "${VALUES_PATH}"
+
+    - name: Commit and push branch
+      id: commit
+      shell: bash
+      working-directory: .argocd-repo
+      env:
+        APP_NAME: ${{ inputs.app-name }}
+        ENV: ${{ inputs.env }}
+        IMAGE_TAG: ${{ inputs.image-tag }}
+        GIT_USER_NAME: ${{ inputs.git-user-name }}
+        GIT_USER_EMAIL: ${{ inputs.git-user-email }}
+      run: |
+        set -euo pipefail
+        git config user.name "${GIT_USER_NAME}"
+        git config user.email "${GIT_USER_EMAIL}"
+
+        BRANCH="bump/${APP_NAME}-${ENV}-${IMAGE_TAG}"
+        git checkout -b "${BRANCH}"
+
+        if git diff --quiet; then
+          echo "::warning::No changes to commit — values file already at target tag/digest."
+          echo "branch=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        git add -A
+        git commit -m "chore(${APP_NAME}/${ENV}): bump image to ${IMAGE_TAG}"
+        git push -u origin "${BRANCH}"
+        echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+    - name: Open PR
+      id: open-pr
+      if: steps.commit.outputs.branch != ''
+      shell: bash
+      working-directory: .argocd-repo
+      env:
+        GH_TOKEN: ${{ inputs.bot-token }}
+        APP_NAME: ${{ inputs.app-name }}
+        ENV: ${{ inputs.env }}
+        IMAGE_TAG: ${{ inputs.image-tag }}
+        IMAGE_DIGEST: ${{ inputs.image-digest }}
+        BRANCH: ${{ steps.commit.outputs.branch }}
+        AUTO_MERGE: ${{ inputs.auto-merge }}
+        VALUES_PATH: ${{ steps.resolve.outputs.values-path }}
+        ARGOCD_REPO: ${{ inputs.argocd-repo }}
+        SOURCE_REPO: ${{ github.repository }}
+        SOURCE_SHA: ${{ github.sha }}
+        RUN_ID: ${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        BODY=$(cat <<EOF
+        Automated image bump for **${APP_NAME}** in **${ENV}**.
+
+        - **Tag**: \`${IMAGE_TAG}\`
+        - **Digest**: \`${IMAGE_DIGEST}\`
+        - **Values file**: \`${VALUES_PATH}\`
+        - **Source**: ${SOURCE_REPO}@${SOURCE_SHA}
+        - **Run**: https://github.com/${SOURCE_REPO}/actions/runs/${RUN_ID}
+        EOF
+        )
+
+        PR_URL=$(gh pr create \
+          --title "chore(${APP_NAME}/${ENV}): bump image to ${IMAGE_TAG}" \
+          --body "${BODY}" \
+          --base main \
+          --head "${BRANCH}")
+
+        PR_NUMBER=$(echo "${PR_URL}" | grep -oE '[0-9]+$')
+        echo "pr-number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+        echo "pr-url=${PR_URL}" >> "$GITHUB_OUTPUT"
+
+        if [ "${AUTO_MERGE}" = "true" ]; then
+          gh pr edit "${PR_NUMBER}" --add-label "auto-merge" || \
+            echo "::warning::Could not add auto-merge label — verify it exists in ${ARGOCD_REPO}."
+        fi

--- a/.github/actions/argocd-tag-bump/action.yml
+++ b/.github/actions/argocd-tag-bump/action.yml
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # argocd-tag-bump
 #
-# Mirrors qbiq-ai/platform-workflows@3bb35df .github/actions/argocd-tag-bump
+# Mirrors platform-workflows@3bb35df .github/actions/argocd-tag-bump
 # (2026-06 platform-workflows consolidation sync). Adapted to platform-design's
 # argocd config repo (100rd/argocd) and bot identity.
 # -----------------------------------------------------------------------------

--- a/.github/actions/argocd-wait-sync-and-smoke/action.yml
+++ b/.github/actions/argocd-wait-sync-and-smoke/action.yml
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # argocd-wait-sync-and-smoke
 #
-# Mirrors qbiq-ai/platform-workflows@3bb35df
+# Mirrors platform-workflows@3bb35df
 # .github/actions/argocd-wait-sync-and-smoke
 # (2026-06 platform-workflows consolidation sync).
 # -----------------------------------------------------------------------------

--- a/.github/actions/argocd-wait-sync-and-smoke/action.yml
+++ b/.github/actions/argocd-wait-sync-and-smoke/action.yml
@@ -1,0 +1,165 @@
+# -----------------------------------------------------------------------------
+# argocd-wait-sync-and-smoke
+#
+# Mirrors qbiq-ai/platform-workflows@3bb35df
+# .github/actions/argocd-wait-sync-and-smoke
+# (2026-06 platform-workflows consolidation sync).
+# -----------------------------------------------------------------------------
+name: "ArgoCD Wait Sync and Smoke"
+description: "Wait for an ArgoCD Application to become Synced + Healthy, then probe an HTTP endpoint for 2xx. Used as a post-deploy gate to catch broken rollouts before they sit unnoticed."
+
+inputs:
+  app-name:
+    description: "ArgoCD Application name to wait on."
+    required: true
+  argocd-server:
+    description: "ArgoCD server hostname (e.g. `argocd.platform-design.local`). No scheme."
+    required: true
+  argocd-auth-token:
+    description: "ArgoCD auth token (read-only, project-scoped). Pass via secrets."
+    required: true
+  smoke-url:
+    description: "HTTP(S) URL to probe after Sync+Healthy. Empty string skips the HTTP probe (argocd wait only)."
+    required: false
+    default: ""
+  timeout-seconds:
+    description: "Max seconds to wait for argocd Healthy AND smoke HTTP 2xx combined."
+    required: false
+    default: "300"
+  smoke-method:
+    description: "HTTP method for the smoke probe."
+    required: false
+    default: "GET"
+  smoke-expected-status:
+    description: "Expected HTTP status code(s). Comma-separated list of codes or ranges (e.g. `200,204` or `200-299`)."
+    required: false
+    default: "200-299"
+  smoke-retry-delay-seconds:
+    description: "Delay between smoke probe retries."
+    required: false
+    default: "5"
+  argocd-version:
+    description: "argocd CLI version to install."
+    required: false
+    default: "v2.13.0"
+  insecure:
+    description: "If `true`, pass `--insecure` to argocd CLI (skips TLS verification). Use only for internal/dev clusters."
+    required: false
+    default: "false"
+
+outputs:
+  app-status:
+    description: "Final ArgoCD app status (e.g. `Synced/Healthy` or `OutOfSync/Degraded`)."
+    value: ${{ steps.wait.outputs.status }}
+  smoke-http-status:
+    description: "Final HTTP status from the smoke probe, when smoke-url is set."
+    value: ${{ steps.smoke.outputs.http-status }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install argocd CLI
+      shell: bash
+      env:
+        ARGOCD_VERSION: ${{ inputs.argocd-version }}
+      run: |
+        set -euo pipefail
+        BIN_DIR="${RUNNER_TEMP}/argocd-bin"
+        mkdir -p "${BIN_DIR}"
+        URL="https://github.com/argoproj/argo-cd/releases/download/${ARGOCD_VERSION}/argocd-linux-amd64"
+        curl -fsSL -o "${BIN_DIR}/argocd" "${URL}"
+        chmod +x "${BIN_DIR}/argocd"
+        echo "${BIN_DIR}" >> "$GITHUB_PATH"
+        "${BIN_DIR}/argocd" version --client
+
+    - name: Mask argocd auth token
+      shell: bash
+      env:
+        TOKEN: ${{ inputs.argocd-auth-token }}
+      run: |
+        set -euo pipefail
+        # Belt-and-braces: register the token as a secret in the log mask layer
+        # in addition to GitHub's automatic masking for secret-typed inputs.
+        echo "::add-mask::${TOKEN}"
+
+    - name: Wait for ArgoCD app Synced + Healthy
+      id: wait
+      shell: bash
+      env:
+        APP_NAME: ${{ inputs.app-name }}
+        ARGOCD_SERVER: ${{ inputs.argocd-server }}
+        ARGOCD_AUTH_TOKEN: ${{ inputs.argocd-auth-token }}
+        TIMEOUT: ${{ inputs.timeout-seconds }}
+        INSECURE: ${{ inputs.insecure }}
+      run: |
+        set -uo pipefail
+
+        ARGS=(app wait "${APP_NAME}" --sync --health --timeout "${TIMEOUT}")
+        if [ "${INSECURE}" = "true" ]; then
+          ARGS+=(--insecure)
+        fi
+
+        set +e
+        argocd "${ARGS[@]}" --server "${ARGOCD_SERVER}" --auth-token "${ARGOCD_AUTH_TOKEN}" --grpc-web
+        RC=$?
+        set -e
+
+        STATUS=$(argocd app get "${APP_NAME}" --server "${ARGOCD_SERVER}" --auth-token "${ARGOCD_AUTH_TOKEN}" --grpc-web -o json 2>/dev/null \
+          | python3 -c 'import json,sys; d=json.load(sys.stdin); print(f"{d[\"status\"][\"sync\"][\"status\"]}/{d[\"status\"][\"health\"][\"status\"]}")' \
+          || echo "Unknown/Unknown")
+        echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
+
+        if [ "${RC}" -ne 0 ]; then
+          echo "::error::argocd app wait failed (rc=${RC}, status=${STATUS})."
+          exit "${RC}"
+        fi
+        echo "ArgoCD app ${APP_NAME} is ${STATUS}."
+
+    - name: HTTP smoke probe
+      id: smoke
+      if: inputs.smoke-url != ''
+      shell: bash
+      env:
+        URL: ${{ inputs.smoke-url }}
+        METHOD: ${{ inputs.smoke-method }}
+        EXPECTED: ${{ inputs.smoke-expected-status }}
+        TIMEOUT: ${{ inputs.timeout-seconds }}
+        DELAY: ${{ inputs.smoke-retry-delay-seconds }}
+      run: |
+        set -euo pipefail
+
+        # Expand EXPECTED into a regex that matches any single status code.
+        EXPECTED_REGEX=$(python3 - <<PY
+        import os, re
+        spec = os.environ["EXPECTED"]
+        parts = []
+        for chunk in spec.split(","):
+            chunk = chunk.strip()
+            if "-" in chunk:
+                lo, hi = chunk.split("-", 1)
+                parts.extend(str(x) for x in range(int(lo), int(hi)+1))
+            else:
+                parts.append(chunk)
+        print("^(" + "|".join(re.escape(p) for p in parts) + ")$")
+        PY
+        )
+
+        END_TS=$(( $(date +%s) + TIMEOUT ))
+        HTTP_STATUS=""
+        while [ "$(date +%s)" -lt "${END_TS}" ]; do
+          set +e
+          HTTP_STATUS=$(curl -sk -o /dev/null -w '%{http_code}' -X "${METHOD}" --max-time 10 "${URL}")
+          RC=$?
+          set -e
+          if [ "${RC}" -eq 0 ] && [[ "${HTTP_STATUS}" =~ ${EXPECTED_REGEX} ]]; then
+            echo "Smoke probe ${URL} -> ${HTTP_STATUS} (matches ${EXPECTED})."
+            echo "http-status=${HTTP_STATUS}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "  attempt: status=${HTTP_STATUS:-<curl-fail>} rc=${RC} — retrying in ${DELAY}s..."
+          sleep "${DELAY}"
+        done
+
+        echo "::error::Smoke probe ${URL} did not reach expected status ${EXPECTED} within ${TIMEOUT}s (last status: ${HTTP_STATUS:-<no-response>})."
+        echo "http-status=${HTTP_STATUS:-}" >> "$GITHUB_OUTPUT"
+        exit 1

--- a/.github/actions/cosign-sign/action.yml
+++ b/.github/actions/cosign-sign/action.yml
@@ -1,0 +1,176 @@
+# -----------------------------------------------------------------------------
+# cosign-sign
+#
+# Mirrors qbiq-ai/platform-workflows@3bb35df .github/actions/cosign-sign
+# (2026-06 platform-workflows consolidation sync).
+# -----------------------------------------------------------------------------
+name: "Cosign Sign (keyless)"
+description: "Sign a container image (and optionally attest an SBOM) using cosign keyless via Sigstore + GitHub OIDC. No key management; identity is bound to the GitHub workflow that ran. Signs by digest (immutable) — pass `<registry>/<repo>@sha256:...`."
+
+inputs:
+  image-ref:
+    description: "Fully qualified image reference WITH digest. Example: `<acct>.dkr.ecr.eu-west-1.amazonaws.com/hello-world@sha256:abc...`. Signing by tag is not supported because tags are mutable."
+    required: true
+  sbom-path:
+    description: "Optional path to an SBOM file. If set, the action attaches the SBOM as a signed cosign attestation (predicate-type SPDX or CycloneDX based on `sbom-type`)."
+    required: false
+    default: ""
+  sbom-type:
+    description: "Predicate type for SBOM attestation: `spdxjson` or `cyclonedx`."
+    required: false
+    default: "spdxjson"
+  cosign-version:
+    description: "cosign release version to install."
+    required: false
+    default: "v2.4.1"
+  advisory:
+    description: "If `true`, signing failures are downgraded to warnings (used during Sigstore Fulcio/Rekor incidents). Default `false` — sign failures fail the job."
+    required: false
+    default: "false"
+  rekor-url:
+    description: "Override Rekor transparency log URL. Empty string uses the public Sigstore Rekor."
+    required: false
+    default: ""
+  fulcio-url:
+    description: "Override Fulcio CA URL. Empty string uses the public Sigstore Fulcio."
+    required: false
+    default: ""
+
+outputs:
+  signature-ref:
+    description: "The image reference of the signature artifact in the registry."
+    value: ${{ steps.sign.outputs.signature-ref }}
+  rekor-log-entry:
+    description: "Rekor transparency log URL for the signature, when available."
+    value: ${{ steps.sign.outputs.rekor-log-entry }}
+  attestation-ref:
+    description: "The image reference of the SBOM attestation artifact, when sbom-path is provided."
+    value: ${{ steps.attest.outputs.attestation-ref }}
+
+runs:
+  using: composite
+  steps:
+    - name: Validate image reference includes digest
+      shell: bash
+      env:
+        IMAGE_REF: ${{ inputs.image-ref }}
+      run: |
+        set -euo pipefail
+        case "${IMAGE_REF}" in
+          *@sha256:*) ;;
+          *)
+            echo "::error::image-ref must include a digest. Got: ${IMAGE_REF}"
+            echo "::error::Pass <registry>/<repo>@sha256:... — tags are mutable and cannot be safely signed."
+            exit 1
+            ;;
+        esac
+
+    - name: Install cosign
+      # sigstore/cosign-installer v3.7.0
+      uses: sigstore/cosign-installer@1aa8e0f2454b781fbf0fbf306a4c9533a0c57409
+      with:
+        cosign-release: ${{ inputs.cosign-version }}
+
+    - name: Verify cosign install
+      shell: bash
+      run: |
+        set -euo pipefail
+        cosign version
+
+    - name: Sign image (keyless OIDC)
+      id: sign
+      shell: bash
+      env:
+        IMAGE_REF: ${{ inputs.image-ref }}
+        ADVISORY: ${{ inputs.advisory }}
+        REKOR_URL: ${{ inputs.rekor-url }}
+        FULCIO_URL: ${{ inputs.fulcio-url }}
+        COSIGN_YES: "true"
+        COSIGN_EXPERIMENTAL: "1"
+      run: |
+        set -uo pipefail
+
+        SIGN_ARGS=(sign --yes)
+        if [ -n "${REKOR_URL}" ]; then
+          SIGN_ARGS+=(--rekor-url "${REKOR_URL}")
+        fi
+        if [ -n "${FULCIO_URL}" ]; then
+          SIGN_ARGS+=(--fulcio-url "${FULCIO_URL}")
+        fi
+        SIGN_ARGS+=("${IMAGE_REF}")
+
+        set +e
+        cosign "${SIGN_ARGS[@]}"
+        RC=$?
+        set -e
+
+        # Derive the signature reference: same repo, tagged sha256-<digest>.sig (per OCI 1.1 / cosign convention).
+        DIGEST="${IMAGE_REF##*@sha256:}"
+        REPO="${IMAGE_REF%@*}"
+        SIG_REF="${REPO}:sha256-${DIGEST}.sig"
+        echo "signature-ref=${SIG_REF}" >> "$GITHUB_OUTPUT"
+
+        # Best-effort Rekor URL for the signature, searchable by image digest.
+        REKOR_BASE="${REKOR_URL:-https://rekor.sigstore.dev}"
+        echo "rekor-log-entry=${REKOR_BASE}/api/v1/log/entries (search by image digest ${DIGEST})" >> "$GITHUB_OUTPUT"
+
+        if [ "${RC}" -ne 0 ]; then
+          if [ "${ADVISORY}" = "true" ]; then
+            echo "::warning::cosign sign failed (advisory mode); image NOT signed."
+            exit 0
+          fi
+          echo "::error::cosign sign failed (rc=${RC})."
+          exit "${RC}"
+        fi
+        echo "Signed: ${IMAGE_REF}"
+        echo "Signature: ${SIG_REF}"
+
+    - name: Attest SBOM
+      id: attest
+      if: inputs.sbom-path != ''
+      shell: bash
+      env:
+        IMAGE_REF: ${{ inputs.image-ref }}
+        SBOM_PATH: ${{ inputs.sbom-path }}
+        SBOM_TYPE: ${{ inputs.sbom-type }}
+        ADVISORY: ${{ inputs.advisory }}
+        REKOR_URL: ${{ inputs.rekor-url }}
+        FULCIO_URL: ${{ inputs.fulcio-url }}
+        COSIGN_YES: "true"
+        COSIGN_EXPERIMENTAL: "1"
+      run: |
+        set -uo pipefail
+
+        if [ ! -s "${SBOM_PATH}" ]; then
+          echo "::warning::SBOM file not found at ${SBOM_PATH}; skipping attestation."
+          exit 0
+        fi
+
+        ATTEST_ARGS=(attest --yes --predicate "${SBOM_PATH}" --type "${SBOM_TYPE}")
+        if [ -n "${REKOR_URL}" ]; then
+          ATTEST_ARGS+=(--rekor-url "${REKOR_URL}")
+        fi
+        if [ -n "${FULCIO_URL}" ]; then
+          ATTEST_ARGS+=(--fulcio-url "${FULCIO_URL}")
+        fi
+        ATTEST_ARGS+=("${IMAGE_REF}")
+
+        set +e
+        cosign "${ATTEST_ARGS[@]}"
+        RC=$?
+        set -e
+
+        DIGEST="${IMAGE_REF##*@sha256:}"
+        REPO="${IMAGE_REF%@*}"
+        ATT_REF="${REPO}:sha256-${DIGEST}.att"
+        echo "attestation-ref=${ATT_REF}" >> "$GITHUB_OUTPUT"
+
+        if [ "${RC}" -ne 0 ]; then
+          if [ "${ADVISORY}" = "true" ]; then
+            echo "::warning::cosign attest failed (advisory mode); SBOM NOT attested."
+            exit 0
+          fi
+          echo "::error::cosign attest failed (rc=${RC})."
+          exit "${RC}"
+        fi
+        echo "SBOM attested as ${SBOM_TYPE}: ${ATT_REF}"

--- a/.github/actions/cosign-sign/action.yml
+++ b/.github/actions/cosign-sign/action.yml
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # cosign-sign
 #
-# Mirrors qbiq-ai/platform-workflows@3bb35df .github/actions/cosign-sign
+# Mirrors platform-workflows@3bb35df .github/actions/cosign-sign
 # (2026-06 platform-workflows consolidation sync).
 # -----------------------------------------------------------------------------
 name: "Cosign Sign (keyless)"

--- a/.github/actions/manifest-validate/action.yml
+++ b/.github/actions/manifest-validate/action.yml
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # manifest-validate
 #
-# Mirrors qbiq-ai/platform-workflows@3bb35df .github/actions/manifest-validate
+# Mirrors platform-workflows@3bb35df .github/actions/manifest-validate
 # (2026-06 platform-workflows consolidation sync).
 # -----------------------------------------------------------------------------
 name: "Manifest Validate"

--- a/.github/actions/manifest-validate/action.yml
+++ b/.github/actions/manifest-validate/action.yml
@@ -1,0 +1,195 @@
+# -----------------------------------------------------------------------------
+# manifest-validate
+#
+# Mirrors qbiq-ai/platform-workflows@3bb35df .github/actions/manifest-validate
+# (2026-06 platform-workflows consolidation sync).
+# -----------------------------------------------------------------------------
+name: "Manifest Validate"
+description: "Validate a Helm chart by running helm lint, helm template piped through kubeconform (strict mode), and conftest against OPA policies. Catches typos in API versions, missing required values, and policy violations before ArgoCD tries to sync."
+
+inputs:
+  chart-path:
+    description: "Filesystem path to the Helm chart directory (containing Chart.yaml)."
+    required: true
+  values-files:
+    description: "Newline-separated list of values files passed to `helm template`. Order matters — later files override earlier ones."
+    required: false
+    default: ""
+  release-name:
+    description: "Helm release name used during template rendering."
+    required: false
+    default: "validate"
+  namespace:
+    description: "Namespace passed to `helm template`."
+    required: false
+    default: "default"
+  kubernetes-version:
+    description: "Kubernetes API version targeted by kubeconform (e.g. 1.32.0). Drives schema selection."
+    required: false
+    default: "1.32.0"
+  policies-path:
+    description: "Path to a directory of conftest/Rego policies. Empty string skips conftest entirely."
+    required: false
+    default: "tests/opa"
+  fail-on-policy-violations:
+    description: "If `true`, conftest violations fail the job. If `false`, violations are reported but advisory."
+    required: false
+    default: "false"
+  skip-conftest:
+    description: "Skip the conftest step entirely (e.g. when policies-path is empty)."
+    required: false
+    default: "false"
+  helm-version:
+    description: "Helm release."
+    required: false
+    default: "v3.16.2"
+  kubeconform-version:
+    description: "kubeconform release."
+    required: false
+    default: "v0.6.7"
+  conftest-version:
+    description: "conftest release."
+    required: false
+    default: "v0.57.0"
+
+outputs:
+  rendered-manifest:
+    description: "Path to the rendered manifest written during validation."
+    value: ${{ steps.render.outputs.path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install Helm
+      # azure/setup-helm v4.2.0
+      uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
+      with:
+        version: ${{ inputs.helm-version }}
+
+    - name: Install kubeconform
+      shell: bash
+      env:
+        KC_VERSION: ${{ inputs.kubeconform-version }}
+      run: |
+        set -euo pipefail
+        BIN_DIR="${RUNNER_TEMP}/kubeconform-bin"
+        mkdir -p "${BIN_DIR}"
+        URL="https://github.com/yannh/kubeconform/releases/download/${KC_VERSION}/kubeconform-linux-amd64.tar.gz"
+        curl -fsSL -o "${RUNNER_TEMP}/kubeconform.tgz" "${URL}"
+        tar -xzf "${RUNNER_TEMP}/kubeconform.tgz" -C "${BIN_DIR}" kubeconform
+        chmod +x "${BIN_DIR}/kubeconform"
+        echo "${BIN_DIR}" >> "$GITHUB_PATH"
+        "${BIN_DIR}/kubeconform" -v
+
+    - name: Install conftest
+      if: inputs.skip-conftest != 'true' && inputs.policies-path != ''
+      shell: bash
+      env:
+        CONFTEST_VERSION: ${{ inputs.conftest-version }}
+      run: |
+        set -euo pipefail
+        BIN_DIR="${RUNNER_TEMP}/conftest-bin"
+        mkdir -p "${BIN_DIR}"
+        VER="${CONFTEST_VERSION#v}"
+        URL="https://github.com/open-policy-agent/conftest/releases/download/${CONFTEST_VERSION}/conftest_${VER}_Linux_x86_64.tar.gz"
+        curl -fsSL -o "${RUNNER_TEMP}/conftest.tgz" "${URL}"
+        tar -xzf "${RUNNER_TEMP}/conftest.tgz" -C "${BIN_DIR}" conftest
+        chmod +x "${BIN_DIR}/conftest"
+        echo "${BIN_DIR}" >> "$GITHUB_PATH"
+        "${BIN_DIR}/conftest" --version
+
+    - name: Helm dependency build
+      shell: bash
+      env:
+        CHART_PATH: ${{ inputs.chart-path }}
+      run: |
+        set -euo pipefail
+        if [ -f "${CHART_PATH}/Chart.lock" ] || grep -q '^dependencies:' "${CHART_PATH}/Chart.yaml" 2>/dev/null; then
+          helm dependency build "${CHART_PATH}"
+        else
+          echo "No chart dependencies declared; skipping."
+        fi
+
+    - name: Helm lint
+      shell: bash
+      env:
+        VALUES_FILES: ${{ inputs.values-files }}
+        CHART_PATH: ${{ inputs.chart-path }}
+      run: |
+        set -euo pipefail
+        ARGS=(lint "${CHART_PATH}" --strict)
+        while IFS= read -r vf; do
+          [ -z "${vf}" ] && continue
+          ARGS+=(--values "${vf}")
+        done <<< "${VALUES_FILES}"
+        helm "${ARGS[@]}"
+
+    - name: Helm template
+      id: render
+      shell: bash
+      env:
+        VALUES_FILES: ${{ inputs.values-files }}
+        RELEASE: ${{ inputs.release-name }}
+        NAMESPACE: ${{ inputs.namespace }}
+        CHART_PATH: ${{ inputs.chart-path }}
+      run: |
+        set -euo pipefail
+        OUT="${RUNNER_TEMP}/rendered.yaml"
+        ARGS=(template "${RELEASE}" "${CHART_PATH}" --namespace "${NAMESPACE}")
+        while IFS= read -r vf; do
+          [ -z "${vf}" ] && continue
+          ARGS+=(--values "${vf}")
+        done <<< "${VALUES_FILES}"
+        helm "${ARGS[@]}" > "${OUT}"
+        wc -l "${OUT}"
+        echo "path=${OUT}" >> "$GITHUB_OUTPUT"
+
+    - name: Kubeconform validate
+      shell: bash
+      env:
+        K8S_VERSION: ${{ inputs.kubernetes-version }}
+        RENDERED: ${{ steps.render.outputs.path }}
+      run: |
+        set -euo pipefail
+        kubeconform \
+          -strict \
+          -summary \
+          -kubernetes-version "${K8S_VERSION}" \
+          -schema-location default \
+          -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{ .Group }}/{{ .ResourceKind }}_{{ .ResourceAPIVersion }}.json' \
+          "${RENDERED}"
+
+    - name: Conftest policy check
+      if: inputs.skip-conftest != 'true' && inputs.policies-path != ''
+      shell: bash
+      env:
+        POLICIES_PATH: ${{ inputs.policies-path }}
+        RENDERED: ${{ steps.render.outputs.path }}
+        FAIL_ON_VIOLATION: ${{ inputs.fail-on-policy-violations }}
+      run: |
+        set -uo pipefail
+        if [ ! -d "${POLICIES_PATH}" ]; then
+          echo "::warning::policies-path '${POLICIES_PATH}' not found; skipping conftest."
+          exit 0
+        fi
+        set +e
+        conftest test --policy "${POLICIES_PATH}" "${RENDERED}"
+        RC=$?
+        set -e
+        if [ "${RC}" -ne 0 ]; then
+          if [ "${FAIL_ON_VIOLATION}" = "true" ]; then
+            echo "::error::conftest reported policy violations."
+            exit "${RC}"
+          fi
+          echo "::warning::conftest reported policy violations (advisory mode)."
+        fi
+
+    - name: Upload rendered manifest as artifact
+      if: always()
+      # actions/upload-artifact v4.4.3
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: rendered-manifest-${{ github.run_id }}-${{ github.run_attempt }}
+        path: ${{ steps.render.outputs.path }}
+        if-no-files-found: warn
+        retention-days: 14

--- a/.github/actions/syft-sbom/action.yml
+++ b/.github/actions/syft-sbom/action.yml
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # syft-sbom
 #
-# Mirrors qbiq-ai/platform-workflows@3bb35df .github/actions/syft-sbom
+# Mirrors platform-workflows@3bb35df .github/actions/syft-sbom
 # (2026-06 platform-workflows consolidation sync).
 # -----------------------------------------------------------------------------
 name: "Syft SBOM"

--- a/.github/actions/syft-sbom/action.yml
+++ b/.github/actions/syft-sbom/action.yml
@@ -1,0 +1,47 @@
+# -----------------------------------------------------------------------------
+# syft-sbom
+#
+# Mirrors qbiq-ai/platform-workflows@3bb35df .github/actions/syft-sbom
+# (2026-06 platform-workflows consolidation sync).
+# -----------------------------------------------------------------------------
+name: "Syft SBOM"
+description: "Generate a Software Bill of Materials (SBOM) for a container image using Syft. Uploads as a workflow artifact."
+
+inputs:
+  image-ref:
+    description: "Image reference to inspect (must be loaded in local daemon or accessible via registry)."
+    required: true
+  format:
+    description: "SBOM format. Common: `spdx-json`, `cyclonedx-json`, `syft-json`."
+    required: false
+    default: "spdx-json"
+  output-path:
+    description: "Output file path."
+    required: false
+    default: "sbom.spdx.json"
+  artifact-name:
+    description: "Workflow artifact name."
+    required: false
+    default: "sbom"
+  upload-artifact:
+    description: "Upload the SBOM as a workflow artifact."
+    required: false
+    default: "true"
+
+outputs:
+  output-path:
+    description: "Path to the generated SBOM file."
+    value: ${{ inputs.output-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Generate SBOM with Syft
+      # anchore/sbom-action v0.17.7
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610
+      with:
+        image: ${{ inputs.image-ref }}
+        format: ${{ inputs.format }}
+        output-file: ${{ inputs.output-path }}
+        upload-artifact: ${{ inputs.upload-artifact }}
+        artifact-name: ${{ inputs.artifact-name }}

--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # trivy-scan
 #
-# Mirrors qbiq-ai/platform-workflows@3bb35df .github/actions/trivy-scan
+# Mirrors platform-workflows@3bb35df .github/actions/trivy-scan
 # (2026-06 platform-workflows consolidation sync).
 # Trivy action pinned to v0.35.0 to match platform-design's existing
 # container-build.yml usage.

--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -1,0 +1,76 @@
+# -----------------------------------------------------------------------------
+# trivy-scan
+#
+# Mirrors qbiq-ai/platform-workflows@3bb35df .github/actions/trivy-scan
+# (2026-06 platform-workflows consolidation sync).
+# Trivy action pinned to v0.35.0 to match platform-design's existing
+# container-build.yml usage.
+# -----------------------------------------------------------------------------
+name: "Trivy Scan"
+description: "Scan a container image with Trivy. Fails on configured severity, uploads SARIF to GitHub Security."
+
+inputs:
+  image-ref:
+    description: "Image reference to scan (must be loaded in local daemon or accessible via registry)."
+    required: true
+  severity:
+    description: "Comma-separated severities that count as findings."
+    required: false
+    default: "CRITICAL,HIGH"
+  exit-code:
+    description: "Exit code when findings are present. Set to 0 to make the scan advisory."
+    required: false
+    default: "1"
+  ignore-unfixed:
+    description: "Ignore vulnerabilities without a fix."
+    required: false
+    default: "true"
+  upload-sarif:
+    description: "Upload SARIF results to GitHub Security tab."
+    required: false
+    default: "true"
+  sarif-category:
+    description: "SARIF category. Differentiates multiple scans on the same commit."
+    required: false
+    default: "trivy-container-scan"
+  trivyignores:
+    description: "Optional path to a `.trivyignore` file."
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Trivy table scan (fail on severity)
+      uses: aquasecurity/trivy-action@v0.35.0
+      with:
+        image-ref: ${{ inputs.image-ref }}
+        format: table
+        exit-code: ${{ inputs.exit-code }}
+        severity: ${{ inputs.severity }}
+        ignore-unfixed: ${{ inputs.ignore-unfixed }}
+        trivyignores: ${{ inputs.trivyignores }}
+
+    - name: Trivy SARIF scan
+      if: always()
+      uses: aquasecurity/trivy-action@v0.35.0
+      with:
+        image-ref: ${{ inputs.image-ref }}
+        format: sarif
+        output: trivy-results.sarif
+        severity: ${{ inputs.severity }}
+        ignore-unfixed: ${{ inputs.ignore-unfixed }}
+        trivyignores: ${{ inputs.trivyignores }}
+
+    - name: Upload Trivy SARIF to GitHub Security
+      if: always() && inputs.upload-sarif == 'true'
+      # Best-effort: the vulnerability GATE is the table scan above (fails on
+      # severity). The SARIF upload is reporting-only and requires code scanning
+      # / GitHub Advanced Security on the repo; on repos without it the upload
+      # returns "Resource not accessible by integration". That must not fail the
+      # build, so tolerate it.
+      continue-on-error: true
+      uses: github/codeql-action/upload-sarif@v4
+      with:
+        sarif_file: trivy-results.sarif
+        category: ${{ inputs.sarif-category }}

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -143,7 +143,7 @@ jobs:
       # generate an SBOM, push, then SIGN the pushed image by digest and attest
       # the SBOM — keyless via the job's GitHub OIDC identity. Closes the gap
       # where platform-design pushed unsigned images with no SBOM. Composite
-      # actions live in .github/actions/ (mirrors qbiq-ai/platform-workflows).
+      # actions live in .github/actions/ (mirrors platform-workflows).
       # ---------------------------------------------------------------------
       - name: Generate SBOM (Syft)
         uses: ./.github/actions/syft-sbom

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -138,7 +138,23 @@ jobs:
         with:
           sarif_file: "trivy-results.sarif"
 
+      # ---------------------------------------------------------------------
+      # Supply-chain hardening (platform-workflows consolidation sync):
+      # generate an SBOM, push, then SIGN the pushed image by digest and attest
+      # the SBOM — keyless via the job's GitHub OIDC identity. Closes the gap
+      # where platform-design pushed unsigned images with no SBOM. Composite
+      # actions live in .github/actions/ (mirrors qbiq-ai/platform-workflows).
+      # ---------------------------------------------------------------------
+      - name: Generate SBOM (Syft)
+        uses: ./.github/actions/syft-sbom
+        with:
+          image-ref: "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag-sha }}"
+          format: spdx-json
+          output-path: sbom.spdx.json
+          artifact-name: sbom-${{ steps.meta.outputs.service-name }}-${{ steps.meta.outputs.tag-sha }}
+
       - name: Push image to ECR
+        id: push-ecr
         if: github.ref == 'refs/heads/main' && github.event_name == 'push' && vars.AWS_ROLE_ARN != ''
         uses: docker/build-push-action@v6
         with:
@@ -147,3 +163,11 @@ jobs:
           tags: |
             ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag-sha }}
           cache-from: type=gha,scope=${{ matrix.service }}
+
+      - name: Sign image + attest SBOM (cosign keyless)
+        if: steps.push-ecr.outcome == 'success' && steps.push-ecr.outputs.digest != ''
+        uses: ./.github/actions/cosign-sign
+        with:
+          image-ref: "${{ steps.meta.outputs.image }}@${{ steps.push-ecr.outputs.digest }}"
+          sbom-path: sbom.spdx.json
+          sbom-type: spdxjson

--- a/.github/workflows/reusable-build-and-push.yml
+++ b/.github/workflows/reusable-build-and-push.yml
@@ -1,0 +1,199 @@
+# -----------------------------------------------------------------------------
+# reusable-build-and-push.yml
+#
+# Reusable workflow: build a container image, scan with Trivy, generate an SBOM
+# with Syft, push to ECR, and SIGN the pushed image (cosign keyless) + attest
+# the SBOM. Composed from .github/actions/* composites in this repo.
+#
+# Mirrors qbiq-ai/platform-workflows@3bb35df reusable-build-and-push.yml
+# (2026-06 consolidation sync) and CLOSES the known gap in the source workflow:
+# the upstream reusable-build-and-push builds, scans and pushes but never signs.
+# Here the push job runs cosign-sign on the pushed digest before completing.
+#
+# Caller example:
+#
+#   jobs:
+#     build:
+#       uses: ./.github/workflows/reusable-build-and-push.yml
+#       permissions:
+#         id-token: write
+#         contents: read
+#         security-events: write
+#       with:
+#         app_name: hello-world
+#         ecr_repository: hello-world
+#         build_context: services/hello-world
+#
+# See: docs/ci-cd/README.md
+# -----------------------------------------------------------------------------
+
+name: reusable-build-and-push
+
+on:
+  workflow_call:
+    inputs:
+      app_name:
+        description: "Application name. Used in image tag namespace, SBOM/SARIF naming, and cache keys."
+        type: string
+        required: true
+      ecr_repository:
+        description: "ECR repository name (without registry hostname). Example: hello-world."
+        type: string
+        required: true
+      build_context:
+        description: "Docker build context path."
+        type: string
+        required: false
+        default: "."
+      dockerfile_path:
+        description: "Path to Dockerfile (relative to build_context)."
+        type: string
+        required: false
+        default: "Dockerfile"
+      aws_region:
+        description: "AWS region of the ECR registry."
+        type: string
+        required: false
+        default: "eu-west-1"
+      tag:
+        description: "Image tag override. Defaults to the short git SHA."
+        type: string
+        required: false
+        default: ""
+      push:
+        description: "Push the image to ECR and sign it. Set false for build-only smoke tests."
+        type: boolean
+        required: false
+        default: true
+      sign:
+        description: "Sign the pushed image with cosign keyless and attest the SBOM. Only runs when push is true."
+        type: boolean
+        required: false
+        default: true
+      trivy_severity:
+        description: "Trivy severities that fail the build."
+        type: string
+        required: false
+        default: "CRITICAL,HIGH"
+      trivy_exit_code:
+        description: "Trivy exit code on findings."
+        type: string
+        required: false
+        default: "1"
+      sbom_format:
+        description: "SBOM format for syft (spdx-json, cyclonedx-json, syft-json)."
+        type: string
+        required: false
+        default: "spdx-json"
+    outputs:
+      image_uri:
+        description: "Full image URI (registry/repo:tag)."
+        value: ${{ jobs.build.outputs.image_uri }}
+      image_digest:
+        description: "Image content digest (sha256:...)."
+        value: ${{ jobs.build.outputs.image_digest }}
+      image_tag:
+        description: "Resolved image tag."
+        value: ${{ jobs.build.outputs.image_tag }}
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build, scan, SBOM, push, sign
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      security-events: write
+    outputs:
+      image_uri: ${{ steps.meta.outputs.uri }}
+      image_digest: ${{ steps.push.outputs.digest }}
+      image_tag: ${{ steps.meta.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials via OIDC
+        id: aws-creds
+        if: inputs.push && vars.ECR_PUSH_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.ECR_PUSH_ROLE_ARN }}
+          aws-region: ${{ inputs.aws_region }}
+
+      - name: Login to Amazon ECR
+        id: ecr-login
+        if: inputs.push && vars.ECR_PUSH_ROLE_ARN != ''
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Resolve image metadata
+        id: meta
+        env:
+          REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+          REPO: ${{ inputs.ecr_repository }}
+          TAG_OVERRIDE: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ -n "${TAG_OVERRIDE}" ]; then
+            TAG="${TAG_OVERRIDE}"
+          else
+            TAG="sha-$(git rev-parse --short HEAD)"
+          fi
+          REG="${REGISTRY:-local}"
+          URI="${REG}/${REPO}:${TAG}"
+          echo "registry=${REG}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "uri=${URI}" >> "$GITHUB_OUTPUT"
+          echo "Image URI: ${URI}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image (load for scan)
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.build_context }}
+          file: ${{ inputs.build_context }}/${{ inputs.dockerfile_path }}
+          push: false
+          load: true
+          tags: ${{ steps.meta.outputs.uri }}
+          cache-from: type=gha,scope=${{ inputs.app_name }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.app_name }}
+
+      - name: Trivy scan
+        uses: ./.github/actions/trivy-scan
+        with:
+          image-ref: ${{ steps.meta.outputs.uri }}
+          severity: ${{ inputs.trivy_severity }}
+          exit-code: ${{ inputs.trivy_exit_code }}
+          sarif-category: trivy-${{ inputs.app_name }}
+
+      - name: Generate SBOM (Syft)
+        uses: ./.github/actions/syft-sbom
+        with:
+          image-ref: ${{ steps.meta.outputs.uri }}
+          format: ${{ inputs.sbom_format }}
+          output-path: sbom.spdx.json
+          artifact-name: sbom-${{ inputs.app_name }}-${{ steps.meta.outputs.tag }}
+
+      - name: Build and push image
+        id: push
+        if: inputs.push && steps.ecr-login.outcome == 'success'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.build_context }}
+          file: ${{ inputs.build_context }}/${{ inputs.dockerfile_path }}
+          push: true
+          tags: ${{ steps.meta.outputs.uri }}
+          cache-from: type=gha,scope=${{ inputs.app_name }}
+
+      - name: Sign image + attest SBOM (cosign keyless)
+        # GAP CLOSED: the upstream reusable-build-and-push never signs. We sign
+        # the freshly pushed image BY DIGEST (immutable) and attach the SBOM as a
+        # signed attestation, all keyless via the job's GitHub OIDC identity.
+        if: inputs.push && inputs.sign && steps.push.outputs.digest != ''
+        uses: ./.github/actions/cosign-sign
+        with:
+          image-ref: ${{ steps.meta.outputs.registry }}/${{ inputs.ecr_repository }}@${{ steps.push.outputs.digest }}
+          sbom-path: sbom.spdx.json
+          sbom-type: spdxjson

--- a/.github/workflows/reusable-build-and-push.yml
+++ b/.github/workflows/reusable-build-and-push.yml
@@ -5,7 +5,7 @@
 # with Syft, push to ECR, and SIGN the pushed image (cosign keyless) + attest
 # the SBOM. Composed from .github/actions/* composites in this repo.
 #
-# Mirrors qbiq-ai/platform-workflows@3bb35df reusable-build-and-push.yml
+# Mirrors platform-workflows@3bb35df reusable-build-and-push.yml
 # (2026-06 consolidation sync) and CLOSES the known gap in the source workflow:
 # the upstream reusable-build-and-push builds, scans and pushes but never signs.
 # Here the push job runs cosign-sign on the pushed digest before completing.

--- a/.github/workflows/reusable-deploy-via-argocd.yml
+++ b/.github/workflows/reusable-deploy-via-argocd.yml
@@ -1,0 +1,105 @@
+# -----------------------------------------------------------------------------
+# reusable-deploy-via-argocd.yml
+#
+# Open a PR in the argocd config repo (100rd/argocd) that bumps image.tag and
+# image.digest for an app in a target environment. Non-prod PRs are
+# auto-merge-labelled; prod PRs are left for human review (GitOps deploy gate).
+#
+# Mirrors qbiq-ai/platform-workflows@3bb35df reusable-deploy-via-argocd.yml
+# (2026-06 consolidation sync).
+#
+# Caller example:
+#
+#   jobs:
+#     deploy:
+#       uses: ./.github/workflows/reusable-deploy-via-argocd.yml
+#       with:
+#         app_name: hello-world
+#         env: dev
+#         image_tag: ${{ needs.build.outputs.image_tag }}
+#         image_digest: ${{ needs.build.outputs.image_digest }}
+#         values_path: envs/{env}/values/{app}.yaml
+#       secrets:
+#         argocd_bot_token: ${{ secrets.ARGOCD_BOT_TOKEN }}
+#
+# See: docs/ci-cd/README.md
+# -----------------------------------------------------------------------------
+
+name: reusable-deploy-via-argocd
+
+on:
+  workflow_call:
+    inputs:
+      app_name:
+        description: "Application name."
+        type: string
+        required: true
+      env:
+        description: "Target environment: dev, stage, or prod."
+        type: string
+        required: true
+      image_tag:
+        description: "New image tag."
+        type: string
+        required: true
+      image_digest:
+        description: "Image content digest (sha256:...)."
+        type: string
+        required: true
+      values_path:
+        description: "Path to the values file inside the argocd repo. {app} and {env} are substituted. REQUIRED — no default. Examples: `envs/{env}/values/{app}.yaml` or `workloads/{app}/envs/{env}/values.yaml`."
+        type: string
+        required: true
+      argocd_repo:
+        description: "ArgoCD config repository."
+        type: string
+        required: false
+        default: "100rd/argocd"
+      auto_merge_override:
+        description: "Override auto-merge selection. Empty string keeps default (true for non-prod, false for prod)."
+        type: string
+        required: false
+        default: ""
+    secrets:
+      argocd_bot_token:
+        description: "Token with contents:write and pull-requests:write on the argocd repo."
+        required: true
+
+permissions: {}
+
+jobs:
+  deploy:
+    name: Deploy ${{ inputs.app_name }} -> ${{ inputs.env }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve auto-merge flag
+        id: am
+        env:
+          ENV: ${{ inputs.env }}
+          OVERRIDE: ${{ inputs.auto_merge_override }}
+        run: |
+          set -euo pipefail
+          if [ -n "${OVERRIDE}" ]; then
+            FLAG="${OVERRIDE}"
+          elif [ "${ENV}" = "prod" ]; then
+            FLAG="false"
+          else
+            FLAG="true"
+          fi
+          echo "auto-merge=${FLAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Open argocd bump PR
+        uses: ./.github/actions/argocd-tag-bump
+        with:
+          app-name: ${{ inputs.app_name }}
+          env: ${{ inputs.env }}
+          image-tag: ${{ inputs.image_tag }}
+          image-digest: ${{ inputs.image_digest }}
+          values-path: ${{ inputs.values_path }}
+          argocd-repo: ${{ inputs.argocd_repo }}
+          bot-token: ${{ secrets.argocd_bot_token }}
+          auto-merge: ${{ steps.am.outputs.auto-merge }}

--- a/.github/workflows/reusable-deploy-via-argocd.yml
+++ b/.github/workflows/reusable-deploy-via-argocd.yml
@@ -5,7 +5,7 @@
 # image.digest for an app in a target environment. Non-prod PRs are
 # auto-merge-labelled; prod PRs are left for human review (GitOps deploy gate).
 #
-# Mirrors qbiq-ai/platform-workflows@3bb35df reusable-deploy-via-argocd.yml
+# Mirrors platform-workflows@3bb35df reusable-deploy-via-argocd.yml
 # (2026-06 consolidation sync).
 #
 # Caller example:

--- a/.github/workflows/reusable-manifest-validate.yml
+++ b/.github/workflows/reusable-manifest-validate.yml
@@ -5,7 +5,7 @@
 # Designed to run on tag-bump PRs created by reusable-deploy-via-argocd.yml, and
 # usable directly from any chart-owning repo.
 #
-# Mirrors qbiq-ai/platform-workflows@3bb35df reusable-manifest-validate.yml
+# Mirrors platform-workflows@3bb35df reusable-manifest-validate.yml
 # (2026-06 consolidation sync).
 #
 # Caller example:

--- a/.github/workflows/reusable-manifest-validate.yml
+++ b/.github/workflows/reusable-manifest-validate.yml
@@ -1,0 +1,93 @@
+# -----------------------------------------------------------------------------
+# reusable-manifest-validate.yml
+#
+# Validate a Helm chart with helm lint + helm template | kubeconform + conftest.
+# Designed to run on tag-bump PRs created by reusable-deploy-via-argocd.yml, and
+# usable directly from any chart-owning repo.
+#
+# Mirrors qbiq-ai/platform-workflows@3bb35df reusable-manifest-validate.yml
+# (2026-06 consolidation sync).
+#
+# Caller example:
+#
+#   jobs:
+#     validate:
+#       uses: ./.github/workflows/reusable-manifest-validate.yml
+#       with:
+#         chart_path: charts/hello-world
+#         values_files: |
+#           charts/hello-world/values-dev.yaml
+#         kubernetes_version: "1.32.0"
+#         policies_path: tests/opa
+#         fail_on_policy_violations: false
+#
+# See: docs/ci-cd/README.md
+# -----------------------------------------------------------------------------
+
+name: reusable-manifest-validate
+
+on:
+  workflow_call:
+    inputs:
+      chart_path:
+        description: "Filesystem path to the Helm chart directory (containing Chart.yaml)."
+        type: string
+        required: true
+      values_files:
+        description: "Newline-separated list of values files to apply during helm template."
+        type: string
+        required: false
+        default: ""
+      release_name:
+        description: "Helm release name used during template rendering."
+        type: string
+        required: false
+        default: "validate"
+      namespace:
+        description: "Namespace passed to helm template."
+        type: string
+        required: false
+        default: "default"
+      kubernetes_version:
+        description: "Target Kubernetes API version for kubeconform schema selection."
+        type: string
+        required: false
+        default: "1.32.0"
+      policies_path:
+        description: "Directory of conftest/Rego policies. Empty string skips conftest."
+        type: string
+        required: false
+        default: "tests/opa"
+      fail_on_policy_violations:
+        description: "If true, conftest violations fail the job."
+        type: boolean
+        required: false
+        default: false
+      skip_conftest:
+        description: "Skip the conftest step entirely."
+        type: boolean
+        required: false
+        default: false
+
+permissions: {}
+
+jobs:
+  manifest-validate:
+    name: Validate ${{ inputs.chart_path }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Manifest validate
+        uses: ./.github/actions/manifest-validate
+        with:
+          chart-path: ${{ inputs.chart_path }}
+          values-files: ${{ inputs.values_files }}
+          release-name: ${{ inputs.release_name }}
+          namespace: ${{ inputs.namespace }}
+          kubernetes-version: ${{ inputs.kubernetes_version }}
+          policies-path: ${{ inputs.policies_path }}
+          fail-on-policy-violations: ${{ inputs.fail_on_policy_violations }}
+          skip-conftest: ${{ inputs.skip_conftest }}

--- a/.github/workflows/reusable-pipeline-demo.yml
+++ b/.github/workflows/reusable-pipeline-demo.yml
@@ -1,0 +1,64 @@
+# -----------------------------------------------------------------------------
+# reusable-pipeline-demo.yml
+#
+# Thin caller demonstrating the consolidated reusable pipeline end to end:
+#   reusable-build-and-push (build → trivy → SBOM → push → cosign sign)
+#     -> reusable-deploy-via-argocd (open GitOps image-bump PR in 100rd/argocd)
+#
+# In the real estate these reusable workflows live in the shared
+# qbiq-ai/platform-workflows repo and are referenced as
+# `uses: qbiq-ai/platform-workflows/.github/workflows/<wf>.yml@<ref>`. In this
+# mock they live in-repo and are called via local `./.github/workflows/...`.
+#
+# Manual-only (workflow_dispatch) so it never runs unattended; it shows wiring,
+# not a production trigger. See docs/ci-cd/README.md.
+# -----------------------------------------------------------------------------
+
+name: reusable-pipeline-demo
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_name:
+        description: "Application name (e.g. hello-world)."
+        required: true
+        default: "hello-world"
+      build_context:
+        description: "Docker build context path (e.g. services/hello-world)."
+        required: true
+        default: "services/hello-world"
+      env:
+        description: "Target environment for the GitOps deploy PR."
+        required: true
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - stage
+          - prod
+
+permissions: {}
+
+jobs:
+  build:
+    uses: ./.github/workflows/reusable-build-and-push.yml
+    permissions:
+      id-token: write
+      contents: read
+      security-events: write
+    with:
+      app_name: ${{ inputs.app_name }}
+      ecr_repository: ${{ inputs.app_name }}
+      build_context: ${{ inputs.build_context }}
+
+  deploy:
+    needs: build
+    uses: ./.github/workflows/reusable-deploy-via-argocd.yml
+    with:
+      app_name: ${{ inputs.app_name }}
+      env: ${{ inputs.env }}
+      image_tag: ${{ needs.build.outputs.image_tag }}
+      image_digest: ${{ needs.build.outputs.image_digest }}
+      values_path: envs/{env}/values/{app}.yaml
+    secrets:
+      argocd_bot_token: ${{ secrets.ARGOCD_BOT_TOKEN }}

--- a/.github/workflows/reusable-pipeline-demo.yml
+++ b/.github/workflows/reusable-pipeline-demo.yml
@@ -6,8 +6,8 @@
 #     -> reusable-deploy-via-argocd (open GitOps image-bump PR in 100rd/argocd)
 #
 # In the real estate these reusable workflows live in the shared
-# qbiq-ai/platform-workflows repo and are referenced as
-# `uses: qbiq-ai/platform-workflows/.github/workflows/<wf>.yml@<ref>`. In this
+# platform-workflows repo and are referenced as
+# `uses: platform-workflows/.github/workflows/<wf>.yml@<ref>`. In this
 # mock they live in-repo and are called via local `./.github/workflows/...`.
 #
 # Manual-only (workflow_dispatch) so it never runs unattended; it shows wiring,

--- a/docs/ci-cd/README.md
+++ b/docs/ci-cd/README.md
@@ -1,6 +1,6 @@
 # CI/CD: platform-workflows consolidation model
 
-> **Provenance:** mirrors `qbiq-ai/platform-workflows@3bb35df` (2026-06 sync).
+> **Provenance:** mirrors `platform-workflows@3bb35df` (2026-06 sync).
 > This document and the accompanying `.github/actions/` composite actions and
 > `.github/workflows/reusable-*.yml` reusable workflows reflect the real-estate
 > consolidation into a single shared CI/CD repository. This is a **mock** —
@@ -14,7 +14,7 @@ container build, k8s/helm validation, security scans, etc.) with **no image
 signing, no SBOM, no reusable pipeline pattern**.
 
 In the real estate, the Tier-1 hardening building blocks were **consolidated
-out of `qbiq-ai/infra` into a shared `qbiq-ai/platform-workflows` repository** so
+out of `infra` into a shared `platform-workflows` repository** so
 every service repo composes the same audited actions instead of copy-pasting
 CI. This PR reflects that model inside platform-design:
 
@@ -27,7 +27,7 @@ CI. This PR reflects that model inside platform-design:
   signs** — this port closes that gap.
 
 In real consumer repos the reusables are referenced as
-`uses: qbiq-ai/platform-workflows/.github/workflows/<wf>.yml@<ref>`. In this
+`uses: platform-workflows/.github/workflows/<wf>.yml@<ref>`. In this
 mock they live in-repo and are referenced via local `./.github/...` paths.
 
 ## Tier-1 composite actions (`.github/actions/`)

--- a/docs/ci-cd/README.md
+++ b/docs/ci-cd/README.md
@@ -1,0 +1,112 @@
+# CI/CD: platform-workflows consolidation model
+
+> **Provenance:** mirrors `qbiq-ai/platform-workflows@3bb35df` (2026-06 sync).
+> This document and the accompanying `.github/actions/` composite actions and
+> `.github/workflows/reusable-*.yml` reusable workflows reflect the real-estate
+> consolidation into a single shared CI/CD repository. This is a **mock** —
+> a faithful, representative port, not a 1:1 copy of every upstream action.
+
+## Why this exists
+
+Historically every repo carried its own self-contained CI/CD. platform-design
+still embeds **22 self-contained in-repo workflows** (Terragrunt plan/apply,
+container build, k8s/helm validation, security scans, etc.) with **no image
+signing, no SBOM, no reusable pipeline pattern**.
+
+In the real estate, the Tier-1 hardening building blocks were **consolidated
+out of `qbiq-ai/infra` into a shared `qbiq-ai/platform-workflows` repository** so
+every service repo composes the same audited actions instead of copy-pasting
+CI. This PR reflects that model inside platform-design:
+
+- **Composite actions** under `.github/actions/` — the reusable Tier-1 steps.
+- **Reusable `workflow_call` workflows** under `.github/workflows/reusable-*.yml`
+  — the pipelines that compose those actions.
+- **Signing wired in**: `container-build.yml` and `reusable-build-and-push.yml`
+  now sign pushed images and attest SBOMs. The upstream
+  `reusable-build-and-push` notably **builds, scans and pushes but never
+  signs** — this port closes that gap.
+
+In real consumer repos the reusables are referenced as
+`uses: qbiq-ai/platform-workflows/.github/workflows/<wf>.yml@<ref>`. In this
+mock they live in-repo and are referenced via local `./.github/...` paths.
+
+## Tier-1 composite actions (`.github/actions/`)
+
+| Action | Purpose |
+|--------|---------|
+| `cosign-sign` | Keyless image signing via Sigstore + GitHub OIDC, **by digest** (immutable). Optionally attaches the SBOM as a signed cosign attestation (SPDX/CycloneDX). `advisory: true` downgrades sign failures to warnings during Sigstore incidents. |
+| `syft-sbom` | Generate an SBOM (default `spdx-json`) for an image with Syft and upload it as a workflow artifact. |
+| `trivy-scan` | Scan an image with Trivy; the table scan is the **gate** (fails on `CRITICAL,HIGH`), the SARIF upload is best-effort reporting (tolerates repos without Advanced Security). |
+| `manifest-validate` | `helm lint --strict` + `helm template \| kubeconform -strict` + `conftest` against OPA/Rego policies. Catches bad apiVersions, missing values, and policy violations before ArgoCD syncs. |
+| `argocd-tag-bump` | Open a PR in the argocd config repo (`100rd/argocd`) bumping `image.tag` + `image.digest` in a values file. Labels non-prod PRs `auto-merge`. |
+| `argocd-wait-sync-and-smoke` | Post-deploy gate: wait for the ArgoCD app to reach Synced + Healthy, then HTTP-probe an endpoint for an expected 2xx. |
+
+## Reusable pipelines (`.github/workflows/`)
+
+### `reusable-build-and-push.yml`
+`checkout → AWS OIDC + ECR login → buildx (load) → trivy-scan → syft-sbom →
+push → cosign-sign (+ SBOM attest)`.
+
+Outputs `image_uri`, `image_digest`, `image_tag`. The **sign-by-digest** step is
+the gap closure relative to upstream: it signs the exact pushed digest and
+attests the SBOM, all keyless via the job's GitHub OIDC identity. Set
+`push: false` for build-only smoke runs (skips ECR + signing).
+
+### `reusable-deploy-via-argocd.yml`
+Calls `argocd-tag-bump` to open an image-bump PR in `100rd/argocd`. Auto-merge
+defaults to **true for non-prod, false for prod** (human-gated prod), overridable
+via `auto_merge_override`.
+
+### `reusable-manifest-validate.yml`
+Wraps `manifest-validate`. Intended to run on the tag-bump PRs created by
+`reusable-deploy-via-argocd.yml`, and usable directly from any chart-owning repo.
+
+### `reusable-pipeline-demo.yml`
+Manual (`workflow_dispatch`) thin caller wiring `reusable-build-and-push` →
+`reusable-deploy-via-argocd` end to end.
+
+## GitOps deploy model
+
+Deploys are **PR-based**, never `kubectl apply` from CI:
+
+1. Build/sign produces an immutable `tag` + `digest`.
+2. `argocd-tag-bump` opens a PR in `100rd/argocd` writing both into the env values file.
+3. **Non-prod** PRs are `auto-merge`-labelled and merge once checks pass;
+   **prod** PRs are left for human review.
+4. ArgoCD syncs the merged change; `argocd-wait-sync-and-smoke` confirms
+   Synced + Healthy and smoke-probes the endpoint.
+
+## Expected org-level secrets & variables
+
+Configure at the **organization** (or repo) level; the workflows read them as
+`secrets.*` / `vars.*`.
+
+| Name | Type | Used by | Purpose |
+|------|------|---------|---------|
+| `ECR_PUSH_ROLE_ARN` | var | `reusable-build-and-push`, `container-build` (as `AWS_ROLE_ARN`) | IAM role assumed via GitHub OIDC for ECR push. |
+| `ARGOCD_BOT_TOKEN` | secret | `reusable-deploy-via-argocd`, `argocd-tag-bump` | Token with `contents:write` + `pull-requests:write` on `100rd/argocd`. |
+| `GITOPS_APP_ID` / `GITOPS_APP_KEY` | var / secret | argocd-bump (GitHub App alternative to `ARGOCD_BOT_TOKEN`) | GitHub App credentials minting short-lived bump tokens. |
+| `ARGOCD_AUTH_TOKEN` | secret | `argocd-wait-sync-and-smoke` | Read-only, project-scoped ArgoCD API token. |
+| `ARGOCD_SERVER` | var | `argocd-wait-sync-and-smoke` | ArgoCD server hostname (no scheme). |
+
+> No long-lived AWS keys: image push uses **GitHub OIDC → IAM role assumption**.
+> Image signing is **keyless** — identity is bound to the workflow, no private
+> keys to store or rotate. SBOM attestations are signed the same way.
+
+## Required job permissions
+
+```yaml
+permissions:
+  id-token: write        # OIDC: AWS role assumption + cosign keyless
+  contents: read
+  security-events: write # Trivy SARIF upload to the Security tab
+```
+
+## Relationship to existing platform-design workflows
+
+The 22 existing in-repo workflows are **preserved unchanged** except
+`container-build.yml`, which gains SBOM generation and a `cosign-sign` step on
+push (closing the unsigned-image gap) while keeping its detect-changes matrix,
+Trivy table+SARIF scan, and ECR push intact. The OPA policy machinery this
+repo already has (`conftest-opa.yml`, `tests/opa/`) is what `manifest-validate`
+plugs into via its `policies-path` input.


### PR DESCRIPTION
## Context

In the real estate, Tier-1 CI/CD building blocks were **consolidated out of `qbiq-ai/infra` into a shared `qbiq-ai/platform-workflows` repo** so every service repo composes the same audited actions instead of copy-pasting CI. platform-design, by contrast, still embeds **22 self-contained in-repo workflows** with **no image signing, no SBOM, and no reusable-pipeline pattern**.

This PR reflects that consolidation model inside platform-design (a faithful, representative mock — not a 1:1 copy of every upstream action).

Provenance: mirrors `qbiq-ai/platform-workflows@3bb35df` (2026-06 sync).

## What's added

**Tier-1 composite actions** (`.github/actions/`):
- `cosign-sign` — keyless Sigstore signing **by digest** via GitHub OIDC, plus optional signed SBOM attestation; `advisory` mode for Sigstore incidents.
- `syft-sbom` — Syft SBOM generation + artifact upload.
- `trivy-scan` — table scan as the gate (fails on CRITICAL/HIGH) + best-effort SARIF upload (pinned to `v0.35.0` to match the repo's existing usage).
- `manifest-validate` — `helm lint --strict` + `helm template | kubeconform -strict` + `conftest`/OPA.
- `argocd-tag-bump` — opens an image `tag`+`digest` bump PR in `100rd/argocd` (auto-merge label for non-prod).
- `argocd-wait-sync-and-smoke` — post-deploy gate: wait Synced+Healthy, then HTTP smoke-probe.

**Reusable `workflow_call` pipelines** (`.github/workflows/`):
- `reusable-build-and-push.yml` — build → trivy → syft SBOM → push → **cosign-sign + SBOM attest**. This **closes the upstream gap**: the source `reusable-build-and-push` builds/scans/pushes but never signs; here the pushed digest is signed before the job completes.
- `reusable-deploy-via-argocd.yml` — calls `argocd-tag-bump` (non-prod auto-merge, prod human-gated).
- `reusable-manifest-validate.yml` — wraps `manifest-validate`.
- `reusable-pipeline-demo.yml` — manual thin caller wiring build → deploy end to end.

**Existing workflow wired for signing:**
- `container-build.yml` now generates an SBOM and runs `cosign-sign` (sign-by-digest + SBOM attest) on the ECR push, closing the unsigned-image gap. Its detect-changes matrix, Trivy table+SARIF scan, and ECR push are preserved unchanged.

**Docs:** `docs/ci-cd/README.md` (new dir) documents the consolidation model, the reusable-pipeline pattern, Tier-1 hardening, the PR-based GitOps deploy flow, and the expected org-level secrets/vars (`ECR_PUSH_ROLE_ARN`, `ARGOCD_BOT_TOKEN`, `GITOPS_APP_ID`/`GITOPS_APP_KEY`, `ARGOCD_AUTH_TOKEN`, `ARGOCD_SERVER`).

## Scope & safety

- Touches **only** `.github/` and `docs/ci-cd/`. No `docs/adrs` (owned by another PR).
- All 22 existing workflows preserved; only `container-build.yml` modified (additively).

## Validation

- `actionlint` 1.7.12 — clean (exit 0) across the whole repo.
- `python3 yaml.safe_load` — passes on every new/edited file.
- repo `yamllint` (`.yamllint.yml`) — 0 errors.