### PR TITLE
feat(network): inter-VPC access security model + VPN estate (ADR-0013)

### DIFF
--- a/catalog/units/inter-vpc-security/terragrunt.hcl
+++ b/catalog/units/inter-vpc-security/terragrunt.hcl
@@ -1,0 +1,94 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Inter-VPC Access Security — Catalog Unit (Network Account)
+# ---------------------------------------------------------------------------------------------------------------------
+# Wires ADR-0013's inter-VPC security model on the hub TGW: VPN route-table
+# segmentation, the legacy-side routes (cross-estate join), and the prod NACL
+# backstop. Pairs with the `remote-access-vpn` unit (the VPN host) and reads the
+# TGW from the `transit-gateway` unit.
+#
+# SEQUENCING GATE (ADR-0013): enable_vpn_routing defaults to false. Flip it to
+# true only AFTER the network VPC + attachment are applied AND the prod NACL
+# backstop is in place. Route allow-lists are sourced from account.hcl
+# (inter_vpc_security map) using representative/placeholder CIDRs + attachment
+# IDs — no estate-specific values are hardcoded.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/inter-vpc-security"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  account_name = local.account_vars.locals.account_name
+  aws_region   = local.region_vars.locals.aws_region
+  environment  = local.account_vars.locals.environment
+
+  name = "${local.account_name}-${local.aws_region}"
+
+  ivs   = try(local.account_vars.locals.inter_vpc_security, {})
+  ravpn = try(local.account_vars.locals.remote_access_vpn, {})
+}
+
+dependency "tgw" {
+  config_path = "../transit-gateway"
+
+  mock_outputs = {
+    transit_gateway_id = "tgw-mock"
+    route_table_ids = {
+      prod    = "tgw-rtb-mock-prod"
+      nonprod = "tgw-rtb-mock-nonprod"
+      shared  = "tgw-rtb-mock-shared"
+    }
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+dependency "vpn" {
+  config_path = "../remote-access-vpn"
+
+  mock_outputs = {
+    vpn_client_cidr           = "10.100.0.0/20"
+    vpn_ops_subpool_cidr      = "10.100.0.0/24"
+    vpn_standard_subpool_cidr = "10.100.1.0/24"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+inputs = {
+  name               = local.name
+  transit_gateway_id = dependency.tgw.outputs.transit_gateway_id
+
+  # Sequencing gate — default OFF. Flip in account.hcl only after the network
+  # VPC + attachment exist AND the prod NACL backstop is applied.
+  enable_vpn_routing = try(local.ivs.enable_vpn_routing, false)
+  network_vpc_id     = try(local.ivs.network_vpc_id, "")
+
+  # Outbound allow-list (incl. legacy-side routes via the legacy admin-VPC
+  # attachment). Placeholders unless overridden in account.hcl.
+  vpn_forward_routes = try(local.ivs.vpn_forward_routes, {})
+
+  # Return routes — ops sub-pool CIDR for prod-tier RTs (asymmetric return),
+  # full pool for shared/dev-tier RTs. Placeholders unless overridden.
+  vpn_return_routes = try(local.ivs.vpn_return_routes, {})
+
+  # Prod NACL backstop (design-target) — independent gate so it can be applied
+  # BEFORE routing is switched on.
+  enable_prod_nacl_backstop = try(local.ivs.enable_prod_nacl_backstop, false)
+  prod_subnet_nacl_ids      = try(local.ivs.prod_subnet_nacl_ids, [])
+
+  vpn_ops_subpool_cidr      = try(dependency.vpn.outputs.vpn_ops_subpool_cidr, "10.100.0.0/24")
+  vpn_standard_subpool_cidr = try(dependency.vpn.outputs.vpn_standard_subpool_cidr, "10.100.1.0/24")
+
+  tags = {
+    Environment = local.environment
+    ManagedBy   = "terragrunt"
+    Component   = "inter-vpc-security"
+    ADR         = "0013"
+  }
+}

--- a/catalog/units/remote-access-vpn/terragrunt.hcl
+++ b/catalog/units/remote-access-vpn/terragrunt.hcl
@@ -1,0 +1,90 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Remote-Access VPN — Catalog Unit (Network Account)
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys the management / remote-access VPN host in the Network account and
+# joins it to the hub TGW estate (ADR-0013). The VPN side of the inter-VPC
+# access security model; segmentation routes + the prod NACL backstop are wired
+# by the sibling `inter-vpc-security` unit.
+#
+# Reads the VPC + subnets from the `vpc` unit and the EBS/logs KMS key from the
+# `kms` unit. Trust sub-pools and the reachable-CIDR allow-list come from
+# account.hcl (placeholders / representative ranges — no estate specifics).
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/remote-access-vpn"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  account_name = local.account_vars.locals.account_name
+  account_id   = local.account_vars.locals.account_id
+  aws_region   = local.region_vars.locals.aws_region
+  environment  = local.account_vars.locals.environment
+
+  name = "${local.account_name}-${local.aws_region}"
+
+  # ADR-0013 trust model — representative placeholder ranges (override in account.hcl).
+  ravpn = try(local.account_vars.locals.remote_access_vpn, {})
+}
+
+dependency "vpc" {
+  config_path = "../vpc"
+
+  mock_outputs = {
+    vpc_id          = "vpc-mock"
+    private_subnets = ["subnet-mock-priv-1", "subnet-mock-priv-2"]
+    public_subnets  = ["subnet-mock-pub-1", "subnet-mock-pub-2"]
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+dependency "kms" {
+  config_path = "../kms"
+
+  mock_outputs = {
+    key_arns = {
+      ebs  = "arn:aws:kms:${local.aws_region}:${local.account_id}:key/00000000-0000-0000-0000-000000000000"
+      logs = "arn:aws:kms:${local.aws_region}:${local.account_id}:key/00000000-0000-0000-0000-000000000000"
+    }
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+inputs = {
+  name               = local.name
+  vpc_id             = dependency.vpc.outputs.vpc_id
+  private_subnet_ids = dependency.vpc.outputs.private_subnets
+  public_subnet_ids  = dependency.vpc.outputs.public_subnets
+
+  # Prefer a dedicated EBS/logs key when present; fall back to the ebs key.
+  kms_key_arn = try(dependency.kms.outputs.key_arns["ebs"], dependency.kms.outputs.key_arns["logs"])
+
+  # Trust sub-pools (ADR-0013) — placeholders unless overridden in account.hcl.
+  vpn_client_cidr           = try(local.ravpn.vpn_client_cidr, "10.100.0.0/20")
+  vpn_ops_subpool_cidr      = try(local.ravpn.vpn_ops_subpool_cidr, "10.100.0.0/24")
+  vpn_standard_subpool_cidr = try(local.ravpn.vpn_standard_subpool_cidr, "10.100.1.0/24")
+
+  # Per-CIDR egress allow-list — must agree with the inter-vpc-security TGW routes.
+  reachable_cidrs = try(local.ravpn.reachable_cidrs, [])
+
+  # Secrets are set out-of-band; only the secret shells are created here.
+  secrets_path_prefix = try(local.ravpn.secrets_path_prefix, "org/network/remote-access-vpn")
+  secrets_arn_prefix  = try(local.ravpn.secrets_arn_prefix, "arn:aws:secretsmanager:${local.aws_region}:${local.account_id}:secret:org/network/remote-access-vpn")
+
+  backup_s3_bucket    = try(local.ravpn.backup_s3_bucket, "${local.account_name}-${local.aws_region}-ravpn-backups")
+  alert_sns_topic_arn = try(local.ravpn.alert_sns_topic_arn, "arn:aws:sns:${local.aws_region}:${local.account_id}:network-alerts")
+
+  tags = {
+    Environment = local.environment
+    ManagedBy   = "terragrunt"
+    Component   = "remote-access-vpn"
+    ADR         = "0013"
+  }
+}

--- a/docs/adrs/0013-inter-vpc-access-security-model.md
+++ b/docs/adrs/0013-inter-vpc-access-security-model.md
@@ -4,11 +4,17 @@
   legacy-side return routes and the prod NACL backstop are tracked as
   cross-account follow-ups (see *Consequences*), so those sub-parts are
   *design-target*. Builds on ADR-0005 (hub-spoke TGW).
-- platform-design status: **pending** — the inter-VPC / Pritunl cross-estate
-  join model is not yet ported into this repo (no VPN-join / trust-sub-pool
-  wiring present); the underlying TGW primitives from ADR-0005 exist, but the
-  segmentation model itself is outstanding.
-- Tracked by: #243
+- platform-design status: **synced** — the inter-VPC / cross-estate join model
+  is now ported: `terraform/modules/remote-access-vpn` (Network-account VPN host
+  on AL2023, public NLB TCP_UDP, TGW join, ops/standard trust sub-pools) and
+  `terraform/modules/inter-vpc-security` (deny-by-default TGW route-table
+  segmentation, the legacy-side routes via the legacy admin-VPC attachment, the
+  asymmetric ops-only prod return routes, and the prod NACL backstop), wired
+  through `catalog/units/{remote-access-vpn,inter-vpc-security}` into the network
+  connectivity stack with the `enable_vpn_routing` / `enable_prod_nacl_backstop`
+  sequencing gates defaulting off. Genericised — no real account IDs / CIDRs /
+  attachment IDs (placeholders only); the cross-account legacy-side *return*
+  routes remain owned by legacy-ops out-of-repo as noted in *Consequences*.
 - Date: 2026-06-03
 - Authors: platform-team, security
 - Related issues: (ported)

--- a/terraform/modules/inter-vpc-security/README.md
+++ b/terraform/modules/inter-vpc-security/README.md
@@ -1,0 +1,77 @@
+# Module: `inter-vpc-security`
+
+Inter-VPC access security wiring for the hub Transit Gateway. Implements the
+**segmentation** side of
+[ADR-0013 — Inter-VPC access security model](../../../docs/adrs/0013-inter-vpc-access-security-model.md):
+TGW route-table segmentation per the trust model, the **legacy-side routes**
+(cross-estate VPN join), and the **prod-side NACL backstop** — the two parts
+ADR-0013 flags as design-targets.
+
+Pairs with the [`remote-access-vpn`](../remote-access-vpn/README.md) module
+(the VPN host) and builds on the existing `transit-gateway` module (ADR-0005
+hub-spoke). Ported and genericised from infra `modules/tgw-routing` (infra
+ADR-012) — no real account IDs, CIDRs, or attachment IDs are embedded; callers
+pass representative/placeholder values.
+
+## Why TGW routes are not enough on their own
+
+TGW route tables filter by **destination**, not by source IP within an
+attachment. The ops/standard trust split is therefore enforced by **three
+layered controls**:
+
+| Control | Where | This module |
+|---|---|---|
+| (a) VPN route-push | VPN host profiles advertise different CIDRs per tier | `remote-access-vpn` |
+| (b) Prod NACL backstop | prod subnets deny the standard sub-pool | **here** |
+| (c) Asymmetric return routes | prod-tier RTs return only to the ops sub-pool | **here** |
+
+## What it creates
+
+| Resource | When | Purpose |
+|---|---|---|
+| `aws_ec2_transit_gateway_route_table.network_vpn` | `enable_vpn_routing` | The VPN attachment's own isolated RT (no default route) |
+| `aws_ec2_transit_gateway_route_table_association.network_vpn` | `enable_vpn_routing` | Associates the VPN attachment with its RT |
+| `aws_ec2_transit_gateway_route.vpn_forward[*]` | `enable_vpn_routing` | Outbound allow-list — one route per permitted destination (incl. **legacy-side routes** via the legacy admin-VPC attachment) |
+| `aws_ec2_transit_gateway_route.vpn_return[*]` | `enable_vpn_routing` | Return routes on spoke RTs — **ops sub-pool only** for prod-tier (asymmetric), full pool for shared/dev |
+| `aws_network_acl_rule.prod_allow_ops_subpool[*]` | `enable_prod_nacl_backstop` | ALLOW the ops sub-pool on prod subnets (lower rule number) |
+| `aws_network_acl_rule.prod_deny_standard_subpool[*]` | `enable_prod_nacl_backstop` | **DENY the standard sub-pool** on prod subnets (the backstop) |
+
+## Legacy-side routes (the cross-estate seam)
+
+The legacy estate is reachable **via the Transit Gateway** using the legacy
+admin-VPC's *existing* attachment — **no new VPC peering** (ADR-0013 Alternative
+A, ADR-0005). Pass the legacy ranges as `vpn_forward_routes` entries whose
+`tgw_attachment_id` is the legacy admin-VPC attachment ID. The matching *return*
+routes on the legacy side are owned by legacy-ops (out-of-repo) and tracked as a
+cross-account follow-up in ADR-0013.
+
+## Sequencing gate (read before enabling)
+
+`enable_vpn_routing = true` must be flipped **only after**:
+
+1. the network VPC + its TGW attachment are applied, **and**
+2. the prod NACL backstop (`enable_prod_nacl_backstop = true`) is in place,
+
+otherwise the standard sub-pool transiently reaches prod via the TGW. Both
+flags default to `false`. The NACL backstop is intentionally independent of
+`enable_vpn_routing` so it can be applied *first*.
+
+## Inputs (most-used)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `transit_gateway_id` | (required) | Hub TGW ID. |
+| `enable_vpn_routing` | `false` | Master gate for VPN TGW routing. |
+| `network_vpc_id` | `""` | VPN VPC, used to look up its attachment. |
+| `vpn_forward_routes` | `{}` | `key -> { destination_cidr, tgw_attachment_id }` allow-list (incl. legacy). |
+| `vpn_return_routes` | `{}` | `key -> { route_table_id, vpn_pool_cidr }` (ops sub-pool for prod). |
+| `enable_prod_nacl_backstop` | `false` | Apply the prod NACL deny of the standard sub-pool. |
+| `prod_subnet_nacl_ids` | `[]` | Prod subnet NACL IDs (from the prod-account VPC unit). |
+| `vpn_ops_subpool_cidr` / `vpn_standard_subpool_cidr` | placeholders | Trust sub-pools. |
+
+## Conformance check
+
+A reviewer confirms conformance by verifying that every attachment is
+associated with an explicit custom route table and that **no route table grants
+a dev/standard source a path into prod**. The acceptance test is a **negative
+test**: a non-ops VPN client must NOT reach prod, verified end-to-end.

--- a/terraform/modules/inter-vpc-security/inter-vpc-security.tftest.hcl
+++ b/terraform/modules/inter-vpc-security/inter-vpc-security.tftest.hcl
@@ -1,0 +1,104 @@
+mock_provider "aws" {}
+
+variables {
+  name               = "network-eu-west-1"
+  transit_gateway_id = "tgw-12345"
+
+  tags = {
+    Environment = "network"
+    ManagedBy   = "terraform"
+  }
+}
+
+# Default posture: VPN routing is off and the NACL backstop is off (the
+# sequencing gate). No TGW route table, no routes, no NACL rules.
+run "deny_by_default_creates_nothing" {
+  command = plan
+
+  assert {
+    condition     = length(aws_ec2_transit_gateway_route_table.network_vpn) == 0
+    error_message = "No VPN route table should exist until enable_vpn_routing = true"
+  }
+
+  assert {
+    condition     = length(aws_ec2_transit_gateway_route.vpn_forward) == 0
+    error_message = "No forward routes should exist until enable_vpn_routing = true"
+  }
+
+  assert {
+    condition     = length(aws_network_acl_rule.prod_deny_standard_subpool) == 0
+    error_message = "No NACL backstop rules should exist until enable_prod_nacl_backstop = true"
+  }
+}
+
+# Prod NACL backstop can be applied independently and BEFORE routing is enabled.
+run "prod_nacl_backstop_applies_allow_and_deny" {
+  command = plan
+
+  variables {
+    enable_prod_nacl_backstop = true
+    prod_subnet_nacl_ids      = ["acl-prod-a", "acl-prod-b"]
+  }
+
+  assert {
+    condition     = length(aws_network_acl_rule.prod_allow_ops_subpool) == 2
+    error_message = "Ops ALLOW rule should be applied to each prod subnet NACL"
+  }
+
+  assert {
+    condition     = length(aws_network_acl_rule.prod_deny_standard_subpool) == 2
+    error_message = "Standard DENY rule should be applied to each prod subnet NACL"
+  }
+
+  assert {
+    condition     = alltrue([for r in aws_network_acl_rule.prod_deny_standard_subpool : r.rule_action == "deny"])
+    error_message = "The standard sub-pool rule must be a deny rule"
+  }
+}
+
+# When routing is enabled, the VPN RT and the allow-list forward routes appear.
+run "vpn_routing_creates_segmented_route_table" {
+  command = plan
+
+  variables {
+    enable_vpn_routing = true
+    network_vpc_id     = "vpc-network"
+
+    vpn_forward_routes = {
+      shared = { destination_cidr = "10.10.0.0/16", tgw_attachment_id = "tgw-attach-shared" }
+      prod   = { destination_cidr = "10.30.0.0/16", tgw_attachment_id = "tgw-attach-prod" }
+      legacy = { destination_cidr = "172.21.0.0/16", tgw_attachment_id = "tgw-attach-legacy-admin" }
+    }
+
+    vpn_return_routes = {
+      # Prod-tier RT returns ONLY to the ops sub-pool (asymmetric return).
+      prod = { route_table_id = "tgw-rtb-prod", vpn_pool_cidr = "10.100.0.0/24" }
+      # Shared-tier RT returns the full pool.
+      shared = { route_table_id = "tgw-rtb-shared", vpn_pool_cidr = "10.100.0.0/20" }
+    }
+  }
+
+  assert {
+    condition     = length(aws_ec2_transit_gateway_route_table.network_vpn) == 1
+    error_message = "The isolated VPN route table should be created when routing is enabled"
+  }
+
+  assert {
+    condition     = length(aws_ec2_transit_gateway_route.vpn_forward) == 3
+    error_message = "One forward route per allow-list entry should be created"
+  }
+
+  assert {
+    condition     = length(aws_ec2_transit_gateway_route.vpn_return) == 2
+    error_message = "One return route per spoke RT should be created"
+  }
+}
+
+run "vpn_routing_off_by_default" {
+  command = plan
+
+  assert {
+    condition     = var.enable_vpn_routing == false
+    error_message = "enable_vpn_routing must default to false (sequencing gate)"
+  }
+}

--- a/terraform/modules/inter-vpc-security/main.tf
+++ b/terraform/modules/inter-vpc-security/main.tf
@@ -1,0 +1,127 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Inter-VPC Access Security — TGW segmentation + cross-estate VPN join (ADR-0013)
+# ---------------------------------------------------------------------------------------------------------------------
+# Implements ADR-0013's inter-VPC trust model on the hub Transit Gateway:
+#
+#   Layer 1 (primary)  — TGW route-table segmentation: deny-by-default custom
+#                         route tables; the VPN attachment reaches only the
+#                         spokes its allow-list permits; asymmetric return
+#                         routes keep the standard sub-pool out of prod.
+#   Legacy-side routes  — the cross-estate join: routes to the legacy admin /
+#                         analytics ranges are added on the VPN route table via
+#                         the legacy admin-VPC's existing TGW attachment. No new
+#                         VPC peering is created (ADR-0005 / ADR-0013 Alt A).
+#   Prod NACL backstop  — prod subnets deny the standard VPN sub-pool while
+#                         allowing the ops sub-pool (ADR-0013 Layer 3,
+#                         design-target). Optional, prod-account scoped.
+#
+# IMPORTANT: TGW route tables filter by DESTINATION, not source IP within an
+# attachment. The ops/standard split is enforced by three layered controls:
+#   (a) VPN route-push — ops/standard profiles advertise different CIDRs;
+#   (b) prod NACL backstop — prod subnets deny the standard sub-pool;
+#   (c) asymmetric return routes (here) — prod-tier RTs return ONLY to the ops
+#       sub-pool, so standard-tier clients have no TGW return path from prod.
+#
+# Sequencing gate: `enable_vpn_routing = true` must be flipped ONLY AFTER the
+# network VPC + attachment are applied AND the prod NACL backstop is in place,
+# otherwise the standard sub-pool transiently reaches prod via the TGW.
+# Default is false.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# ─── VPN attachment lookup ────────────────────────────────────────────────────
+# The new-estate Network VPC (VPN host) attachment. Guarded by enable_vpn_routing.
+data "aws_ec2_transit_gateway_vpc_attachment" "network_vpn" {
+  count = var.enable_vpn_routing ? 1 : 0
+
+  filter {
+    name   = "vpc-id"
+    values = [var.network_vpc_id]
+  }
+  filter {
+    name   = "transit-gateway-id"
+    values = [var.transit_gateway_id]
+  }
+}
+
+# Network VPN route table — the VPN attachment's own isolated RT. Lists only the
+# destinations VPN clients may reach (ADR-0013 allow-list, no default route).
+resource "aws_ec2_transit_gateway_route_table" "network_vpn" {
+  count = var.enable_vpn_routing ? 1 : 0
+
+  transit_gateway_id = var.transit_gateway_id
+  tags               = merge(var.tags, { Name = "${var.name}-network-vpn-tgw-rt" })
+}
+
+resource "aws_ec2_transit_gateway_route_table_association" "network_vpn" {
+  count = var.enable_vpn_routing ? 1 : 0
+
+  transit_gateway_attachment_id  = data.aws_ec2_transit_gateway_vpc_attachment.network_vpn[0].id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.network_vpn[0].id
+}
+
+# ─── Network VPN RT: outbound allow-list (forward routes) ─────────────────────
+# One forward route per permitted destination. The destination_cidr_block /
+# attachment pairs come from var.vpn_forward_routes so no estate-specific CIDR
+# is hardcoded — callers pass representative/placeholder ranges.
+#
+# vpn_forward_routes is a map of:
+#   <key> = { destination_cidr = "<cidr>", tgw_attachment_id = "<tgw-attach-id>" }
+# where tgw_attachment_id is either a new-estate spoke attachment or the legacy
+# admin-VPC's existing attachment (the cross-estate join — legacy-side routes).
+resource "aws_ec2_transit_gateway_route" "vpn_forward" {
+  for_each = var.enable_vpn_routing ? var.vpn_forward_routes : {}
+
+  destination_cidr_block         = each.value.destination_cidr
+  transit_gateway_attachment_id  = each.value.tgw_attachment_id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.network_vpn[0].id
+}
+
+# ─── Return routes: spoke RTs -> VPN pool (asymmetric — control c) ────────────
+# Prod-tier route tables return ONLY to the ops sub-pool. Shared/dev-tier route
+# tables return the full VPN pool. var.vpn_return_routes is a map of:
+#   <key> = {
+#     route_table_id = "<tgw-rtb-id>"   # the spoke RT to add the return route to
+#     vpn_pool_cidr  = "<cidr>"         # ops sub-pool for prod RTs; full /20 for shared
+#   }
+# The VPN attachment is the next hop for every return route.
+resource "aws_ec2_transit_gateway_route" "vpn_return" {
+  for_each = var.enable_vpn_routing ? var.vpn_return_routes : {}
+
+  destination_cidr_block         = each.value.vpn_pool_cidr
+  transit_gateway_attachment_id  = data.aws_ec2_transit_gateway_vpc_attachment.network_vpn[0].id
+  transit_gateway_route_table_id = each.value.route_table_id
+}
+
+# ─── Prod NACL backstop (ADR-0013 Layer 3 — design-target) ────────────────────
+# Stateless subnet-level deny for the standard VPN sub-pool on prod subnets,
+# behind the TGW allow-list. The ops sub-pool is explicitly allowed at a lower
+# rule number so it is evaluated first. This is the prod-account VPC unit
+# (cross-account follow-up); enabled independently of enable_vpn_routing so the
+# backstop can be applied BEFORE routing is switched on (the sequencing gate).
+#
+# rule numbers (lower = evaluated first):
+#   100  ALLOW  ops sub-pool        (so ops is never caught by the deny below)
+#   110  DENY   standard sub-pool   (the backstop)
+# Both are applied to every prod subnet NACL passed in var.prod_subnet_nacl_ids.
+
+resource "aws_network_acl_rule" "prod_allow_ops_subpool" {
+  for_each = var.enable_prod_nacl_backstop ? toset(var.prod_subnet_nacl_ids) : toset([])
+
+  network_acl_id = each.value
+  rule_number    = var.nacl_ops_allow_rule_number
+  egress         = false
+  protocol       = "-1"
+  rule_action    = "allow"
+  cidr_block     = var.vpn_ops_subpool_cidr
+}
+
+resource "aws_network_acl_rule" "prod_deny_standard_subpool" {
+  for_each = var.enable_prod_nacl_backstop ? toset(var.prod_subnet_nacl_ids) : toset([])
+
+  network_acl_id = each.value
+  rule_number    = var.nacl_standard_deny_rule_number
+  egress         = false
+  protocol       = "-1"
+  rule_action    = "deny"
+  cidr_block     = var.vpn_standard_subpool_cidr
+}

--- a/terraform/modules/inter-vpc-security/outputs.tf
+++ b/terraform/modules/inter-vpc-security/outputs.tf
@@ -1,0 +1,28 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Inter-VPC Access Security — outputs (ADR-0013)
+# ---------------------------------------------------------------------------------------------------------------------
+
+output "network_vpn_route_table_id" {
+  description = "ID of the isolated Network VPN TGW route table. Null when enable_vpn_routing = false."
+  value       = var.enable_vpn_routing ? aws_ec2_transit_gateway_route_table.network_vpn[0].id : null
+}
+
+output "vpn_forward_route_keys" {
+  description = "Keys of the VPN outbound allow-list forward routes that were created."
+  value       = keys(aws_ec2_transit_gateway_route.vpn_forward)
+}
+
+output "vpn_return_route_keys" {
+  description = "Keys of the VPN return routes that were created on spoke route tables."
+  value       = keys(aws_ec2_transit_gateway_route.vpn_return)
+}
+
+output "prod_nacl_backstop_enabled" {
+  description = "Whether the prod NACL backstop (deny standard sub-pool) is applied."
+  value       = var.enable_prod_nacl_backstop
+}
+
+output "prod_nacl_backstop_subnet_count" {
+  description = "Number of prod subnet NACLs the backstop rules were applied to."
+  value       = var.enable_prod_nacl_backstop ? length(var.prod_subnet_nacl_ids) : 0
+}

--- a/terraform/modules/inter-vpc-security/variables.tf
+++ b/terraform/modules/inter-vpc-security/variables.tf
@@ -1,0 +1,106 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Inter-VPC Access Security — input variables (ADR-0013)
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "name" {
+  description = "Name prefix for resources and tags. Use <account>-<region>."
+  type        = string
+}
+
+variable "transit_gateway_id" {
+  description = "ID of the hub Transit Gateway (from the transit-gateway module)."
+  type        = string
+}
+
+# ─── VPN routing (sequencing-gated) ───────────────────────────────────────────
+
+variable "enable_vpn_routing" {
+  description = "Master gate for the VPN TGW routing (ADR-0013 sequencing gate). Flip to true ONLY after the network VPC + attachment are applied AND the prod NACL backstop is in place. Default false."
+  type        = bool
+  default     = false
+}
+
+variable "network_vpc_id" {
+  description = "VPC ID of the Network-account VPN VPC. Used to look up its TGW attachment. Only required when enable_vpn_routing = true."
+  type        = string
+  default     = ""
+}
+
+variable "vpn_forward_routes" {
+  description = <<-EOT
+    Outbound allow-list for the VPN route table — one forward route per permitted
+    destination. Map of key -> { destination_cidr, tgw_attachment_id }. The
+    attachment is either a new-estate spoke attachment or the legacy admin-VPC's
+    existing attachment (the cross-estate join / legacy-side routes). Use
+    representative/placeholder CIDRs and attachment IDs; no estate-specific value
+    is hardcoded in the module.
+  EOT
+  type = map(object({
+    destination_cidr  = string
+    tgw_attachment_id = string
+  }))
+  default = {}
+}
+
+variable "vpn_return_routes" {
+  description = <<-EOT
+    Return routes added on spoke route tables pointing back at the VPN pool. Map
+    of key -> { route_table_id, vpn_pool_cidr }. For PROD-tier route tables pass
+    the ops sub-pool CIDR (asymmetric return — control c); for shared/dev-tier
+    route tables pass the full VPN pool CIDR. The VPN attachment is the next hop.
+  EOT
+  type = map(object({
+    route_table_id = string
+    vpn_pool_cidr  = string
+  }))
+  default = {}
+}
+
+# ─── Prod NACL backstop (ADR-0013 Layer 3 — design-target) ────────────────────
+
+variable "enable_prod_nacl_backstop" {
+  description = "Whether to apply the prod NACL backstop (deny the standard VPN sub-pool on prod subnets, allow the ops sub-pool). Prod-account scoped. Independent of enable_vpn_routing so it can be applied BEFORE routing is switched on."
+  type        = bool
+  default     = false
+}
+
+variable "prod_subnet_nacl_ids" {
+  description = "Network ACL IDs of the production subnets to apply the backstop to. Typically passed from the prod-account VPC unit."
+  type        = list(string)
+  default     = []
+}
+
+variable "vpn_ops_subpool_cidr" {
+  description = "Ops-tier VPN sub-pool CIDR. Allowed by the prod NACL and used for prod-tier asymmetric return routes."
+  type        = string
+  default     = "10.100.0.0/24"
+}
+
+variable "vpn_standard_subpool_cidr" {
+  description = "Standard-tier VPN sub-pool CIDR. Denied by the prod NACL backstop."
+  type        = string
+  default     = "10.100.1.0/24"
+}
+
+variable "nacl_ops_allow_rule_number" {
+  description = "NACL inbound rule number for the ops sub-pool ALLOW rule. Must be lower than the standard DENY rule so it is evaluated first."
+  type        = number
+  default     = 100
+}
+
+variable "nacl_standard_deny_rule_number" {
+  description = "NACL inbound rule number for the standard sub-pool DENY rule. Must be higher than the ops ALLOW rule."
+  type        = number
+  default     = 110
+
+  validation {
+    condition     = var.nacl_standard_deny_rule_number > var.nacl_ops_allow_rule_number
+    error_message = "The standard DENY rule number must be greater than the ops ALLOW rule number so ops is evaluated first."
+  }
+}
+
+variable "tags" {
+  description = "Additional tags merged on top of default tags."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/inter-vpc-security/versions.tf
+++ b/terraform/modules/inter-vpc-security/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/modules/remote-access-vpn/README.md
+++ b/terraform/modules/remote-access-vpn/README.md
@@ -1,0 +1,80 @@
+# Module: `remote-access-vpn`
+
+Management / remote-access VPN host for the **Network account**, joined to the
+hub Transit Gateway estate. Implements the VPN side of
+[ADR-0013 — Inter-VPC access security model](../../../docs/adrs/0013-inter-vpc-access-security-model.md).
+
+Ported and genericised from the infra source-of-truth `modules/pritunl-vpn`
+(infra ADR-012). No real account IDs, IPs, or product-specific identifiers are
+embedded — everything is driven by variables/placeholders. The default VPN
+software is Pritunl OSS, but the module is product-neutral: the only public
+surface is `internet -> NLB` on the VPN data port.
+
+## What it creates
+
+| Resource | Notes |
+|---|---|
+| `aws_instance.vpn` | AL2023 x86_64 (SSM param AMI), IMDSv2 required, `source_dest_check=false` for client forwarding |
+| `aws_lb.vpn` + `aws_eip.nlb` | Public NLB with a static EIP — the stable VPN endpoint |
+| `aws_lb_target_group.vpn_data` / `aws_lb_listener.vpn_data` | One **TCP_UDP** target group + listener on the data port (UDP + TCP fallback), `target_type=ip` |
+| `aws_security_group.nlb` / `aws_security_group.instance` | NLB SG is the only public surface; the instance SG admits the data plane via an SG-reference to the NLB SG — **no `0.0.0.0/0` on the host** |
+| `aws_ebs_volume.datastore` + root EBS | KMS-encrypted; dedicated datastore volume for isolated snapshots |
+| `aws_cloudwatch_metric_alarm.*` | EC2 auto-recovery + NetworkOut anomaly-detection egress alarm |
+| `aws_dlm_lifecycle_policy.vpn` | Daily EBS snapshots |
+| `aws_flow_log.vpn_vpc` + log groups | VPC flow logs + app logs (KMS) |
+| `aws_secretsmanager_secret.*` | Secret *shells* only; values injected out-of-band |
+
+## Trust model (ADR-0013)
+
+The VPN client pool is sub-divided by trust level:
+
+| Sub-pool | Variable | Reaches |
+|---|---|---|
+| **ops** | `vpn_ops_subpool_cidr` | new prod + shared + network + all legacy ranges |
+| **standard** | `vpn_standard_subpool_cidr` | the shared range **only** |
+
+Only the **ops** sub-pool is routed/propagated to production. Enforcement is
+layered and does **not** rely on the VPN host alone:
+
+1. **TGW route-table segmentation** (primary) — see the sibling
+   [`inter-vpc-security`](../inter-vpc-security/README.md) module. Prod-tier
+   route tables carry a return route only for the ops sub-pool (asymmetric
+   return), so standard-tier clients have no TGW return path from prod.
+2. **Security groups** (this module) — default-deny; the data-plane source is
+   the NLB SG; routed egress is an explicit per-CIDR allow-list
+   (`reachable_cidrs`) that must agree with the TGW routes.
+3. **Prod NACL backstop** — prod subnets deny the standard sub-pool (a
+   cross-account, *design-target* control, modelled in `inter-vpc-security`).
+4. **Centralized inspection** (future) — route inter-segment traffic through
+   the inspection VPC.
+
+The **negative test** is an acceptance requirement: a non-ops VPN client must
+NOT reach prod.
+
+## Inputs (most-used)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `name` | (required) | Prefix for resource names. Use `<account>-<region>`. |
+| `vpc_id` / `private_subnet_ids` / `public_subnet_ids` | (required) | Network-account VPC + subnets. |
+| `kms_key_arn` | (required) | Encrypts EBS + log groups. |
+| `vpn_client_cidr` | `10.100.0.0/20` | Full client pool (placeholder range). |
+| `vpn_ops_subpool_cidr` | `10.100.0.0/24` | Ops tier — routed to prod. |
+| `vpn_standard_subpool_cidr` | `10.100.1.0/24` | Standard tier — shared only. |
+| `reachable_cidrs` | `[]` | Per-CIDR egress allow-list (must agree with TGW routes). |
+| `secrets_arn_prefix` / `secrets_path_prefix` | placeholder | Scopes the IAM read + names the secret shells. |
+
+## Security posture
+
+- **No SSH** — SSM Session Manager only.
+- **No public UI** — the web UI is reachable only from the VPN client pool over the TGW.
+- **IMDSv2 required**, `hop_limit=1`.
+- The NLB must be public to accept VPN connections; this is intentional and
+  scoped to the data port only.
+
+## Wiring
+
+Deployed via the `remote-access-vpn` catalog unit in the network connectivity
+stack (`terragrunt/network/<region>/connectivity`). TGW routes + the prod NACL
+backstop are wired by the `inter-vpc-security` unit, which depends on this
+module's `vpn_*_cidr` and `instance_security_group_id` outputs.

--- a/terraform/modules/remote-access-vpn/main.tf
+++ b/terraform/modules/remote-access-vpn/main.tf
@@ -1,0 +1,648 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Remote-Access VPN — Network Account
+# ---------------------------------------------------------------------------------------------------------------------
+# A management / remote-access VPN host that runs in the Network account and
+# joins the TGW estate (ADR-0013). Ported and genericised from the infra
+# source-of-truth `modules/pritunl-vpn` (infra ADR-012). The default VPN
+# software is Pritunl, but the module is product-neutral — the only public
+# surface is internet -> NLB on the VPN data port.
+#
+# Resources:
+#   - IAM instance profile (SSM + CloudWatch agent + scoped Secrets Manager/KMS/S3)
+#   - Security groups (NLB edge attached to the NLB; instance SG references the
+#     NLB SG for the data-plane ingress — no 0.0.0.0/0 on the host)
+#   - EIP + public NLB (target_type=ip) + TCP_UDP target group/listener on the
+#     data port (one listener serves both UDP and TCP fallback)
+#   - EC2 instance (AL2023 x86_64 via SSM param; IMDSv2; source_dest_check=false)
+#   - Root EBS (KMS) + dedicated data EBS (KMS) for the VPN datastore
+#   - EC2 auto-recovery alarm + NetworkOut anomaly-detection egress alarm
+#   - DLM EBS snapshot lifecycle policy
+#   - VPC flow logs + app logs -> CloudWatch log groups (KMS)
+#   - Secrets Manager secret shells (values injected out-of-band)
+#
+# Security model (ADR-0013 Layer 2 — security groups):
+#   - The data-plane source is the NLB SG (target_type=ip). The instance SG
+#     references the NLB SG; there is no 0.0.0.0/0 ingress on the host.
+#   - No public UI, no SSH (SSM Session Manager only).
+#   - VPN routed egress is an explicit per-CIDR allow-list (var.reachable_cidrs)
+#     that must agree with the TGW route tables in the inter-vpc-security module.
+#
+# ADR-0013 | trust model: ops / standard VPN sub-pools (see variables.tf).
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_region" "current" {}
+
+# Latest Amazon Linux 2023 x86_64 AMI via the SSM public parameter. Avoids a
+# hardcoded AMI ID and always resolves to the latest AL2023 kernel default.
+data "aws_ssm_parameter" "al2023_ami" {
+  name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+}
+
+# ─── IAM — instance role ──────────────────────────────────────────────────────
+
+resource "aws_iam_role" "vpn" {
+  name        = "${var.name}-vpn-role"
+  description = "Instance role for the remote-access VPN host. Grants SSM, CloudWatch agent, and scoped Secrets Manager / KMS / S3 access."
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-role" })
+}
+
+# SSM managed instance core — enables Session Manager (replaces SSH).
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.vpn.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# CloudWatch agent — app-log + metrics publishing.
+resource "aws_iam_role_policy_attachment" "cw_agent" {
+  role       = aws_iam_role.vpn.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+# Scoped inline policy: Secrets Manager (prefix-only) + KMS decrypt + S3 backup.
+resource "aws_iam_role_policy" "vpn_secrets" {
+  name = "${var.name}-vpn-secrets-policy"
+  role = aws_iam_role.vpn.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "SecretsManagerRead"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret"
+        ]
+        # Scoped to this deployment's secret prefix only (least privilege).
+        Resource = "${var.secrets_arn_prefix}/*"
+      },
+      {
+        Sid    = "KmsDecrypt"
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:DescribeKey"
+        ]
+        Resource = var.kms_key_arn
+      },
+      {
+        Sid    = "S3BackupWrite"
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          "arn:aws:s3:::${var.backup_s3_bucket}",
+          "arn:aws:s3:::${var.backup_s3_bucket}/${var.name}/*"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_instance_profile" "vpn" {
+  name = "${var.name}-vpn-profile"
+  role = aws_iam_role.vpn.name
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-profile" })
+}
+
+# ─── Security groups ──────────────────────────────────────────────────────────
+
+# NLB security group — world-facing UDP/TCP edge (the only public surface).
+resource "aws_security_group" "nlb" {
+  name        = "${var.name}-vpn-nlb-sg"
+  description = "VPN NLB edge SG. Allows internet UDP/TCP ${var.vpn_data_port} for the VPN data plane."
+  vpc_id      = var.vpc_id
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-nlb-sg" })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nlb_vpn_udp" {
+  security_group_id = aws_security_group.nlb.id
+  description       = "VPN data plane UDP ${var.vpn_data_port} from internet to NLB"
+  ip_protocol       = "udp"
+  from_port         = var.vpn_data_port
+  to_port           = var.vpn_data_port
+  cidr_ipv4         = "0.0.0.0/0"
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-nlb-udp" })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nlb_vpn_tcp" {
+  security_group_id = aws_security_group.nlb.id
+  description       = "VPN data plane fallback TCP ${var.vpn_data_port} from internet to NLB"
+  ip_protocol       = "tcp"
+  from_port         = var.vpn_data_port
+  to_port           = var.vpn_data_port
+  cidr_ipv4         = "0.0.0.0/0"
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-nlb-tcp" })
+}
+
+resource "aws_vpc_security_group_egress_rule" "nlb_to_instance" {
+  security_group_id            = aws_security_group.nlb.id
+  description                  = "NLB forwarding traffic to the VPN instance SG"
+  ip_protocol                  = "-1"
+  referenced_security_group_id = aws_security_group.instance.id
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-nlb-egress" })
+}
+
+# ─── Instance security group (ADR-0013 Layer 2) ───────────────────────────────
+# The NLB target group uses target_type=ip. Referencing the NLB SG here is more
+# precise than CIDRs and keeps the host with no 0.0.0.0/0 ingress.
+resource "aws_security_group" "instance" {
+  name        = "${var.name}-vpn-sg"
+  description = "VPN instance SG. Data-plane ingress from the NLB SG only. No SSH (SSM only)."
+  vpc_id      = var.vpc_id
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-sg" })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "instance_vpn_udp" {
+  security_group_id            = aws_security_group.instance.id
+  description                  = "VPN data plane UDP ${var.vpn_data_port} from NLB SG"
+  ip_protocol                  = "udp"
+  from_port                    = var.vpn_data_port
+  to_port                      = var.vpn_data_port
+  referenced_security_group_id = aws_security_group.nlb.id
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-instance-udp" })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "instance_vpn_tcp" {
+  security_group_id            = aws_security_group.instance.id
+  description                  = "VPN data plane TCP ${var.vpn_data_port} from NLB SG"
+  ip_protocol                  = "tcp"
+  from_port                    = var.vpn_data_port
+  to_port                      = var.vpn_data_port
+  referenced_security_group_id = aws_security_group.nlb.id
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-instance-tcp" })
+}
+
+# NLB health check on the UI port (distinct from the data port so the TCP probe
+# does not conflict with active VPN sessions).
+resource "aws_vpc_security_group_ingress_rule" "instance_health_check" {
+  security_group_id            = aws_security_group.instance.id
+  description                  = "NLB health check TCP ${var.vpn_ui_port} from NLB SG"
+  ip_protocol                  = "tcp"
+  from_port                    = var.vpn_ui_port
+  to_port                      = var.vpn_ui_port
+  referenced_security_group_id = aws_security_group.nlb.id
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-instance-health" })
+}
+
+# Web UI from the VPN client pool only (TGW-internal; no public UI).
+resource "aws_vpc_security_group_ingress_rule" "instance_ui_vpn_clients" {
+  security_group_id = aws_security_group.instance.id
+  description       = "VPN web UI TCP ${var.vpn_ui_port} from the VPN client pool (TGW-internal; no public access)"
+  ip_protocol       = "tcp"
+  from_port         = var.vpn_ui_port
+  to_port           = var.vpn_ui_port
+  cidr_ipv4         = var.vpn_client_cidr
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-instance-ui" })
+}
+
+# ─── Egress — split control-plane vs. routed spoke ────────────────────────────
+# Control-plane HTTPS (SSM, KMS, SecretsManager, S3, CloudWatch) is served by
+# VPC endpoints. Follow-up (ADR-0013 design-target): scope this rule to the VPC
+# CIDR / endpoint prefix-lists once all endpoints are confirmed, removing the
+# broad internet fallback.
+resource "aws_vpc_security_group_egress_rule" "instance_ctrl_plane_https" {
+  security_group_id = aws_security_group.instance.id
+  description       = "Control-plane HTTPS egress for SSM, KMS, SecretsManager, S3, CloudWatch via VPC endpoints. Restrict to VPC CIDR once endpoints confirmed."
+  ip_protocol       = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_ipv4         = "0.0.0.0/0"
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-instance-ctrl-https" })
+}
+
+# Local single-node datastore (loopback only).
+resource "aws_vpc_security_group_egress_rule" "instance_datastore_egress" {
+  security_group_id = aws_security_group.instance.id
+  description       = "VPN datastore TCP ${var.datastore_port} local single-node on the same instance (loopback)"
+  ip_protocol       = "tcp"
+  from_port         = var.datastore_port
+  to_port           = var.datastore_port
+  cidr_ipv4         = "127.0.0.1/32"
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-instance-datastore" })
+}
+
+# Routed VPN egress — one rule per permitted spoke/legacy CIDR (ADR-0013
+# allow-list). source_dest_check=false lets the instance forward on behalf of
+# VPN clients. These CIDRs must agree with the TGW route tables.
+resource "aws_vpc_security_group_egress_rule" "instance_spoke_egress" {
+  for_each = toset(var.reachable_cidrs)
+
+  security_group_id = aws_security_group.instance.id
+  description       = "VPN routed egress to permitted spoke or legacy CIDR ${each.value} (ADR-0013 allow-list)"
+  ip_protocol       = "-1"
+  cidr_ipv4         = each.value
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-egress-${replace(each.value, "/", "-")}" })
+}
+
+# ─── EIP + NLB ────────────────────────────────────────────────────────────────
+
+resource "aws_eip" "nlb" {
+  domain = "vpc"
+
+  # Prevent accidental EIP deletion — this is the stable VPN endpoint IP.
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-nlb-eip" })
+}
+
+# Public NLB with the static EIP via subnet_mapping and the NLB SG attached.
+# The NLB must be public to accept VPN connections from the internet.
+resource "aws_lb" "vpn" {
+  name               = "${var.name}-vpn-nlb"
+  load_balancer_type = "network"
+  internal           = false
+  security_groups    = [aws_security_group.nlb.id]
+
+  subnet_mapping {
+    subnet_id     = var.public_subnet_ids[0]
+    allocation_id = aws_eip.nlb.id
+  }
+
+  enable_deletion_protection       = var.enable_deletion_protection
+  enable_cross_zone_load_balancing = true
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-nlb" })
+}
+
+# ─── Target group + listener (target_type=ip, TCP_UDP) ────────────────────────
+# A single TCP_UDP target group + listener serves both the UDP data plane and
+# the TCP fallback on one port (an NLB cannot have separate TCP and UDP
+# listeners on the same port). name_prefix keeps names unique across deploys
+# (AWS limits the TG name_prefix to 6 chars; the env is carried in the Name tag).
+resource "aws_lb_target_group" "vpn_data" {
+  name_prefix     = "ravpn"
+  port            = var.vpn_data_port
+  protocol        = "TCP_UDP"
+  vpc_id          = var.vpc_id
+  target_type     = "ip"
+  ip_address_type = "ipv4"
+
+  preserve_client_ip = true
+
+  health_check {
+    enabled             = true
+    protocol            = "TCP"
+    port                = var.vpn_ui_port
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    interval            = 10
+  }
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-tg-data" })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_lb_listener" "vpn_data" {
+  load_balancer_arn = aws_lb.vpn.arn
+  port              = var.vpn_data_port
+  protocol          = "TCP_UDP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.vpn_data.arn
+  }
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-listener-data" })
+}
+
+# Register the instance private IP (target_type=ip requires an IP, not an ID).
+resource "aws_lb_target_group_attachment" "vpn_data" {
+  target_group_arn  = aws_lb_target_group.vpn_data.arn
+  target_id         = aws_instance.vpn.private_ip
+  port              = var.vpn_data_port
+  availability_zone = aws_instance.vpn.availability_zone
+}
+
+# ─── EC2 instance ─────────────────────────────────────────────────────────────
+
+resource "aws_instance" "vpn" {
+  ami                    = data.aws_ssm_parameter.al2023_ami.value
+  instance_type          = var.instance_type
+  subnet_id              = var.private_subnet_ids[0]
+  vpc_security_group_ids = [aws_security_group.instance.id]
+  iam_instance_profile   = aws_iam_instance_profile.vpn.name
+
+  # VPN router mode: the instance forwards packets on behalf of VPN clients.
+  source_dest_check = false
+
+  # IMDSv2 required; hop_limit=1 prevents SSRF lateral movement.
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
+  root_block_device {
+    volume_type           = "gp3"
+    volume_size           = var.root_volume_size_gb
+    encrypted             = true
+    kms_key_id            = var.kms_key_arn
+    delete_on_termination = true
+
+    tags = merge(var.tags, { Name = "${var.name}-vpn-root" })
+  }
+
+  user_data = templatefile("${path.module}/userdata.sh.tftpl", {
+    name             = var.name
+    aws_region       = data.aws_region.current.id
+    secrets_prefix   = var.secrets_path_prefix
+    backup_s3_bucket = var.backup_s3_bucket
+    datastore_device = "/dev/xvdf"
+    datastore_mount  = "/var/lib/mongodb"
+    datastore_port   = var.datastore_port
+    vpn_ui_port      = var.vpn_ui_port
+  })
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn" })
+
+  lifecycle {
+    # Prevent replacement from AMI / user_data drift; update via a new launch.
+    ignore_changes = [ami, user_data]
+  }
+}
+
+# Dedicated EBS volume for the VPN datastore — separate from root for isolated snapshots.
+resource "aws_ebs_volume" "datastore" {
+  availability_zone = aws_instance.vpn.availability_zone
+  size              = var.datastore_volume_size_gb
+  type              = "gp3"
+  encrypted         = true
+  kms_key_id        = var.kms_key_arn
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-datastore" })
+}
+
+resource "aws_volume_attachment" "datastore" {
+  device_name  = "/dev/xvdf"
+  volume_id    = aws_ebs_volume.datastore.id
+  instance_id  = aws_instance.vpn.id
+  force_detach = false
+}
+
+# ─── EC2 auto-recovery alarm (ADR-0013 detective controls) ────────────────────
+
+resource "aws_cloudwatch_metric_alarm" "ec2_auto_recovery" {
+  alarm_name          = "${var.name}-vpn-auto-recovery"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "StatusCheckFailed_System"
+  namespace           = "AWS/EC2"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = 0
+  alarm_description   = "VPN host EC2 system status check failed triggers auto-recovery"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    InstanceId = aws_instance.vpn.id
+  }
+
+  alarm_actions = [
+    "arn:aws:automate:${data.aws_region.current.id}:ec2:recover",
+    var.alert_sns_topic_arn
+  ]
+
+  ok_actions = [var.alert_sns_topic_arn]
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-auto-recovery" })
+}
+
+# Anomaly-detection egress alarm — adapts to the actual traffic baseline rather
+# than a fixed threshold. Catches sudden NetworkOut spikes (possible exfil)
+# without false positives from normal VPN load growth.
+resource "aws_cloudwatch_metric_alarm" "high_egress_anomaly" {
+  alarm_name          = "${var.name}-vpn-egress-anomaly"
+  comparison_operator = "GreaterThanUpperThreshold"
+  evaluation_periods  = 3
+  threshold_metric_id = "e1"
+  alarm_description   = "VPN host NetworkOut exceeds the anomaly-detection upper band, possible exfil or misconfiguration"
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "m1"
+    return_data = true
+
+    metric {
+      metric_name = "NetworkOut"
+      namespace   = "AWS/EC2"
+      period      = 300
+      stat        = "Average"
+
+      dimensions = {
+        InstanceId = aws_instance.vpn.id
+      }
+    }
+  }
+
+  metric_query {
+    id          = "e1"
+    expression  = "ANOMALY_DETECTION_BAND(m1, 3)"
+    label       = "NetworkOut expected"
+    return_data = true
+  }
+
+  alarm_actions = [var.alert_sns_topic_arn]
+  ok_actions    = [var.alert_sns_topic_arn]
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-egress-anomaly" })
+}
+
+# ─── DLM EBS snapshot lifecycle ───────────────────────────────────────────────
+
+resource "aws_iam_role" "dlm" {
+  name        = "${var.name}-vpn-dlm-role"
+  description = "IAM role for the DLM EBS snapshot lifecycle policy for the VPN volumes."
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "dlm.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-dlm-role" })
+}
+
+resource "aws_iam_role_policy_attachment" "dlm_lifecycle" {
+  role       = aws_iam_role.dlm.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSDataLifecycleManagerServiceRole"
+}
+
+resource "aws_dlm_lifecycle_policy" "vpn" {
+  description        = "Daily EBS snapshots for the VPN root and datastore volumes ${var.dlm_snapshot_retain_days} day retention"
+  execution_role_arn = aws_iam_role.dlm.arn
+  state              = "ENABLED"
+
+  policy_details {
+    resource_types = ["VOLUME"]
+
+    schedule {
+      name = "daily-${var.dlm_snapshot_retain_days}d"
+
+      create_rule {
+        interval      = 24
+        interval_unit = "HOURS"
+        times         = ["02:00"]
+      }
+
+      retain_rule {
+        count = var.dlm_snapshot_retain_days
+      }
+
+      copy_tags = true
+    }
+
+    target_tags = {
+      Name   = "${var.name}-vpn"
+      Backup = "remote-access-vpn"
+    }
+  }
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-dlm" })
+}
+
+# Tag volumes for DLM targeting.
+resource "aws_ec2_tag" "root_backup_tag" {
+  resource_id = aws_instance.vpn.root_block_device[0].volume_id
+  key         = "Backup"
+  value       = "remote-access-vpn"
+}
+
+resource "aws_ec2_tag" "datastore_backup_tag" {
+  resource_id = aws_ebs_volume.datastore.id
+  key         = "Backup"
+  value       = "remote-access-vpn"
+}
+
+# ─── CloudWatch log groups ────────────────────────────────────────────────────
+
+# VPC-level flow logs (all traffic on the network VPC — ADR-0013 detective controls).
+resource "aws_cloudwatch_log_group" "flow_logs" {
+  name              = "/aws/vpc/${var.name}-vpn-flowlogs"
+  retention_in_days = var.flow_log_retention_days
+  kms_key_id        = var.kms_key_arn
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-flowlogs" })
+}
+
+# Application log group — the CloudWatch agent writes VPN/datastore/backup logs here.
+resource "aws_cloudwatch_log_group" "app_logs" {
+  name              = "/remote-access-vpn/${var.name}"
+  retention_in_days = var.flow_log_retention_days
+  kms_key_id        = var.kms_key_arn
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-applogs" })
+}
+
+# ─── VPC flow logs IAM + flow log ─────────────────────────────────────────────
+
+resource "aws_iam_role" "flow_logs" {
+  name        = "${var.name}-vpn-flowlogs-role"
+  description = "IAM role for VPC flow logs to CloudWatch for the VPN network VPC."
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "vpc-flow-logs.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-flowlogs-role" })
+}
+
+resource "aws_iam_role_policy" "flow_logs" {
+  name = "${var.name}-vpn-flowlogs-policy"
+  role = aws_iam_role.flow_logs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams"
+      ]
+      Resource = "${aws_cloudwatch_log_group.flow_logs.arn}:*"
+    }]
+  })
+}
+
+resource "aws_flow_log" "vpn_vpc" {
+  iam_role_arn    = aws_iam_role.flow_logs.arn
+  log_destination = aws_cloudwatch_log_group.flow_logs.arn
+  traffic_type    = "ALL"
+  vpc_id          = var.vpc_id
+
+  tags = merge(var.tags, { Name = "${var.name}-vpn-flowlog" })
+}
+
+# ─── Secrets Manager secret shells (values injected out-of-band) ──────────────
+# Secret names are constructed from var.secrets_path_prefix so the module is
+# reusable. Values are NEVER stored in this repo; operators set them out-of-band.
+
+resource "aws_secretsmanager_secret" "datastore_uri" {
+  name        = "${var.secrets_path_prefix}/datastore-uri"
+  description = "VPN datastore connection URI (local single-node on the same instance). Set out-of-band."
+  kms_key_id  = var.kms_key_arn
+
+  recovery_window_in_days = 7
+
+  tags = merge(var.tags, { Name = "${var.secrets_path_prefix}/datastore-uri" })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_secretsmanager_secret" "setup_key" {
+  name        = "${var.secrets_path_prefix}/setup-key"
+  description = "VPN one-time setup key generated on first boot. Set out-of-band."
+  kms_key_id  = var.kms_key_arn
+
+  recovery_window_in_days = 7
+
+  tags = merge(var.tags, { Name = "${var.secrets_path_prefix}/setup-key" })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/terraform/modules/remote-access-vpn/outputs.tf
+++ b/terraform/modules/remote-access-vpn/outputs.tf
@@ -1,0 +1,88 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Remote-Access VPN — outputs (ADR-0013)
+# ---------------------------------------------------------------------------------------------------------------------
+
+output "instance_id" {
+  description = "EC2 instance ID of the VPN host."
+  value       = aws_instance.vpn.id
+}
+
+output "instance_private_ip" {
+  description = "Primary private IP of the VPN host. Used as the NLB IP-mode target (target_type=ip)."
+  value       = aws_instance.vpn.private_ip
+}
+
+output "nlb_dns_name" {
+  description = "DNS name of the NLB. Prefer nlb_eip_public_ip as the stable endpoint."
+  value       = aws_lb.vpn.dns_name
+}
+
+output "nlb_arn" {
+  description = "ARN of the VPN Network Load Balancer."
+  value       = aws_lb.vpn.arn
+}
+
+output "nlb_eip_public_ip" {
+  description = "Stable public EIP attached to the NLB. This is the VPN client endpoint — survives instance replacement."
+  value       = aws_eip.nlb.public_ip
+}
+
+output "nlb_eip_allocation_id" {
+  description = "EIP allocation ID for the NLB EIP."
+  value       = aws_eip.nlb.allocation_id
+}
+
+output "instance_security_group_id" {
+  description = "ID of the instance-level security group."
+  value       = aws_security_group.instance.id
+}
+
+output "nlb_security_group_id" {
+  description = "ID of the NLB edge security group."
+  value       = aws_security_group.nlb.id
+}
+
+output "iam_role_arn" {
+  description = "ARN of the VPN instance IAM role."
+  value       = aws_iam_role.vpn.arn
+}
+
+output "vpn_client_cidr" {
+  description = "Full VPN client pool CIDR. Add return routes for this CIDR on permitted spoke RTs (see inter-vpc-security module)."
+  value       = var.vpn_client_cidr
+}
+
+output "vpn_ops_subpool_cidr" {
+  description = "Ops-tier VPN sub-pool CIDR. Only this sub-pool is routed to production (ADR-0013)."
+  value       = var.vpn_ops_subpool_cidr
+}
+
+output "vpn_standard_subpool_cidr" {
+  description = "Standard-tier VPN sub-pool CIDR. Blocked from production by the prod NACL backstop (ADR-0013)."
+  value       = var.vpn_standard_subpool_cidr
+}
+
+output "flow_log_group_name" {
+  description = "CloudWatch log group name for VPC flow logs."
+  value       = aws_cloudwatch_log_group.flow_logs.name
+}
+
+output "app_log_group_name" {
+  description = "CloudWatch log group name for VPN application logs."
+  value       = aws_cloudwatch_log_group.app_logs.name
+}
+
+output "datastore_secret_arn" {
+  description = "ARN of the Secrets Manager secret shell for the datastore URI (value set out-of-band)."
+  value       = aws_secretsmanager_secret.datastore_uri.arn
+}
+
+output "setup_key_secret_arn" {
+  description = "ARN of the Secrets Manager secret shell for the VPN setup key (value set out-of-band)."
+  value       = aws_secretsmanager_secret.setup_key.arn
+}
+
+output "datastore_ebs_volume_id" {
+  description = "EBS volume ID for the dedicated VPN datastore volume."
+  value       = aws_ebs_volume.datastore.id
+}

--- a/terraform/modules/remote-access-vpn/remote-access-vpn.tftest.hcl
+++ b/terraform/modules/remote-access-vpn/remote-access-vpn.tftest.hcl
@@ -1,0 +1,92 @@
+mock_provider "aws" {}
+
+variables {
+  name               = "network-eu-west-1"
+  vpc_id             = "vpc-12345"
+  private_subnet_ids = ["subnet-aaa", "subnet-bbb"]
+  public_subnet_ids  = ["subnet-ccc", "subnet-ddd"]
+  kms_key_arn        = "arn:aws:kms:eu-west-1:000000000000:key/00000000-0000-0000-0000-000000000000"
+  secrets_arn_prefix = "arn:aws:secretsmanager:eu-west-1:000000000000:secret:org/network/remote-access-vpn"
+  backup_s3_bucket   = "org-network-ravpn-backups"
+
+  alert_sns_topic_arn        = "arn:aws:sns:eu-west-1:000000000000:network-alerts"
+  enable_deletion_protection = false
+
+  reachable_cidrs = ["10.10.0.0/16"]
+
+  tags = {
+    Environment = "network"
+    ManagedBy   = "terraform"
+  }
+}
+
+run "creates_vpn_host_and_nlb" {
+  command = plan
+
+  assert {
+    condition     = aws_instance.vpn.source_dest_check == false
+    error_message = "VPN host must disable source/dest check to forward client traffic"
+  }
+
+  assert {
+    condition     = aws_lb.vpn.load_balancer_type == "network"
+    error_message = "VPN edge must be a Network Load Balancer"
+  }
+
+  assert {
+    condition     = aws_lb.vpn.internal == false
+    error_message = "VPN NLB must be public to accept internet VPN connections"
+  }
+}
+
+run "nlb_uses_tcp_udp_target_group" {
+  command = plan
+
+  assert {
+    condition     = aws_lb_target_group.vpn_data.protocol == "TCP_UDP"
+    error_message = "A single TCP_UDP target group must serve both UDP and TCP-fallback on the data port"
+  }
+
+  assert {
+    condition     = aws_lb_target_group.vpn_data.target_type == "ip"
+    error_message = "Target group must use target_type=ip so the NLB SG-reference data-plane rule applies"
+  }
+
+  assert {
+    condition     = aws_lb_listener.vpn_data.protocol == "TCP_UDP"
+    error_message = "The data listener must be TCP_UDP on a single port"
+  }
+}
+
+run "instance_data_plane_ingress_is_sg_reference_not_world" {
+  command = plan
+
+  # ADR-0013 Layer 2: the host admits the data plane from the NLB SG, never 0.0.0.0/0.
+  assert {
+    condition     = aws_vpc_security_group_ingress_rule.instance_vpn_udp.referenced_security_group_id != null
+    error_message = "Instance UDP ingress must reference the NLB SG, not a world CIDR"
+  }
+
+  assert {
+    condition     = aws_vpc_security_group_ingress_rule.instance_vpn_tcp.referenced_security_group_id != null
+    error_message = "Instance TCP ingress must reference the NLB SG, not a world CIDR"
+  }
+}
+
+run "imdsv2_required" {
+  command = plan
+
+  assert {
+    condition     = aws_instance.vpn.metadata_options[0].http_tokens == "required"
+    error_message = "IMDSv2 (http_tokens=required) must be enforced on the VPN host"
+  }
+}
+
+run "trust_subpools_are_distinct" {
+  command = plan
+
+  assert {
+    condition     = var.vpn_ops_subpool_cidr != var.vpn_standard_subpool_cidr
+    error_message = "Ops and standard VPN sub-pools must be distinct CIDRs for the trust model"
+  }
+}

--- a/terraform/modules/remote-access-vpn/userdata.sh.tftpl
+++ b/terraform/modules/remote-access-vpn/userdata.sh.tftpl
@@ -1,0 +1,204 @@
+#!/bin/bash
+# =============================================================================
+# Remote-Access VPN — cloud-init userdata (Amazon Linux 2023 x86_64)
+# ADR-0013 | Network account | Region: ${aws_region}
+#
+# Default VPN software is Pritunl OSS with a local single-node MongoDB datastore.
+# This script is idempotent: running it again on an existing instance is safe.
+# All sensitive values are fetched from Secrets Manager at runtime — never
+# stored in this template or in the Terraform state.
+# =============================================================================
+
+# No `-e`: a non-critical step failure must not abort the whole VPN bring-up;
+# critical steps are checked/logged explicitly.
+set -uo pipefail
+exec > >(tee /var/log/remote-access-vpn-userdata.log | logger -t ravpn-userdata) 2>&1
+
+echo "=== Remote-access VPN userdata starting: $(date -Iseconds) ==="
+
+# IMDSv2 token (required; hop_limit=1 — SSRF protection)
+IMDS_TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" \
+  -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" -m5)
+INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" \
+  http://169.254.169.254/latest/meta-data/instance-id -m5)
+echo "Instance: $INSTANCE_ID"
+
+# ─── 1. System packages ───────────────────────────────────────────────────────
+echo "--- Installing dependencies ---"
+dnf update -y --security
+# AL2023 ships curl-minimal (provides the curl command) and amazon-ssm-agent
+# preinstalled. Installing `curl` conflicts with curl-minimal and aborts dnf;
+# omit it. --allowerasing guards against any other transient conflicts.
+dnf install -y --allowerasing \
+  gnupg2 \
+  jq \
+  unzip \
+  xfsprogs \
+  amazon-cloudwatch-agent
+
+# ─── 2. Datastore data volume ─────────────────────────────────────────────────
+DATASTORE_MOUNT="${datastore_mount}"
+mkdir -p "$DATASTORE_MOUNT"
+
+# Resolve the dedicated datastore EBS volume. On Nitro the configured device name
+# (${datastore_device}) may surface under a different /dev/nvme* name, so fall back
+# to the first unmounted data disk. If none is found, the datastore uses root.
+DATASTORE_DEVICE=""
+for cand in "${datastore_device}" $(lsblk -dpn -o NAME,MOUNTPOINT,TYPE | awk '$3=="disk" && $2=="" {print $1}'); do
+  if [ -b "$cand" ]; then DATASTORE_DEVICE="$cand"; break; fi
+done
+
+if [ -n "$DATASTORE_DEVICE" ]; then
+  echo "--- Datastore data volume: $DATASTORE_DEVICE ---"
+  blkid "$DATASTORE_DEVICE" &>/dev/null || mkfs.xfs -f "$DATASTORE_DEVICE"
+  grep -q "$DATASTORE_DEVICE" /etc/fstab || echo "$DATASTORE_DEVICE  $DATASTORE_MOUNT  xfs  defaults,nofail  0  2" >> /etc/fstab
+  mountpoint -q "$DATASTORE_MOUNT" || mount "$DATASTORE_DEVICE" "$DATASTORE_MOUNT"
+else
+  echo "--- No dedicated data volume found; datastore will use the root volume ---"
+fi
+
+# ─── 3. MongoDB (VPN datastore backend) ───────────────────────────────────────
+echo "--- Installing MongoDB ---"
+cat > /etc/yum.repos.d/mongodb-org-7.0.repo <<'EOF'
+[mongodb-org-7.0]
+name=MongoDB Repository
+baseurl=https://repo.mongodb.org/yum/amazon/2023/mongodb-org/7.0/x86_64/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.mongodb.org/static/pgp/server-7.0.asc
+EOF
+
+dnf install -y mongodb-org
+
+# Point the datastore data dir to the dedicated volume.
+mkdir -p "$DATASTORE_MOUNT"
+chown -R mongod:mongod "$DATASTORE_MOUNT"
+
+# Minimal mongod config (single-node, bind to loopback; the VPN app manages auth).
+cat > /etc/mongod.conf <<EOF
+systemLog:
+  destination: file
+  logAppend: true
+  path: /var/log/mongodb/mongod.log
+storage:
+  dbPath: ${datastore_mount}
+net:
+  port: ${datastore_port}
+  bindIp: 127.0.0.1
+EOF
+
+systemctl enable --now mongod
+
+# ─── 4. VPN software (Pritunl OSS) ────────────────────────────────────────────
+echo "--- Installing Pritunl OSS ---"
+cat > /etc/yum.repos.d/pritunl.repo <<'EOF'
+[pritunl]
+name=Pritunl Repository
+baseurl=https://repo.pritunl.com/stable/yum/amazonlinux/2023/
+gpgcheck=1
+enabled=1
+EOF
+
+# Import the Pritunl GPG key.
+rpm --import https://raw.githubusercontent.com/pritunl/pgp/master/pritunl_repo_pub.asc
+dnf install -y pritunl
+
+# ─── 5. Fetch secrets from Secrets Manager ────────────────────────────────────
+echo "--- Fetching secrets ---"
+REGION="${aws_region}"
+SECRETS_PREFIX="${secrets_prefix}"
+
+# Datastore URI — set only if the secret has a value (out-of-band injection).
+DATASTORE_URI=$(aws secretsmanager get-secret-value \
+  --region "$REGION" \
+  --secret-id "$${SECRETS_PREFIX}/datastore-uri" \
+  --query SecretString --output text 2>/dev/null || echo "")
+
+# Default to the local single-node datastore when no URI is injected.
+if [ -z "$DATASTORE_URI" ]; then
+  DATASTORE_URI="mongodb://localhost:${datastore_port}/pritunl"
+fi
+echo "--- Configuring VPN datastore URI ---"
+pritunl set-mongodb "$DATASTORE_URI" || true
+
+# Web console on vpn_ui_port (the NLB health-checks this). Default would clash
+# with the data plane; also disable the :80 redirect server.
+pritunl set app.server_port ${vpn_ui_port} || true
+pritunl set app.redirect_server false || true
+
+# ─── 6. Enable and start the VPN service ──────────────────────────────────────
+echo "--- Starting VPN service ---"
+systemctl enable --now pritunl
+
+# ─── 7. mongodump nightly backup cron ─────────────────────────────────────────
+echo "--- Installing datastore backup cron ---"
+cat > /etc/cron.d/ravpn-datastore-backup <<'CRON'
+# Nightly mongodump to S3 — 01:30 UTC (before the DLM snapshot at 02:00)
+30 1 * * * root /usr/local/bin/ravpn-datastore-backup.sh >> /var/log/ravpn-backup.log 2>&1
+CRON
+
+cat > /usr/local/bin/ravpn-datastore-backup.sh <<SCRIPT
+#!/bin/bash
+set -euo pipefail
+DATE=\$(date +%Y%m%d-%H%M%S)
+BACKUP_DIR="/tmp/datastore-backup-\$DATE"
+S3_BUCKET="${backup_s3_bucket}"
+
+mongodump --host 127.0.0.1 --port ${datastore_port} --out "\$BACKUP_DIR"
+tar czf "/tmp/ravpn-datastore-\$DATE.tar.gz" -C /tmp "datastore-backup-\$DATE"
+aws s3 cp "/tmp/ravpn-datastore-\$DATE.tar.gz" "s3://\$S3_BUCKET/${name}/\$DATE.tar.gz" \
+  --region ${aws_region}
+rm -rf "\$BACKUP_DIR" "/tmp/ravpn-datastore-\$DATE.tar.gz"
+echo "Backup completed: \$DATE"
+SCRIPT
+
+chmod +x /usr/local/bin/ravpn-datastore-backup.sh
+
+# ─── 8. CloudWatch agent config ───────────────────────────────────────────────
+echo "--- Configuring CloudWatch agent ---"
+cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<'CWCONFIG'
+{
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/remote-access-vpn*.log",
+            "log_group_name": "/remote-access-vpn/${name}",
+            "log_stream_name": "{instance_id}/vpn",
+            "timezone": "UTC"
+          },
+          {
+            "file_path": "/var/log/mongodb/mongod.log",
+            "log_group_name": "/remote-access-vpn/${name}",
+            "log_stream_name": "{instance_id}/datastore",
+            "timezone": "UTC"
+          },
+          {
+            "file_path": "/var/log/ravpn-backup.log",
+            "log_group_name": "/remote-access-vpn/${name}",
+            "log_stream_name": "{instance_id}/backup",
+            "timezone": "UTC"
+          }
+        ]
+      }
+    }
+  },
+  "metrics": {
+    "namespace": "RemoteAccessVPN",
+    "metrics_collected": {
+      "mem": { "measurement": ["mem_used_percent"] },
+      "disk": {
+        "measurement": ["disk_used_percent"],
+        "resources": ["/", "${datastore_mount}"]
+      }
+    }
+  }
+}
+CWCONFIG
+
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+  -a fetch-config -m ec2 \
+  -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+
+echo "=== Remote-access VPN userdata complete: $(date -Iseconds) ==="

--- a/terraform/modules/remote-access-vpn/variables.tf
+++ b/terraform/modules/remote-access-vpn/variables.tf
@@ -1,0 +1,144 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Remote-Access VPN — input variables (ADR-0013)
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "name" {
+  description = "Name prefix for all resources and tags. Use <account>-<region> (e.g. network-eu-west-1)."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "ID of the Network-account VPC in which to deploy the VPN host."
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs for the VPN EC2 instance. At least one required."
+  type        = list(string)
+}
+
+variable "public_subnet_ids" {
+  description = "Public subnet IDs for the NLB (EIP attachment). At least one required."
+  type        = list(string)
+}
+
+variable "kms_key_arn" {
+  description = "ARN of the KMS key used to encrypt EBS volumes and CloudWatch log groups."
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for the VPN host."
+  type        = string
+  default     = "t3.small"
+}
+
+variable "root_volume_size_gb" {
+  description = "Size in GiB of the root EBS volume."
+  type        = number
+  default     = 20
+}
+
+variable "datastore_volume_size_gb" {
+  description = "Size in GiB of the dedicated EBS data volume for the VPN datastore (/var/lib/mongodb)."
+  type        = number
+  default     = 30
+}
+
+variable "datastore_port" {
+  description = "TCP port for the local single-node VPN datastore (MongoDB default 27017). Loopback only."
+  type        = number
+  default     = 27017
+}
+
+# ─── VPN client pool + trust sub-pools (ADR-0013 trust model) ─────────────────
+
+variable "vpn_client_cidr" {
+  description = "CIDR for the entire VPN client pool. Must not overlap any estate CIDR. Use a placeholder/representative range."
+  type        = string
+  default     = "10.100.0.0/20"
+}
+
+variable "vpn_ops_subpool_cidr" {
+  description = "Sub-CIDR for ops-tier VPN clients. Only this sub-pool is routed to production (ADR-0013 trust model)."
+  type        = string
+  default     = "10.100.0.0/24"
+}
+
+variable "vpn_standard_subpool_cidr" {
+  description = "Sub-CIDR for standard-tier VPN clients. Routed to the shared range only; blocked from production by the prod NACL backstop (ADR-0013)."
+  type        = string
+  default     = "10.100.1.0/24"
+}
+
+variable "vpn_data_port" {
+  description = "UDP/TCP port for the VPN data plane (Pritunl default 443)."
+  type        = number
+  default     = 443
+}
+
+variable "vpn_ui_port" {
+  description = "TCP port for the VPN web UI + NLB health check. Reachable only over TGW from admin networks; not public. Must differ from vpn_data_port."
+  type        = number
+  default     = 8443
+}
+
+variable "reachable_cidrs" {
+  description = "Spoke/legacy CIDRs VPN clients may reach. Added as instance-SG egress rules. Routing to these CIDRs is configured by the inter-vpc-security module's TGW route tables (ADR-0013 allow-list)."
+  type        = list(string)
+  default     = []
+}
+
+# ─── Secrets + backups ────────────────────────────────────────────────────────
+
+variable "secrets_path_prefix" {
+  description = "Secrets Manager path prefix for this deployment (e.g. org/network/remote-access-vpn). Secret names are <prefix>/datastore-uri and <prefix>/setup-key. Values are set out-of-band and never stored in this repo."
+  type        = string
+  default     = "org/network/remote-access-vpn"
+}
+
+variable "secrets_arn_prefix" {
+  description = "Full ARN prefix for Secrets Manager secrets read by the instance at boot (e.g. arn:aws:secretsmanager:eu-west-1:000000000000:secret:org/network/remote-access-vpn). Used in the IAM policy Resource condition. Use a placeholder account ID."
+  type        = string
+}
+
+variable "backup_s3_bucket" {
+  description = "Name of the S3 bucket used for datastore backups. The bucket must exist with SSE-KMS enabled before apply."
+  type        = string
+}
+
+# ─── Observability ────────────────────────────────────────────────────────────
+
+variable "alert_sns_topic_arn" {
+  description = "ARN of the SNS topic to which CloudWatch alarms send notifications."
+  type        = string
+}
+
+variable "flow_log_retention_days" {
+  description = "Retention period in days for the VPC flow log and application log CloudWatch log groups."
+  type        = number
+  default     = 90
+
+  validation {
+    condition     = contains([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653], var.flow_log_retention_days)
+    error_message = "flow_log_retention_days must be a valid CloudWatch log group retention value."
+  }
+}
+
+variable "dlm_snapshot_retain_days" {
+  description = "Number of days to retain EBS snapshots created by the DLM lifecycle policy."
+  type        = number
+  default     = 7
+}
+
+variable "enable_deletion_protection" {
+  description = "Whether to enable deletion protection on the NLB. Set false for non-production test environments."
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Additional tags merged on top of default tags for all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/remote-access-vpn/versions.tf
+++ b/terraform/modules/remote-access-vpn/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terragrunt/network/account.hcl
+++ b/terragrunt/network/account.hcl
@@ -49,4 +49,54 @@ locals {
     #   ]
     # }
   }
+
+  # ---------------------------------------------------------------------------
+  # ADR-0013 — Inter-VPC access security model
+  # ---------------------------------------------------------------------------
+  # Remote-access VPN trust sub-pools (representative placeholder ranges). The
+  # ops sub-pool is the only tier routed to production; the standard sub-pool
+  # reaches the shared range only. Override these per estate as needed.
+  remote_access_vpn = {
+    vpn_client_cidr           = "10.100.0.0/20"
+    vpn_ops_subpool_cidr      = "10.100.0.0/24"
+    vpn_standard_subpool_cidr = "10.100.1.0/24"
+
+    # Per-CIDR egress allow-list on the VPN instance SG. Must agree with the
+    # inter_vpc_security.vpn_forward_routes below.
+    reachable_cidrs = [
+      # "10.10.0.0/16",  # shared
+      # "10.30.0.0/16",  # production (ops only — see TGW asymmetric return)
+    ]
+  }
+
+  # Inter-VPC TGW segmentation + legacy-side routes + prod NACL backstop.
+  #
+  # SEQUENCING GATE: keep enable_vpn_routing = false until (1) the network VPC +
+  # attachment are applied AND (2) enable_prod_nacl_backstop is applied —
+  # otherwise the standard sub-pool transiently reaches prod via the TGW.
+  inter_vpc_security = {
+    enable_vpn_routing = false
+    network_vpc_id     = "" # set to the network VPN VPC ID before enabling routing
+
+    # Outbound allow-list. tgw_attachment_id is either a new-estate spoke
+    # attachment or the LEGACY admin-VPC's existing attachment (the cross-estate
+    # join — legacy-side routes). Placeholders; fill with real IDs out-of-band.
+    vpn_forward_routes = {
+      # shared       = { destination_cidr = "10.10.0.0/16",  tgw_attachment_id = "tgw-attach-shared" }
+      # production   = { destination_cidr = "10.30.0.0/16",  tgw_attachment_id = "tgw-attach-prod" }
+      # legacy-admin = { destination_cidr = "172.21.0.0/16", tgw_attachment_id = "tgw-attach-legacy-admin" }
+    }
+
+    # Return routes. PROD-tier RTs return ONLY to the ops sub-pool (asymmetric
+    # return); shared/dev-tier RTs return the full pool.
+    vpn_return_routes = {
+      # production = { route_table_id = "tgw-rtb-prod",   vpn_pool_cidr = "10.100.0.0/24" }
+      # shared     = { route_table_id = "tgw-rtb-shared", vpn_pool_cidr = "10.100.0.0/20" }
+    }
+
+    # Prod NACL backstop (ADR-0013 design-target, prod-account scoped). Apply
+    # this BEFORE flipping enable_vpn_routing. NACL IDs come from the prod VPC.
+    enable_prod_nacl_backstop = false
+    prod_subnet_nacl_ids      = [] # e.g. ["acl-xxxx", "acl-yyyy"]
+  }
 }

--- a/terragrunt/network/eu-west-1/connectivity/terragrunt.stack.hcl
+++ b/terragrunt/network/eu-west-1/connectivity/terragrunt.stack.hcl
@@ -38,3 +38,17 @@ unit "route53-resolver" {
   source = "${get_repo_root()}/catalog/units/route53-resolver"
   path   = "route53-resolver"
 }
+
+# ADR-0013 — Inter-VPC access security model: remote-access VPN host (Network
+# account, joined to the TGW estate) + TGW segmentation / legacy-side routes /
+# prod NACL backstop. inter-vpc-security depends on remote-access-vpn for the
+# trust sub-pool CIDRs and on transit-gateway for the hub TGW.
+unit "remote-access-vpn" {
+  source = "${get_repo_root()}/catalog/units/remote-access-vpn"
+  path   = "remote-access-vpn"
+}
+
+unit "inter-vpc-security" {
+  source = "${get_repo_root()}/catalog/units/inter-vpc-security"
+  path   = "inter-vpc-security"
+}


### PR DESCRIPTION
Closes #243.

Ports ADR-0013's design-target from the infra source-of-truth into platform-design (genericised — no product/account/IP specifics):
- **`terraform/modules/remote-access-vpn`** — Network-account remote-access VPN host (AL2023, userdata templated), joined to the TGW estate via an NLB TCP_UDP listener; mirrors infra `modules/pritunl-vpn`.
- **`terraform/modules/inter-vpc-security`** — TGW route-table segmentation per the trust model + legacy-side routes + prod-side NACL backstop (the parts ADR-0013 flagged as design-target).
- **`catalog/units/{remote-access-vpn,inter-vpc-security}`** + `terragrunt/network/` wiring.
- Flips **ADR-0013 platform-design status pending → synced**.

Validation: `terraform fmt` clean; `terraform validate` — inter-vpc-security valid, remote-access-vpn passes (deprecation warnings only). Completes the 2026-06 ADR-driven backlog (with #245/#246/#247/#248).