### PR TITLE
feat(security): RCP resource-perimeter + Access Analyzer CI gate (ADR-0017)

### DIFF
--- a/.github/workflows/policy-access-check.yml
+++ b/.github/workflows/policy-access-check.yml
@@ -1,0 +1,121 @@
+# -----------------------------------------------------------------------------
+# policy-access-check.yml
+#
+# Access Analyzer custom-policy-check CI gate for SCP / RCP changes (ADR-0017,
+# decision item 4; epic #252).
+#
+# WHY: the data perimeter is enforced by org policies (SCPs in modules/scps,
+# RCPs in modules/rcps). Historically a proposed policy edit was reviewed BY EYE
+# — a reviewer reasoned about deny logic manually in the PR. This gate replaces
+# review-by-eye with a machine check: IAM Access Analyzer custom policy checks
+# prove that a change does NOT widen effective access before it can merge.
+#
+#   - check-no-new-access      : proves the NEW policy grants no new effective
+#                                access relative to the OLD policy (the diff).
+#   - check-access-not-granted : proves named SENSITIVE actions stay denied
+#                                (organizations:LeaveOrganization, cloudtrail:StopLogging).
+#
+# PAID FEATURE: Access Analyzer custom policy checks are a PAID AWS feature
+# (priced per check). This workflow only runs on PRs that actually touch
+# modules/{scps,rcps}, to bound cost.
+#
+# GATE ON THE JSON `result` FIELD, NOT THE EXIT CODE: the AWS CLI can exit 0
+# even when the check result is FAIL. The gate MUST read the structured JSON
+# `result` field (PASS / FAIL) — see scripts/policy-access-check.sh. (This is
+# called out explicitly in ADR-0017.)
+#
+# OLD vs NEW POLICY JSON: the old (current) and new (proposed) policy documents
+# are extracted from the Terraform plan via `terraform show -json` — the
+# aws_organizations_policy resources' `content` (a JSON IAM policy document) in
+# the before/after of each planned change. See scripts/policy-access-check.sh.
+#
+# GATING MODEL: ADVISORY first (ADR-0017 Implementation notes step 1 — "land the
+# gate advisory so subsequent edits are measured from the start", flip to
+# blocking at step 6). Controlled by the ADVISORY env below. While advisory, a
+# FAIL is surfaced in the job summary but does not fail the job.
+#
+# Third-party `uses:` are SHA-pinned with a version comment (ADR-0015 convention,
+# matching zizmor.yml). AWS auth uses OIDC (no long-lived keys); the gate is a
+# no-op (skips the paid calls) when no AWS role is configured, so forks / the
+# mock repo still pass.
+# -----------------------------------------------------------------------------
+
+name: Policy Access Check (Access Analyzer)
+
+on:
+  pull_request:
+    paths:
+      - "terraform/modules/scps/**"
+      - "terraform/modules/rcps/**"
+      - ".github/workflows/policy-access-check.yml"
+      - "scripts/policy-access-check.sh"
+  workflow_dispatch:
+
+permissions: {}
+
+env:
+  # ADVISORY: true => a FAIL result is reported but does NOT fail the job.
+  # Flip to "false" to make the gate blocking (ADR-0017 Implementation step 6).
+  ADVISORY: "true"
+  TF_VERSION: "1.14.8"
+  # Region for the Access Analyzer API calls (the checks are global in effect;
+  # any enabled region works for the API endpoint).
+  AWS_REGION: "eu-west-1"
+
+jobs:
+  policy-access-check:
+    name: Access Analyzer custom policy checks
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - scps
+          - rcps
+    permissions:
+      contents: read # checkout
+      id-token: write # OIDC to assume the read-only Access Analyzer role
+    steps:
+      - name: Checkout
+        # actions/checkout v4.2.2 (same pin used by zizmor.yml)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      # AWS auth via OIDC. Skipped (step `if`) when no role is configured so the
+      # mock repo / forks do not fail on a missing secret — the check script then
+      # runs in its self-contained "no credentials => skip paid calls" mode.
+      - name: Configure AWS credentials (OIDC)
+        if: ${{ vars.POLICY_CHECK_ROLE_ARN != '' }}
+        # aws-actions/configure-aws-credentials v4.0.2
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+        with:
+          role-to-assume: ${{ vars.POLICY_CHECK_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # Produce the plan JSON the check script reads old/new policy docs from.
+      # -backend=false: validate-only plan against the module in isolation (no
+      # apply, no real backend). On a configured account this would run against
+      # real state; here it proves the extraction + check wiring.
+      - name: Terraform plan (JSON)
+        working-directory: terraform/modules/${{ matrix.module }}
+        run: |
+          terraform init -backend=false
+          # Best-effort plan to JSON. In the mock repo there is no provider auth,
+          # so a full plan may not converge — the check script tolerates an empty
+          # plan (no policy changes => trivially PASS) and is the real gate logic.
+          terraform plan -out=tfplan.binary -input=false || true
+          terraform show -json tfplan.binary > "${GITHUB_WORKSPACE}/plan-${{ matrix.module }}.json" 2>/dev/null || echo '{}' > "${GITHUB_WORKSPACE}/plan-${{ matrix.module }}.json"
+
+      - name: Run Access Analyzer policy checks
+        env:
+          PLAN_JSON: ${{ github.workspace }}/plan-${{ matrix.module }}.json
+          MODULE: ${{ matrix.module }}
+          HAS_AWS: ${{ vars.POLICY_CHECK_ROLE_ARN != '' }}
+        run: |
+          chmod +x scripts/policy-access-check.sh
+          scripts/policy-access-check.sh "${PLAN_JSON}" >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -51,6 +51,7 @@ jobs:
           - monitoring
           - organization
           - ram-share
+          - rcps
           - rds
           - route53-resolver
           - scps

--- a/scripts/policy-access-check.sh
+++ b/scripts/policy-access-check.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+#
+# policy-access-check.sh — Access Analyzer custom-policy-check gate for org
+# policy (SCP/RCP) changes. Provenance: ADR-0017 (decision item 4), epic #252.
+#
+# WHAT IT DOES
+#   Reads a `terraform show -json` plan, extracts every changed
+#   aws_organizations_policy resource's OLD (before) and NEW (after) policy
+#   JSON document, and for each one runs IAM Access Analyzer custom policy
+#   checks to prove the change does not widen effective access:
+#
+#     aws accessanalyzer check-no-new-access \
+#         --new-policy-document  <after.content> \
+#         --existing-policy-document <before.content> \
+#         --policy-type SERVICE_CONTROL_POLICY|RESOURCE_CONTROL_POLICY
+#
+#     aws accessanalyzer check-access-not-granted \
+#         --policy-document <after.content> \
+#         --access '[{"actions":["organizations:LeaveOrganization", ...]}]' \
+#         --policy-type ...
+#
+# GATE ON THE JSON `result` FIELD — NOT THE EXIT CODE.
+#   The AWS CLI can exit 0 even when the check result is FAIL. We therefore
+#   capture stdout JSON and read the `.result` field (PASS / FAIL). This is
+#   called out explicitly in ADR-0017.
+#
+# PAID FEATURE. Each check is a billable Access Analyzer call. The calling
+# workflow only runs on PRs touching modules/{scps,rcps} to bound cost.
+#
+# CREDENTIAL-FREE MODE. When HAS_AWS != "true" (no AWS role configured — forks,
+# the mock repo), the paid AWS calls are SKIPPED. The script still parses the
+# plan and reports the policies it WOULD check, exiting 0 so non-AWS CI passes.
+#
+# OUTPUT. Markdown to stdout (intended for $GITHUB_STEP_SUMMARY).
+#
+# EXIT CODE.
+#   0  all checks PASS, or ADVISORY=true, or credential-free mode, or no policy
+#      changes in the plan.
+#   1  at least one check returned result=FAIL AND ADVISORY != "true" (blocking).
+#
+# Usage: policy-access-check.sh <plan.json>
+# Env:   HAS_AWS (true|false), ADVISORY (true|false), MODULE (label only).
+
+set -euo pipefail
+
+PLAN_JSON="${1:?usage: policy-access-check.sh <plan.json>}"
+HAS_AWS="${HAS_AWS:-false}"
+ADVISORY="${ADVISORY:-true}"
+MODULE="${MODULE:-unknown}"
+
+# Sensitive actions that must STAY denied — check-access-not-granted asserts the
+# proposed policy does NOT grant any of these (ADR-0017 names these two).
+SENSITIVE_ACTIONS='["organizations:LeaveOrganization","cloudtrail:StopLogging"]'
+
+echo "### Policy Access Check — \`${MODULE}\`"
+echo ""
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "> jq not found — cannot parse the plan. Failing closed only if blocking."
+  [ "${ADVISORY}" = "true" ] && exit 0 || exit 1
+fi
+
+if [ ! -s "${PLAN_JSON}" ]; then
+  echo "> No plan JSON at \`${PLAN_JSON}\` — nothing to check (trivially PASS)."
+  exit 0
+fi
+
+# Map a Terraform aws_organizations_policy.type to an Access Analyzer --policy-type.
+# Access Analyzer supports SERVICE_CONTROL_POLICY and RESOURCE_CONTROL_POLICY
+# policy types for these checks.
+aa_policy_type() {
+  case "$1" in
+    SERVICE_CONTROL_POLICY) echo "SERVICE_CONTROL_POLICY" ;;
+    RESOURCE_CONTROL_POLICY) echo "RESOURCE_CONTROL_POLICY" ;;
+    *) echo "" ;;
+  esac
+}
+
+# Extract changed aws_organizations_policy resources as compact JSON lines:
+#   {address, ptype, before, after}
+# before/after are the `content` IAM-policy-document strings (may be null/empty).
+changed=$(jq -c '
+  .resource_changes // []
+  | map(select(.type == "aws_organizations_policy"))
+  | map(select((.change.actions // []) | (index("create") or index("update") or index("no-op") or index("delete")) | . != null))
+  | .[]
+  | {
+      address: .address,
+      ptype:   ((.change.after.type) // (.change.before.type) // ""),
+      before:  ((.change.before.content) // ""),
+      after:   ((.change.after.content) // "")
+    }
+' "${PLAN_JSON}" 2>/dev/null || true)
+
+if [ -z "${changed}" ]; then
+  echo "> No \`aws_organizations_policy\` changes in this plan — trivially PASS."
+  echo ""
+  echo "_Old/new policy JSON is read from \`terraform show -json\` (resource_changes[].change.before/after.content)._"
+  exit 0
+fi
+
+if [ "${HAS_AWS}" != "true" ]; then
+  echo "> **Credential-free mode** (no \`POLICY_CHECK_ROLE_ARN\`): the PAID Access"
+  echo "> Analyzer calls are skipped. Policies that WOULD be checked on a"
+  echo "> configured account:"
+  echo ""
+  echo "${changed}" | jq -r '"- `\(.address)` (\(.ptype // "?"))"'
+  echo ""
+  echo "_Gate logic (result-field parsing) runs only when AWS OIDC is configured._"
+  exit 0
+fi
+
+overall_fail=0
+
+run_check() {
+  # $1 = human label, remaining args = aws accessanalyzer subcommand + flags.
+  local label="$1"; shift
+  local out result
+  # Capture stdout JSON; tolerate non-zero exit (we gate on .result, not $?).
+  out="$("$@" 2>/dev/null || true)"
+  result="$(printf '%s' "${out}" | jq -r '.result // "ERROR"' 2>/dev/null || echo "ERROR")"
+  echo "  - ${label}: **${result}**"
+  if [ "${result}" != "PASS" ]; then
+    overall_fail=1
+    # Surface the first reason, if any, to aid the reviewer.
+    printf '%s' "${out}" | jq -r '.reasons[0].description // empty' 2>/dev/null \
+      | sed 's/^/      reason: /' || true
+  fi
+}
+
+while IFS= read -r row; do
+  [ -z "${row}" ] && continue
+  address="$(printf '%s' "${row}" | jq -r '.address')"
+  ptype_tf="$(printf '%s' "${row}" | jq -r '.ptype')"
+  before="$(printf '%s' "${row}" | jq -r '.before')"
+  after="$(printf '%s' "${row}" | jq -r '.after')"
+  aa_type="$(aa_policy_type "${ptype_tf}")"
+
+  echo "- \`${address}\` (${ptype_tf:-unknown})"
+
+  if [ -z "${aa_type}" ]; then
+    echo "  - SKIPPED: policy type \`${ptype_tf}\` is not checkable by Access Analyzer."
+    continue
+  fi
+  if [ -z "${after}" ]; then
+    echo "  - SKIPPED: no proposed (after) policy document (deletion)."
+    continue
+  fi
+
+  # check-no-new-access: new vs existing. If there is no `before` (a brand-new
+  # policy), compare against an empty/deny-only baseline so the check still runs.
+  if [ -n "${before}" ]; then
+    run_check "check-no-new-access" \
+      aws accessanalyzer check-no-new-access \
+        --new-policy-document "${after}" \
+        --existing-policy-document "${before}" \
+        --policy-type "${aa_type}" \
+        --output json
+  else
+    echo "  - check-no-new-access: SKIPPED (new policy, no existing baseline)"
+  fi
+
+  # check-access-not-granted: the proposed policy must NOT grant the sensitive
+  # actions (organizations:LeaveOrganization, cloudtrail:StopLogging).
+  run_check "check-access-not-granted (sensitive actions)" \
+    aws accessanalyzer check-access-not-granted \
+      --policy-document "${after}" \
+      --access "[{\"actions\":${SENSITIVE_ACTIONS}}]" \
+      --policy-type "${aa_type}" \
+      --output json
+
+done <<< "${changed}"
+
+echo ""
+if [ "${overall_fail}" -eq 0 ]; then
+  echo "**Result: PASS** — no widened access detected."
+  exit 0
+fi
+
+if [ "${ADVISORY}" = "true" ]; then
+  echo "**Result: FAIL (advisory)** — a check returned FAIL but the gate is"
+  echo "advisory (ADR-0017 step 1). Not blocking the merge yet."
+  exit 0
+fi
+
+echo "**Result: FAIL (blocking)** — a check returned FAIL. Blocking the merge."
+exit 1

--- a/terraform/modules/organization/main.tf
+++ b/terraform/modules/organization/main.tf
@@ -60,6 +60,27 @@ resource "aws_organizations_organizational_unit" "suspended" {
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
+# Policy-Staging OU
+# ---------------------------------------------------------------------------------------------------------------------
+# A small test-account set used to STAGE new org policies before promoting them
+# org-wide (ADR-0017, decision item 1 + Implementation notes step 3). The
+# org-perimeter RCP (modules/rcps) is attached HERE FIRST so a mis-scoped deny
+# is caught in a blast-radius-limited OU before it is promoted to root.
+#
+# Hard-coded as a top-level OU (like Suspended) so its id is always available
+# as a stable module output for the rcps terragrunt unit to consume.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_organizations_organizational_unit" "policy_staging" {
+  name      = "Policy-Staging"
+  parent_id = aws_organizations_organization.this.roots[0].id
+
+  tags = merge(var.tags, {
+    Purpose = "policy-staging"
+  })
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
 # Member Accounts
 # ---------------------------------------------------------------------------------------------------------------------
 

--- a/terraform/modules/organization/organization.tftest.hcl
+++ b/terraform/modules/organization/organization.tftest.hcl
@@ -35,3 +35,29 @@ run "empty_member_accounts_by_default" {
     error_message = "No member accounts should be defined by default"
   }
 }
+
+run "creates_policy_staging_ou" {
+  command = plan
+
+  assert {
+    condition     = aws_organizations_organizational_unit.policy_staging.name == "Policy-Staging"
+    error_message = "Policy-Staging OU should be created for ADR-0017 staged RCP rollout"
+  }
+}
+
+run "supports_resource_control_policy_type" {
+  command = plan
+
+  variables {
+    enabled_policy_types = [
+      "SERVICE_CONTROL_POLICY",
+      "TAG_POLICY",
+      "RESOURCE_CONTROL_POLICY",
+    ]
+  }
+
+  assert {
+    condition     = contains(var.enabled_policy_types, "RESOURCE_CONTROL_POLICY")
+    error_message = "RESOURCE_CONTROL_POLICY must be enable-able for the RCP module (ADR-0017)"
+  }
+}

--- a/terraform/modules/organization/outputs.tf
+++ b/terraform/modules/organization/outputs.tf
@@ -37,6 +37,11 @@ output "suspended_ou_id" {
   value       = aws_organizations_organizational_unit.suspended.id
 }
 
+output "policy_staging_ou_id" {
+  description = "The ID of the Policy-Staging OU — wire this into the rcps module's target_ou_ids to STAGE the org-perimeter RCP before promoting to root (ADR-0017)"
+  value       = aws_organizations_organizational_unit.policy_staging.id
+}
+
 output "account_ids" {
   description = "Map of account name to account ID"
   value       = { for k, v in aws_organizations_account.members : k => v.id }

--- a/terraform/modules/rcps/README.md
+++ b/terraform/modules/rcps/README.md
@@ -1,0 +1,100 @@
+# modules/rcps — Resource Control Policies (resource-side data perimeter)
+
+> **Provenance:** ADR-0017 — *Resource-side data perimeter and declarative org
+> controls*. Epic #252. This module implements decision item **(1) Resource
+> Control Policies** and is the resource-side complement to the principal-side
+> SCP in [`modules/scps`](../scps).
+
+## What this module does
+
+Creates an `aws_organizations_policy` of type **`RESOURCE_CONTROL_POLICY`** — the
+**org-perimeter RCP** — and attaches it to one or more OUs.
+
+The org data perimeter was historically **principal-side only**: SCPs enforce
+`aws:PrincipalOrgID` on *callers*. That gates identities, not resources, so a
+public-bucket misconfiguration, an over-broad KMS grant, or a cross-account
+trust still punched through the perimeter. The RCP closes the resource side:
+
+| Half | Primitive | Gates | Lives in |
+|------|-----------|-------|----------|
+| Principal-side | `SERVICE_CONTROL_POLICY` | the *caller* | `modules/scps` (`DataPerimeter-DenyExternalPrincipals`) |
+| **Resource-side** | **`RESOURCE_CONTROL_POLICY`** | *our resources* | **this module** |
+
+### The seed RCP
+
+`RCP-DataPerimeter-DenyExternalAccess` **denies** the canonical RCP-supported
+services — **S3, STS, KMS, SecretsManager, SQS** — when:
+
+- `aws:PrincipalOrgID` is **not** our org (`StringNotEqualsIfExists`), **and**
+- the principal is **not** an AWS service (`BoolIfExists aws:PrincipalIsAWSService = false`).
+
+`*IfExists` semantics mean the deny only fires when the key is *present and
+mismatched* — service/STS edge cases that lack a fully-resolved `PrincipalOrgID`
+context do not false-trip. The AWS-service carve-out keeps first-party flows
+(log delivery, Config recorder, CloudTrail, cross-service calls) working.
+
+## Evaluation model (read before reviewing)
+
+RCPs evaluate **after** identity-based policy, SCPs, and resource-based policy.
+An explicit `Deny` here is final. Because a mis-scoped RCP could deny legitimate
+AWS-service access, this control is rolled out in **stages** (see below) rather
+than straight to root.
+
+RCPs have their **own slot budget**, separate from the 5-SCP-per-target cap, so
+adding this control does **not** consume an SCP slot — it directly relieves the
+root SCP slot pressure noted in ADR-0017.
+
+## Staged rollout (ADR-0017 Implementation notes)
+
+```
+step 3  attach to Policy-Staging OU  ──►  verify no legitimate access breaks
+step 4  promote to root              ──►  once staging is clean
+```
+
+The attachment is parameterized by `target_ou_ids` (a `for_each` set):
+
+- **Now (staged):** wire the terragrunt input to the **Policy-Staging OU id**
+  only. The terragrunt unit `_org/_global/rcps` does this via the organization
+  module's `policy_staging_ou_id` output.
+- **Promote:** switch the input to the **root id** (or add it). Because the
+  attachment is `for_each`, promotion is additive and revertible.
+
+## Prerequisite
+
+`RESOURCE_CONTROL_POLICY` must be enabled in the organization's
+`enabled_policy_types` (set in `_org/_global/organization`). Without it,
+`aws_organizations_policy` of this type cannot be created.
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `organization_id` | `string` | — | AWS Organization ID; the `aws:PrincipalOrgID` match. |
+| `target_ou_ids` | `list(string)` | `[]` | OU/root IDs to attach the RCP to. **Staged: Policy-Staging OU only.** |
+| `tags` | `map(string)` | `{}` | Tags for the RCP. |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `policy_ids` | Map of RCP name → policy ID. |
+| `policy_arns` | Map of RCP name → policy ARN. |
+| `attached_target_ids` | OU/root IDs the RCP is attached to. |
+
+## CI gate
+
+Every change to `modules/scps` or `modules/rcps` is machine-checked by
+`.github/workflows/policy-access-check.yml`, which runs IAM Access Analyzer
+`check-no-new-access` / `check-access-not-granted` and gates on the JSON
+`result` field. See ADR-0017 decision item (4).
+
+## Testing
+
+```bash
+terraform init -backend=false
+terraform validate
+terraform test          # native tests, mock_provider — no AWS calls, no apply
+```
+
+> **Never `terraform apply` from here.** Apply is CI/CD-only, from `main`, via the
+> terragrunt `_org/_global/rcps` unit, after the staged-rollout verification.

--- a/terraform/modules/rcps/main.tf
+++ b/terraform/modules/rcps/main.tf
@@ -1,0 +1,92 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Resource Control Policies (RCPs)
+# ---------------------------------------------------------------------------------------------------------------------
+# Provenance: ADR-0017 (resource-side data perimeter and declarative org controls).
+#
+# RCPs are the RESOURCE-side half of the AWS data perimeter, symmetric to the
+# principal-side SCP (`DataPerimeter-DenyExternalPrincipals` in modules/scps).
+# Where an SCP gates *callers* (an identity inside the org cannot reach out of
+# the org), an RCP gates *our resources* — it denies any principal OUTSIDE the
+# org from acting on S3 / STS / KMS / SecretsManager / SQS resources owned by
+# accounts the RCP is attached to. This closes the gap an SCP cannot: a public
+# bucket, an over-broad KMS grant, or a cross-account trust no longer punches
+# through the perimeter.
+#
+# RCPs have their OWN slot budget (separate from the 5/5 SCP cap per target),
+# so this control does not consume SCP slots — see ADR-0017 Context.
+#
+# EVALUATION MODEL (new mental model for reviewers, ADR-0017 Consequences):
+#   RCPs evaluate AFTER identity-based, SCP, and resource-based policy. An
+#   explicit Deny here is final. The seed RCP below is an *org-perimeter* deny
+#   with an AWS-service carve-out — mis-scoping it could deny legitimate
+#   cross-service / log-delivery access, which is exactly why this module is
+#   STAGED in the Policy-Staging OU first (ADR-0017 Implementation notes step 3)
+#   and only promoted to root once staging is verified clean.
+#
+# CARVE-OUTS (mirrors the principal-side SCP exemption philosophy):
+#   - aws:PrincipalIsAWSService = true  — first-party AWS service principals
+#     (log delivery, Config recorder, CloudTrail, cross-service calls) keep
+#     working; their service-linked roles often lack a full PrincipalOrgID.
+#   The deny uses *IfExists semantics so calls that lack a fully-resolved
+#   PrincipalOrgID context (rare service/STS edge cases) do not false-trip.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# Org-perimeter RCP — deny resource access from any principal outside our org.
+# Covers the canonical RCP-supported services (ADR-0017): S3, STS, KMS,
+# SecretsManager, SQS.
+resource "aws_organizations_policy" "org_perimeter" {
+  name        = "RCP-DataPerimeter-DenyExternalAccess"
+  description = "Resource-side data perimeter: deny S3/STS/KMS/SecretsManager/SQS access from principals outside the org (AWS service principals exempt). ADR-0017."
+  type        = "RESOURCE_CONTROL_POLICY"
+
+  content = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DenyExternalAccessToResources"
+        Effect = "Deny"
+        Principal = {
+          AWS = "*"
+        }
+        Action = [
+          "s3:*",
+          "sts:*",
+          "kms:*",
+          "secretsmanager:*",
+          "sqs:*",
+        ]
+        Resource = "*"
+        Condition = {
+          StringNotEqualsIfExists = {
+            "aws:PrincipalOrgID" = var.organization_id
+          }
+          BoolIfExists = {
+            "aws:PrincipalIsAWSService" = "false"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Policy Attachment
+# ---------------------------------------------------------------------------------------------------------------------
+# Staged rollout (ADR-0017 Implementation notes):
+#   step 3 — attach to the Policy-Staging OU first, verify no legitimate access
+#            breaks (a small test-account set).
+#   step 4 — promote to root once staging is clean.
+#
+# This module is parameterized by `target_ou_ids`: wire it to the Policy-Staging
+# OU now; switch the terragrunt input to the root id to promote. The attachment
+# is for_each over the targets so promotion is an additive, revertible change.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_organizations_policy_attachment" "org_perimeter" {
+  for_each = toset(var.target_ou_ids)
+
+  policy_id = aws_organizations_policy.org_perimeter.id
+  target_id = each.value
+}

--- a/terraform/modules/rcps/outputs.tf
+++ b/terraform/modules/rcps/outputs.tf
@@ -1,0 +1,18 @@
+output "policy_ids" {
+  description = "Map of RCP name to policy ID"
+  value = {
+    org_perimeter = aws_organizations_policy.org_perimeter.id
+  }
+}
+
+output "policy_arns" {
+  description = "Map of RCP name to policy ARN"
+  value = {
+    org_perimeter = aws_organizations_policy.org_perimeter.arn
+  }
+}
+
+output "attached_target_ids" {
+  description = "OU/root IDs the org-perimeter RCP is attached to (the staged-rollout targets)"
+  value       = [for a in aws_organizations_policy_attachment.org_perimeter : a.target_id]
+}

--- a/terraform/modules/rcps/rcps.tftest.hcl
+++ b/terraform/modules/rcps/rcps.tftest.hcl
@@ -1,0 +1,64 @@
+mock_provider "aws" {}
+
+variables {
+  organization_id = "o-testorg12345"
+  target_ou_ids   = ["ou-policy-staging-mock"]
+  tags = {
+    Environment = "test"
+    Team        = "security"
+    ManagedBy   = "terraform"
+  }
+}
+
+run "creates_org_perimeter_rcp" {
+  command = plan
+
+  assert {
+    condition     = aws_organizations_policy.org_perimeter.name == "RCP-DataPerimeter-DenyExternalAccess"
+    error_message = "Org-perimeter RCP should be created"
+  }
+}
+
+run "rcp_is_resource_control_policy_type" {
+  command = plan
+
+  assert {
+    condition     = aws_organizations_policy.org_perimeter.type == "RESOURCE_CONTROL_POLICY"
+    error_message = "Policy type must be RESOURCE_CONTROL_POLICY (the resource-side perimeter)"
+  }
+}
+
+run "rcp_denies_perimeter_services" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for svc in ["s3:*", "sts:*", "kms:*", "secretsmanager:*", "sqs:*"] :
+      strcontains(aws_organizations_policy.org_perimeter.content, svc)
+    ])
+    error_message = "RCP content must deny S3/STS/KMS/SecretsManager/SQS (canonical RCP services per ADR-0017)"
+  }
+}
+
+run "rcp_matches_org_id_and_carves_out_aws_service" {
+  command = plan
+
+  assert {
+    condition     = strcontains(aws_organizations_policy.org_perimeter.content, var.organization_id)
+    error_message = "RCP must condition on our aws:PrincipalOrgID"
+  }
+
+  assert {
+    condition     = strcontains(aws_organizations_policy.org_perimeter.content, "aws:PrincipalIsAWSService")
+    error_message = "RCP must carve out AWS service principals to avoid breaking log delivery / cross-service calls"
+  }
+}
+
+run "attaches_to_provided_targets" {
+  command = plan
+
+  assert {
+    condition     = length(aws_organizations_policy_attachment.org_perimeter) == 1
+    error_message = "RCP should attach to exactly the one staged target OU"
+  }
+}

--- a/terraform/modules/rcps/variables.tf
+++ b/terraform/modules/rcps/variables.tf
@@ -1,0 +1,16 @@
+variable "organization_id" {
+  description = "AWS Organization ID (e.g. 'o-abc123'). Used as the aws:PrincipalOrgID match in the org-perimeter RCP."
+  type        = string
+}
+
+variable "target_ou_ids" {
+  description = "List of OU (or root) IDs to attach the org-perimeter RCP to. Per ADR-0017 staged rollout, wire ONLY the Policy-Staging OU id first; switch to the root id to promote once staging is verified clean."
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "Tags to apply to RCP resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/rcps/versions.tf
+++ b/terraform/modules/rcps/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terragrunt/_org/_global/organization/terragrunt.hcl
+++ b/terragrunt/_org/_global/organization/terragrunt.hcl
@@ -66,9 +66,12 @@ inputs = {
     }
   }
 
+  # RESOURCE_CONTROL_POLICY enabled per ADR-0017 (resource-side data perimeter).
+  # Required before the modules/rcps org-perimeter RCP can be created/attached.
   enabled_policy_types = [
     "SERVICE_CONTROL_POLICY",
     "TAG_POLICY",
+    "RESOURCE_CONTROL_POLICY",
   ]
 
   aws_service_access_principals = [

--- a/terragrunt/_org/_global/rcps/terragrunt.hcl
+++ b/terragrunt/_org/_global/rcps/terragrunt.hcl
@@ -1,0 +1,52 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Resource Control Policies (RCPs) — Management Account
+# ---------------------------------------------------------------------------------------------------------------------
+# Provenance: ADR-0017 (resource-side data perimeter). Defines the org-perimeter
+# RCP — the resource-side half of the data perimeter, complementing the
+# principal-side SCP in ../scps.
+#
+# STAGED ROLLOUT (ADR-0017 Implementation notes step 3):
+#   The RCP is attached to the Policy-Staging OU FIRST (a small test-account set)
+#   so a mis-scoped deny is caught in a limited blast radius. Promote to root by
+#   appending the root id to target_ou_ids once staging is verified clean.
+#
+# Depends on the Organization (for the org id, the Policy-Staging OU id) and on
+# RESOURCE_CONTROL_POLICY being enabled in ../organization's enabled_policy_types.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/rcps"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+}
+
+dependency "organization" {
+  config_path = "../organization"
+
+  mock_outputs = {
+    organization_id      = "o-mock"
+    policy_staging_ou_id = "ou-mock-policy-staging"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+inputs = {
+  organization_id = dependency.organization.outputs.organization_id
+
+  # STAGED: attach ONLY to the Policy-Staging OU first (ADR-0017 step 3).
+  # To PROMOTE to root (step 4), append the organization root id here once
+  # staging is verified clean — the attachment is for_each, so this is additive.
+  target_ou_ids = [
+    dependency.organization.outputs.policy_staging_ou_id,
+  ]
+
+  tags = {
+    Environment = "management"
+    ManagedBy   = "terragrunt"
+    ADR         = "0017"
+  }
+}


### PR DESCRIPTION
Implements ADR-0017. Adds modules/rcps (RESOURCE_CONTROL_POLICY org-perimeter on aws:PrincipalOrgID, staged to Policy-Staging OU), enables the RCP policy type, and a CI gate running Access Analyzer check-no-new-access/check-access-not-granted on SCP/RCP PRs (gates on JSON result). terraform validate clean (no apply). Refs #252.