### PR TITLE
spike(ci): zizmor workflow SAST + Harden-Runner runtime egress monitoring

### DIFF
--- a/.github/actions/harden-runner/action.yml
+++ b/.github/actions/harden-runner/action.yml
@@ -1,0 +1,68 @@
+# -----------------------------------------------------------------------------
+# harden-runner
+#
+# Runtime security monitoring for GitHub-hosted runners via StepSecurity
+# Harden-Runner (https://github.com/step-security/harden-runner). Wrap this as
+# the VERY FIRST step of a CI job so it installs its eBPF agent before any other
+# step runs — it then records every outbound network connection, file write, and
+# spawned process for that job.
+#
+# Why (ADR-0016 follow-up): the Tier-1 set is entirely STATIC / build-time
+# (CodeQL, Trivy, pip-audit/osv, gitleaks, cosign). It gives ZERO runtime egress
+# visibility on the runner itself — so a compromised or typo-squatted action that
+# exfiltrates secrets at run time (the 2025 tj-actions/changed-files class of
+# attack) would leave no trace. Harden-Runner is the missing runtime layer: it
+# baselines and (optionally) blocks runner egress.
+#
+# Rollout model — START IN AUDIT, FLIP TO BLOCK LATER:
+#   * `egress-policy: audit` (default here) — observe only. Every connection is
+#     logged to the StepSecurity insights page linked in the job summary; nothing
+#     is blocked, so it CANNOT break a build. Run it across CI for a few weeks to
+#     learn the legitimate endpoint set.
+#   * Then flip to `egress-policy: block` and pass the learned endpoints via
+#     `allowed-endpoints` (newline-separated `host:port`). Example:
+#         egress-policy: block
+#         allowed-endpoints: >
+#           github.com:443
+#           api.github.com:443
+#           objects.githubusercontent.com:443
+#           *.ecr.eu-west-1.amazonaws.com:443
+#           ghcr.io:443
+#     In block mode any connection outside the allowlist is denied and surfaced
+#     as a job annotation.
+#
+# Third-party `uses:` is SHA-pinned with a version comment (the Renovate-comment
+# convention from ADR-0015 / the .github/actions composites).
+# -----------------------------------------------------------------------------
+name: "Harden Runner"
+description: "Install StepSecurity Harden-Runner as the first job step for runtime egress / file / process monitoring (audit by default; flip to block when the egress baseline is known)."
+
+inputs:
+  egress-policy:
+    description: "`audit` (observe only, never blocks — default) or `block` (deny anything outside allowed-endpoints)."
+    required: false
+    default: "audit"
+  allowed-endpoints:
+    description: "Newline-separated `host:port` allowlist. Only consulted when egress-policy is `block`. Empty in audit mode."
+    required: false
+    default: ""
+  disable-sudo:
+    description: "Disallow sudo on the runner for the rest of the job. Keep false unless a job is known not to need it."
+    required: false
+    default: "false"
+  disable-telemetry:
+    description: "Disable Harden-Runner telemetry to StepSecurity (set true on private/internal repos that must not egress run data)."
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Harden runner
+      # step-security/harden-runner v2.19.4
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411
+      with:
+        egress-policy: ${{ inputs.egress-policy }}
+        allowed-endpoints: ${{ inputs.allowed-endpoints }}
+        disable-sudo: ${{ inputs.disable-sudo }}
+        disable-telemetry: ${{ inputs.disable-telemetry }}

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -29,6 +29,15 @@ jobs:
     outputs:
       services: ${{ steps.changes.outputs.services }}
     steps:
+      # Runtime egress monitoring — MUST be the first step so the agent is
+      # installed before anything else runs. Audit mode: observe-only, never
+      # blocks the build. See .github/actions/harden-runner for the flip-to-block
+      # rollout and docs/ci-cd/supply-chain-runtime.md.
+      - name: Harden runner (audit)
+        uses: ./.github/actions/harden-runner
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
@@ -71,6 +80,14 @@ jobs:
       matrix:
         service: ${{ fromJson(needs.detect-changes.outputs.services) }}
     steps:
+      # Runtime egress monitoring — first step (before checkout / AWS / buildx)
+      # so it can baseline this job's outbound traffic to ECR, the GitHub API,
+      # Sigstore (cosign) and the buildx cache. Audit mode: never blocks.
+      - name: Harden runner (audit)
+        uses: ./.github/actions/harden-runner
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v4
 
       - name: Configure AWS credentials

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,70 @@
+# -----------------------------------------------------------------------------
+# zizmor.yml
+#
+# Static analysis of THIS repo's own GitHub Actions workflows + composite actions
+# with zizmor (https://github.com/zizmorcore/zizmor). Findings are uploaded as
+# SARIF to GitHub Code Scanning, alongside the existing Trivy / CodeQL / gitleaks
+# surfaces (ADR-0016).
+#
+# Why: the Tier-1 set (ADR-0016) lints app code (CodeQL), scans images (Trivy),
+# scans deps (pip-audit/osv) and signs images (cosign) — but nothing ever lints
+# the CI workflows themselves. zizmor closes that gap: it catches unpinned
+# actions, dangerous `pull_request_target` + checkout patterns, template-injection
+# sinks, over-broad `GITHUB_TOKEN` permissions, and credential-persistence — the
+# exact class of weakness behind the 2025 tj-actions/changed-files compromise.
+#
+# Gating model (matches reusable-sast.yml / ADR-0016): ADVISORY at the workflow
+# level. With `advanced-security: true` zizmor does NOT fail the job on findings —
+# SARIF flows to Code Scanning and merge-blocking is enforced by branch protection
+# on the "zizmor" Code Scanning check, not by failing this job. The job only fails
+# on an internal zizmor error.
+# TODO(security): once findings are triaged to zero, add a branch-protection rule
+# requiring the zizmor Code Scanning check on `main` to make it merge-blocking.
+#
+# Third-party `uses:` are SHA-pinned with a version comment (the Renovate-comment
+# convention from ADR-0015 / the .github/actions composites).
+# -----------------------------------------------------------------------------
+
+name: zizmor (Actions SAST)
+
+on:
+  push:
+    branches: [main, feature/terragrunt]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/zizmor.yml"
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/zizmor.yml"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor Actions static analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout
+      security-events: write # upload SARIF to Code Scanning
+      actions: read # read workflow metadata (private/internal repos)
+    steps:
+      - name: Checkout
+        # actions/checkout v4.2.2 (same pin used by .github/actions/argocd-tag-bump)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        # zizmorcore/zizmor-action v0.5.6
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d
+        with:
+          # Lint the whole .github tree (workflows + composite actions).
+          inputs: .github/
+          # advanced-security: true (default) => zizmor uploads SARIF to Code
+          # Scanning itself and does NOT fail the job on findings (advisory).
+          # Honours an optional repo-local .github/zizmor.yml advisory config.
+          advanced-security: true

--- a/docs/ci-cd/supply-chain-runtime.md
+++ b/docs/ci-cd/supply-chain-runtime.md
@@ -1,0 +1,114 @@
+# CI supply-chain: workflow SAST + runtime egress monitoring
+
+> **Provenance:** spike from the 2026-06 platform supply-chain research, applying
+> the lesson of the **2025 `tj-actions/changed-files` compromise** (a popular
+> third-party action was backdoored to dump CI secrets into build logs).
+> Extends **ADR-0016** (Tier-1 supply-chain hardening). Audit-mode by default,
+> so it is non-breaking on day one.
+
+## The gap this closes
+
+ADR-0016 / ADR-0015 gave platform-design a strong **static, build-time**
+supply-chain posture:
+
+| Layer | Control | What it covers |
+|-------|---------|----------------|
+| App code SAST | CodeQL (`sast-codeql`) | Vulnerabilities in *our* application source |
+| Image scan | Trivy (`trivy-scan`) | OS / system-lib CVEs in built images |
+| Dependency scan | pip-audit + osv / npm audit (`*-dep-scan`) | Application-dependency CVEs |
+| Secrets | gitleaks (`secret-scan.yml`) | Hard-coded secrets in source |
+| Provenance | cosign keyless + SBOM attest (`cosign-sign`) | Image signing by digest |
+
+Two blind spots remained — and they are **exactly** the class behind the
+tj-actions incident:
+
+1. **Nothing lints our own GitHub Actions.** CodeQL lints app code; nothing ever
+   inspected the workflows and composite actions themselves for unpinned actions,
+   dangerous `pull_request_target` + checkout, template-injection sinks, or
+   over-broad `GITHUB_TOKEN` permissions.
+2. **Zero runtime egress visibility on runners.** Every control above is
+   static/build-time. If a compromised or typo-squatted action exfiltrated
+   secrets *at run time*, no control would see the outbound connection.
+
+This note documents the two additions that close them.
+
+## 1. zizmor — static analysis of our GitHub Actions
+
+[`zizmor`](https://github.com/zizmorcore/zizmor) is a dedicated SAST tool for
+GitHub Actions. The workflow lives at
+[`.github/workflows/zizmor.yml`](../../.github/workflows/zizmor.yml) and runs on
+any change under `.github/` (plus `workflow_dispatch`).
+
+- **Scope:** the whole `.github/` tree — both `workflows/` and the `actions/`
+  composites.
+- **Output:** SARIF uploaded to **GitHub Code Scanning**, joining the existing
+  Trivy / CodeQL / gitleaks findings surface.
+- **Gating:** **advisory at the workflow level**, mirroring `reusable-sast.yml`
+  (ADR-0016). With `advanced-security: true` zizmor uploads SARIF and does **not**
+  fail the job on findings; the job only fails on an internal zizmor error.
+  Merge-blocking is enforced by **branch protection on the `zizmor` Code Scanning
+  check**, not by failing the job — so it can be adopted without breaking open
+  PRs.
+- **TODO (tracked in the workflow):** once findings are triaged to zero, add the
+  branch-protection rule on `main` to make the check merge-blocking.
+
+The action is **SHA-pinned with a version comment**
+(`zizmorcore/zizmor-action@5f14fd08…  # v0.5.6`), per the ADR-0015 convention.
+
+## 2. StepSecurity Harden-Runner — runtime egress monitoring
+
+[`Harden-Runner`](https://github.com/step-security/harden-runner) installs an
+eBPF agent on the runner that records every **outbound network connection, file
+write, and spawned process** for a job. Wrapped as a composite action at
+[`.github/actions/harden-runner`](../../.github/actions/harden-runner/action.yml)
+and demonstrated as the **first step** of both jobs in
+[`container-build.yml`](../../.github/workflows/container-build.yml).
+
+> It **must be the first step** so the agent is in place before any other step
+> (checkout, AWS login, buildx, cosign) runs.
+
+### Audit first, block later
+
+- **Audit (default, what we ship):** `egress-policy: audit` — observe only.
+  Every connection is logged to the StepSecurity insights page linked in the job
+  summary; **nothing is blocked**, so it cannot break a build. Run it across CI
+  for a few weeks to learn the legitimate endpoint set (ECR, the GitHub API,
+  Sigstore/Fulcio/Rekor for cosign, the buildx GHA cache, package registries).
+- **Block (the goal):** flip to `egress-policy: block` and pass the learned
+  endpoints via `allowed-endpoints`. Any connection outside the allowlist is then
+  **denied** and surfaced as a job annotation — turning the runner into a deny-by-
+  default network.
+
+```yaml
+- name: Harden runner
+  uses: ./.github/actions/harden-runner
+  with:
+    egress-policy: block
+    allowed-endpoints: >
+      github.com:443
+      api.github.com:443
+      objects.githubusercontent.com:443
+      *.ecr.eu-west-1.amazonaws.com:443
+      fulcio.sigstore.dev:443
+      rekor.sigstore.dev:443
+```
+
+The action is **SHA-pinned with a version comment**
+(`step-security/harden-runner@9af89fc7…  # v2.19.4`).
+
+### Rollout
+
+1. **Now:** audit mode wired into `container-build.yml` — zero behaviour change.
+2. **Next:** review the StepSecurity insights for a few weeks; collect the real
+   egress baseline per job.
+3. **Then:** add the harden-runner step (audit) to the remaining high-value jobs
+   (`reusable-build-and-push.yml`, the Terragrunt apply/plan workflows).
+4. **Finally:** flip the highest-trust jobs (build/push, signing) to
+   `egress-policy: block` with the learned `allowed-endpoints`.
+
+## Relationship to ADR-0016
+
+This is a **strict extension** of ADR-0016, not a replacement: the static Tier-1
+controls stay exactly as they are. zizmor adds the missing *Actions-SAST* layer;
+Harden-Runner adds the missing *runtime* layer. Both ship **advisory / audit** so
+adoption is non-breaking, with a documented path to enforcement.


### PR DESCRIPTION
## Spike — CI supply-chain hardening (from the 2026-06 platform supply-chain research)

Our CI has a strong **static / build-time** supply-chain posture (ADR-0015 / ADR-0016): CodeQL lints app code, Trivy scans images, pip-audit/osv scan deps, gitleaks scans secrets, cosign signs images keyless by digest with SBOM attestation.

But two blind spots remained — and they are **exactly** the class behind the **2025 `tj-actions/changed-files` compromise** (a popular third-party action backdoored to exfiltrate CI secrets at run time):

1. **We never lint our own GitHub Actions.** CodeQL lints app code; nothing inspected the workflows/composites themselves for unpinned actions, dangerous `pull_request_target` + checkout, template-injection sinks, or over-broad `GITHUB_TOKEN` perms.
2. **Zero runtime egress visibility on runners.** Every existing control is static. A compromised/typo-squatted action exfiltrating secrets at run time would leave no trace.

This spike closes both, **non-breaking by default**.

### What's added
- **`.github/workflows/zizmor.yml`** — runs [`zizmorcore/zizmor`](https://github.com/zizmorcore/zizmor) (Actions SAST) over the whole `.github/` tree on any `.github/**` change. SARIF → **Code Scanning** (joins Trivy/CodeQL/gitleaks). **Advisory** at the workflow level, mirroring `reusable-sast.yml` / ADR-0016 — merge-blocking is enforced by branch protection on the `zizmor` Code Scanning check, not by failing the job. TODO in-file to flip to merge-blocking once findings hit zero.
- **`.github/actions/harden-runner/action.yml`** — composite wrapping [`step-security/harden-runner`](https://github.com/step-security/harden-runner) as the FIRST job step (eBPF runtime egress/file/process monitoring). Ships **`egress-policy: audit`** (observe-only, never blocks) with an inline, documented path to flip to **`block` + `allowed-endpoints`** once the egress baseline is known.
- **`container-build.yml`** — demonstrates Harden-Runner as the first step of both jobs (`detect-changes`, `build`), additive, nothing else touched.
- **`docs/ci-cd/supply-chain-runtime.md`** — explains both, the gap they close, the audit→block rollout, and the tie to **ADR-0016** (this is a strict extension, not a replacement). `docs/adrs/` left untouched.

### Supply-chain hygiene of the change itself
Both new third-party actions are **SHA-pinned with a version comment** (ADR-0015 convention), verified against upstream tags:
- `zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d` # v0.5.6
- `step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411` # v2.19.4

zizmor's checkout reuses the repo's existing `actions/checkout@de0fac2e…` pin, with `persist-credentials: false`.

### Why audit-mode by default
Both controls report rather than block on day one: zizmor is advisory (SARIF only), Harden-Runner is audit (observe-only). So this can merge and start producing signal **without risk of breaking any existing pipeline**. Enforcement is a documented, deliberate follow-up.

### Test plan
- [x] YAML validated (`python3 yaml.safe_load`) — all 3 touched/new YAML files parse.
- [x] `actionlint` (docker) clean on the new/edited workflows. The one SC2129 shellcheck note is **pre-existing** in `container-build.yml`'s unchanged `detect-changes` script (present on `main`), not introduced here.
- [x] Both action SHAs verified against upstream release tags via `git ls-remote`.
- [x] Scope: touches only `.github/` + `docs/ci-cd/`.
- [ ] On first run: confirm zizmor SARIF lands in Code Scanning and Harden-Runner audit insights populate (requires CI on the branch).

Extends ADR-0016. Spike — do not merge without a maintainer review of the rollout plan.