### PR TITLE
feat(eks): prod public endpoint CIDR allow-list (ADR-0010)

### DIFF
--- a/catalog/units/eks/terragrunt.hcl
+++ b/catalog/units/eks/terragrunt.hcl
@@ -86,11 +86,23 @@ inputs = {
   subnet_ids               = dependency.vpc.outputs.private_subnets
   control_plane_subnet_ids = dependency.vpc.outputs.private_subnets
 
-  # Endpoint access
-  # Dev environments allow public access for developer convenience; staging/prod are private only.
+  # ---------------------------------------------------------------------------
+  # Endpoint access (ADR-0010 — parameterised public-endpoint CIDR allow-list)
+  #
+  # Dev environments allow public access for developer convenience; staging/prod
+  # are private-endpoint-only. The public-endpoint allow-list is a first-class,
+  # per-account input (`eks_public_access_cidrs` in each account.hcl), never the
+  # implicit AWS-wide-open default.
+  #
+  # Documented default: `[]` (fail-closed — no public reachability) when an
+  # account.hcl omits the key. Public access must be opted into explicitly with
+  # an account-scoped allow-list; prod/data-plane accounts MUST NOT use
+  # 0.0.0.0/0 (see terragrunt/prod/account.hcl and terragrunt/_org/account.hcl
+  # `admin_cidr_allowlist`).
+  # ---------------------------------------------------------------------------
   cluster_endpoint_public_access       = local.account_vars.locals.eks_public_access
   cluster_endpoint_private_access      = true
-  cluster_endpoint_public_access_cidrs = try(local.account_vars.locals.eks_public_access_cidrs, ["0.0.0.0/0"])
+  cluster_endpoint_public_access_cidrs = try(local.account_vars.locals.eks_public_access_cidrs, [])
 
   # IRSA (IAM Roles for Service Accounts)
   enable_irsa = true

--- a/docs/adrs/0010-eks-public-endpoint-cidr-allowlist.md
+++ b/docs/adrs/0010-eks-public-endpoint-cidr-allowlist.md
@@ -1,11 +1,15 @@
 # ADR-0010: EKS public API endpoint with a parameterised CIDR allow-list
 
 - Status: **Accepted** — decision is *adopted (live in source estate)*
-- platform-design status: **partial** — the CIDR allow-list is parameterised
-  (`catalog/units/eks/terragrunt.hcl` sets
-  `cluster_endpoint_public_access_cidrs`, defaulting to `["0.0.0.0/0"]`), so the
-  variable is first-class and never relies on the implicit default. The narrow
-  prod-tier allow-list / private-only endpoint remains a design-target.
+- platform-design status: **synced** — the CIDR allow-list is parameterised
+  (`catalog/units/eks/terragrunt.hcl` wires `cluster_endpoint_public_access_cidrs`
+  from each account's `eks_public_access_cidrs`, with a fail-closed `[]` default —
+  no implicit `0.0.0.0/0`). The prod tier is now closed: `terragrunt/prod/account.hcl`
+  is private-endpoint-only (`eks_public_access = false`) and carries a restricted,
+  org-driven allow-list placeholder (`10.0.0.0/8` corp/VPN, mirroring
+  `terragrunt/_org/account.hcl` `admin_cidr_allowlist`) instead of `0.0.0.0/0`, so
+  enabling public access can never widen prod to the internet. Dev keeps
+  `0.0.0.0/0`; staging stays private-only.
 - Date: 2026-06-03
 - Authors: platform-team
 - Related issues: (ported)
@@ -85,10 +89,14 @@ cannot be tightened without a module change. Externalising it is the whole point
 
 ## Implementation notes
 
-- `cluster_endpoint_public_access_cidrs` plumbed through `_envcommon` → the EKS
-  `terragrunt.hcl` unit.
-- Shared/non-prod: `["0.0.0.0/0"]` (documented). Prod: narrow allow-list /
-  private — to be set when the prod cluster lands.
+- `cluster_endpoint_public_access_cidrs` plumbed from each account's
+  `eks_public_access_cidrs` local (`account.hcl`) into the catalog EKS unit
+  (`catalog/units/eks/terragrunt.hcl`); documented fail-closed `[]` default.
+- Dev: `["0.0.0.0/0"]` (documented, developer convenience). Staging: `[]`
+  (private-only). Prod: `eks_public_access = false` (private-only) plus a
+  restricted org-driven allow-list placeholder (`10.0.0.0/8` corp/VPN, mirroring
+  `_org/account.hcl` `admin_cidr_allowlist`) so any future public-access flip is
+  constrained — never `0.0.0.0/0`.
 
 ## References
 

--- a/terragrunt/_org/account.hcl
+++ b/terragrunt/_org/account.hcl
@@ -49,6 +49,19 @@ locals {
   # Network account reference
   network_account_id = "555555555555"
 
+  # ---------------------------------------------------------------------------
+  # Admin / operator CIDR allow-list (ADR-0010)
+  # Org-level reference for the trusted source ranges allowed to reach an EKS
+  # *public* API endpoint in restricted (prod-tier) environments. Each workload
+  # account composes its own narrow allow-list from these ranges in its own
+  # account.hcl instead of falling back to 0.0.0.0/0.
+  #
+  # TODO: replace the placeholder corp range below with the real office / VPN
+  # egress CIDRs (and any CI runner ranges) before enabling prod public access.
+  admin_cidr_allowlist = [
+    "10.0.0.0/8", # PLACEHOLDER: corporate / VPN egress range — DO NOT ship as-is
+  ]
+
   # SSO
   sso_instance_arn = "" # Populated after SSO setup
 }

--- a/terragrunt/prod/account.hcl
+++ b/terragrunt/prod/account.hcl
@@ -20,17 +20,31 @@ locals {
   transit_gateway_id    = ""    # Populate after network account deployment
   tgw_route_table_id    = ""    # prod route table ID from network account
 
-  single_nat_gateway      = false
-  eks_public_access       = false
-  eks_public_access_cidrs = []
-  eks_instance_types      = ["m6i.2xlarge"]
-  eks_min_size            = 3
-  eks_max_size            = 10
-  eks_desired_size        = 5
-  rds_instance_class      = "db.r6g.xlarge"
-  rds_allocated_storage   = 100
-  rds_multi_az            = true
-  monitoring_replicas     = 3
+  single_nat_gateway = false
+
+  # ---------------------------------------------------------------------------
+  # EKS public API endpoint (ADR-0010)
+  # Prod is private-endpoint-only by default (strongest posture). If public
+  # access is ever enabled for break-glass/operator reach, it MUST be locked to
+  # a narrow, org-driven allow-list and NEVER 0.0.0.0/0. The catalog EKS unit
+  # wires `eks_public_access_cidrs` into `cluster_endpoint_public_access_cidrs`,
+  # so this list is the only source of public reachability for prod.
+  #
+  # TODO: replace the placeholder corp range with the real office / VPN egress
+  # CIDRs (mirror of _org/account.hcl `admin_cidr_allowlist`) before flipping
+  # `eks_public_access` to true.
+  eks_public_access = false
+  eks_public_access_cidrs = [
+    "10.0.0.0/8", # PLACEHOLDER: corporate / VPN egress range — restricted, NOT 0.0.0.0/0
+  ]
+  eks_instance_types    = ["m6i.2xlarge"]
+  eks_min_size          = 3
+  eks_max_size          = 10
+  eks_desired_size      = 5
+  rds_instance_class    = "db.r6g.xlarge"
+  rds_allocated_storage = 100
+  rds_multi_az          = true
+  monitoring_replicas   = 3
 
   # --- Scaling stack ---
   karpenter_controller_replicas = 3


### PR DESCRIPTION
## Summary

Closes the ADR-0010 `partial` gap. The EKS public API endpoint CIDR allow-list was already parameterised, but the catalog unit silently fell back to `0.0.0.0/0` and the prod tier had no restricted, org-driven allow-list — it was a design-target.

This PR makes prod safe-by-construction:

- **`catalog/units/eks/terragrunt.hcl`** — `cluster_endpoint_public_access_cidrs` fallback changed from `["0.0.0.0/0"]` to a fail-closed `[]` (no implicit wide-open). Allow-list remains a first-class per-account input via `eks_public_access_cidrs`.
- **`terragrunt/prod/account.hcl`** — prod stays private-endpoint-only (`eks_public_access = false`) and now carries a restricted, org-driven allow-list placeholder (`10.0.0.0/8` corp/VPN + TODO) instead of `[]`/`0.0.0.0/0`. Any future flip of `eks_public_access` to `true` is constrained to the corp range, never the internet.
- **`terragrunt/_org/account.hcl`** — adds org-level `admin_cidr_allowlist` placeholder (corp/VPN egress) as the canonical source the prod allow-list mirrors.
- **`docs/adrs/0010-eks-public-endpoint-cidr-allowlist.md`** — flips `platform-design status: partial -> synced` and updates the reason + implementation notes.

## Scope
- dev keeps `0.0.0.0/0` (developer convenience) — unchanged.
- staging stays private-only (`[]`) — unchanged.
- prod: no open `0.0.0.0/0`.

## Placeholders / follow-up
- The `10.0.0.0/8` value is a clearly-marked PLACEHOLDER (no real public IP invented). Replace with real office/VPN egress CIDRs before enabling prod public access.

## Validation
- `terragrunt hcl fmt --check` clean on all touched HCL files.

Modeled on infra ADR-009 (per-env parameterised public-endpoint CIDR allow-list).