### PR TITLE
ci: complete Tier-1 hardening — dep-scan + CodeQL SAST (ADR-0016)

### DIFF
--- a/.github/actions/node-dep-scan/action.yml
+++ b/.github/actions/node-dep-scan/action.yml
@@ -1,0 +1,276 @@
+# -----------------------------------------------------------------------------
+# node-dep-scan
+#
+# Mirrors platform-workflows@3bb35df .github/actions/node-dep-scan
+# (2026-06 platform-workflows consolidation sync).
+# Completes the Tier-1 set started in PR #241 (ADR-0016): application-dependency
+# CVE scanning for Node projects (npm audit + osv-scanner), which the Trivy
+# image scan (OS/system libs only) does not cover.
+# -----------------------------------------------------------------------------
+name: "Node Dependency Scan"
+description: "Scan Node project dependencies for known CVEs using `npm audit --audit-level=high` plus `osv-scanner`. Honours a `.audit-ignore` allowlist and uploads osv-scanner SARIF to GitHub Security."
+
+inputs:
+  working-directory:
+    description: "Project root containing package.json + lockfile."
+    required: false
+    default: "."
+  package-manager:
+    description: "npm, pnpm, or yarn. Affects which audit command runs."
+    required: false
+    default: "npm"
+  ignore-file:
+    description: "Path (relative to working-directory) to a newline-delimited file of CVE/GHSA/OSV IDs to ignore. Blank lines and `#` comments are skipped."
+    required: false
+    default: ".audit-ignore"
+  audit-level:
+    description: "Severity threshold for `npm audit`. One of `info`, `low`, `moderate`, `high`, `critical`."
+    required: false
+    default: "high"
+  node-version:
+    description: "Node version to set up before scanning."
+    required: false
+    default: "20"
+  install-command:
+    description: "Install command run before scanning. Empty string skips install (assumes node_modules already present)."
+    required: false
+    default: ""
+  exit-code:
+    description: "Exit code when in-scope findings are present. Set 0 for advisory mode."
+    required: false
+    default: "1"
+  sarif-category:
+    description: "SARIF category for osv-scanner upload. Differentiates multiple Node scans on the same commit."
+    required: false
+    default: "node-dep-scan"
+  upload-sarif:
+    description: "Upload osv-scanner SARIF to GitHub Security."
+    required: false
+    default: "true"
+
+outputs:
+  npm-audit-report:
+    description: "Path to npm audit JSON report."
+    value: ${{ steps.npm-audit.outputs.report-path }}
+  osv-sarif:
+    description: "Path to osv-scanner SARIF output."
+    value: ${{ steps.osv.outputs.sarif-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Node.js ${{ inputs.node-version }}
+      # actions/setup-node v4.1.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: ${{ inputs.package-manager }}
+        cache-dependency-path: ${{ inputs.working-directory }}/${{ inputs.package-manager == 'pnpm' && 'pnpm-lock.yaml' || inputs.package-manager == 'yarn' && 'yarn.lock' || 'package-lock.json' }}
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        PM: ${{ inputs.package-manager }}
+        CUSTOM: ${{ inputs.install-command }}
+      run: |
+        set -euo pipefail
+        if [ -n "${CUSTOM}" ]; then
+          # Run via `bash -lc` instead of `eval` — one round of shell parsing
+          # only, no double expansion of variables already in CUSTOM.
+          bash -lc "${CUSTOM}"
+          exit 0
+        fi
+        case "${PM}" in
+          npm) npm ci ;;
+          pnpm) corepack enable && pnpm install --frozen-lockfile ;;
+          yarn) corepack enable && yarn install --immutable ;;
+          *) echo "::error::Unknown package-manager: ${PM}"; exit 1 ;;
+        esac
+
+    - name: Run npm audit
+      id: npm-audit
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        PM: ${{ inputs.package-manager }}
+        AUDIT_LEVEL: ${{ inputs.audit-level }}
+        REPORT_PATH: npm-audit-report.json
+      run: |
+        set -uo pipefail
+        # npm audit returns non-zero on findings; capture the JSON regardless.
+        case "${PM}" in
+          npm) npm audit --omit=dev --audit-level="${AUDIT_LEVEL}" --json > "${REPORT_PATH}" || true ;;
+          pnpm) corepack enable && pnpm audit --prod --audit-level="${AUDIT_LEVEL}" --json > "${REPORT_PATH}" || true ;;
+          yarn) corepack enable && yarn npm audit --severity "${AUDIT_LEVEL}" --json > "${REPORT_PATH}" || true ;;
+        esac
+        if [ ! -s "${REPORT_PATH}" ]; then
+          printf '{"vulnerabilities":{}}' > "${REPORT_PATH}"
+        fi
+        echo "report-path=${{ inputs.working-directory }}/${REPORT_PATH}" >> "$GITHUB_OUTPUT"
+
+    - name: Apply ignore-file + gate npm audit findings
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        REPORT_PATH: npm-audit-report.json
+        IGNORE_FILE: ${{ inputs.ignore-file }}
+        AUDIT_LEVEL: ${{ inputs.audit-level }}
+        EXIT_CODE: ${{ inputs.exit-code }}
+      run: |
+        set -euo pipefail
+
+        # NOTE: grep returns 1 on "no matches" which would trip `set -e`; suppress.
+        if [ -f "${IGNORE_FILE}" ]; then
+          IGNORES=$(grep -vE '^\s*(#|$)' "${IGNORE_FILE}" | tr '\n' ',' | sed 's/,$//' || true)
+        else
+          IGNORES=""
+        fi
+        export IGNORES
+
+        python3 - <<'PY'
+        import json
+        import os
+        import sys
+
+        with open(os.environ["REPORT_PATH"]) as fh:
+            data = json.load(fh)
+
+        ignores = {i.strip() for i in os.environ.get("IGNORES", "").split(",") if i.strip()}
+        audit_level = os.environ["AUDIT_LEVEL"].lower()
+        order = ["info", "low", "moderate", "high", "critical"]
+        threshold = order.index(audit_level)
+
+        in_scope = []
+        for pkg, info in (data.get("vulnerabilities") or {}).items():
+            sev = (info.get("severity") or "").lower()
+            if sev not in order or order.index(sev) < threshold:
+                continue
+            # `via` may be a list of advisories or transitive deps.
+            ids = set()
+            for v in info.get("via", []) or []:
+                if isinstance(v, dict):
+                    url = v.get("url", "")
+                    advisory_id = url.rsplit("/", 1)[-1] if url else ""
+                    if advisory_id:
+                        ids.add(advisory_id)
+                    src = v.get("source")
+                    if src:
+                        ids.add(f"npm-{src}")
+            if ids & ignores:
+                continue
+            in_scope.append({"package": pkg, "severity": sev, "advisories": sorted(ids)})
+
+        with open("npm-audit-in-scope.json", "w") as fh:
+            json.dump(in_scope, fh, indent=2)
+
+        print(f"npm audit in-scope findings: {len(in_scope)}", file=sys.stderr)
+        for f in in_scope:
+            print(f"  - {f['package']} severity={f['severity']} advisories={','.join(f['advisories']) or 'none'}", file=sys.stderr)
+
+        gh_out = os.environ.get("GITHUB_OUTPUT")
+        if gh_out:
+            with open(gh_out, "a") as fh:
+                fh.write(f"npm-in-scope-findings={len(in_scope)}\n")
+        PY
+
+        IN_SCOPE=$(python3 -c 'import json; print(len(json.load(open("npm-audit-in-scope.json"))))')
+        if [ "${IN_SCOPE}" -gt 0 ]; then
+          echo "::error::npm audit found ${IN_SCOPE} in-scope findings (level=${AUDIT_LEVEL}, ignore-file=${IGNORE_FILE})."
+          exit "${EXIT_CODE}"
+        fi
+        echo "npm audit clean at level ${AUDIT_LEVEL}."
+
+    - name: Install osv-scanner
+      shell: bash
+      env:
+        OSV_VERSION: "1.9.1"
+      run: |
+        set -euo pipefail
+        BIN_DIR="${RUNNER_TEMP}/osv-scanner-bin"
+        mkdir -p "${BIN_DIR}"
+        URL="https://github.com/google/osv-scanner/releases/download/v${OSV_VERSION}/osv-scanner_linux_amd64"
+        curl -fsSL -o "${BIN_DIR}/osv-scanner" "${URL}"
+        chmod +x "${BIN_DIR}/osv-scanner"
+        echo "${BIN_DIR}" >> "$GITHUB_PATH"
+        "${BIN_DIR}/osv-scanner" --version
+
+    - name: Run osv-scanner
+      id: osv
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        SARIF_PATH: osv-scanner.sarif
+        IGNORE_FILE: ${{ inputs.ignore-file }}
+        EXIT_CODE: ${{ inputs.exit-code }}
+        PM: ${{ inputs.package-manager }}
+      run: |
+        set -uo pipefail
+
+        IGNORE_ARGS=()
+        if [ -f "${IGNORE_FILE}" ]; then
+          while IFS= read -r id; do
+            [ -z "${id}" ] && continue
+            case "${id}" in '#'*) continue;; esac
+            IGNORE_ARGS+=(--ignore-vuln "${id}")
+          done < "${IGNORE_FILE}"
+        fi
+
+        # osv-scanner returns 1 on vuln findings, 0 on clean, >1 on real errors.
+        # Select the lockfile matching the requested package manager — without
+        # this, pnpm/yarn projects would fail with "missing package-lock.json".
+        case "${PM}" in
+          pnpm) LOCKFILE="pnpm-lock.yaml" ;;
+          yarn) LOCKFILE="yarn.lock" ;;
+          *)    LOCKFILE="package-lock.json" ;;
+        esac
+        set +e
+        osv-scanner --lockfile="${LOCKFILE}" --format=sarif --output="${SARIF_PATH}" "${IGNORE_ARGS[@]}"
+        OSV_RC=$?
+        set -e
+
+        if [ ! -s "${SARIF_PATH}" ]; then
+          # osv-scanner did not produce SARIF (likely missing lockfile). Emit empty SARIF for upload step.
+          cat > "${SARIF_PATH}" <<'JSON'
+        {
+          "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+          "version": "2.1.0",
+          "runs": [{"tool": {"driver": {"name": "osv-scanner", "informationUri": "https://github.com/google/osv-scanner"}}, "results": []}]
+        }
+        JSON
+        fi
+
+        echo "sarif-path=${{ inputs.working-directory }}/${SARIF_PATH}" >> "$GITHUB_OUTPUT"
+
+        if [ "${OSV_RC}" -eq 1 ]; then
+          echo "::error::osv-scanner found vulnerabilities (after ignore-file filtering)."
+          exit "${EXIT_CODE}"
+        fi
+        if [ "${OSV_RC}" -gt 1 ]; then
+          echo "::error::osv-scanner exited ${OSV_RC} (unexpected error)."
+          exit "${OSV_RC}"
+        fi
+        echo "osv-scanner clean."
+
+    - name: Upload osv-scanner SARIF to GitHub Security
+      if: always() && inputs.upload-sarif == 'true'
+      # github/codeql-action/upload-sarif v3.27.0
+      # continue-on-error: upload may fail on repos without Code Scanning enabled.
+      continue-on-error: true
+      uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa
+      with:
+        sarif_file: ${{ steps.osv.outputs.sarif-path }}
+        category: ${{ inputs.sarif-category }}
+
+    - name: Upload raw reports as artifact
+      if: always()
+      # actions/upload-artifact v4.4.3
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: node-dep-scan-${{ github.run_id }}-${{ github.run_attempt }}
+        path: |
+          ${{ inputs.working-directory }}/npm-audit-report.json
+          ${{ inputs.working-directory }}/npm-audit-in-scope.json
+          ${{ inputs.working-directory }}/osv-scanner.sarif
+        if-no-files-found: warn
+        retention-days: 30

--- a/.github/actions/python-dep-scan/action.yml
+++ b/.github/actions/python-dep-scan/action.yml
@@ -1,0 +1,261 @@
+# -----------------------------------------------------------------------------
+# python-dep-scan
+#
+# Mirrors platform-workflows@3bb35df .github/actions/python-dep-scan
+# (2026-06 platform-workflows consolidation sync).
+# Completes the Tier-1 set started in PR #241 (ADR-0016): application-dependency
+# CVE scanning, which the Trivy image scan (OS/system libs only) does not cover.
+# -----------------------------------------------------------------------------
+name: "Python Dependency Scan"
+description: "Scan Python project dependencies for known CVEs using pip-audit. Reads vulnerabilities from PyPI Advisory DB + OSV. Fails on HIGH/CRITICAL by default, with `.audit-ignore` allowlist support."
+
+inputs:
+  working-directory:
+    description: "Project root containing pyproject.toml / requirements*.txt."
+    required: false
+    default: "."
+  ignore-file:
+    description: "Path (relative to working-directory) to a newline-delimited file of CVE/GHSA IDs to ignore. Lines starting with `#` and blank lines are skipped. Missing file is treated as empty."
+    required: false
+    default: ".audit-ignore"
+  severity-threshold:
+    description: "Comma-separated severities that fail the job. pip-audit does not natively gate on severity, so this action enforces the gate by post-filtering the JSON report."
+    required: false
+    default: "CRITICAL,HIGH"
+  python-version:
+    description: "Python version to set up before running pip-audit."
+    required: false
+    default: "3.12"
+  install-command:
+    description: "Command run before scanning to install project deps so pip-audit can resolve the resolved environment. Empty string skips."
+    required: false
+    default: "pip install -e '.[dev]'"
+  exit-code:
+    description: "Exit code when in-scope vulnerabilities are present. Set to 0 to make the scan advisory."
+    required: false
+    default: "1"
+  sarif-category:
+    description: "SARIF category. Differentiates multiple Python scans on the same commit."
+    required: false
+    default: "python-dep-scan"
+  upload-sarif:
+    description: "Upload pip-audit findings as SARIF to GitHub Security."
+    required: false
+    default: "true"
+
+outputs:
+  report-path:
+    description: "Path to the JSON report produced by pip-audit."
+    value: ${{ steps.scan.outputs.report-path }}
+  in-scope-findings:
+    description: "Number of findings that match severity-threshold AND are not in ignore-file."
+    value: ${{ steps.gate.outputs.in-scope-findings }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      # actions/setup-python v5.3.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install project dependencies
+      if: inputs.install-command != ''
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+        python -m pip install --upgrade pip
+        ${{ inputs.install-command }}
+
+    - name: Install pip-audit
+      shell: bash
+      run: |
+        set -euo pipefail
+        python -m pip install --upgrade 'pip-audit==2.7.3'
+        pip-audit --version
+
+    - name: Run pip-audit (JSON report)
+      id: scan
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        REPORT_PATH: pip-audit-report.json
+      run: |
+        set -uo pipefail
+        # pip-audit returns non-zero when findings exist; we want the report regardless.
+        pip-audit --format json --output "${REPORT_PATH}" || true
+        if [ ! -s "${REPORT_PATH}" ]; then
+          echo "::warning::pip-audit produced no JSON output — treating as zero findings."
+          printf '{"dependencies":[]}' > "${REPORT_PATH}"
+        fi
+        echo "report-path=${{ inputs.working-directory }}/${REPORT_PATH}" >> "$GITHUB_OUTPUT"
+
+    - name: Apply ignore-file + severity gate
+      id: gate
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        REPORT_PATH: pip-audit-report.json
+        IGNORE_FILE: ${{ inputs.ignore-file }}
+        SEVERITY: ${{ inputs.severity-threshold }}
+        EXIT_CODE: ${{ inputs.exit-code }}
+      run: |
+        set -euo pipefail
+
+        # Build the ignore set (CVE/GHSA IDs). Empty if file missing or all-comments.
+        # NOTE: grep returns 1 on "no matches" which would trip `set -e`; suppress with `|| true`.
+        if [ -f "${IGNORE_FILE}" ]; then
+          IGNORES=$(grep -vE '^\s*(#|$)' "${IGNORE_FILE}" | tr '\n' ',' | sed 's/,$//' || true)
+        else
+          IGNORES=""
+        fi
+        export IGNORES
+
+        python - <<PY
+        import json
+        import os
+        import sys
+
+        report_path = os.environ["REPORT_PATH"]
+        severity = {s.strip().upper() for s in os.environ["SEVERITY"].split(",") if s.strip()}
+        ignores = {i.strip() for i in os.environ.get("IGNORES", "").split(",") if i.strip()}
+
+        with open(report_path) as fh:
+            data = json.load(fh)
+
+        in_scope = []
+        for dep in data.get("dependencies", []):
+            for v in dep.get("vulns", []):
+                vid = v.get("id", "")
+                # pip-audit reports an `id` (PYSEC-... or GHSA-...) and `aliases` list incl. CVE.
+                aliases = set(v.get("aliases", [])) | {vid}
+                if aliases & ignores:
+                    continue
+                # Severity isn't always in the report; default to UNKNOWN -> in-scope (be safe).
+                sev_vals = {(s or "").upper() for s in v.get("severity", [])} if isinstance(v.get("severity"), list) else {str(v.get("severity", "")).upper()}
+                if not sev_vals or "UNKNOWN" in sev_vals or sev_vals & severity:
+                    in_scope.append({
+                        "package": dep.get("name"),
+                        "version": dep.get("version"),
+                        "id": vid,
+                        "aliases": sorted(aliases),
+                        "severity": sorted(sev_vals),
+                        "fix_versions": v.get("fix_versions", []),
+                    })
+
+        with open("pip-audit-in-scope.json", "w") as fh:
+            json.dump(in_scope, fh, indent=2)
+
+        print(f"In-scope findings: {len(in_scope)}", file=sys.stderr)
+        for f in in_scope:
+            print(
+                f"  - {f['package']}=={f['version']} {f['id']} severity={','.join(f['severity']) or 'UNKNOWN'} fix={','.join(f['fix_versions']) or 'no-fix'}",
+                file=sys.stderr,
+            )
+
+        # GITHUB_OUTPUT
+        gh_out = os.environ.get("GITHUB_OUTPUT")
+        if gh_out:
+            with open(gh_out, "a") as fh:
+                fh.write(f"in-scope-findings={len(in_scope)}\n")
+
+        PY
+
+        IN_SCOPE=$(python -c 'import json; print(len(json.load(open("pip-audit-in-scope.json"))))')
+        if [ "${IN_SCOPE}" -gt 0 ]; then
+          echo "::error::pip-audit found ${IN_SCOPE} in-scope vulnerabilities (severity ${SEVERITY}, ignore-file=${IGNORE_FILE})."
+          exit "${EXIT_CODE}"
+        fi
+        echo "pip-audit clean (in-scope severity: ${SEVERITY})."
+
+    - name: Convert findings to SARIF
+      if: always() && inputs.upload-sarif == 'true'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+
+        IN_SCOPE_FILE="pip-audit-in-scope.json"
+        if [ ! -f "${IN_SCOPE_FILE}" ]; then
+          echo '[]' > "${IN_SCOPE_FILE}"
+        fi
+
+        python - <<'PY' > pip-audit.sarif
+        import json
+        from pathlib import Path
+
+        findings = json.loads(Path("pip-audit-in-scope.json").read_text())
+
+        sarif = {
+            "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+            "version": "2.1.0",
+            "runs": [
+                {
+                    "tool": {
+                        "driver": {
+                            "name": "pip-audit",
+                            "informationUri": "https://github.com/pypa/pip-audit",
+                            "rules": [],
+                        }
+                    },
+                    "results": [],
+                }
+            ],
+        }
+
+        rule_ids = {}
+        for f in findings:
+            rid = f["id"] or "PYSEC-UNKNOWN"
+            if rid not in rule_ids:
+                rule_ids[rid] = {
+                    "id": rid,
+                    "shortDescription": {"text": f"{f['package']} vulnerability {rid}"},
+                    "helpUri": f"https://osv.dev/vulnerability/{rid}",
+                }
+                sarif["runs"][0]["tool"]["driver"]["rules"].append(rule_ids[rid])
+            sarif["runs"][0]["results"].append(
+                {
+                    "ruleId": rid,
+                    "level": "error",
+                    "message": {
+                        "text": f"{f['package']}=={f['version']} affected by {rid} (aliases: {', '.join(f['aliases'])}). Fix versions: {', '.join(f['fix_versions']) or 'none'}."
+                    },
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {"uri": "pyproject.toml"},
+                                "region": {"startLine": 1},
+                            }
+                        }
+                    ],
+                }
+            )
+
+        print(json.dumps(sarif, indent=2))
+        PY
+
+    - name: Upload SARIF to GitHub Security
+      if: always() && inputs.upload-sarif == 'true'
+      # github/codeql-action/upload-sarif v3.27.0
+      # continue-on-error: upload may fail on repos without Code Scanning enabled
+      # (free private repos without GHAS, or forks without write tokens). The
+      # scan result is still surfaced via the previous gate step + artifact.
+      continue-on-error: true
+      uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa
+      with:
+        sarif_file: ${{ inputs.working-directory }}/pip-audit.sarif
+        category: ${{ inputs.sarif-category }}
+
+    - name: Upload raw report as artifact
+      if: always()
+      # actions/upload-artifact v4.4.3
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: pip-audit-${{ github.run_id }}-${{ github.run_attempt }}
+        path: |
+          ${{ inputs.working-directory }}/pip-audit-report.json
+          ${{ inputs.working-directory }}/pip-audit-in-scope.json
+        if-no-files-found: warn
+        retention-days: 30

--- a/.github/actions/sast-codeql/action.yml
+++ b/.github/actions/sast-codeql/action.yml
@@ -1,0 +1,91 @@
+# -----------------------------------------------------------------------------
+# sast-codeql
+#
+# Mirrors platform-workflows@3bb35df .github/actions/sast-codeql
+# (2026-06 platform-workflows consolidation sync).
+# Completes the Tier-1 set started in PR #241 (ADR-0016): static application
+# security analysis (SAST). SARIF flows to GitHub Code Scanning; merge-blocking
+# is left to branch protection (advisory-by-default at the action level).
+# -----------------------------------------------------------------------------
+name: "SAST CodeQL"
+description: "Run GitHub CodeQL static analysis for a single language. Uploads results to GitHub Code Scanning. Wraps github/codeql-action."
+
+inputs:
+  language:
+    description: "CodeQL language: python, javascript, typescript, go, java, csharp, cpp, ruby, swift, kotlin."
+    required: true
+  queries:
+    description: "CodeQL query suite. Common choices: `security-and-quality` (default), `security-extended`, `security-experimental`. Or a comma list of `.qls` paths."
+    required: false
+    default: "security-and-quality"
+  working-directory:
+    description: "Subdirectory of the checkout to focus the build on. Empty string means whole repo."
+    required: false
+    default: ""
+  config-file:
+    description: "Optional CodeQL config file path (relative to repo root)."
+    required: false
+    default: ""
+  sarif-category:
+    description: "SARIF category. Differentiates multi-language runs on the same commit."
+    required: false
+    default: ""
+  ram:
+    description: "Megabytes of RAM the CodeQL extractor may use. Default 0 lets CodeQL pick."
+    required: false
+    default: "0"
+  threads:
+    description: "Number of threads. Default 0 lets CodeQL pick."
+    required: false
+    default: "0"
+
+outputs:
+  sarif-output:
+    description: "Directory where CodeQL wrote the SARIF results."
+    value: ${{ steps.analyze.outputs.sarif-output }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve SARIF category
+      id: cat
+      shell: bash
+      env:
+        LANG: ${{ inputs.language }}
+        CAT_OVERRIDE: ${{ inputs.sarif-category }}
+      run: |
+        set -euo pipefail
+        if [ -n "${CAT_OVERRIDE}" ]; then
+          echo "value=${CAT_OVERRIDE}" >> "$GITHUB_OUTPUT"
+        else
+          echo "value=codeql-${LANG}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Initialize CodeQL
+      # github/codeql-action/init v3.27.0
+      uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa
+      with:
+        languages: ${{ inputs.language }}
+        queries: ${{ inputs.queries }}
+        config-file: ${{ inputs.config-file }}
+        source-root: ${{ inputs.working-directory }}
+        # ram / threads only passed when non-zero — CodeQL rejects literal "0".
+        ram: ${{ inputs.ram != '0' && inputs.ram || '' }}
+        threads: ${{ inputs.threads != '0' && inputs.threads || '' }}
+
+    - name: Autobuild
+      # github/codeql-action/autobuild v3.27.0
+      uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa
+      with:
+        working-directory: ${{ inputs.working-directory }}
+
+    - name: Perform CodeQL analysis
+      id: analyze
+      if: always()  # ensure SARIF uploads even if autobuild failed (the `upload` input is boolean, not "always")
+      # github/codeql-action/analyze v3.27.0
+      uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa
+      with:
+        category: ${{ steps.cat.outputs.value }}
+        upload: true
+        ram: ${{ inputs.ram != '0' && inputs.ram || '' }}
+        threads: ${{ inputs.threads != '0' && inputs.threads || '' }}

--- a/.github/workflows/reusable-dep-scan.yml
+++ b/.github/workflows/reusable-dep-scan.yml
@@ -1,0 +1,143 @@
+# -----------------------------------------------------------------------------
+# reusable-dep-scan.yml
+#
+# Reusable workflow: scan application dependencies for known CVEs. Wraps the
+# `python-dep-scan` (pip-audit) and `node-dep-scan` (npm audit + osv-scanner)
+# composites from .github/actions/* in this repo.
+#
+# Completes the Tier-1 set started in PR #241 (ADR-0016): the Trivy image scan
+# in reusable-build-and-push only covers OS/system libs, so application-level
+# dependency CVEs went uncaught. This is the gating dep-scan layer.
+#
+# Findings flow to GitHub Security (SARIF). The scan GATES the job by default
+# (fails on CRITICAL/HIGH), with a per-repo `.audit-ignore` allowlist; set
+# `advisory: true` to downgrade to reporting-only.
+#
+# Mirrors platform-workflows@3bb35df dep-scan wiring (2026-06 consolidation
+# sync). In the real estate this lives in the shared platform-workflows repo and
+# is referenced as `uses: platform-workflows/.github/workflows/reusable-dep-scan.yml@<ref>`.
+# In this mock it lives in-repo and is called via local `./.github/...` paths.
+#
+# Caller example:
+#
+#   jobs:
+#     dep-scan:
+#       uses: ./.github/workflows/reusable-dep-scan.yml
+#       permissions:
+#         contents: read
+#         security-events: write
+#       with:
+#         language: python
+#         working_directory: services/render-manager
+#
+# See: docs/ci-cd/README.md
+# -----------------------------------------------------------------------------
+
+name: reusable-dep-scan
+
+on:
+  workflow_call:
+    inputs:
+      language:
+        description: "python or node. Selects which dep-scan composite runs."
+        type: string
+        required: true
+      working_directory:
+        description: "Project root containing the manifest + lockfile."
+        type: string
+        required: false
+        default: "."
+      ignore_file:
+        description: "Allowlist file (relative to working_directory) of CVE/GHSA/OSV IDs to ignore."
+        type: string
+        required: false
+        default: ".audit-ignore"
+      severity_threshold:
+        description: "Python: comma-separated severities that fail (pip-audit gate)."
+        type: string
+        required: false
+        default: "CRITICAL,HIGH"
+      audit_level:
+        description: "Node: npm audit severity threshold (info|low|moderate|high|critical)."
+        type: string
+        required: false
+        default: "high"
+      python_version:
+        description: "Python version for the pip-audit run."
+        type: string
+        required: false
+        default: "3.12"
+      node_version:
+        description: "Node version for the npm audit / osv-scanner run."
+        type: string
+        required: false
+        default: "20"
+      package_manager:
+        description: "Node: npm, pnpm, or yarn."
+        type: string
+        required: false
+        default: "npm"
+      install_command:
+        description: "Override the language-specific dependency install command. Empty string uses the composite default."
+        type: string
+        required: false
+        default: ""
+      advisory:
+        description: "If true, findings are reporting-only (exit-code 0). Default false = gating."
+        type: boolean
+        required: false
+        default: false
+      upload_sarif:
+        description: "Upload findings as SARIF to GitHub Security."
+        type: boolean
+        required: false
+        default: true
+
+permissions: {}
+
+jobs:
+  python-dep-scan:
+    name: Python dependency scan
+    if: inputs.language == 'python'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Python dependency scan
+        uses: ./.github/actions/python-dep-scan
+        with:
+          working-directory: ${{ inputs.working_directory }}
+          ignore-file: ${{ inputs.ignore_file }}
+          severity-threshold: ${{ inputs.severity_threshold }}
+          python-version: ${{ inputs.python_version }}
+          # Empty install_command -> fall back to the composite default.
+          install-command: ${{ inputs.install_command != '' && inputs.install_command || 'pip install -e ''.[dev]''' }}
+          exit-code: ${{ inputs.advisory && '0' || '1' }}
+          sarif-category: python-dep-scan-${{ inputs.working_directory }}
+          upload-sarif: ${{ inputs.upload_sarif }}
+
+  node-dep-scan:
+    name: Node dependency scan
+    if: inputs.language == 'node'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Node dependency scan
+        uses: ./.github/actions/node-dep-scan
+        with:
+          working-directory: ${{ inputs.working_directory }}
+          package-manager: ${{ inputs.package_manager }}
+          ignore-file: ${{ inputs.ignore_file }}
+          audit-level: ${{ inputs.audit_level }}
+          node-version: ${{ inputs.node_version }}
+          install-command: ${{ inputs.install_command }}
+          exit-code: ${{ inputs.advisory && '0' || '1' }}
+          sarif-category: node-dep-scan-${{ inputs.working_directory }}
+          upload-sarif: ${{ inputs.upload_sarif }}

--- a/.github/workflows/reusable-sast.yml
+++ b/.github/workflows/reusable-sast.yml
@@ -1,0 +1,92 @@
+# -----------------------------------------------------------------------------
+# reusable-sast.yml
+#
+# Reusable workflow: run CodeQL static application security testing (SAST) over
+# a matrix of languages. Wraps the `sast-codeql` composite from
+# .github/actions/* in this repo.
+#
+# Completes the Tier-1 set started in PR #241 (ADR-0016). Per ADR-0016 the SAST
+# gate is ADVISORY at the workflow level — SARIF flows to GitHub Code Scanning
+# and merge-blocking is enforced by branch protection on the Code Scanning
+# check, not by failing this job. Set `fail_on_error: true` to hard-fail the
+# job on a CodeQL analysis error.
+#
+# Mirrors platform-workflows@3bb35df SAST wiring (2026-06 consolidation sync).
+# In the real estate this lives in the shared platform-workflows repo
+# (`uses: platform-workflows/.github/workflows/reusable-sast.yml@<ref>`); in this
+# mock it lives in-repo and the composite is called via local `./.github/...`.
+#
+# Caller example:
+#
+#   jobs:
+#     sast:
+#       uses: ./.github/workflows/reusable-sast.yml
+#       permissions:
+#         contents: read
+#         security-events: write
+#         actions: read
+#       with:
+#         languages: '["python","javascript"]'
+#
+# See: docs/ci-cd/README.md
+# -----------------------------------------------------------------------------
+
+name: reusable-sast
+
+on:
+  workflow_call:
+    inputs:
+      languages:
+        description: "JSON array of CodeQL languages to analyse. e.g. '[\"go\",\"python\"]'."
+        type: string
+        required: false
+        default: '["go"]'
+      queries:
+        description: "CodeQL query suite. Default security-and-quality."
+        type: string
+        required: false
+        default: "security-and-quality"
+      working_directory:
+        description: "Subdirectory to focus the build on. Empty = whole repo."
+        type: string
+        required: false
+        default: ""
+      config_file:
+        description: "Optional CodeQL config file path (relative to repo root)."
+        type: string
+        required: false
+        default: ""
+      fail_on_error:
+        description: "Hard-fail the job on a CodeQL analysis error. Default false (advisory; findings gate via branch protection on the Code Scanning check)."
+        type: boolean
+        required: false
+        default: false
+
+permissions: {}
+
+jobs:
+  codeql:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    # Advisory by default: a CodeQL extractor/analysis error must not block the
+    # build (findings gate via branch protection on the Code Scanning check, not
+    # this job). Flip fail_on_error to make analysis errors hard-fail.
+    continue-on-error: ${{ !inputs.fail_on_error }}
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ${{ fromJSON(inputs.languages) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: CodeQL SAST
+        uses: ./.github/actions/sast-codeql
+        with:
+          language: ${{ matrix.language }}
+          queries: ${{ inputs.queries }}
+          working-directory: ${{ inputs.working_directory }}
+          config-file: ${{ inputs.config_file }}

--- a/docs/adrs/0016-tier1-supply-chain-hardening.md
+++ b/docs/adrs/0016-tier1-supply-chain-hardening.md
@@ -1,17 +1,19 @@
 # ADR-0016: Tier 1 CI/CD hardening — dep scan, secrets, SAST, signing, manifest validation, smoke
 
-- Status: **Accepted** — rolling out. Extends ADR-0015; the signing /
-  manifest-validation / smoke controls are *implemented in this repo* by PR #241.
-  The dep-scan and SAST composite actions are not yet wired org-wide — that
-  remainder stays a *design-target*.
-- platform-design status: **synced** — image signing (`cosign-sign`, keyless,
-  wired into `reusable-build-and-push` after push by digest + SBOM attestation),
-  manifest validation (`manifest-validate` action + `reusable-manifest-validate`
-  workflow + `conftest-opa.yml`), and post-deploy smoke
-  (`argocd-wait-sync-and-smoke`) are present. Secrets scanning runs via the
-  standalone `secret-scan.yml`. Remaining design-target: the `python-dep-scan` /
-  `node-dep-scan` / `sast-codeql` composite actions are not yet packaged
-  org-wide.
+- Status: **Accepted** — implemented. Extends ADR-0015. The signing /
+  manifest-validation / smoke controls landed in PR #241; the remaining dep-scan
+  and SAST composites are now wired in, so the full Tier-1 set is in-repo.
+- platform-design status: **synced** — the complete Tier-1 set is present.
+  Dependency scanning (`python-dep-scan` = pip-audit + OSV; `node-dep-scan` =
+  npm audit + osv-scanner; gating on CRITICAL/HIGH with a `.audit-ignore`
+  allowlist, wired via `reusable-dep-scan`), SAST (`sast-codeql` =
+  CodeQL `security-and-quality`, SARIF → Code Scanning, advisory at the workflow
+  level / merge-blocking via branch protection, wired via `reusable-sast`),
+  image signing (`cosign-sign`, keyless, wired into `reusable-build-and-push`
+  after push by digest + SBOM attestation), manifest validation
+  (`manifest-validate` action + `reusable-manifest-validate` workflow +
+  `conftest-opa.yml`), and post-deploy smoke (`argocd-wait-sync-and-smoke`) are
+  all present. Secrets scanning runs via the standalone `secret-scan.yml`.
 - Implemented by: PR #241 (Tier-1 composite actions + reusable workflows +
   cosign signing; consolidated CI/CD).
 - Date: 2026-06-03
@@ -133,5 +135,6 @@ CodeQL minutes become a problem.
 ---
 *Ported from infra@572b54d (and argocd@c364c6c) during the 2026-06
 platform-design sync. Signing / manifest-validation / smoke implemented in
-platform-design by PR #241. Status: Accepted — rolling out; the dep-scan and
-SAST composite actions remain a design-target.*
+platform-design by PR #241; the dep-scan (`python-dep-scan` / `node-dep-scan`)
+and SAST (`sast-codeql`) composites + their `reusable-dep-scan` / `reusable-sast`
+wiring complete the Tier-1 set. Status: Accepted — implemented; fully synced.*

--- a/docs/ci-cd/README.md
+++ b/docs/ci-cd/README.md
@@ -32,14 +32,22 @@ mock they live in-repo and are referenced via local `./.github/...` paths.
 
 ## Tier-1 composite actions (`.github/actions/`)
 
-| Action | Purpose |
-|--------|---------|
-| `cosign-sign` | Keyless image signing via Sigstore + GitHub OIDC, **by digest** (immutable). Optionally attaches the SBOM as a signed cosign attestation (SPDX/CycloneDX). `advisory: true` downgrades sign failures to warnings during Sigstore incidents. |
-| `syft-sbom` | Generate an SBOM (default `spdx-json`) for an image with Syft and upload it as a workflow artifact. |
-| `trivy-scan` | Scan an image with Trivy; the table scan is the **gate** (fails on `CRITICAL,HIGH`), the SARIF upload is best-effort reporting (tolerates repos without Advanced Security). |
-| `manifest-validate` | `helm lint --strict` + `helm template \| kubeconform -strict` + `conftest` against OPA/Rego policies. Catches bad apiVersions, missing values, and policy violations before ArgoCD syncs. |
-| `argocd-tag-bump` | Open a PR in the argocd config repo (`100rd/argocd`) bumping `image.tag` + `image.digest` in a values file. Labels non-prod PRs `auto-merge`. |
-| `argocd-wait-sync-and-smoke` | Post-deploy gate: wait for the ArgoCD app to reach Synced + Healthy, then HTTP-probe an endpoint for an expected 2xx. |
+The full Tier-1 set is now in-repo. The **dependency-scan and SAST composites
+(`python-dep-scan`, `node-dep-scan`, `sast-codeql`) were the remaining
+ADR-0016 design-target** and are added here — completing the set whose signing /
+SBOM / manifest-validation / smoke half landed in PR #241.
+
+| Action | Purpose | Gate |
+|--------|---------|------|
+| `python-dep-scan` | Scan Python deps for CVEs with `pip-audit` (PyPI Advisory DB + OSV). Post-filters the JSON report on `severity-threshold`, honours a `.audit-ignore` allowlist, emits SARIF. Catches application-dependency CVEs that the Trivy **image** scan (OS/system libs only) misses. | **Gating** — fails on `CRITICAL,HIGH` (set `exit-code: 0` for advisory). |
+| `node-dep-scan` | Scan Node deps for CVEs with `npm audit --audit-level=high` + `osv-scanner`. Honours `.audit-ignore`, uploads osv-scanner SARIF. | **Gating** — fails on `high`+ (set `exit-code: 0` for advisory). |
+| `sast-codeql` | GitHub CodeQL static analysis for one language (`security-and-quality` suite). SARIF → Code Scanning. Wraps `github/codeql-action`. | **Advisory** — findings surface in Code Scanning; merge-blocking is enforced by branch protection on that check, not by the job. |
+| `cosign-sign` | Keyless image signing via Sigstore + GitHub OIDC, **by digest** (immutable). Optionally attaches the SBOM as a signed cosign attestation (SPDX/CycloneDX). `advisory: true` downgrades sign failures to warnings during Sigstore incidents. | Gating (unless `advisory`). |
+| `syft-sbom` | Generate an SBOM (default `spdx-json`) for an image with Syft and upload it as a workflow artifact. | n/a |
+| `trivy-scan` | Scan an image with Trivy; the table scan is the **gate** (fails on `CRITICAL,HIGH`), the SARIF upload is best-effort reporting (tolerates repos without Advanced Security). | Gating. |
+| `manifest-validate` | `helm lint --strict` + `helm template \| kubeconform -strict` + `conftest` against OPA/Rego policies. Catches bad apiVersions, missing values, and policy violations before ArgoCD syncs. | Gating (conftest advisory in v1). |
+| `argocd-tag-bump` | Open a PR in the argocd config repo (`100rd/argocd`) bumping `image.tag` + `image.digest` in a values file. Labels non-prod PRs `auto-merge`. | n/a |
+| `argocd-wait-sync-and-smoke` | Post-deploy gate: wait for the ArgoCD app to reach Synced + Healthy, then HTTP-probe an endpoint for an expected 2xx. | Gating. |
 
 ## Reusable pipelines (`.github/workflows/`)
 
@@ -60,6 +68,20 @@ via `auto_merge_override`.
 ### `reusable-manifest-validate.yml`
 Wraps `manifest-validate`. Intended to run on the tag-bump PRs created by
 `reusable-deploy-via-argocd.yml`, and usable directly from any chart-owning repo.
+
+### `reusable-dep-scan.yml`
+Wraps `python-dep-scan` / `node-dep-scan` (selected by the `language` input).
+**Gating** by default (fails on `CRITICAL,HIGH` / `high`+); `advisory: true`
+flips it to reporting-only. Honours a per-repo `.audit-ignore` allowlist and
+uploads SARIF to GitHub Security. Run it as an upstream gate alongside language
+lint/test, before `reusable-build-and-push`.
+
+### `reusable-sast.yml`
+Wraps `sast-codeql` over a matrix of `languages` (CodeQL `security-and-quality`).
+**Advisory** at the workflow level — SARIF flows to Code Scanning and
+merge-blocking is enforced by branch protection on that check, not by failing the
+job (`continue-on-error` unless `fail_on_error: true`). SAST is the long pole;
+per ADR-0016 it can move to a scheduled scan if CI minutes blow up.
 
 ### `reusable-pipeline-demo.yml`
 Manual (`workflow_dispatch`) thin caller wiring `reusable-build-and-push` →


### PR DESCRIPTION
## What

Closes the remaining **ADR-0016 (Tier-1 CI/CD hardening)** design-target. PR #241 landed the signing / SBOM / manifest-validation / smoke half of Tier-1; the **dependency-scan and SAST composites were the outstanding remainder**. This PR adds them, completing the Tier-1 set.

### New composite actions (`.github/actions/`)
Ported faithfully from `platform-workflows/.github/actions/` (adapted naming + the in-repo provenance-header style used by the #241 composites):

- **`python-dep-scan`** — `pip-audit` (PyPI Advisory DB + OSV), post-filtered on a `severity-threshold` gate, `.audit-ignore` allowlist, SARIF → GitHub Security. **Gating** on `CRITICAL,HIGH`.
- **`node-dep-scan`** — `npm audit --audit-level=high` + `osv-scanner`, `.audit-ignore` allowlist, osv-scanner SARIF → GitHub Security. **Gating** on `high`+.
- **`sast-codeql`** — `github/codeql-action` (`security-and-quality` suite), SARIF → Code Scanning. **Advisory** at the workflow level; merge-blocking enforced by branch protection on the Code Scanning check.

These catch the application-dependency CVEs and SAST findings that the existing Trivy **image** scan (OS/system libs only) does not.

### Reusable workflow wiring (`.github/workflows/`)
Following #241's `permissions: {}` + per-job-grant + local-`./.github/...`-path pattern:

- **`reusable-dep-scan.yml`** — selects `python-dep-scan` / `node-dep-scan` by `language`; gating by default, `advisory: true` for reporting-only.
- **`reusable-sast.yml`** — CodeQL over a `languages` matrix; advisory (`continue-on-error` unless `fail_on_error: true`).

Existing workflows are untouched and keep working.

### Docs + ADR
- `docs/ci-cd/README.md` — lists the now-complete Tier-1 set with a gating-vs-advisory column and documents the two new reusables.
- `docs/adrs/0016-tier1-supply-chain-hardening.md` — `platform-design status` flipped to fully **synced**; dep-scan/SAST design-target caveat dropped.

## Validation
- `actionlint` on both new reusable workflows: clean (exit 0).
- `python3 yaml.safe_load` on all 5 new/edited YAML files: parse OK.
- Third-party `uses:` SHA-pinned with the Renovate-comment convention (matching the source + ADR-0015).

## Test plan
- [ ] CI: workflow files parse / actionlint in repo CI passes.
- [ ] Smoke a `reusable-dep-scan` call on a sample Python and Node service.
- [ ] Confirm CodeQL SARIF lands in the Security tab on a `reusable-sast` run.

Do not merge yet.