### PR TITLE
feat(security): break-glass-user module with prevent_destroy (ADR-0011)

### DIFF
--- a/catalog/units/break-glass-user/terragrunt.hcl
+++ b/catalog/units/break-glass-user/terragrunt.hcl
@@ -1,0 +1,45 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Break-glass User — Catalog Unit (ADR-0011)
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys the per-account emergency-access IAM user with destroy protection:
+#   - lifecycle { prevent_destroy = true } + force_destroy = false (ADR-0011)
+#   - inline MFA-enforcement policy + AdministratorAccess (MFA-present only)
+#   - CloudWatch alarm on any break-glass usage (wired to the org CloudTrail log group)
+#
+# Deploy in every long-lived account (management, network, dev, staging, prod, dr).
+# The user name is derived from account.hcl's account_name -> break-glass-<account_name>.
+#
+# The usage alarm is created only when both cloudtrail_log_group_name and
+# alarm_sns_topic_arn are supplied — wire them from the cloudtrail / monitoring
+# units in the consuming stack.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/break-glass-user"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  account_name = local.account_vars.locals.account_name
+}
+
+inputs = {
+  account_name = local.account_name
+  name_prefix  = ""
+
+  # Safe by default: the initial access key and console login are opt-in. Set to
+  # true on a single bootstrap apply, capture the secret, then revert to false.
+  # See variables.tf for the full bootstrap workflow.
+  create_access_key    = false
+  create_console_login = false
+
+  # Wire these from the cloudtrail + monitoring units to enable the usage alarm.
+  # Left empty here so the catalog default is self-contained; override per stack.
+  cloudtrail_log_group_name = ""
+  alarm_sns_topic_arn       = ""
+
+  tags = {
+    ManagedBy  = "terragrunt"
+    Compliance = "adr-0011"
+  }
+}

--- a/docs/adrs/0011-break-glass-iam-destroy-protection.md
+++ b/docs/adrs/0011-break-glass-iam-destroy-protection.md
@@ -1,12 +1,14 @@
 # ADR-0011: Break-glass IAM user destroy protection
 
 - Status: **Accepted** — decision is *adopted (live in source estate)*
-- platform-design status: **partial** — break-glass access exists here via an
-  SSO permission set (`terragrunt/_org/_global/sso`), the `iam-baseline`
-  MFA-enforcement policy, and `docs/break-glass-procedure.md`, but the specific
-  guard this ADR mandates — `lifecycle { prevent_destroy = true }` on
-  `aws_iam_user.this` in a `modules/break-glass-user` — is not present (no such
-  module / IAM-user resource in this repo yet).
+- platform-design status: **synced** — the dedicated
+  `terraform/modules/break-glass-user` module now exists with the guard this ADR
+  mandates: `lifecycle { prevent_destroy = true }` plus `force_destroy = false`
+  on `aws_iam_user.this`, an MFA-enforcement inline policy, and a CloudWatch
+  alarm on break-glass usage. It is wired in the management account via
+  `terragrunt/_org/_global/break-glass-user` (and reusable via
+  `catalog/units/break-glass-user`), alongside the pre-existing SSO permission
+  set, `iam-baseline` MFA policy, and `docs/break-glass-procedure.md`.
 - Date: 2026-06-03
 - Authors: platform-team
 - Related issues: (ported)

--- a/terraform/modules/break-glass-user/README.md
+++ b/terraform/modules/break-glass-user/README.md
@@ -1,0 +1,98 @@
+# break-glass-user
+
+Single emergency-access IAM user per account, used **only** when AWS SSO /
+Identity Center is unavailable (control-plane outage, mis-configured permission
+set, accidental SSO org detachment).
+
+Implements **ADR-0011 — Break-glass IAM user destroy protection**. The user
+carries two independent destruction guards:
+
+| Guard | Trigger | What it stops |
+|---|---|---|
+| `lifecycle { prevent_destroy = true }` | plan time | The user can never appear in any destroy plan — targeted destroy, full destroy, or a stray `moved` block — until the block is deliberately removed via PR. |
+| `force_destroy = false` | apply time | Terraform fails if it tries to delete the user while attached policies still exist. |
+
+## Resources
+
+| Resource | Purpose |
+|---|---|
+| `aws_iam_user.this` | The break-glass user, name `break-glass-<account_name>`, path `/break-glass/`, with `prevent_destroy` + `force_destroy = false` |
+| `aws_iam_user_policy.mfa_enforcement` | Inline deny — locks the user to MFA-only setup actions until MFA is enrolled and `aws:MultiFactorAuthPresent = true` |
+| `aws_iam_user_policy_attachment.administrator_access` | AWS-managed `AdministratorAccess` (only effective within an MFA-present session) |
+| `aws_iam_user_login_profile.this` | Optional console login (`create_console_login`), password reset required on first login |
+| `aws_iam_access_key.this` | Optional initial programmatic key (`create_access_key`, sensitive output) |
+| `aws_cloudwatch_log_metric_filter.usage` + `aws_cloudwatch_metric_alarm.usage` | Alarm on any CloudTrail event with `userIdentity.userName = break-glass-<account_name>` |
+
+## Inputs
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `account_name` | yes | — | Account short name; user becomes `break-glass-<account_name>` |
+| `name_prefix` | no | `""` | Prefix for the inline-policy and alarm names (not the user name) |
+| `create_access_key` | no | `false` | Whether to create the initial access key (opt-in, single-apply bootstrap) |
+| `create_console_login` | no | `false` | Whether to create a console login profile for emergency console access |
+| `alarm_sns_topic_arn` | no | `""` | SNS topic to notify on break-glass use. Skips the alarm if empty |
+| `cloudtrail_log_group_name` | no | `""` | CloudWatch Logs group receiving CloudTrail. Required for the metric filter |
+| `tags` | no | `{}` | Extra tags merged over the module defaults |
+
+## Outputs
+
+- `user_name`, `user_arn` — identifiers for documentation
+- `mfa_serial` — *expected* MFA device ARN once enrolled (a hint, not a real device)
+- `access_key_id`, `access_key_secret` (sensitive) — copy once, then rotate
+- `console_password` (sensitive) — initial console password when `create_console_login = true`
+- `alarm_arn` — for downstream dashboards
+
+## Break-glass runbook
+
+1. **Confirm SSO is unavailable.** Don't reach for break-glass for routine work.
+2. **Retrieve credentials from the team password manager** for the target account
+   (access_key_id, secret_access_key, MFA serial, and console password if used).
+3. **Export the access key:**
+   ```bash
+   export AWS_ACCESS_KEY_ID=<from-vault>
+   export AWS_SECRET_ACCESS_KEY=<from-vault>
+   ```
+4. **Acquire an MFA-present session token** (every other API call is denied by the
+   inline policy without it):
+   ```bash
+   aws sts get-session-token \
+     --serial-number arn:aws:iam::<acct>:mfa/break-glass-<account_name> \
+     --token-code <6-digit-MFA-code> \
+     --duration-seconds 3600
+   ```
+   Export the returned `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and
+   `AWS_SESSION_TOKEN`.
+5. **Verify** with `aws sts get-caller-identity` — should report the break-glass
+   user with `aws:MultiFactorAuthPresent = true`.
+6. **Operate.** Full Administrator policy is now in effect.
+7. **After the incident (within 24h):**
+   - Document the use in the incident retro.
+   - Rotate the access key: create a new key, save it, then delete the old one.
+   - Confirm the CloudWatch alarm fired and was acknowledged by security.
+
+See [`docs/break-glass-procedure.md`](../../../docs/break-glass-procedure.md) for the
+full operating procedure.
+
+## Intentional removal
+
+The `prevent_destroy` guard is deliberate friction. To remove a break-glass user:
+
+1. Open a PR removing the `lifecycle { prevent_destroy = true }` block.
+2. Get it reviewed and merged.
+3. Apply.
+
+This is the desired workflow, not a bug — see ADR-0011.
+
+## Anti-features (deliberately not done)
+
+- **No automatic rotation.** Rotating into vaults from Terraform creates a leak surface.
+- **No groups, no shared roles.** Single-purpose user, no membership management.
+- **No SSO permission set.** Break-glass is the *fallback* when SSO is the thing that's broken.
+
+## See also
+
+- [`docs/adrs/0011-break-glass-iam-destroy-protection.md`](../../../docs/adrs/0011-break-glass-iam-destroy-protection.md) — the ADR this module implements
+- [`modules/iam-baseline`](../iam-baseline/) — per-account password policy + MFA enforcement policy + Access Analyzer
+- [`modules/cloudtrail`](../cloudtrail/) — provides the CloudWatch log group this module's alarm reads from
+- [`modules/scps`](../scps/) — org guardrails that complement the destroy protection

--- a/terraform/modules/break-glass-user/break-glass-user.tftest.hcl
+++ b/terraform/modules/break-glass-user/break-glass-user.tftest.hcl
@@ -1,0 +1,128 @@
+mock_provider "aws" {
+  # Pin the partition / account so policy-document ARNs render as valid ARNs that
+  # the IAM policy validators accept (the default mock returns random strings).
+  override_data {
+    target = data.aws_partition.current
+    values = {
+      partition = "aws"
+    }
+  }
+
+  override_data {
+    target = data.aws_caller_identity.current
+    values = {
+      account_id = "000000000000"
+    }
+  }
+
+  # The iam_policy_document data source is provider-computed; the default mock
+  # returns a random string that fails IAM's JSON-policy validator. Supply a
+  # minimal valid policy document so the inline-policy resource validates.
+  override_data {
+    target = data.aws_iam_policy_document.mfa_enforcement
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"Test\",\"Effect\":\"Deny\",\"Action\":\"*\",\"Resource\":\"*\"}]}"
+    }
+  }
+}
+
+variables {
+  account_name = "management"
+  name_prefix  = "platform-"
+  tags = {
+    Environment = "test"
+    Team        = "security"
+  }
+}
+
+run "user_name_follows_convention" {
+  command = plan
+
+  assert {
+    condition     = aws_iam_user.this.name == "break-glass-management"
+    error_message = "Break-glass user name must be break-glass-<account_name>"
+  }
+
+  assert {
+    condition     = aws_iam_user.this.path == "/break-glass/"
+    error_message = "Break-glass user must live under the /break-glass/ path"
+  }
+}
+
+run "destroy_protection_guards_present" {
+  command = plan
+
+  # ADR-0011: apply-time backstop must be in place.
+  assert {
+    condition     = aws_iam_user.this.force_destroy == false
+    error_message = "ADR-0011: break-glass user must set force_destroy = false"
+  }
+}
+
+run "mfa_enforcement_policy_attached" {
+  command = plan
+
+  assert {
+    condition     = aws_iam_user_policy.mfa_enforcement.name == "platform-break-glass-management-mfa-enforcement"
+    error_message = "MFA enforcement inline policy should be created with the prefixed name"
+  }
+}
+
+run "no_access_key_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(aws_iam_access_key.this) == 0
+    error_message = "Access key must be opt-in (create_access_key defaults to false)"
+  }
+}
+
+run "no_console_login_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(aws_iam_user_login_profile.this) == 0
+    error_message = "Console login must be opt-in (create_console_login defaults to false)"
+  }
+}
+
+run "access_key_created_when_requested" {
+  command = plan
+
+  variables {
+    create_access_key = true
+  }
+
+  assert {
+    condition     = length(aws_iam_access_key.this) == 1
+    error_message = "Access key should be created when create_access_key = true"
+  }
+}
+
+run "alarm_skipped_without_log_group" {
+  command = plan
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.usage) == 0
+    error_message = "Usage alarm must not be created when cloudtrail_log_group_name is empty"
+  }
+}
+
+run "alarm_created_when_wired" {
+  command = plan
+
+  variables {
+    cloudtrail_log_group_name = "/aws/cloudtrail/org-trail"
+    alarm_sns_topic_arn       = "arn:aws:sns:eu-west-1:000000000000:security-alerts"
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.usage) == 1
+    error_message = "Usage alarm should be created when both log group and SNS topic are provided"
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_log_metric_filter.usage) == 1
+    error_message = "Metric filter should be created when both log group and SNS topic are provided"
+  }
+}

--- a/terraform/modules/break-glass-user/main.tf
+++ b/terraform/modules/break-glass-user/main.tf
@@ -1,0 +1,206 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Break-glass User — Emergency IAM Access (ADR-0011)
+# ---------------------------------------------------------------------------------------------------------------------
+# Single emergency-access IAM user per account. Used ONLY when SSO / Identity
+# Center is unavailable (control-plane outage, mis-configured permission set,
+# accidental SSO org detachment).
+#
+# Guarantees mandated by ADR-0011:
+#   - lifecycle { prevent_destroy = true }  — plan-time protection: the user can
+#     never appear in any destroy plan (targeted destroy, full destroy, stray
+#     `moved` block) until the lifecycle block is deliberately removed via PR.
+#   - force_destroy = false                 — apply-time backstop: Terraform fails
+#     if it tries to delete the user while attached policies exist.
+#
+# MFA is enforced via an inline deny-without-MFA policy. The initial access key
+# (and optional console password) are created once and stored in the team
+# password manager; rotation is manual by design.
+#
+# Companion: docs/break-glass-procedure.md
+# Source-of-truth: infra ADR-010 / modules/break-glass-user
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
+locals {
+  user_name = "break-glass-${var.account_name}"
+  default_tags = {
+    Purpose        = "BreakGlass"
+    ManagedBy      = "Terraform"
+    Module         = "break-glass-user"
+    UseRequirement = "MFA"
+    ADR            = "ADR-0011"
+  }
+  effective_tags = merge(local.default_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# IAM user — protected against destruction (ADR-0011)
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_iam_user" "this" {
+  name = local.user_name
+  path = "/break-glass/"
+
+  # Apply-time backstop. Removing a break-glass user erases an emergency-access
+  # vector — it should be a deliberate, explicit operation.
+  force_destroy = false
+
+  tags = local.effective_tags
+
+  lifecycle {
+    # Plan-time protection mandated by ADR-0011. Terraform errors at plan time if
+    # any configuration produces a destroy action for this user. To intentionally
+    # remove the user: PR removing this block, get it reviewed/merged, then apply.
+    prevent_destroy = true
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MFA enforcement (inline deny-without-MFA)
+# ---------------------------------------------------------------------------------------------------------------------
+# Allows the user to manage *only* its own MFA device when no MFA session is
+# present. Every other API call is denied unless aws:MultiFactorAuthPresent is
+# true.
+
+data "aws_iam_policy_document" "mfa_enforcement" {
+  statement {
+    sid    = "AllowViewAccountInfo"
+    effect = "Allow"
+    actions = [
+      "iam:GetAccountPasswordPolicy",
+      "iam:GetAccountSummary",
+      "iam:ListVirtualMFADevices",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "AllowManageOwnVirtualMFADevice"
+    effect = "Allow"
+    actions = [
+      "iam:CreateVirtualMFADevice",
+      "iam:DeleteVirtualMFADevice",
+    ]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:mfa/$${aws:username}",
+    ]
+  }
+
+  statement {
+    sid    = "AllowManageOwnUserMFA"
+    effect = "Allow"
+    actions = [
+      "iam:DeactivateMFADevice",
+      "iam:EnableMFADevice",
+      "iam:ListMFADevices",
+      "iam:ResyncMFADevice",
+    ]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:user/$${aws:username}",
+    ]
+  }
+
+  statement {
+    sid    = "DenyAllExceptListedIfNoMFA"
+    effect = "Deny"
+    not_actions = [
+      "iam:CreateVirtualMFADevice",
+      "iam:EnableMFADevice",
+      "iam:GetUser",
+      "iam:ListMFADevices",
+      "iam:ListVirtualMFADevices",
+      "iam:ResyncMFADevice",
+      "sts:GetSessionToken",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "BoolIfExists"
+      variable = "aws:MultiFactorAuthPresent"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_iam_user_policy" "mfa_enforcement" {
+  name   = "${var.name_prefix}${local.user_name}-mfa-enforcement"
+  user   = aws_iam_user.this.name
+  policy = data.aws_iam_policy_document.mfa_enforcement.json
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Administrator policy (effective only with an MFA-present session)
+# ---------------------------------------------------------------------------------------------------------------------
+# Combined with the inline deny above, this grants full admin ONLY AFTER the user
+# enrolls an MFA device and calls sts:GetSessionToken with --serial-number.
+
+resource "aws_iam_user_policy_attachment" "administrator_access" {
+  user       = aws_iam_user.this.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AdministratorAccess"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Console login profile (optional — for emergency console access when SSO is down)
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_iam_user_login_profile" "this" {
+  count                   = var.create_console_login ? 1 : 0
+  user                    = aws_iam_user.this.name
+  password_reset_required = true
+
+  lifecycle {
+    # The generated password is only meaningful at creation time. Ignore later
+    # drift so the password isn't reset on every apply.
+    ignore_changes = [password_reset_required]
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Initial access key (stored once in the team password manager, rotated manually)
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_iam_access_key" "this" {
+  count = var.create_access_key ? 1 : 0
+  user  = aws_iam_user.this.name
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CloudWatch alarm on break-glass usage
+# ---------------------------------------------------------------------------------------------------------------------
+# Only creates the alarm chain if both the CloudTrail log group AND an SNS topic
+# ARN are supplied. The org-wide CloudTrail trail must already deliver to
+# var.cloudtrail_log_group_name.
+
+resource "aws_cloudwatch_log_metric_filter" "usage" {
+  count          = var.cloudtrail_log_group_name != "" && var.alarm_sns_topic_arn != "" ? 1 : 0
+  name           = "${var.name_prefix}${local.user_name}-usage"
+  log_group_name = var.cloudtrail_log_group_name
+
+  # Triggers on any CloudTrail event where userIdentity.userName matches the
+  # break-glass user, regardless of action.
+  pattern = "{ $.userIdentity.userName = \"${local.user_name}\" }"
+
+  metric_transformation {
+    name      = "${local.user_name}-event-count"
+    namespace = "BreakGlass"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "usage" {
+  count               = var.cloudtrail_log_group_name != "" && var.alarm_sns_topic_arn != "" ? 1 : 0
+  alarm_name          = "${var.name_prefix}${local.user_name}-used"
+  alarm_description   = "Break-glass user ${local.user_name} authenticated against account ${data.aws_caller_identity.current.account_id}. Investigate within 1 business hour."
+  namespace           = "BreakGlass"
+  metric_name         = "${local.user_name}-event-count"
+  statistic           = "Sum"
+  period              = 60
+  evaluation_periods  = 1
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [var.alarm_sns_topic_arn]
+  ok_actions          = []
+  tags                = local.effective_tags
+}

--- a/terraform/modules/break-glass-user/outputs.tf
+++ b/terraform/modules/break-glass-user/outputs.tf
@@ -1,0 +1,44 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Break-glass User Outputs
+# ---------------------------------------------------------------------------------------------------------------------
+
+output "user_name" {
+  description = "Name of the break-glass IAM user."
+  value       = aws_iam_user.this.name
+}
+
+output "user_arn" {
+  description = "ARN of the break-glass IAM user."
+  value       = aws_iam_user.this.arn
+}
+
+output "mfa_serial" {
+  description = <<-EOT
+    Expected MFA device ARN once the user enrolls a virtual MFA token. The actual
+    MFA serial is created by the operator on first login (the user is allowed to
+    create its own virtual MFA device). Used as a hint in the break-glass runbook.
+  EOT
+  value       = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:mfa/${aws_iam_user.this.name}"
+}
+
+output "access_key_id" {
+  description = "Access key ID for the break-glass user. Copy into the team password manager on first apply. Null when create_access_key = false."
+  value       = try(aws_iam_access_key.this[0].id, null)
+}
+
+output "access_key_secret" {
+  description = "Secret for the break-glass user's access key. SENSITIVE. Copy into the team password manager on first apply, then rotate. Null when create_access_key = false."
+  value       = try(aws_iam_access_key.this[0].secret, null)
+  sensitive   = true
+}
+
+output "console_password" {
+  description = "Initial console password (reset required on first login). SENSITIVE. Null when create_console_login = false."
+  value       = try(aws_iam_user_login_profile.this[0].password, null)
+  sensitive   = true
+}
+
+output "alarm_arn" {
+  description = "ARN of the CloudWatch alarm that fires on break-glass usage. Null if the alarm chain was disabled (cloudtrail_log_group_name or alarm_sns_topic_arn unset)."
+  value       = try(aws_cloudwatch_metric_alarm.usage[0].arn, null)
+}

--- a/terraform/modules/break-glass-user/variables.tf
+++ b/terraform/modules/break-glass-user/variables.tf
@@ -1,0 +1,78 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Break-glass User Variables
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "account_name" {
+  description = "Account short name (e.g. management, prod, security). Used to build the IAM user name break-glass-<account_name>."
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "Optional prefix for the inline-policy and alarm names (e.g. 'platform-'). The IAM user name is always break-glass-<account_name> and is not prefixed."
+  type        = string
+  default     = ""
+}
+
+variable "create_access_key" {
+  description = <<-EOT
+    Create an initial AWS access key for the break-glass user. Default is false
+    (safe by default — the access key is opt-in, set this to true on a single
+    apply only when bootstrapping a new break-glass user).
+
+    Bootstrap workflow:
+      1. Set to true in the consuming Terragrunt unit
+      2. terragrunt apply — creates the user + access key
+      3. Capture the secret via: terragrunt output -raw access_key_secret
+         (only available once, at creation time)
+      4. Move the secret into the team password manager and delete the local file
+      5. Remove the resource from state:
+         terragrunt state rm 'aws_iam_access_key.this[0]'
+      6. Revert this variable to false in the unit so future plans don't create a
+         duplicate key (max 2 access keys per IAM user)
+
+    To rotate the key after bootstrap, use 'aws iam create-access-key' and
+    'aws iam delete-access-key' directly — Terraform does not track the key after
+    the state-rm step.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "create_console_login" {
+  description = <<-EOT
+    Create a console login profile for the break-glass user so it can sign in to
+    the AWS Console when SSO is unavailable. Default is false (programmatic access
+    only). When true, an initial password is generated (sensitive output) and the
+    user must reset it on first login.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "alarm_sns_topic_arn" {
+  description = <<-EOT
+    SNS topic ARN to notify when the break-glass user authenticates. Leave empty to
+    skip the CloudWatch alarm (not recommended for production accounts). The topic
+    must exist before this module is applied and must be reachable by CloudWatch
+    Logs in this account.
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "cloudtrail_log_group_name" {
+  description = <<-EOT
+    Name of the CloudWatch Logs group receiving CloudTrail events for this account.
+    Required for the break-glass usage alarm. If empty, no metric filter / alarm is
+    created and the consumer is responsible for monitoring break-glass use through
+    org-wide CloudTrail trails directly.
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Tags to apply to taggable resources in this module."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/break-glass-user/versions.tf
+++ b/terraform/modules/break-glass-user/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terragrunt/_org/_global/break-glass-user/terragrunt.hcl
+++ b/terragrunt/_org/_global/break-glass-user/terragrunt.hcl
@@ -1,0 +1,53 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Break-glass User — Management Account (ADR-0011)
+# ---------------------------------------------------------------------------------------------------------------------
+# Emergency-access IAM user for the management account, used only when SSO /
+# Identity Center is unavailable. Carries the ADR-0011 destroy guards
+# (prevent_destroy + force_destroy = false) and an MFA-enforced admin policy.
+#
+# The usage alarm reads from the organization CloudTrail trail's CloudWatch log
+# group (the cloudtrail unit in this folder). Provide alarm_sns_topic_arn below
+# to enable the alarm — left empty until the security alerting topic exists.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/break-glass-user"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  account_name = local.account_vars.locals.account_name
+}
+
+dependency "cloudtrail" {
+  config_path = "../cloudtrail"
+
+  mock_outputs = {
+    cloudwatch_log_group_name = "/aws/cloudtrail/org-trail-mock"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+inputs = {
+  account_name = local.account_name
+  name_prefix  = ""
+
+  # Safe by default: the access key and console login are opt-in. Flip to true on
+  # a single bootstrap apply, capture the secret, then revert. See variables.tf.
+  create_access_key    = false
+  create_console_login = false
+
+  # Alarm on any break-glass usage. The log group comes from the org CloudTrail
+  # trail. Set alarm_sns_topic_arn to the security alerting topic to enable the
+  # CloudWatch alarm chain (metric filter + alarm).
+  cloudtrail_log_group_name = dependency.cloudtrail.outputs.cloudwatch_log_group_name
+  alarm_sns_topic_arn       = "" # TODO: set to the security SNS topic ARN to enable the usage alarm
+
+  tags = {
+    Environment = "management"
+    ManagedBy   = "terragrunt"
+    Compliance  = "adr-0011"
+  }
+}


### PR DESCRIPTION
## Summary

Closes the **ADR-0011 partial gap** in platform-design. Previously the repo had break-glass access via an SSO permission set, the `iam-baseline` MFA policy, and a procedure doc — but **not** the dedicated `break-glass-user` module with the `prevent_destroy` lifecycle guard the ADR mandates.

This PR ports that module from the infra source-of-truth (`infra/modules/break-glass-user`, infra ADR-010), adapted to platform-design conventions (no real account IDs, `~> 1.11` / `aws ~> 6.0`, `mock_provider` tests, sibling `iam-baseline` style).

## What's included

- **`terraform/modules/break-glass-user/`** — per-account emergency IAM user:
  - `aws_iam_user.this` with **`lifecycle { prevent_destroy = true }`** (plan-time guard) **and** `force_destroy = false` (apply-time backstop) — the dual guard ADR-0011 requires.
  - Inline **MFA-enforcement** policy (deny-without-MFA) + `AdministratorAccess` (effective only in an MFA-present session).
  - Optional console login + access key (both opt-in, safe by default).
  - **CloudWatch metric filter + alarm** on any break-glass usage (CloudTrail `userIdentity.userName` match).
  - `versions.tf`, `variables.tf`, `outputs.tf`, `README.md` (with runbook), and `break-glass-user.tftest.hcl` (8 `terraform test` runs, all passing).
- **Wiring**:
  - `terragrunt/_org/_global/break-glass-user/` — management-account unit, alarm wired to the org CloudTrail log group via a `dependency` (alongside `iam-baseline` / `cloudtrail`).
  - `catalog/units/break-glass-user/` — reusable per-account catalog unit.
- **ADR**: flips `docs/adrs/0011-...` platform-design status **partial → synced** with an updated one-line reason.

## Validation

- `terraform fmt -check` — clean.
- `terraform init -backend=false && terraform validate` — `Success! The configuration is valid.`
- `terraform test` — **8 passed, 0 failed** (asserts naming, `force_destroy=false`, MFA policy, opt-in key/console, and conditional alarm wiring).

Does **not** edit `docs/adrs/README.md` (reconciled separately).