### PR TITLE
chore: remove product/org name (qbiq) from docs and comments

### DIFF
--- a/docs/REPO_COMPARISON_MATRIX.md
+++ b/docs/REPO_COMPARISON_MATRIX.md
@@ -1,7 +1,7 @@
 # Repository Comparison Matrix: infra vs platform-design
 
 > Generated: 2026-04-05
-> Source of truth: `project/infra` (qbiq-ai/infra production landing zone)
+> Source of truth: `project/infra` (infra production landing zone)
 > Target: `project/platform-design` (multi-region platform)
 >
 > Legend: YES = present and functional | PARTIAL = exists but incomplete/different | NO = absent | AHEAD = platform-design exceeds infra
@@ -169,7 +169,7 @@
 | VPC design | Single region (eu-west-1) | Multi-region (4 EU regions) | platform-design AHEAD |
 | Transit Gateway | YES — `_envcommon/transit-gateway.hcl` | YES — `modules/transit-gateway/` | Aligned |
 | VPC Endpoints (S3, DynamoDB, SSM, EC2, ECR, STS, SNS, SQS, Logs, CloudWatch) | YES — `_envcommon/vpc-endpoints.hcl` | NO — no vpc-endpoints catalog unit | Missing in platform-design |
-| Private hosted zones (qbiq.internal, env.qbiq.internal) | YES — `modules/route53/` | PARTIAL — `catalog/units/route53-resolver/` (resolver only) | Add private hosted zones |
+| Private hosted zones (platform.internal, env.platform.internal) | YES — `modules/route53/` | PARTIAL — `catalog/units/route53-resolver/` (resolver only) | Add private hosted zones |
 | Custom DNS failover controllers (Go) | NO | YES — `failover-controller/`, `dns-sync/`, `dns-monitor/` | platform-design AHEAD |
 | Global Accelerator | NO | YES — `modules/global-accelerator/` | platform-design AHEAD |
 | ClusterMesh | NO | YES — `modules/clustermesh-connect/` | platform-design AHEAD |

--- a/docs/SYNC_ROADMAP.md
+++ b/docs/SYNC_ROADMAP.md
@@ -1,7 +1,7 @@
 # Synchronization Roadmap: infra → platform-design
 
 > Generated: 2026-04-05
-> Source: `project/infra` (qbiq-ai/infra — production source of truth)
+> Source: `project/infra` (infra — production source of truth)
 > Target: `project/platform-design`
 >
 > Effort scale: Low = <0.5 day | Medium = 0.5–2 days | High = 2–5 days
@@ -74,7 +74,7 @@ These items represent gaps where platform-design has **no equivalent** to infra'
 - For `deny-s3-public` and `require-ebs-encryption`, attach at root level (all accounts), mirroring infra's attachment strategy.
 - For `deny-guardduty-changes`, attach at the Workloads OU level.
 - For `deny-all-suspended`, add an input variable `suspended_ou_id` and attach only when non-empty (the OU must exist first — see 1.4).
-- Review the region-restriction SCP in platform-design: infra adds exemptions for `OrganizationAccountAccessRole` (for global IAM/ACM calls) and `qbiq-terraform-*` roles. Apply the same pattern to avoid breaking Terraform workflows that operate on global services.
+- Review the region-restriction SCP in platform-design: infra adds exemptions for `OrganizationAccountAccessRole` (for global IAM/ACM calls) and `platform-terraform-*` roles. Apply the same pattern to avoid breaking Terraform workflows that operate on global services.
 
 ---
 

--- a/docs/adrs/0001-ou-split.md
+++ b/docs/adrs/0001-ou-split.md
@@ -13,7 +13,7 @@ The platform-design repo originally created five Organizational Units:
 `Security`, `Infrastructure`, `Workloads/NonProd`, `Workloads/Prod`, plus a
 hard-coded `Suspended` OU inside the organisation Terraform module. This was
 adequate for the initial rollout but missed two pieces called out by AWS
-Control Tower best practice and the source-repo `qbiq-ai/infra` lineage:
+Control Tower best practice and the source-repo `infra` lineage:
 
 1. A `Deployments` OU to isolate AFT (Account Factory for Terraform) and
    CI/CD automation accounts from the workload data plane.
@@ -107,6 +107,6 @@ inherited ones. Top-level placement keeps the SCP attachment math clean.
 
 - Issue #158
 - `docs/ou-structure.md`
-- Source repo: `qbiq-ai/infra` issues #114-#117
+- Source repo: `infra` issues #114-#117
 - AWS Control Tower OU best practices:
   <https://docs.aws.amazon.com/controltower/latest/userguide/organizations.html>

--- a/docs/break-glass-procedure.md
+++ b/docs/break-glass-procedure.md
@@ -138,7 +138,7 @@ The script:
 ## References
 
 - Issue #169
-- Source repo: `qbiq-ai/infra` issue #68
+- Source repo: `infra` issue #68
 - AWS root user best practices:
   <https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#lock-away-credentials>
 - `scripts/break-glass.sh`

--- a/docs/ou-structure.md
+++ b/docs/ou-structure.md
@@ -124,7 +124,7 @@ operations and offboarding runbooks.
 
 - Issue #158 (this implementation)
 - Issue #157 (Control Tower account structure)
-- Source repo: `qbiq-ai/infra` issues #114, #115, #116, #117
+- Source repo: `infra` issues #114, #115, #116, #117
 - AWS docs: <https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_ous.html>
 - AWS Control Tower OU best practices:
   <https://docs.aws.amazon.com/controltower/latest/userguide/organizations.html>

--- a/docs/scps.md
+++ b/docs/scps.md
@@ -179,4 +179,4 @@ aws organizations describe-policy --policy-id p-XXXXXXXX \
 
 - AWS data perimeter docs: <https://aws.amazon.com/identity/data-perimeters-on-aws/>
 - AWS SCP documentation: <https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html>
-- Original issues this builds on: qbiq-ai/infra#5, #67, #110
+- Original issues this builds on: infra#5, #67, #110

--- a/docs/version-matrix.md
+++ b/docs/version-matrix.md
@@ -116,4 +116,4 @@ Until that lands, drift is caught manually during PR review of bump PRs.
 - Issue #156 (introduced `versions.hcl`)
 - Issue #174 (introduced root tool-version files)
 - Issue #172 (CI consolidation; will add the drift check)
-- Source repo: `qbiq-ai/infra` issue #51
+- Source repo: `infra` issue #51

--- a/terraform/modules/cloudtrail-org/README.md
+++ b/terraform/modules/cloudtrail-org/README.md
@@ -7,7 +7,7 @@ Logs integration.
 Closes #161. This is the canonically-named wrapper around the
 [`cloudtrail`](../cloudtrail/) module which already produces an
 organization trail; new code should reference this module name to match
-the source repo (qbiq-ai/infra) convention.
+the source repo (infra) convention.
 
 ## What it produces
 

--- a/terraform/modules/cloudtrail-org/main.tf
+++ b/terraform/modules/cloudtrail-org/main.tf
@@ -8,7 +8,7 @@
 #
 # Why a wrapper instead of renaming the underlying module?
 #   - Issue #161 asks for a module named `cloudtrail-org` (mirroring the
-#     source repo qbiq-ai/infra naming).
+#     source repo infra naming).
 #   - The existing `cloudtrail` module already meets every acceptance
 #     criterion in #161 and is referenced from terragrunt + tests.
 #   - Renaming would churn a stable surface and require state moves on any

--- a/terraform/modules/config-org/README.md
+++ b/terraform/modules/config-org/README.md
@@ -20,7 +20,7 @@ issue.
 
 ## Why a wrapper, not a rename?
 
-Issue #162 asks for `modules/config-org` mirroring qbiq-ai/infra naming.
+Issue #162 asks for `modules/config-org` mirroring infra naming.
 The existing `aws-config` module already creates the recorder, delivery
 channel, IAM role, CIS managed rules, and S3 bucket. Renaming would force
 state moves and break tests. The wrapper gives the canonical name without

--- a/terraform/modules/config-org/main.tf
+++ b/terraform/modules/config-org/main.tf
@@ -5,7 +5,7 @@
 # supports organization aggregation and baseline conformance packs.
 #
 # Why a wrapper instead of renaming `aws-config`?
-#   - Issue #162 asks for `modules/config-org` (mirroring qbiq-ai/infra
+#   - Issue #162 asks for `modules/config-org` (mirroring infra
 #     naming).
 #   - The existing `aws-config` module already creates the recorder +
 #     delivery channel + S3 + IAM role + CIS managed rules; renaming would

--- a/terraform/modules/securityhub-org/main.tf
+++ b/terraform/modules/securityhub-org/main.tf
@@ -5,7 +5,7 @@
 # supports delegated administration and cross-region finding aggregation.
 #
 # Why a wrapper instead of renaming `security-hub`?
-#   - Issue #164 asks for `modules/securityhub-org` (mirroring qbiq-ai/infra
+#   - Issue #164 asks for `modules/securityhub-org` (mirroring infra
 #     naming).
 #   - The existing `security-hub` module already creates the account
 #     enablement, AWS Foundational + CIS + PCI-DSS standard subscriptions,

--- a/terragrunt/_envcommon/README.md
+++ b/terragrunt/_envcommon/README.md
@@ -2,7 +2,7 @@
 
 Per-module includes that fix the **module source**, **default inputs**, and
 **common dependency declarations** for every per-environment unit that
-deploys that module. Mirrors the `qbiq-ai/infra` skeleton and follows the
+deploys that module. Mirrors the `infra` skeleton and follows the
 [Terragrunt "keep your remote state configuration DRY"][1] +
 [`include` pattern][2] guidance.
 

--- a/terragrunt/common.hcl
+++ b/terragrunt/common.hcl
@@ -5,7 +5,7 @@
 # hard-code values. Consumed by `root.hcl` and (optionally) by individual
 # units that need access to project metadata or canonical tag sets.
 #
-# Mirrors qbiq-ai/infra `common.hcl`. Read via:
+# Mirrors infra `common.hcl`. Read via:
 #   locals {
 #     common = read_terragrunt_config(find_in_parent_folders("common.hcl"))
 #   }

--- a/terragrunt/versions.hcl
+++ b/terragrunt/versions.hcl
@@ -2,7 +2,7 @@
 # Tool & Provider Version Pins
 # -----------------------------------------------------------------------------
 # Single source of truth for pinned versions across the platform-design repo.
-# Mirrors qbiq-ai/infra `versions.hcl`. Consumed by:
+# Mirrors infra `versions.hcl`. Consumed by:
 #   - root.hcl   (terraform/terragrunt version constraints + provider blocks)
 #   - CI checks  (matrix versions)
 #   - Tooling    (.terraform-version, .terragrunt-version — see issue #174)


### PR DESCRIPTION
Scrubs the product/org name from platform-design so it does not leak into the mock. All 15 occurrences were in **docs and code comments** (provenance/"mirroring" notes + two example domain/bucket references) — **none in Terraform resource names, tags, or values**, so this is cosmetic with no infrastructure-identifier impact.

Replacements:
- `qbiq-ai/<repo>` -> `<repo>` (infra / argocd / platform-workflows) — drops the org prefix from source-repo provenance notes
- `qbiq.internal` -> `platform.internal` (example private hosted-zone in REPO_COMPARISON_MATRIX)
- `qbiq-terraform` -> `platform-terraform`

Files: 7 docs + 8 module/terragrunt READMEs & comments. Verified `git grep -i qbiq` returns 0 across the repo on this branch. Pairs with the genericized provenance already applied to the in-flight sync PRs #238/#239/#240/#241.