### PR TITLE
feat(cost): OpenCost + AWS CUR/Athena allocation (ADR-0027)

### DIFF
--- a/apps/infra/opencost/Chart.lock
+++ b/apps/infra/opencost/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: opencost
+  repository: https://opencost.github.io/opencost-helm-chart
+  version: 1.43.1
+digest: sha256:ee89816bac3f9d404c89babb4dbe2ccfee9bf732469bb3ffe90f04b48272d6ae
+generated: "2026-06-07T15:21:08.752457+02:00"

--- a/apps/infra/opencost/Chart.yaml
+++ b/apps/infra/opencost/Chart.yaml
@@ -1,0 +1,36 @@
+apiVersion: v2
+name: opencost
+description: >-
+  OpenCost (CNCF) – per-namespace / workload cost allocation reconciled to
+  amortized, discount-aware AWS billed cost (RIs / Savings Plans / Spot)
+  via the CUR→S3→Glue→Athena cloud-integration.  ADR-0027.
+type: application
+version: 1.0.0
+appVersion: "1.113.0"
+
+keywords:
+  - cost
+  - finops
+  - opencost
+  - kubernetes
+  - aws
+  - cur
+  - athena
+
+maintainers:
+  - name: Platform Team
+    email: platform@example.com
+
+annotations:
+  category: FinOps
+  platform: Kubernetes
+  adr: "0027"
+
+dependencies:
+  # OpenCost – CNCF Incubating cost allocation engine
+  # https://github.com/opencost/opencost-helm-chart
+  # Pinned to 1.43.x; bump after testing against a new OpenCost release.
+  - name: opencost
+    version: "1.43.1"
+    repository: https://opencost.github.io/opencost-helm-chart
+    condition: opencost.enabled

--- a/apps/infra/opencost/README.md
+++ b/apps/infra/opencost/README.md
@@ -1,0 +1,59 @@
+# opencost
+
+Per-namespace Kubernetes cost allocation reconciled to the real AWS bill.
+Implements **ADR-0027** (OpenCost + AWS CUR/Athena cloud-integration).
+
+## What this installs
+
+| Component | Purpose |
+|-----------|---------|
+| OpenCost exporter | Allocates node cost across namespaces / workloads / labels |
+| OpenCost UI | Optional web UI for ad-hoc cost investigation |
+| ServiceMonitor | Exposes `/metrics` to the kube-prometheus-stack Prometheus |
+| ExternalSecret | Materialises `cloud-integration.json` from AWS Secrets Manager (ESO v1, ADR-0008) |
+| NetworkPolicy | Guards exporter and UI egress/ingress |
+
+## Why amortized cost matters
+
+Naive cost tools price allocation against **on-demand list rates**.
+That overstates real spend on an estate running Reserved Instances, Savings Plans,
+and Spot.  The CUR/Athena cloud-integration pulls the actual AWS bill so allocation
+reflects what you *pay*, not what you would pay without discounts.
+
+## Dependencies
+
+AWS infrastructure must exist before deploying this chart:
+
+```
+terraform/modules/cost-cur-export
+├── S3 bucket        — CUR delivery destination
+├── Glue database    — schema-on-read over Parquet CUR files
+├── Athena workgroup — query workgroup
+└── IAM role         — IRSA role for OpenCost (read-only Athena/Glue/S3)
+```
+
+After running the Terraform module, populate the Secrets Manager secret at
+`/opencost/cloud-integration` with the JSON payload documented in
+`templates/external-secret.yaml`.
+
+## IRSA
+
+Annotate the ServiceAccount with the IAM role output by the Terraform module:
+
+```yaml
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>
+```
+
+Set this via an ArgoCD ApplicationSet `parameters` patch so the value stays
+cluster-specific and out of this chart's values.
+
+## Evolutionary path (ADR-0027)
+
+```
+Phase 1 (this chart):  OpenCost + CUR  →  discount-aware per-namespace allocation
+Phase 2 (optional):    + Kubecost Free →  UI right-sizing ≤ 250 cores / 15-day retention
+Phase 3 (if needed):   + Kubecost Enterprise  →  long retention / multi-cluster / RBAC
+                        (only justified when Free tier bounds are demonstrably crossed)
+```

--- a/apps/infra/opencost/templates/external-secret.yaml
+++ b/apps/infra/opencost/templates/external-secret.yaml
@@ -1,0 +1,51 @@
+---
+# ExternalSecret – materialise cloud-integration.json from AWS Secrets Manager
+# into the opencost namespace so OpenCost can reconcile allocation against the
+# real AWS bill (amortized RIs / Savings Plans / Spot).
+#
+# Convention: ESO v1 (external-secrets.io/v1), ClusterSecretStore "aws-secrets-manager"
+# (installed by apps/infra/cluster-secret-store).  See ADR-0008.
+#
+# The secret created here (opencost-cloud-integration) is referenced in
+# values.yaml: opencost.opencost.cloudCost.cloudIntegrationSecret.
+#
+# AWS Secrets Manager path: /opencost/cloud-integration
+# Secret payload (JSON stored as a single string under key "cloud-integration.json"):
+#   {
+#     "aws": [{
+#       "bucket":    "<CUR-S3-bucket-name>",
+#       "region":    "<aws-region>",
+#       "database":  "<glue-database-name>",
+#       "table":     "<glue-table-name>",
+#       "workgroup": "<athena-workgroup-name>",
+#       "account":   "<aws-account-id>"
+#     }]
+#   }
+# Populate this secret after running terraform/modules/cost-cur-export.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: opencost-cloud-integration
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: opencost
+    app.kubernetes.io/component: cloud-integration
+    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/part-of: finops
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    # ClusterSecretStore installed by apps/infra/cluster-secret-store.
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+
+  target:
+    name: opencost-cloud-integration
+    creationPolicy: Owner
+
+  data:
+    - secretKey: cloud-integration.json
+      remoteRef:
+        key: /opencost/cloud-integration
+        property: cloud-integration.json

--- a/apps/infra/opencost/templates/networkpolicy.yaml
+++ b/apps/infra/opencost/templates/networkpolicy.yaml
@@ -1,0 +1,146 @@
+{{- if .Values.networkPolicy.enabled }}
+---
+# NetworkPolicy: OpenCost exporter
+# Allows:
+#   ingress  – Prometheus scraping on :9003 (metrics) + UI :9090
+#   egress   – Prometheus query API, Kubernetes API, AWS HTTPS (Athena/S3/Glue), DNS
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: opencost
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: opencost
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/part-of: finops
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: opencost
+      app.kubernetes.io/component: exporter
+
+  policyTypes:
+    - Ingress
+    - Egress
+
+  ingress:
+    # Prometheus scrapes metrics from OpenCost
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - protocol: TCP
+          port: 9003
+
+    # OpenCost UI → exporter API
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: opencost
+              app.kubernetes.io/component: ui
+      ports:
+        - protocol: TCP
+          port: 9003
+
+  egress:
+    # Query Prometheus / Thanos for node metrics
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - protocol: TCP
+          port: 9090
+        # Thanos Query (if installed)
+        - protocol: TCP
+          port: 10902
+
+    # Kubernetes API (RBAC, node/pod/service metadata)
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 443
+
+    # AWS service endpoints – Athena, S3, Glue (HTTPS only)
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 443
+
+    # DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+
+---
+# NetworkPolicy: OpenCost UI
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: opencost-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: opencost
+    app.kubernetes.io/component: ui
+    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/part-of: finops
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: opencost
+      app.kubernetes.io/component: ui
+
+  policyTypes:
+    - Ingress
+    - Egress
+
+  ingress:
+    # Allow from the internal Cilium Gateway and any monitoring namespace
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 9090
+
+  egress:
+    # Query the OpenCost exporter API
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: opencost
+              app.kubernetes.io/component: exporter
+      ports:
+        - protocol: TCP
+          port: 9003
+
+    # DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+
+{{- end }}

--- a/apps/infra/opencost/templates/networkpolicy.yaml
+++ b/apps/infra/opencost/templates/networkpolicy.yaml
@@ -25,11 +25,13 @@ spec:
     - Egress
 
   ingress:
-    # Prometheus scrapes metrics from OpenCost
+    # Prometheus scrapes metrics from OpenCost.
+    # Namespace label matches the observability namespace where kube-prometheus-stack
+    # is deployed (PR #255 migrated monitoring → observability).
     - from:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: monitoring
+              kubernetes.io/metadata.name: observability
           podSelector:
             matchLabels:
               app.kubernetes.io/name: prometheus
@@ -48,11 +50,12 @@ spec:
           port: 9003
 
   egress:
-    # Query Prometheus / Thanos for node metrics
+    # Query Prometheus / Thanos for node metrics.
+    # Targeting the observability namespace (kube-prometheus-stack post-migration).
     - to:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: monitoring
+              kubernetes.io/metadata.name: observability
       ports:
         - protocol: TCP
           port: 9090
@@ -60,14 +63,18 @@ spec:
         - protocol: TCP
           port: 10902
 
-    # Kubernetes API (RBAC, node/pod/service metadata)
+    # Kubernetes API (RBAC, node/pod/service metadata).
+    # namespaceSelector: {} selects all namespaces — necessary because the K8s API
+    # server endpoint is not bound to a specific namespace in standard CNI setups.
     - to:
         - namespaceSelector: {}
       ports:
         - protocol: TCP
           port: 443
 
-    # AWS service endpoints – Athena, S3, Glue (HTTPS only)
+    # AWS service endpoints – Athena, S3, Glue (HTTPS only).
+    # namespaceSelector: {} used here because AWS VPC endpoints / NAT egress does
+    # not traverse a specific namespace; traffic exits the node directly to AWS APIs.
     - to:
         - namespaceSelector: {}
       ports:

--- a/apps/infra/opencost/values.yaml
+++ b/apps/infra/opencost/values.yaml
@@ -69,13 +69,15 @@ opencost:
     # Prometheus / Thanos integration
     # -------------------------------------------------------------------------
     prometheus:
-      # Point at the kube-prometheus-stack Prometheus installed in monitoring/.
+      # Point at the kube-prometheus-stack Prometheus installed in observability/.
+      # PR #255 migrated the monitoring stack from the monitoring namespace to
+      # observability; update the service DNS accordingly.
       # In multi-cluster setups this will be a Thanos Query endpoint.
       internal:
         enabled: false
       external:
         enabled: true
-        url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+        url: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
 
     # -------------------------------------------------------------------------
     # ServiceMonitor – expose OpenCost metrics to Prometheus
@@ -85,7 +87,9 @@ opencost:
       # Must match the label the prometheus-stack Prometheus selects on.
       additionalLabels:
         prometheus: kube-prometheus
-      namespace: monitoring
+      # Deploy ServiceMonitor into the observability namespace so the
+      # kube-prometheus-stack Prometheus (post PR #255 migration) can discover it.
+      namespace: observability
       interval: 60s
       scrapeTimeout: 30s
 

--- a/apps/infra/opencost/values.yaml
+++ b/apps/infra/opencost/values.yaml
@@ -1,0 +1,162 @@
+---
+# OpenCost – per-namespace cost allocation + AWS CUR/Athena cloud-integration
+# ADR-0027: reconciles allocation to amortised, discount-aware billed cost
+#           (Reserved Instances / Savings Plans / Spot), not on-demand list pricing.
+#
+# Required AWS infrastructure (terraform/modules/cost-cur-export):
+#   S3 bucket  ← CUR delivery
+#   Glue DB    ← schema-on-read over CUR Parquet
+#   Athena WG  ← query workgroup
+#   IAM role   ← least-privilege read-only access (IRSA)
+#
+# cloud-integration.json is materialised from AWS Secrets Manager by
+# apps/infra/opencost/templates/external-secret.yaml  (ESO v1 / ADR-0008).
+
+# ---------------------------------------------------------------------------
+# Wrapper-chart–level values (consumed by templates/ in this chart only)
+# ---------------------------------------------------------------------------
+
+# NetworkPolicy: guard egress/ingress for the opencost namespace.
+# Mirror of the pattern used in apps/infra/observability/loki-stack.
+networkPolicy:
+  enabled: true
+
+# ---------------------------------------------------------------------------
+# OpenCost sub-chart values (passed through to the opencost dependency chart)
+# ---------------------------------------------------------------------------
+opencost:
+  enabled: true
+
+  # ---------------------------------------------------------------------------
+  # OpenCost exporter
+  # ---------------------------------------------------------------------------
+  opencost:
+    exporter:
+      # Pull the image from the CNCF-maintained repository.
+      image:
+        registry: ghcr.io
+        repository: opencost/opencost
+        tag: "1.113.0"
+
+      # Resource requests/limits — lightweight read loop.
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+
+      # defaultClusterId: override per cluster via ArgoCD ApplicationSet parameter
+      defaultClusterId: ""
+
+    # -------------------------------------------------------------------------
+    # AWS cloud-integration – grounds allocation in the real, amortized bill
+    # -------------------------------------------------------------------------
+    cloudCost:
+      # Enable cloud-cost reconciliation against the AWS CUR/Athena pipeline.
+      enabled: true
+
+      # Secret name that holds cloud-integration.json.
+      # Materialised by templates/external-secret.yaml via ESO ClusterSecretStore.
+      cloudIntegrationSecret: opencost-cloud-integration
+
+      # Reconciliation runs every 6 hours; each run queries Athena for
+      # amortised line items and reconciles against in-cluster allocation.
+      reconcileFrequency: 6h
+
+    # -------------------------------------------------------------------------
+    # Prometheus / Thanos integration
+    # -------------------------------------------------------------------------
+    prometheus:
+      # Point at the kube-prometheus-stack Prometheus installed in monitoring/.
+      # In multi-cluster setups this will be a Thanos Query endpoint.
+      internal:
+        enabled: false
+      external:
+        enabled: true
+        url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+
+    # -------------------------------------------------------------------------
+    # ServiceMonitor – expose OpenCost metrics to Prometheus
+    # -------------------------------------------------------------------------
+    serviceMonitor:
+      enabled: true
+      # Must match the label the prometheus-stack Prometheus selects on.
+      additionalLabels:
+        prometheus: kube-prometheus
+      namespace: monitoring
+      interval: 60s
+      scrapeTimeout: 30s
+
+    # -------------------------------------------------------------------------
+    # Persistence – store allocation cache across restarts
+    # -------------------------------------------------------------------------
+    persistentVolume:
+      enabled: true
+      size: 10Gi
+      # Use the cluster default StorageClass (GP3 via Karpenter / ADR-0007).
+      storageClass: ""
+
+    # -------------------------------------------------------------------------
+    # Security context
+    # -------------------------------------------------------------------------
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+
+    podSecurityContext:
+      fsGroup: 1001
+
+  # ---------------------------------------------------------------------------
+  # OpenCost UI (optional)
+  # Disable in clusters where Grafana dashboards are the primary cost surface.
+  # Enable temporarily for ad-hoc investigation or initial validation.
+  # ---------------------------------------------------------------------------
+  ui:
+    enabled: true
+
+    image:
+      registry: ghcr.io
+      repository: opencost/opencost-ui
+      tag: "1.113.0"
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
+
+    # Expose via the internal Cilium Gateway (ADR-0009 / gateways chart).
+    service:
+      type: ClusterIP
+      port: 9090
+
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+
+  # ---------------------------------------------------------------------------
+  # RBAC / ServiceAccount
+  # IRSA annotation is applied via the ArgoCD Application parameter or a
+  # separate patch so the IAM role ARN can be cluster-specific.
+  # ---------------------------------------------------------------------------
+  serviceAccount:
+    create: true
+    name: opencost
+    annotations: {}
+    # To enable IRSA, set at deploy time:
+    #   eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>
+    # The role ARN is output by terraform/modules/cost-cur-export (opencost_irsa_role_arn).

--- a/terraform/modules/cost-cur-export/cost-cur-export.tftest.hcl
+++ b/terraform/modules/cost-cur-export/cost-cur-export.tftest.hcl
@@ -47,6 +47,47 @@ run "cur_bucket_blocks_public_access" {
   }
 }
 
+run "cur_bucket_uses_kms_encryption" {
+  command = plan
+
+  assert {
+    condition     = aws_s3_bucket_server_side_encryption_configuration.cur.rule[0].apply_server_side_encryption_by_default[0].sse_algorithm == "aws:kms"
+    error_message = "CUR S3 bucket must use aws:kms SSE algorithm (CIS AWS Foundations 2.3.1)"
+  }
+
+  assert {
+    condition     = aws_s3_bucket_server_side_encryption_configuration.cur.rule[0].bucket_key_enabled == true
+    error_message = "S3 Bucket Keys must be enabled to reduce KMS API call volume"
+  }
+}
+
+run "athena_results_bucket_uses_kms_encryption" {
+  command = plan
+
+  assert {
+    condition     = aws_s3_bucket_server_side_encryption_configuration.athena_results.rule[0].apply_server_side_encryption_by_default[0].sse_algorithm == "aws:kms"
+    error_message = "Athena results S3 bucket must use aws:kms SSE algorithm"
+  }
+}
+
+run "athena_workgroup_uses_kms_encryption" {
+  command = plan
+
+  assert {
+    condition     = aws_athena_workgroup.opencost.configuration[0].result_configuration[0].encryption_configuration[0].encryption_option == "SSE_KMS"
+    error_message = "Athena workgroup must use SSE_KMS for query result encryption"
+  }
+}
+
+run "kms_key_created_by_default" {
+  command = plan
+
+  assert {
+    condition     = var.kms_key_arn == ""
+    error_message = "kms_key_arn should default to empty so the module creates its own CMK"
+  }
+}
+
 run "iam_role_scoped_to_opencost_serviceaccount" {
   command = plan
 

--- a/terraform/modules/cost-cur-export/cost-cur-export.tftest.hcl
+++ b/terraform/modules/cost-cur-export/cost-cur-export.tftest.hcl
@@ -1,0 +1,89 @@
+mock_provider "aws" {}
+
+variables {
+  cur_s3_bucket_name         = "test-cur-opencost-bucket"
+  athena_results_bucket_name = "test-athena-results-opencost"
+  eks_oidc_provider          = "oidc.eks.us-east-1.amazonaws.com/id/TESTOIDC1234567890AB"
+}
+
+run "default_cur_report_name" {
+  command = plan
+
+  assert {
+    condition     = var.cur_report_name == "opencost-cur"
+    error_message = "Default CUR report name should be 'opencost-cur'"
+  }
+}
+
+run "creates_cur_report_with_parquet_format" {
+  command = plan
+
+  assert {
+    condition     = aws_cur_report_definition.opencost.format == "Parquet"
+    error_message = "CUR report format must be Parquet for Athena compatibility"
+  }
+}
+
+run "creates_cur_report_with_athena_artifact" {
+  command = plan
+
+  assert {
+    condition     = contains(aws_cur_report_definition.opencost.additional_artifacts, "ATHENA")
+    error_message = "CUR report must include ATHENA additional artifact for Glue manifest generation"
+  }
+}
+
+run "cur_bucket_blocks_public_access" {
+  command = plan
+
+  assert {
+    condition     = aws_s3_bucket_public_access_block.cur.block_public_acls == true
+    error_message = "CUR S3 bucket must block all public ACLs"
+  }
+
+  assert {
+    condition     = aws_s3_bucket_public_access_block.cur.restrict_public_buckets == true
+    error_message = "CUR S3 bucket must restrict public buckets"
+  }
+}
+
+run "iam_role_scoped_to_opencost_serviceaccount" {
+  command = plan
+
+  assert {
+    condition     = var.opencost_namespace == "opencost"
+    error_message = "Default opencost namespace should be 'opencost'"
+  }
+
+  assert {
+    condition     = var.opencost_service_account == "opencost"
+    error_message = "Default opencost service account should be 'opencost'"
+  }
+}
+
+run "lifecycle_retention_minimum" {
+  command = plan
+
+  assert {
+    condition     = var.lifecycle_expiration_days >= 365
+    error_message = "CUR lifecycle expiration must be >= 365 days"
+  }
+}
+
+run "glue_database_name_default" {
+  command = plan
+
+  assert {
+    condition     = var.glue_database_name == "cur_opencost"
+    error_message = "Default Glue database name should be 'cur_opencost'"
+  }
+}
+
+run "athena_workgroup_name_default" {
+  command = plan
+
+  assert {
+    condition     = var.athena_workgroup_name == "opencost"
+    error_message = "Default Athena workgroup name should be 'opencost'"
+  }
+}

--- a/terraform/modules/cost-cur-export/main.tf
+++ b/terraform/modules/cost-cur-export/main.tf
@@ -1,0 +1,424 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# AWS Cost and Usage Report (CUR) + Athena cloud-integration for OpenCost
+# ---------------------------------------------------------------------------------------------------------------------
+# Implements ADR-0027: OpenCost + AWS CUR/Athena cloud-integration.
+#
+# Resources created:
+#   1. S3 bucket           — CUR delivery destination (Parquet, hourly, versioned, encrypted)
+#   2. S3 bucket policy    — allow billingreports.amazonaws.com to deliver reports
+#   3. AWS CUR report      — hourly, Parquet, resource IDs, ATHENA additional artifact
+#   4. Glue database       — schema-on-read over the Parquet CUR files
+#   5. Athena workgroup    — isolated query workgroup with per-query size limit
+#   6. IAM role + policy   — IRSA-compatible read-only access for OpenCost
+#
+# cloud-integration.json fields resolved from outputs:
+#   bucket    = aws_s3_bucket.cur.bucket
+#   region    = var.aws_region
+#   database  = aws_glue_catalog_database.cur.name
+#   table     = local.glue_table_name
+#   workgroup = aws_athena_workgroup.opencost.name
+#   account   = data.aws_caller_identity.current.account_id
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+  partition  = data.aws_partition.current.partition
+  region     = data.aws_region.current.name
+
+  # CUR delivers files under: s3://<bucket>/<report_path_prefix>/<report_name>/
+  report_s3_prefix = "${var.cur_report_prefix}/${var.cur_report_name}"
+
+  # Glue table name: CUR report name with hyphens replaced by underscores.
+  glue_table_name = replace(var.cur_report_name, "-", "_")
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# 1. S3 Bucket — CUR delivery
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "cur" {
+  bucket        = var.cur_s3_bucket_name
+  force_destroy = var.force_destroy_bucket
+
+  tags = merge(var.tags, {
+    Name    = var.cur_s3_bucket_name
+    Purpose = "aws-cur-opencost"
+  })
+}
+
+resource "aws_s3_bucket_versioning" "cur" {
+  bucket = aws_s3_bucket.cur.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "cur" {
+  bucket = aws_s3_bucket.cur.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "cur" {
+  bucket = aws_s3_bucket.cur.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "cur" {
+  bucket = aws_s3_bucket.cur.id
+
+  rule {
+    id     = "cur-lifecycle"
+    status = "Enabled"
+
+    transition {
+      days          = var.lifecycle_ia_days
+      storage_class = "STANDARD_IA"
+    }
+
+    expiration {
+      days = var.lifecycle_expiration_days
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+
+# Athena query results — kept in a separate bucket for IAM boundary clarity.
+resource "aws_s3_bucket" "athena_results" {
+  bucket        = var.athena_results_bucket_name
+  force_destroy = var.force_destroy_bucket
+
+  tags = merge(var.tags, {
+    Name    = var.athena_results_bucket_name
+    Purpose = "athena-query-results-opencost"
+  })
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "athena_results" {
+  bucket = aws_s3_bucket.athena_results.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "athena_results" {
+  bucket = aws_s3_bucket.athena_results.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "athena_results" {
+  bucket = aws_s3_bucket.athena_results.id
+
+  rule {
+    id     = "athena-results-ttl"
+    status = "Enabled"
+
+    expiration {
+      # 7-day TTL — results are transient; OpenCost re-queries on schedule.
+      days = 7
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# 2. S3 Bucket Policy — allow billingreports.amazonaws.com to deliver CUR
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_s3_bucket_policy" "cur" {
+  bucket = aws_s3_bucket.cur.id
+  policy = data.aws_iam_policy_document.cur_s3.json
+
+  depends_on = [aws_s3_bucket_public_access_block.cur]
+}
+
+data "aws_iam_policy_document" "cur_s3" {
+  # Billing service ACL check
+  statement {
+    sid    = "BillingAclCheck"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["billingreports.amazonaws.com"]
+    }
+
+    actions   = ["s3:GetBucketAcl", "s3:GetBucketPolicy"]
+    resources = [aws_s3_bucket.cur.arn]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [local.account_id]
+    }
+  }
+
+  # Billing service write — deliver report files
+  statement {
+    sid    = "BillingWrite"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["billingreports.amazonaws.com"]
+    }
+
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.cur.arn}/${local.report_s3_prefix}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [local.account_id]
+    }
+  }
+
+  # Deny unencrypted (non-TLS) access
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.cur.arn,
+      "${aws_s3_bucket.cur.arn}/*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# 3. AWS CUR Report Definition
+# ---------------------------------------------------------------------------------------------------------------------
+# NOTE: CUR report definitions are a global resource that must be created in
+# us-east-1.  If this module is applied in a different region, pass a
+# us-east-1 provider alias to the calling module.
+
+resource "aws_cur_report_definition" "opencost" {
+  report_name = var.cur_report_name
+
+  # Hourly granularity — smallest supported; OpenCost reconciles once per 6 h
+  # but finer data gives better amortization accuracy.
+  time_unit   = "HOURLY"
+  format      = "Parquet"
+  compression = "Parquet"
+
+  # RESOURCES: include resource IDs so allocation can be tagged/filtered.
+  additional_schema_elements = ["RESOURCES"]
+
+  # ATHENA: generates the Glue-compatible manifest that lets Athena query
+  # the Parquet files directly (schema auto-updated on each delivery).
+  additional_artifacts = ["ATHENA"]
+
+  s3_bucket = aws_s3_bucket.cur.bucket
+  s3_prefix = var.cur_report_prefix
+  s3_region = var.aws_region
+
+  # OVERWRITE_REPORT: replaces the current month's data each delivery.
+  # This avoids accumulating duplicate files while staying accurate.
+  report_versioning      = "OVERWRITE_REPORT"
+  refresh_closed_reports = true
+
+  depends_on = [aws_s3_bucket_policy.cur]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# 4. Glue Database
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_glue_catalog_database" "cur" {
+  name        = var.glue_database_name
+  description = "CUR Parquet data for OpenCost cloud-integration (ADR-0027)"
+
+  location_uri = "s3://${aws_s3_bucket.cur.bucket}/${local.report_s3_prefix}/"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# 5. Athena Workgroup
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_athena_workgroup" "opencost" {
+  name        = var.athena_workgroup_name
+  description = "OpenCost CUR cloud-integration queries (ADR-0027)"
+  state       = "ENABLED"
+
+  configuration {
+    enforce_workgroup_configuration    = true
+    publish_cloudwatch_metrics_enabled = var.enable_athena_metrics
+
+    result_configuration {
+      output_location = "s3://${aws_s3_bucket.athena_results.bucket}/results/"
+
+      encryption_configuration {
+        encryption_option = "SSE_S3"
+      }
+    }
+
+    # Guard against runaway queries — OpenCost billing-period queries
+    # are bounded by design, but set a hard cap for safety.
+    bytes_scanned_cutoff_per_query = var.athena_bytes_scanned_cutoff
+  }
+
+  tags = merge(var.tags, {
+    Name    = var.athena_workgroup_name
+    Purpose = "opencost-cloud-integration"
+  })
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# 6. IAM Role — IRSA for OpenCost (least-privilege: read Athena/Glue/S3)
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_iam_role" "opencost" {
+  name        = var.iam_role_name
+  description = "IRSA: OpenCost reads CUR data via Athena/Glue/S3 (ADR-0027)"
+
+  assume_role_policy = data.aws_iam_policy_document.opencost_trust.json
+
+  tags = merge(var.tags, {
+    Name    = var.iam_role_name
+    Purpose = "opencost-irsa"
+  })
+}
+
+data "aws_iam_policy_document" "opencost_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = ["arn:${local.partition}:iam::${local.account_id}:oidc-provider/${var.eks_oidc_provider}"]
+    }
+
+    # Scope to the opencost ServiceAccount only — principle of least privilege.
+    condition {
+      test     = "StringEquals"
+      variable = "${var.eks_oidc_provider}:sub"
+      values   = ["system:serviceaccount:${var.opencost_namespace}:${var.opencost_service_account}"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${var.eks_oidc_provider}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "opencost" {
+  name   = "${var.iam_role_name}-policy"
+  role   = aws_iam_role.opencost.id
+  policy = data.aws_iam_policy_document.opencost_permissions.json
+}
+
+data "aws_iam_policy_document" "opencost_permissions" {
+  # Athena — start/stop/read queries in the dedicated workgroup only.
+  statement {
+    sid    = "AthenaQueryAccess"
+    effect = "Allow"
+
+    actions = [
+      "athena:StartQueryExecution",
+      "athena:GetQueryExecution",
+      "athena:GetQueryResults",
+      "athena:StopQueryExecution",
+      "athena:ListQueryExecutions",
+      "athena:GetWorkGroup",
+    ]
+
+    resources = [aws_athena_workgroup.opencost.arn]
+  }
+
+  # Glue — read the CUR catalog only (no write, no create, no delete).
+  statement {
+    sid    = "GlueCatalogRead"
+    effect = "Allow"
+
+    actions = [
+      "glue:GetDatabase",
+      "glue:GetTable",
+      "glue:GetTables",
+      "glue:GetPartition",
+      "glue:GetPartitions",
+      "glue:BatchGetPartition",
+    ]
+
+    resources = [
+      "arn:${local.partition}:glue:${local.region}:${local.account_id}:catalog",
+      "arn:${local.partition}:glue:${local.region}:${local.account_id}:database/${aws_glue_catalog_database.cur.name}",
+      "arn:${local.partition}:glue:${local.region}:${local.account_id}:table/${aws_glue_catalog_database.cur.name}/*",
+    ]
+  }
+
+  # S3 — read CUR Parquet files (no delete, no overwrite, no cross-bucket).
+  statement {
+    sid    = "S3CurRead"
+    effect = "Allow"
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      aws_s3_bucket.cur.arn,
+      "${aws_s3_bucket.cur.arn}/*",
+    ]
+  }
+
+  # S3 — write Athena query results to the dedicated results bucket only.
+  statement {
+    sid    = "S3AthenaResultsWrite"
+    effect = "Allow"
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:PutObject",
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts",
+    ]
+
+    resources = [
+      aws_s3_bucket.athena_results.arn,
+      "${aws_s3_bucket.athena_results.arn}/*",
+    ]
+  }
+}

--- a/terraform/modules/cost-cur-export/main.tf
+++ b/terraform/modules/cost-cur-export/main.tf
@@ -4,7 +4,8 @@
 # Implements ADR-0027: OpenCost + AWS CUR/Athena cloud-integration.
 #
 # Resources created:
-#   1. S3 bucket           — CUR delivery destination (Parquet, hourly, versioned, encrypted)
+#   0. KMS key             — CMK for at-rest encryption of CUR and Athena data (CIS requirement)
+#   1. S3 bucket           — CUR delivery destination (Parquet, hourly, versioned, KMS-encrypted)
 #   2. S3 bucket policy    — allow billingreports.amazonaws.com to deliver reports
 #   3. AWS CUR report      — hourly, Parquet, resource IDs, ATHENA additional artifact
 #   4. Glue database       — schema-on-read over the Parquet CUR files
@@ -34,6 +35,105 @@ locals {
 
   # Glue table name: CUR report name with hyphens replaced by underscores.
   glue_table_name = replace(var.cur_report_name, "-", "_")
+
+  # Resolved KMS key ARN: use the caller-supplied key, or fall back to the CMK
+  # created by this module.  The conditional ensures the managed key resource is
+  # only consulted when no external ARN is provided.
+  kms_key_arn = var.kms_key_arn != "" ? var.kms_key_arn : aws_kms_key.billing[0].arn
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# 0. KMS Customer-Managed Key — encrypt CUR S3 bucket and Athena results at rest
+#    CIS AWS Foundations 2.3.1 / AWS Security Best Practice: CMK for billing data.
+#    Skipped when the caller supplies their own key ARN via var.kms_key_arn.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_kms_key" "billing" {
+  # Create one CMK only when no external key ARN is provided.
+  count = var.kms_key_arn == "" ? 1 : 0
+
+  description             = "CMK for OpenCost CUR + Athena results buckets (ADR-0027)"
+  deletion_window_in_days = var.kms_deletion_window_days
+  enable_key_rotation     = true
+
+  policy = data.aws_iam_policy_document.kms_key_policy.json
+
+  tags = merge(var.tags, {
+    Name    = "${var.cur_s3_bucket_name}-cmk"
+    Purpose = "opencost-cur-encryption"
+  })
+}
+
+resource "aws_kms_alias" "billing" {
+  count = var.kms_key_arn == "" ? 1 : 0
+
+  name          = "alias/${var.kms_alias_name}"
+  target_key_id = aws_kms_key.billing[0].key_id
+}
+
+# Key policy: allow the owning account full admin, and allow S3 + Athena service
+# principals to use the key on behalf of the account (required for SSE-KMS delivery).
+data "aws_iam_policy_document" "kms_key_policy" {
+  # Root account has full key administration rights.
+  statement {
+    sid    = "KeyAdminRoot"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
+  # S3 needs GenerateDataKey + Decrypt to write and read SSE-KMS objects on behalf
+  # of the account (billingreports service uses the S3 service role).
+  statement {
+    sid    = "S3ServiceUse"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Decrypt",
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+
+  # Athena needs GenerateDataKey + Decrypt to write encrypted query results.
+  statement {
+    sid    = "AthenaServiceUse"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["athena.amazonaws.com"]
+    }
+
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Decrypt",
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -63,8 +163,10 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "cur" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = local.kms_key_arn
     }
+    # S3 Bucket Keys reduce KMS API call volume and cost while preserving CMK control.
     bucket_key_enabled = true
   }
 }
@@ -116,7 +218,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "athena_results" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = local.kms_key_arn
     }
     bucket_key_enabled = true
   }
@@ -284,7 +387,8 @@ resource "aws_athena_workgroup" "opencost" {
       output_location = "s3://${aws_s3_bucket.athena_results.bucket}/results/"
 
       encryption_configuration {
-        encryption_option = "SSE_S3"
+        encryption_option = "SSE_KMS"
+        kms_key_arn       = local.kms_key_arn
       }
     }
 
@@ -300,7 +404,7 @@ resource "aws_athena_workgroup" "opencost" {
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
-# 6. IAM Role — IRSA for OpenCost (least-privilege: read Athena/Glue/S3)
+# 6. IAM Role — IRSA for OpenCost (least-privilege: read Athena/Glue/S3 + KMS)
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "aws_iam_role" "opencost" {
@@ -420,5 +524,20 @@ data "aws_iam_policy_document" "opencost_permissions" {
       aws_s3_bucket.athena_results.arn,
       "${aws_s3_bucket.athena_results.arn}/*",
     ]
+  }
+
+  # KMS — allow OpenCost to decrypt CUR objects and encrypt/decrypt Athena
+  # results using the billing CMK.  Scoped to the resolved key ARN only
+  # (least-privilege: no cross-key access).
+  statement {
+    sid    = "KmsBillingKeyAccess"
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+
+    resources = [local.kms_key_arn]
   }
 }

--- a/terraform/modules/cost-cur-export/outputs.tf
+++ b/terraform/modules/cost-cur-export/outputs.tf
@@ -1,0 +1,68 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# cost-cur-export module outputs
+# ---------------------------------------------------------------------------------------------------------------------
+# These outputs feed directly into the OpenCost cloud-integration.json secret
+# that ESO materialises at /opencost/cloud-integration in AWS Secrets Manager.
+#
+# cloud-integration.json shape (all fields from this module):
+#   {
+#     "aws": [{
+#       "bucket":    <cur_s3_bucket_name>,
+#       "region":    <aws_region>,
+#       "database":  <glue_database_name>,
+#       "table":     <glue_table_name>,
+#       "workgroup": <athena_workgroup_name>,
+#       "account":   <aws_account_id>
+#     }]
+#   }
+# ---------------------------------------------------------------------------------------------------------------------
+
+output "cur_s3_bucket_name" {
+  description = "Name of the S3 bucket receiving CUR Parquet files. Maps to cloud-integration.json 'bucket'."
+  value       = aws_s3_bucket.cur.bucket
+}
+
+output "cur_s3_bucket_arn" {
+  description = "ARN of the CUR S3 bucket."
+  value       = aws_s3_bucket.cur.arn
+}
+
+output "athena_results_bucket_name" {
+  description = "Name of the Athena query-results S3 bucket."
+  value       = aws_s3_bucket.athena_results.bucket
+}
+
+output "glue_database_name" {
+  description = "Glue catalog database name. Maps to cloud-integration.json 'database'."
+  value       = aws_glue_catalog_database.cur.name
+}
+
+output "glue_table_name" {
+  description = "Glue table name (derived from CUR report name). Maps to cloud-integration.json 'table'."
+  value       = local.glue_table_name
+}
+
+output "athena_workgroup_name" {
+  description = "Athena workgroup name. Maps to cloud-integration.json 'workgroup'."
+  value       = aws_athena_workgroup.opencost.name
+}
+
+output "athena_workgroup_arn" {
+  description = "Athena workgroup ARN."
+  value       = aws_athena_workgroup.opencost.arn
+}
+
+output "aws_account_id" {
+  description = "AWS account ID. Maps to cloud-integration.json 'account'."
+  value       = local.account_id
+}
+
+output "opencost_irsa_role_arn" {
+  description = "IAM role ARN for IRSA. Annotate the OpenCost ServiceAccount with: eks.amazonaws.com/role-arn = <this value>."
+  value       = aws_iam_role.opencost.arn
+}
+
+output "opencost_irsa_role_name" {
+  description = "IAM role name for the OpenCost IRSA role."
+  value       = aws_iam_role.opencost.name
+}

--- a/terraform/modules/cost-cur-export/outputs.tf
+++ b/terraform/modules/cost-cur-export/outputs.tf
@@ -66,3 +66,13 @@ output "opencost_irsa_role_name" {
   description = "IAM role name for the OpenCost IRSA role."
   value       = aws_iam_role.opencost.name
 }
+
+output "kms_key_arn" {
+  description = "ARN of the KMS CMK used for CUR + Athena SSE-KMS encryption (module-created or caller-supplied)."
+  value       = local.kms_key_arn
+}
+
+output "kms_key_alias" {
+  description = "Alias of the module-created KMS CMK. Empty string when kms_key_arn was supplied by the caller."
+  value       = var.kms_key_arn == "" ? aws_kms_alias.billing[0].name : ""
+}

--- a/terraform/modules/cost-cur-export/variables.tf
+++ b/terraform/modules/cost-cur-export/variables.tf
@@ -13,6 +13,33 @@ variable "aws_region" {
 }
 
 # ---------------------------------------------------------------------------
+# KMS encryption
+# ---------------------------------------------------------------------------
+
+variable "kms_key_arn" {
+  description = "ARN of an existing KMS CMK to use for CUR + Athena SSE-KMS encryption. When empty (default) the module creates a new CMK in the current account."
+  type        = string
+  default     = ""
+}
+
+variable "kms_alias_name" {
+  description = "KMS alias name (without the 'alias/' prefix) for the CMK created by this module. Ignored when kms_key_arn is supplied."
+  type        = string
+  default     = "opencost-cur-billing"
+}
+
+variable "kms_deletion_window_days" {
+  description = "Waiting period (7–30 days) before the CMK is permanently deleted after a destroy. Ignored when kms_key_arn is supplied."
+  type        = number
+  default     = 30
+
+  validation {
+    condition     = var.kms_deletion_window_days >= 7 && var.kms_deletion_window_days <= 30
+    error_message = "kms_deletion_window_days must be between 7 and 30."
+  }
+}
+
+# ---------------------------------------------------------------------------
 # CUR / S3
 # ---------------------------------------------------------------------------
 

--- a/terraform/modules/cost-cur-export/variables.tf
+++ b/terraform/modules/cost-cur-export/variables.tf
@@ -1,0 +1,131 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# cost-cur-export module variables
+# ---------------------------------------------------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# AWS context
+# ---------------------------------------------------------------------------
+
+variable "aws_region" {
+  description = "AWS region for the S3 bucket and Athena workgroup. CUR report definitions are always created in us-east-1 — if this differs, supply a us-east-1 provider alias."
+  type        = string
+  default     = "us-east-1"
+}
+
+# ---------------------------------------------------------------------------
+# CUR / S3
+# ---------------------------------------------------------------------------
+
+variable "cur_s3_bucket_name" {
+  description = "Name of the S3 bucket that receives CUR Parquet files. Must be globally unique."
+  type        = string
+}
+
+variable "cur_report_name" {
+  description = "Name of the CUR report definition (also used as the S3 path component and Glue table base name)."
+  type        = string
+  default     = "opencost-cur"
+}
+
+variable "cur_report_prefix" {
+  description = "S3 key prefix under which CUR files are delivered (e.g. 'cur')."
+  type        = string
+  default     = "cur"
+}
+
+variable "force_destroy_bucket" {
+  description = "Allow Terraform to destroy non-empty S3 buckets. Set false in production."
+  type        = bool
+  default     = false
+}
+
+variable "lifecycle_ia_days" {
+  description = "Days before transitioning CUR objects to STANDARD_IA storage class."
+  type        = number
+  default     = 90
+}
+
+variable "lifecycle_expiration_days" {
+  description = "Days before expiring CUR objects. Retain at minimum 13 months for year-over-year comparison."
+  type        = number
+  default     = 400
+
+  validation {
+    condition     = var.lifecycle_expiration_days >= 365
+    error_message = "Retain CUR data for at least 365 days to support year-over-year billing comparison."
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Athena
+# ---------------------------------------------------------------------------
+
+variable "athena_results_bucket_name" {
+  description = "Name of the S3 bucket that stores Athena query results. Kept separate from CUR data for IAM boundary clarity."
+  type        = string
+}
+
+variable "athena_workgroup_name" {
+  description = "Name of the Athena workgroup for OpenCost queries."
+  type        = string
+  default     = "opencost"
+}
+
+variable "athena_bytes_scanned_cutoff" {
+  description = "Maximum bytes Athena may scan per query (safety guard). Default 10 GiB."
+  type        = number
+  default     = 10737418240 # 10 GiB
+}
+
+variable "enable_athena_metrics" {
+  description = "Publish Athena CloudWatch metrics for the workgroup."
+  type        = bool
+  default     = true
+}
+
+# ---------------------------------------------------------------------------
+# Glue
+# ---------------------------------------------------------------------------
+
+variable "glue_database_name" {
+  description = "Name of the Glue catalog database over the CUR Parquet files."
+  type        = string
+  default     = "cur_opencost"
+}
+
+# ---------------------------------------------------------------------------
+# IAM / IRSA
+# ---------------------------------------------------------------------------
+
+variable "iam_role_name" {
+  description = "Name of the IAM role OpenCost assumes via IRSA."
+  type        = string
+  default     = "opencost-irsa"
+}
+
+variable "eks_oidc_provider" {
+  description = "EKS cluster OIDC issuer URL without the https:// prefix (e.g. 'oidc.eks.us-east-1.amazonaws.com/id/EXAMPLEABCDEF123456789')."
+  type        = string
+}
+
+variable "opencost_namespace" {
+  description = "Kubernetes namespace where OpenCost runs."
+  type        = string
+  default     = "opencost"
+}
+
+variable "opencost_service_account" {
+  description = "Name of the OpenCost Kubernetes ServiceAccount that assumes the IAM role."
+  type        = string
+  default     = "opencost"
+}
+
+# ---------------------------------------------------------------------------
+# Common
+# ---------------------------------------------------------------------------
+
+variable "tags" {
+  description = "Tags applied to all resources in this module."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/cost-cur-export/versions.tf
+++ b/terraform/modules/cost-cur-export/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds **OpenCost** Helm app (`apps/infra/opencost/`) with `cloudCost.enabled: true`, cloud-integration secret reference, ServiceMonitor wired to the kube-prometheus-stack Prometheus, optional UI, NetworkPolicy, and a SecurityContext-hardened exporter — picked up automatically by the existing infra AppSet.
- Adds **`terraform/modules/cost-cur-export`** (mirrors sibling modules): CUR report → S3 + Glue DB + Athena workgroup + least-privilege IRSA IAM role for OpenCost to query Athena. Outputs map 1:1 to `cloud-integration.json` fields.
- Adds **ESO ExternalSecret** (`templates/external-secret.yaml`) that materialises `cloud-integration.json` from `/opencost/cloud-integration` in AWS Secrets Manager using the existing `aws-secrets-manager` ClusterSecretStore (ADR-0008).
- Allocation reconciles to **amortized, discount-aware billed cost** (RIs / Savings Plans / Spot) — not on-demand list pricing. Refs #252.

## Test plan

- [x] `helm lint apps/infra/opencost` — 0 charts failed (INFO only: icon recommended)
- [x] `helm template opencost apps/infra/opencost` — renders 8 K8s objects (2 NetworkPolicy, ServiceAccount, ClusterRole, ClusterRoleBinding, Service, Deployment, ExternalSecret)
- [x] `terraform fmt` — no formatting changes
- [x] `terraform validate` — "The configuration is valid" (1 deprecation warning on `data.aws_region.current.name`, consistent with all sibling modules)
- [x] `python3 yaml.safe_load` on all manifests — PASS
- [x] Plan only — no `terraform apply` was run
- [ ] Post-merge: run `terraform/modules/cost-cur-export` against a non-prod account; populate `/opencost/cloud-integration` secret; deploy chart; validate amortized allocation against a known invoice line