### PR TITLE
feat(delivery): Kargo 1.9 promotion layer + Prometheus gates (ADR-0021)

### DIFF
--- a/apps/infra/kargo/Chart.lock
+++ b/apps/infra/kargo/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: kargo
+  repository: oci://ghcr.io/akuity/kargo-charts
+  version: 1.9.8
+digest: sha256:fc8d9fe2071d502e86d123c113983262caab523f4731eeca4600701522e35c3e
+generated: "2026-06-07T20:59:39.458786+02:00"

--- a/apps/infra/kargo/Chart.yaml
+++ b/apps/infra/kargo/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: kargo
 description: Kargo progressive delivery controller
 type: application
-version: 0.1.0
-appVersion: "1.2.0"
+version: 0.2.0
+appVersion: "1.9.0"
 dependencies:
   - name: kargo
-    version: "~1.2"
+    version: "~1.9"
     repository: oci://ghcr.io/akuity/kargo-charts

--- a/kargo/README.md
+++ b/kargo/README.md
@@ -1,0 +1,59 @@
+# kargo/
+
+Kargo environment-promotion configuration for the platform.
+
+## Provenance
+
+Implemented per **ADR-0021** (Kargo as the GitOps environment-promotion layer).
+Chart bumped 1.2 -> 1.9 (`apps/infra/kargo/`); Prometheus `AnalysisTemplate`s
+added to replace job-probe verification gates.
+
+Argo Rollouts is **not** deployed in this repo. Kargo promotes **Argo CD
+Applications directly** across environments. A future ADR may introduce Argo
+Rollouts canary _below_ Kargo (within a single environment); that is explicitly
+out of scope for ADR-0021.
+
+## Structure
+
+```
+kargo/
+├── analysis-templates/
+│   ├── health-check.yaml            # job-probe: ArgoCD sync/health check
+│   ├── smoke-test.yaml              # job-probe: HTTP probe
+│   ├── integration-test.yaml        # job-probe: /health + /ready probes
+│   ├── prometheus-5xx-error-rate.yaml  # Prometheus: 5xx error-rate gate (ADR-0021)
+│   └── prometheus-p95-latency.yaml     # Prometheus: p95 latency gate (ADR-0021)
+├── projects/                        # Kargo Project CRDs (5 projects)
+├── stages/                          # Stage CRDs per project x environment
+│   └── <project>/
+│       ├── dev.yaml                 # auto-promote, health-check only
+│       ├── integration.yaml         # auto-promote, health-check + integration-test
+│       ├── staging.yaml             # manual ok, + prometheus gates
+│       └── prod.yaml                # manual/digest-pinned, + prometheus gates
+└── warehouses/                      # Warehouse CRDs (image sources)
+```
+
+## Promotion graph
+
+```
+dev (auto) -> integration (auto) -> staging -> prod (manual, digest-pinned)
+```
+
+Dev and integration auto-promote. Staging and prod require the
+Prometheus gates (`prometheus-5xx-error-rate`, `prometheus-p95-latency`) to pass,
+in addition to the existing job-probe checks.
+
+## Prometheus gates (ADR-0021)
+
+Metrics are sourced from **Tempo metrics-generator RED metrics** (requires
+ADR-0019 — Tempo wiring). Without ADR-0019, the gates fail open/closed with no
+data. Sequencing: activate ADR-0019 before flipping gates from job-probe to metric.
+
+| Template | Metric | Threshold |
+|---|---|---|
+| `prometheus-5xx-error-rate` | `http_server_request_errors_total` / `http_server_requests_total` | < 1 % error rate |
+| `prometheus-p95-latency` | `http_server_request_duration_seconds_bucket` p95 | < 500 ms (tunable) |
+
+Both templates accept `service`, `namespace`, `prometheus-address` args
+(and `latency-threshold-ms` for the latency gate) that can be overridden
+per-Stage if needed.

--- a/kargo/analysis-templates/prometheus-5xx-error-rate.yaml
+++ b/kargo/analysis-templates/prometheus-5xx-error-rate.yaml
@@ -1,0 +1,58 @@
+---
+# Prometheus-provider AnalysisTemplate: 5xx error-rate gate
+# Provenance: ADR-0021 (Kargo activation).
+# Queries Tempo metrics-generator RED metrics (ADR-0019 dependency).
+# Used as a stage verification gate in staging and prod Stages.
+# Argo Rollouts has no native OTel provider — Prometheus is the bridge
+# between Tempo spanmetrics and this analysis gate.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: prometheus-5xx-error-rate
+spec:
+  args:
+    - name: service
+      # Default to a broad selector; override per-Stage via analysisTemplates[].args
+      value: ".*"
+    - name: namespace
+      value: "default"
+    - name: prometheus-address
+      value: "http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090"
+  metrics:
+    - name: 5xx-error-rate
+      # Gate: 5xx rate must be below 1 % over the last 5 minutes.
+      # RED metrics produced by Tempo metrics-generator (span_name / service_name labels).
+      # Formula: sum(rate(http_server_request_errors_total[5m])) /
+      #            sum(rate(http_server_requests_total[5m]))
+      # Falls back gracefully when no traffic (or() vector defaults).
+      provider:
+        prometheus:
+          address: "{{args.prometheus-address}}"
+          query: |
+            (
+              sum(rate(
+                http_server_request_errors_total{
+                  service_name=~"{{args.service}}",
+                  namespace="{{args.namespace}}",
+                  http_response_status_code=~"5.."
+                }[5m]
+              ))
+              or on() vector(0)
+            )
+            /
+            (
+              sum(rate(
+                http_server_requests_total{
+                  service_name=~"{{args.service}}",
+                  namespace="{{args.namespace}}"
+                }[5m]
+              ))
+              or on() vector(1)
+            )
+      # Succeed when error rate stays below 1 % for the entire observation window.
+      successCondition: result[0] < 0.01
+      failureCondition: result[0] >= 0.05
+      failureLimit: 1
+      # 5-minute observation window sampled every 60 s = 5 data points.
+      interval: 60s
+      count: 5

--- a/kargo/analysis-templates/prometheus-p95-latency.yaml
+++ b/kargo/analysis-templates/prometheus-p95-latency.yaml
@@ -1,0 +1,49 @@
+---
+# Prometheus-provider AnalysisTemplate: p95 latency gate
+# Provenance: ADR-0021 (Kargo activation).
+# Queries Tempo metrics-generator RED metrics (ADR-0019 dependency).
+# Used as a stage verification gate in staging and prod Stages.
+# Argo Rollouts has no native OTel provider — Prometheus is the bridge
+# between Tempo spanmetrics and this analysis gate.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: prometheus-p95-latency
+spec:
+  args:
+    - name: service
+      # Default to a broad selector; override per-Stage via analysisTemplates[].args
+      value: ".*"
+    - name: namespace
+      value: "default"
+    - name: prometheus-address
+      value: "http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090"
+    - name: latency-threshold-ms
+      # 500 ms p95 threshold; tune per environment via analysisTemplates[].args
+      value: "500"
+  metrics:
+    - name: p95-latency-ms
+      # Gate: p95 request latency must be below latency-threshold-ms milliseconds.
+      # Duration histogram produced by Tempo metrics-generator RED spans.
+      # histogram_quantile(0.95, ...) over the last 5 minutes, converted to ms.
+      provider:
+        prometheus:
+          address: "{{args.prometheus-address}}"
+          query: |
+            histogram_quantile(0.95,
+              sum by (le) (
+                rate(
+                  http_server_request_duration_seconds_bucket{
+                    service_name=~"{{args.service}}",
+                    namespace="{{args.namespace}}"
+                  }[5m]
+                )
+              )
+            ) * 1000
+      # Succeed when p95 is strictly below the configured threshold (in ms).
+      successCondition: result[0] < {{args.latency-threshold-ms}}
+      failureCondition: result[0] >= {{args.latency-threshold-ms}} * 2
+      failureLimit: 1
+      # 5-minute observation window sampled every 60 s = 5 data points.
+      interval: 60s
+      count: 5

--- a/kargo/stages/chains/prod.yaml
+++ b/kargo/stages/chains/prod.yaml
@@ -58,3 +58,5 @@ spec:
       - name: health-check
       - name: smoke-test
       - name: integration-test
+      - name: prometheus-5xx-error-rate
+      - name: prometheus-p95-latency

--- a/kargo/stages/chains/staging.yaml
+++ b/kargo/stages/chains/staging.yaml
@@ -55,3 +55,5 @@ spec:
     analysisTemplates:
       - name: health-check
       - name: smoke-test
+      - name: prometheus-5xx-error-rate
+      - name: prometheus-p95-latency

--- a/kargo/stages/direct/prod.yaml
+++ b/kargo/stages/direct/prod.yaml
@@ -58,3 +58,5 @@ spec:
       - name: health-check
       - name: smoke-test
       - name: integration-test
+      - name: prometheus-5xx-error-rate
+      - name: prometheus-p95-latency

--- a/kargo/stages/direct/staging.yaml
+++ b/kargo/stages/direct/staging.yaml
@@ -55,3 +55,5 @@ spec:
     analysisTemplates:
       - name: health-check
       - name: smoke-test
+      - name: prometheus-5xx-error-rate
+      - name: prometheus-p95-latency

--- a/kargo/stages/listeners/prod.yaml
+++ b/kargo/stages/listeners/prod.yaml
@@ -58,3 +58,5 @@ spec:
       - name: health-check
       - name: smoke-test
       - name: integration-test
+      - name: prometheus-5xx-error-rate
+      - name: prometheus-p95-latency

--- a/kargo/stages/listeners/staging.yaml
+++ b/kargo/stages/listeners/staging.yaml
@@ -55,3 +55,5 @@ spec:
     analysisTemplates:
       - name: health-check
       - name: smoke-test
+      - name: prometheus-5xx-error-rate
+      - name: prometheus-p95-latency

--- a/kargo/stages/mono/prod.yaml
+++ b/kargo/stages/mono/prod.yaml
@@ -60,3 +60,5 @@ spec:
       - name: health-check
       - name: smoke-test
       - name: integration-test
+      - name: prometheus-5xx-error-rate
+      - name: prometheus-p95-latency

--- a/kargo/stages/mono/staging.yaml
+++ b/kargo/stages/mono/staging.yaml
@@ -56,3 +56,5 @@ spec:
     analysisTemplates:
       - name: health-check
       - name: smoke-test
+      - name: prometheus-5xx-error-rate
+      - name: prometheus-p95-latency

--- a/kargo/stages/protocols/prod.yaml
+++ b/kargo/stages/protocols/prod.yaml
@@ -58,3 +58,5 @@ spec:
       - name: health-check
       - name: smoke-test
       - name: integration-test
+      - name: prometheus-5xx-error-rate
+      - name: prometheus-p95-latency

--- a/kargo/stages/protocols/staging.yaml
+++ b/kargo/stages/protocols/staging.yaml
@@ -55,3 +55,5 @@ spec:
     analysisTemplates:
       - name: health-check
       - name: smoke-test
+      - name: prometheus-5xx-error-rate
+      - name: prometheus-p95-latency


### PR DESCRIPTION
## Summary

Implements ADR-0021. Bumps Kargo 1.2->1.9; adds Prometheus 5xx/p95 AnalysisTemplates as stage verification gates (replacing job-probes); keeps dev/integration auto-promo, prod manual/digest-pinned. Kargo promotes Argo CD Applications directly (no Rollouts in repo). Refs #252.

- Bump `apps/infra/kargo/` chart pin 1.2 -> 1.9 (`Chart.yaml` + `Chart.lock` @ `1.9.8`, digest-pinned via `helm dep update`)
- Add `kargo/analysis-templates/prometheus-5xx-error-rate.yaml`: Prometheus provider querying Tempo RED metrics (`http_server_request_errors_total`); success < 1 % error rate, fail >= 5 %; 5 × 60 s observation window
- Add `kargo/analysis-templates/prometheus-p95-latency.yaml`: Prometheus provider; `histogram_quantile(0.95, ...)` on `http_server_request_duration_seconds_bucket`; default threshold 500 ms (tunable per-Stage via `latency-threshold-ms` arg)
- Wire both gates into `spec.verification.analysisTemplates` for **staging** and **prod** across all 5 projects (`chains`, `direct`, `listeners`, `mono`, `protocols`); `dev` and `integration` unchanged (auto-promote, job-probe only)
- Add `kargo/README.md`: provenance note (ADR-0021); explicit statement that Argo Rollouts is a separate future ADR; promotion graph; Prometheus gate reference table

**No Argo Rollouts** — Kargo sits directly above Argo CD Applications.
**Prometheus gates require ADR-0019** (Tempo RED metrics feed) to be live before flipping stages from job-probe to metric.

## Test plan

- [ ] `helm lint apps/infra/kargo` — 0 charts failed (verified locally, 1 INFO icon warning only)
- [ ] `helm template kargo apps/infra/kargo --set kargo.api.adminAccount.passwordHash=... --set kargo.api.adminAccount.tokenSigningKey=...` — renders cleanly
- [ ] `python3 -c yaml.safe_load_all` on all 35 `kargo/` YAML files — ALL YAML VALID
- [ ] Spot-check `kargo/stages/direct/staging.yaml` and `kargo/stages/direct/prod.yaml` — both have `prometheus-5xx-error-rate` and `prometheus-p95-latency` in `spec.verification.analysisTemplates`
- [ ] Spot-check `kargo/stages/direct/dev.yaml` and `integration.yaml` — no Prometheus templates (auto-promote unchanged)
- [ ] Verify `Chart.lock` pins `kargo: 1.9.8` with SHA256 digest