### PR TITLE
docs(adr): ADR-driven readiness — sync-status fields, promote CI ADRs, ROADMAP cross-links

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,13 @@ historical context — covers transaction-analytics work, see `docs/transaction-
 analytics/`) and the granular `TODO.md` (kept as a per-task checklist working
 file). Issue #183.
 
+> **ADRs govern decisions; ROADMAP tracks work.** Each phase and GATE below cites
+> the ADR number(s) that govern its decisions — see the catalog and the
+> per-ADR **platform-design status** (`synced` / `partial` / `pending`) in
+> [`docs/adrs/README.md`](docs/adrs/README.md). When an ADR is `partial` or
+> `pending`, the gap is the work this ROADMAP tracks; when a phase introduces a
+> new controversial trade-off, file an ADR first and link it here.
+
 ## Phase status legend
 
 - DONE — landed on `main`, has tests and runbook
@@ -27,6 +34,13 @@ Initial multi-account AWS, EKS, observability, GitOps stack. See `docs/02-terrag
 ## Phase 1 — Landing zone (DONE / IN PROGRESS)
 
 GATE umbrella: **#207 [GATE] Landing Zone Done**.
+
+Governing ADRs: [ADR-0001](docs/adrs/0001-ou-split.md) (OU split),
+[ADR-0005](docs/adrs/0005-hub-spoke-transit-gateway.md) (hub-spoke TGW),
+[ADR-0011](docs/adrs/0011-break-glass-iam-destroy-protection.md) (break-glass —
+`partial`: SSO/procedure model, no break-glass-user `prevent_destroy` yet),
+[ADR-0013](docs/adrs/0013-inter-vpc-access-security-model.md) (inter-VPC model —
+`pending`, tracked by #243).
 
 | # | Title | Status |
 |---|-------|--------|
@@ -52,6 +66,11 @@ GATE umbrella: **#207 [GATE] Landing Zone Done**.
 
 ## Phase 2 — Networking (PLANNED)
 
+Governing ADRs: [ADR-0005](docs/adrs/0005-hub-spoke-transit-gateway.md) (hub-spoke
+TGW — `synced`),
+[ADR-0013](docs/adrs/0013-inter-vpc-access-security-model.md) (inter-VPC security
+model incl. the inspection VPC — `pending`, tracked by #243).
+
 | # | Title | Status | Depends on |
 |---|-------|--------|-----------|
 | #170 | Transit Gateway hub-and-spoke (modules: `transit-gateway`, `tgw-attachment`) | DONE | #157 |
@@ -62,6 +81,13 @@ GATE umbrella: **#207 [GATE] Landing Zone Done**.
 ## Phase 3 — CI/CD hardening (IN PROGRESS)
 
 GATE umbrella: **#208 [GATE] CI/CD Hardened**.
+
+Governing ADRs: [ADR-0015](docs/adrs/0015-reusable-ci-pipelines.md) (reusable
+CI/CD pipelines) and
+[ADR-0016](docs/adrs/0016-tier1-supply-chain-hardening.md) (Tier-1 hardening) —
+both **Accepted — rolling out**, implemented in-repo by #241 (`synced`); the
+org-wide `@v1` fan-out and the dep-scan/SAST composite actions are the remaining
+design-target.
 
 | # | Title | Status | Depends on |
 |---|-------|--------|-----------|
@@ -79,6 +105,11 @@ GATE umbrella: **#208 [GATE] CI/CD Hardened**.
 
 ## Phase 4 — Cost & operations (IN PROGRESS)
 
+Governing ADRs: [ADR-0001](docs/adrs/0001-ou-split.md) (per-account / per-OU cost
+allocation underpins per-account budgets),
+[ADR-0004](docs/adrs/0004-terragrunt-over-plain-terraform.md) (the
+`generate "provider"` `default_tags` that drive cost-allocation tags).
+
 | # | Title | Status |
 |---|-------|--------|
 | #175 | AWS Budgets module + per-account cost alerts | DONE |
@@ -87,6 +118,11 @@ GATE umbrella: **#208 [GATE] CI/CD Hardened**.
 ---
 
 ## Phase 5 — Observability extensions (PLANNED)
+
+Governing ADRs: [ADR-0001](docs/adrs/0001-ou-split.md) (the Security / Log-Archive
+account the org-wide log pattern lands in),
+[ADR-0006](docs/adrs/0006-argocd-for-gitops.md) (observability stack is delivered
+as ArgoCD ApplicationSets).
 
 | # | Title | Status | Depends on |
 |---|-------|--------|-----------|
@@ -97,6 +133,16 @@ GATE umbrella: **#208 [GATE] CI/CD Hardened**.
 
 ## Phase 6 — EKS data plane (PLANNED)
 
+Governing ADRs: [ADR-0003](docs/adrs/0003-cilium-over-aws-vpc-cni.md) (Cilium CNI
+— `synced`; #186 mTLS extends it),
+[ADR-0007](docs/adrs/0007-karpenter-over-cluster-autoscaler.md) (Karpenter —
+`synced`),
+[ADR-0009](docs/adrs/0009-cilium-gateway-api-ingress.md) (Cilium Gateway API
+ingress — `partial`: only HTTPRoute scaffolding, cluster ingress still
+nlb-ingress),
+[ADR-0014](docs/adrs/0014-argo-rollouts-canary-progressive-delivery.md) (Argo
+Rollouts canary — `synced`, #238).
+
 | # | Title | Status |
 |---|-------|--------|
 | #185 | Velero for Kubernetes backup/migration | PLANNED |
@@ -105,6 +151,11 @@ GATE umbrella: **#208 [GATE] CI/CD Hardened**.
 ---
 
 ## Phase 7 — Documentation & process (DONE / IN PROGRESS)
+
+Governing ADRs: [ADR-0011](docs/adrs/0011-break-glass-iam-destroy-protection.md)
+(break-glass — #169 ships the procedure runbook; the IAM-user `prevent_destroy`
+guard is the `partial` remainder). #176 stands up the ADR catalog itself
+([`docs/adrs/README.md`](docs/adrs/README.md)).
 
 | # | Title | Status |
 |---|-------|--------|
@@ -118,10 +169,10 @@ GATE umbrella: **#208 [GATE] CI/CD Hardened**.
 
 ## GATE umbrella issues
 
-| GATE | Issue | Children | Status |
-|---|---|---|---|
-| Landing Zone Done | [#207](https://github.com/100rd/platform-design/issues/207) | #156-167, #168-169, #173 | 12/15 done |
-| CI/CD Hardened | [#208](https://github.com/100rd/platform-design/issues/208) | #172, #173, #177, #180, #187 | 2/5 done |
+| GATE | Issue | Children | Governing ADRs | Status |
+|---|---|---|---|---|
+| Landing Zone Done | [#207](https://github.com/100rd/platform-design/issues/207) | #156-167, #168-169, #173 | ADR-0001, 0005, 0011, 0013 | 12/15 done |
+| CI/CD Hardened | [#208](https://github.com/100rd/platform-design/issues/208) | #172, #173, #177, #180, #187 | ADR-0015, 0016 | 2/5 done |
 
 Add new GATE umbrellas in pull-requests when initiating any multi-issue effort that spans more than 3 children.
 
@@ -129,9 +180,18 @@ Add new GATE umbrellas in pull-requests when initiating any multi-issue effort t
 
 ## Cross-cutting decisions
 
-ADRs live in `docs/adrs/`. The two filed at the time of writing:
+ADRs live in `docs/adrs/` — see the [index](docs/adrs/README.md) for the full
+catalog (0001–0016) with each ADR's **platform-design status**. The two native
+foundation ADRs:
 - [ADR-0001 OU split](docs/adrs/0001-ou-split.md) — explains why `Prod` / `NonProd` aliases were preserved instead of renaming to canonical `Production` / `Non-Production`.
 - [ADR-0002 TF-only state backend bootstrap](docs/adrs/0002-tf-only-state-backend.md) — bootstrap chicken-and-egg resolution.
+
+ADRs 0003–0016 were ported from the source-of-truth estate during the 2026-06
+sync; 0015/0016 (CI/CD) are implemented in-repo by #241. The per-ADR
+**platform-design status** column flags where the mock still lags a decision
+(`partial`/`pending`) — those rows are the work the phases above track
+(notably 0009 ingress, 0010 prod allow-list, 0011 break-glass guard, 0013
+inter-VPC tracked by #243).
 
 When a phase introduces a controversial trade-off, file an ADR. The 7-section template at `docs/adrs/0000-template.md` keeps the format consistent.
 

--- a/docs/adrs/0003-cilium-over-aws-vpc-cni.md
+++ b/docs/adrs/0003-cilium-over-aws-vpc-cni.md
@@ -1,6 +1,9 @@
 # ADR-0003: Cilium over aws-vpc-cni as the EKS CNI
 
 - Status: **Accepted** — decision is *adopted (live in source estate)*
+- platform-design status: **synced** — Cilium modules present
+  (`terraform/modules/cilium`, EKS add-on disabled in favour of Cilium;
+  GPU-inference Cilium variants under `gpu-inference-cilium*`).
 - Date: 2026-06-03
 - Authors: platform-team
 - Related issues: (ported)

--- a/docs/adrs/0004-terragrunt-over-plain-terraform.md
+++ b/docs/adrs/0004-terragrunt-over-plain-terraform.md
@@ -1,6 +1,9 @@
 # ADR-0004: Terragrunt over plain Terraform for multi-account orchestration
 
 - Status: **Accepted** — decision is *adopted (live in source estate)*
+- platform-design status: **synced** — Terragrunt is the orchestration layer
+  (`terragrunt/root.hcl`, `terragrunt/_envcommon/`, `catalog/units/` +
+  `catalog/stacks/`); modules under `terraform/modules/`.
 - Date: 2026-06-03
 - Authors: platform-team
 - Related issues: (ported)

--- a/docs/adrs/0005-hub-spoke-transit-gateway.md
+++ b/docs/adrs/0005-hub-spoke-transit-gateway.md
@@ -1,6 +1,9 @@
 # ADR-0005: Hub-and-spoke connectivity via AWS Transit Gateway
 
 - Status: **Accepted** — decision is *adopted (live in source estate)*
+- platform-design status: **synced** — TGW hub-and-spoke modules present
+  (`terraform/modules/transit-gateway`, `tgw-attachment`, `tgw-peering`);
+  network-account connectivity stack wires them.
 - Date: 2026-06-03
 - Authors: platform-team
 - Related issues: (ported)

--- a/docs/adrs/0006-argocd-for-gitops.md
+++ b/docs/adrs/0006-argocd-for-gitops.md
@@ -1,6 +1,9 @@
 # ADR-0006: ArgoCD for GitOps delivery of Kubernetes workloads
 
 - Status: **Accepted** — decision is *adopted (live in source estate)*
+- platform-design status: **synced** — ArgoCD app-of-apps present
+  (`argocd/bootstrap/`, ApplicationSets for infra / observability / workloads /
+  cluster-roles, `appproject-workloads.yaml`, Kargo bootstrap).
 - Date: 2026-06-03
 - Authors: platform-team
 - Related issues: (ported)

--- a/docs/adrs/0007-karpenter-over-cluster-autoscaler.md
+++ b/docs/adrs/0007-karpenter-over-cluster-autoscaler.md
@@ -1,6 +1,9 @@
 # ADR-0007: Karpenter over Cluster Autoscaler for EKS node provisioning
 
 - Status: **Accepted** — decision is *adopted (live in source estate)*
+- platform-design status: **synced** — Karpenter modules present
+  (`terraform/modules/karpenter` controller + `karpenter-nodepools` for
+  `NodePool`/`EC2NodeClass` CRDs).
 - Date: 2026-06-03
 - Authors: platform-team
 - Related issues: (ported)

--- a/docs/adrs/0008-external-secrets-operator.md
+++ b/docs/adrs/0008-external-secrets-operator.md
@@ -1,6 +1,10 @@
 # ADR-0008: External Secrets Operator over native K8s secrets
 
 - Status: **Accepted** — decision is *adopted (live in source estate)*
+- platform-design status: **synced** — ESO present
+  (`apps/infra/cluster-secret-store/` with `ClusterSecretStore` +
+  parameter-store templates; `apps/infra/external-secrets`). The ESO IRSA
+  binding (`eso-irsa`) is in-flight WIP.
 - Date: 2026-06-03
 - Authors: platform-team
 - Related issues: (ported)

--- a/docs/adrs/0009-cilium-gateway-api-ingress.md
+++ b/docs/adrs/0009-cilium-gateway-api-ingress.md
@@ -1,6 +1,12 @@
 # ADR-0009: Cilium Gateway API as the cluster ingress controller
 
 - Status: **Accepted** — decision is *adopted (live in source estate)*
+- platform-design status: **partial** — only the per-workload `HTTPRoute`
+  scaffolding exists (`helm/app/templates/httproute.yaml`, `httpRoute.enabled`,
+  default-off, on the canary path). Cilium is **not** enabled as the cluster
+  ingress controller here (no `gatewayAPI.enabled=true`, no cluster-level
+  `Gateway`/`GatewayClass`); in-tree ingress is still `nlb-ingress` +
+  `aws-lb-controller` + `external-dns`.
 - Date: 2026-06-03
 - Authors: platform-team
 - Related issues: (ported)

--- a/docs/adrs/0010-eks-public-endpoint-cidr-allowlist.md
+++ b/docs/adrs/0010-eks-public-endpoint-cidr-allowlist.md
@@ -1,6 +1,11 @@
 # ADR-0010: EKS public API endpoint with a parameterised CIDR allow-list
 
 - Status: **Accepted** — decision is *adopted (live in source estate)*
+- platform-design status: **partial** — the CIDR allow-list is parameterised
+  (`catalog/units/eks/terragrunt.hcl` sets
+  `cluster_endpoint_public_access_cidrs`, defaulting to `["0.0.0.0/0"]`), so the
+  variable is first-class and never relies on the implicit default. The narrow
+  prod-tier allow-list / private-only endpoint remains a design-target.
 - Date: 2026-06-03
 - Authors: platform-team
 - Related issues: (ported)

--- a/docs/adrs/0011-break-glass-iam-destroy-protection.md
+++ b/docs/adrs/0011-break-glass-iam-destroy-protection.md
@@ -1,6 +1,12 @@
 # ADR-0011: Break-glass IAM user destroy protection
 
 - Status: **Accepted** — decision is *adopted (live in source estate)*
+- platform-design status: **partial** — break-glass access exists here via an
+  SSO permission set (`terragrunt/_org/_global/sso`), the `iam-baseline`
+  MFA-enforcement policy, and `docs/break-glass-procedure.md`, but the specific
+  guard this ADR mandates — `lifecycle { prevent_destroy = true }` on
+  `aws_iam_user.this` in a `modules/break-glass-user` — is not present (no such
+  module / IAM-user resource in this repo yet).
 - Date: 2026-06-03
 - Authors: platform-team
 - Related issues: (ported)

--- a/docs/adrs/0012-cluster-role-label-scheme-for-appsets.md
+++ b/docs/adrs/0012-cluster-role-label-scheme-for-appsets.md
@@ -1,6 +1,13 @@
 # ADR-0012: `cluster_role` label scheme for ArgoCD ApplicationSet selectors
 
 - Status: **Accepted** — decision is *adopted (live in source estate)*
+- platform-design status: **synced** — ApplicationSets select on a
+  `cluster-role` label (`argocd/bootstrap/applicationsets/role-apps-appset.yaml`
+  matchExpression + `apps/cluster-roles/{{cluster-role}}/*`; infra /
+  observability appsets and overlay kustomizations set the label). Concrete
+  role values here are `dex` / `backend` / `3rd-party` / `velocity` /
+  `listeners` rather than the ADR's illustrative `platform`/`app`/`data`, but
+  the label-driven selector scheme is the live decision.
 - Date: 2026-06-03
 - Authors: platform-team
 - Related issues: (ported)

--- a/docs/adrs/0013-inter-vpc-access-security-model.md
+++ b/docs/adrs/0013-inter-vpc-access-security-model.md
@@ -4,6 +4,11 @@
   legacy-side return routes and the prod NACL backstop are tracked as
   cross-account follow-ups (see *Consequences*), so those sub-parts are
   *design-target*. Builds on ADR-0005 (hub-spoke TGW).
+- platform-design status: **pending** — the inter-VPC / Pritunl cross-estate
+  join model is not yet ported into this repo (no VPN-join / trust-sub-pool
+  wiring present); the underlying TGW primitives from ADR-0005 exist, but the
+  segmentation model itself is outstanding.
+- Tracked by: #243
 - Date: 2026-06-03
 - Authors: platform-team, security
 - Related issues: (ported)

--- a/docs/adrs/0014-argo-rollouts-canary-progressive-delivery.md
+++ b/docs/adrs/0014-argo-rollouts-canary-progressive-delivery.md
@@ -1,6 +1,9 @@
 # ADR-0014: Argo Rollouts canary with Gateway API traffic-routing and analysis
 
 - Status: **Accepted** — decision is *adopted (live in source estate)*
+- platform-design status: **synced** (#238) — the shared `helm/app` chart ships
+  `rollout.yaml` (canary + `gatewayAPI` traffic plugin), `analysistemplate.yaml`
+  (`error-rate` / `latency-p95`), and `service-canary.yaml`.
 - Date: 2026-06-03
 - Authors: platform-team
 - Related issues: (ported)

--- a/docs/adrs/0015-reusable-ci-pipelines.md
+++ b/docs/adrs/0015-reusable-ci-pipelines.md
@@ -1,8 +1,16 @@
 # ADR-0015: Reusable CI/CD pipelines for the platform organisation
 
-- Status: **Proposed** — decision is a *design-target* (the reusable-pipeline
-  platform is being rolled out; source estate has the seed `build-and-push`
-  workflow live)
+- Status: **Accepted** — rolling out. The two-layer reuse model is *implemented
+  in this repo* by PR #241; org-wide adoption across every caller repo is the
+  remaining *design-target*.
+- platform-design status: **synced** — composite actions (`cosign-sign`,
+  `manifest-validate`, `argocd-tag-bump`, `argocd-wait-sync-and-smoke`,
+  `syft-sbom`, `trivy-scan`) + reusable workflows (`reusable-build-and-push`,
+  `reusable-deploy-via-argocd`, `reusable-manifest-validate`) + the
+  `github-oidc` module + a demo caller (`reusable-pipeline-demo.yml`) are all
+  present. Org-wide `@v1` fan-out to every caller repo is still rolling out.
+- Implemented by: PR #241 (CI/CD consolidation — Tier-1 composite actions,
+  reusable `workflow_call` pipelines, central OIDC→ECR role, cosign signing).
 - Date: 2026-06-03
 - Authors: platform-team, security
 - Related issues: (ported)
@@ -116,5 +124,7 @@ are needed.
 
 ---
 *Ported from infra@572b54d (and argocd@c364c6c) during the 2026-06
-platform-design sync. Decision status in the source estate: Proposed / rolling
-out (design-target); the seed OIDC+ECR+Trivy build workflow is live.*
+platform-design sync. Implemented in platform-design by PR #241 (composite
+actions + reusable workflows + central OIDC→ECR + cosign). Status: Accepted —
+rolling out; org-wide `@v1` adoption across every caller repo remains a
+design-target.*

--- a/docs/adrs/0016-tier1-supply-chain-hardening.md
+++ b/docs/adrs/0016-tier1-supply-chain-hardening.md
@@ -1,7 +1,19 @@
 # ADR-0016: Tier 1 CI/CD hardening — dep scan, secrets, SAST, signing, manifest validation, smoke
 
-- Status: **Proposed** — decision is a *design-target* (extends ADR-0015; rolling
-  out)
+- Status: **Accepted** — rolling out. Extends ADR-0015; the signing /
+  manifest-validation / smoke controls are *implemented in this repo* by PR #241.
+  The dep-scan and SAST composite actions are not yet wired org-wide — that
+  remainder stays a *design-target*.
+- platform-design status: **synced** — image signing (`cosign-sign`, keyless,
+  wired into `reusable-build-and-push` after push by digest + SBOM attestation),
+  manifest validation (`manifest-validate` action + `reusable-manifest-validate`
+  workflow + `conftest-opa.yml`), and post-deploy smoke
+  (`argocd-wait-sync-and-smoke`) are present. Secrets scanning runs via the
+  standalone `secret-scan.yml`. Remaining design-target: the `python-dep-scan` /
+  `node-dep-scan` / `sast-codeql` composite actions are not yet packaged
+  org-wide.
+- Implemented by: PR #241 (Tier-1 composite actions + reusable workflows +
+  cosign signing; consolidated CI/CD).
 - Date: 2026-06-03
 - Authors: platform-team, security
 - Related issues: (ported)
@@ -120,5 +132,6 @@ CodeQL minutes become a problem.
 
 ---
 *Ported from infra@572b54d (and argocd@c364c6c) during the 2026-06
-platform-design sync. Decision status in the source estate: Proposed / rolling
-out (design-target).*
+platform-design sync. Signing / manifest-validation / smoke implemented in
+platform-design by PR #241. Status: Accepted — rolling out; the dep-scan and
+SAST composite actions remain a design-target.*

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -9,28 +9,42 @@ the 2026-06 platform-design sync** from the source-of-truth estate
 (`infra@572b54d` and `argocd@c364c6c`), with wording adapted to
 this transaction-analytics platform. Each ported ADR carries a provenance footer
 and is marked **adopted** (live in the source estate) or **design-target**
-(proposed / rolling out).
+(proposed / rolling out). The two CI/CD ADRs (0015, 0016) were promoted from
+Proposed to **Accepted — rolling out** once PR #241 implemented them in-repo
+(Tier-1 composite actions + reusable workflows + cosign signing).
+
+Every ported ADR also carries a **platform-design status** (`synced` / `partial`
+/ `pending`) recording whether the decision is actually wired into *this* repo —
+see the column in the index below. This makes the catalog a development driver:
+the ROADMAP can point at the `partial` / `pending` rows as the remaining work.
 
 ## Index
 
-| ADR | Title | Status | Provenance |
-|-----|-------|--------|------------|
-| [0001](0001-ou-split.md) | OU split — Prod / Non-Prod / Deployments / Suspended / Sandbox | Accepted | native |
-| [0002](0002-tf-only-state-backend.md) | Terraform-only state backend bootstrap | Accepted | native |
-| [0003](0003-cilium-over-aws-vpc-cni.md) | Cilium over aws-vpc-cni as the EKS CNI | Accepted | ported · adopted |
-| [0004](0004-terragrunt-over-plain-terraform.md) | Terragrunt over plain Terraform for multi-account orchestration | Accepted | ported · adopted |
-| [0005](0005-hub-spoke-transit-gateway.md) | Hub-and-spoke connectivity via AWS Transit Gateway | Accepted | ported · adopted |
-| [0006](0006-argocd-for-gitops.md) | ArgoCD for GitOps delivery of Kubernetes workloads | Accepted | ported · adopted |
-| [0007](0007-karpenter-over-cluster-autoscaler.md) | Karpenter over Cluster Autoscaler for EKS node provisioning | Accepted | ported · adopted |
-| [0008](0008-external-secrets-operator.md) | External Secrets Operator over native K8s secrets | Accepted | ported · adopted |
-| [0009](0009-cilium-gateway-api-ingress.md) | Cilium Gateway API as the cluster ingress controller | Accepted | ported · adopted |
-| [0010](0010-eks-public-endpoint-cidr-allowlist.md) | EKS public API endpoint with a parameterised CIDR allow-list | Accepted | ported · adopted (prod allow-list is a design-target) |
-| [0011](0011-break-glass-iam-destroy-protection.md) | Break-glass IAM user destroy protection | Accepted | ported · adopted |
-| [0012](0012-cluster-role-label-scheme-for-appsets.md) | `cluster_role` label scheme for ArgoCD ApplicationSet selectors | Accepted | ported · adopted |
-| [0013](0013-inter-vpc-access-security-model.md) | Inter-VPC access security model (TGW segmentation + cross-estate VPN join) | Accepted | ported · adopted (legacy-side routes + prod NACL backstop are design-targets) |
-| [0014](0014-argo-rollouts-canary-progressive-delivery.md) | Argo Rollouts canary with Gateway API traffic-routing and analysis | Accepted | ported · adopted |
-| [0015](0015-reusable-ci-pipelines.md) | Reusable CI/CD pipelines for the platform organisation | Proposed | ported · design-target |
-| [0016](0016-tier1-supply-chain-hardening.md) | Tier 1 CI/CD hardening — dep scan, secrets, SAST, signing, manifest validation, smoke | Proposed | ported · design-target |
+The **platform-design status** column records whether each decision is actually
+present in *this* repo (verified against modules / apps / charts), independent of
+its status in the source estate: `synced` (decision wired in-repo), `partial`
+(decision partly present or parameterised but not fully enforced), `pending` (not
+yet ported). It is the signal the ROADMAP uses to see where the mock lags a
+decision.
+
+| ADR | Title | Status | platform-design status | Provenance |
+|-----|-------|--------|------------------------|------------|
+| [0001](0001-ou-split.md) | OU split — Prod / Non-Prod / Deployments / Suspended / Sandbox | Accepted | n/a (native) | native |
+| [0002](0002-tf-only-state-backend.md) | Terraform-only state backend bootstrap | Accepted | n/a (native) | native |
+| [0003](0003-cilium-over-aws-vpc-cni.md) | Cilium over aws-vpc-cni as the EKS CNI | Accepted | synced | ported · adopted |
+| [0004](0004-terragrunt-over-plain-terraform.md) | Terragrunt over plain Terraform for multi-account orchestration | Accepted | synced | ported · adopted |
+| [0005](0005-hub-spoke-transit-gateway.md) | Hub-and-spoke connectivity via AWS Transit Gateway | Accepted | synced | ported · adopted |
+| [0006](0006-argocd-for-gitops.md) | ArgoCD for GitOps delivery of Kubernetes workloads | Accepted | synced | ported · adopted |
+| [0007](0007-karpenter-over-cluster-autoscaler.md) | Karpenter over Cluster Autoscaler for EKS node provisioning | Accepted | synced | ported · adopted |
+| [0008](0008-external-secrets-operator.md) | External Secrets Operator over native K8s secrets | Accepted | synced (eso-irsa WIP) | ported · adopted |
+| [0009](0009-cilium-gateway-api-ingress.md) | Cilium Gateway API as the cluster ingress controller | Accepted | partial (HTTPRoute scaffolding only; ingress still nlb-ingress) | ported · adopted |
+| [0010](0010-eks-public-endpoint-cidr-allowlist.md) | EKS public API endpoint with a parameterised CIDR allow-list | Accepted | partial (parameterised; prod allow-list pending) | ported · adopted (prod allow-list is a design-target) |
+| [0011](0011-break-glass-iam-destroy-protection.md) | Break-glass IAM user destroy protection | Accepted | partial (SSO/procedure model; no break-glass-user `prevent_destroy`) | ported · adopted |
+| [0012](0012-cluster-role-label-scheme-for-appsets.md) | `cluster_role` label scheme for ArgoCD ApplicationSet selectors | Accepted | synced | ported · adopted |
+| [0013](0013-inter-vpc-access-security-model.md) | Inter-VPC access security model (TGW segmentation + cross-estate VPN join) | Accepted | pending (tracked by #243) | ported · adopted (legacy-side routes + prod NACL backstop are design-targets) |
+| [0014](0014-argo-rollouts-canary-progressive-delivery.md) | Argo Rollouts canary with Gateway API traffic-routing and analysis | Accepted | synced (#238) | ported · adopted |
+| [0015](0015-reusable-ci-pipelines.md) | Reusable CI/CD pipelines for the platform organisation | Accepted — rolling out | synced (#241) | ported · implemented by #241 |
+| [0016](0016-tier1-supply-chain-hardening.md) | Tier 1 CI/CD hardening — dep scan, secrets, SAST, signing, manifest validation, smoke | Accepted — rolling out | synced (#241; dep-scan/SAST composites pending) | ported · implemented by #241 |
 
 ## Notes on the sync
 


### PR DESCRIPTION
Makes the ADR catalog usable as the development driver rather than a static record.

## What

1. **Per-ADR `platform-design status`** (`synced` / `partial` / `pending`) on every ported ADR (0003–0016), each verified against the actual tree (modules / apps / charts), so it's visible where this mock lags the decision. Surfaced as a new column in the `docs/adrs/README.md` index.
2. **Promotes ADR-0015 (reusable CI pipelines) and ADR-0016 (Tier-1 hardening)** from `Proposed` → **`Accepted — rolling out`**, with an `Implemented by: #241` line (Tier-1 composite actions + reusable `workflow_call` pipelines + central OIDC→ECR role + cosign signing). The design-target note is kept for the sub-parts not yet wired org-wide (the `@v1` fan-out, and the dep-scan/SAST composite actions).
3. **Cross-links `ROADMAP.md` ↔ ADRs**: each existing phase and GATE now cites its governing ADR number(s) (Landing Zone → 0001/0005/0011/0013; CI/CD → 0015/0016; EKS data plane → 0003/0007/0009/0014; etc.), plus a top note 'ADRs govern decisions; ROADMAP tracks work' linking the catalog. No phases invented — only existing ones annotated.

## Remaining open work flagged

- **0009** Cilium Gateway API ingress → `partial`: only per-workload `HTTPRoute` scaffolding exists in `helm/app` (default-off, canary path); cluster ingress is still nlb-ingress + aws-lb-controller + external-dns, no `gatewayAPI.enabled`.
- **0010** EKS public endpoint allow-list → `partial`: parameterised (`cluster_endpoint_public_access_cidrs`), prod narrow allow-list still a design-target.
- **0011** break-glass → `partial`: SSO permission-set + procedure model present, but the `prevent_destroy` guard on a `break-glass-user` IAM module the ADR mandates is not in this repo.
- **0012** cluster_role label scheme → `synced` (ApplicationSets do select on a `cluster-role` label).
- **0013** inter-VPC / Pritunl → `pending`, tracked by #243.

Docs-only — `git diff` touches only `docs/adrs/` and `ROADMAP.md`.