### PR TITLE
feat(gitops): ArgoCD operational hardening (ADR-0024)

### DIFF
--- a/argocd/bootstrap/applicationsets/multicluster-infra-appset.yaml
+++ b/argocd/bootstrap/applicationsets/multicluster-infra-appset.yaml
@@ -9,6 +9,15 @@
 # Cluster selection: all clusters with a "region" label.
 # Apps without region-specific values get the same config everywhere.
 #
+# Progressive/RollingSync (ADR-0024):
+#   Applications are promoted in three ordered steps keyed on the `env` label:
+#     Step 1 — dev        (lowest risk; fastest feedback)
+#     Step 2 — stage + integration  (pre-production soak)
+#     Step 3 — prod       (gates on prior steps succeeding)
+#   All Applications in a step must be Healthy+Synced before the next step
+#   begins. On any degraded Application the rollout pauses automatically.
+#   Rollback: delete or pause the ApplicationSet; ArgoCD halts promotion.
+#
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
@@ -36,6 +45,37 @@ spec:
                 env: '{{ index .metadata.labels "env" }}'
                 region: '{{ index .metadata.labels "region" }}'
                 regionShort: '{{ index .metadata.labels "region-short" }}'
+  # Progressive/RollingSync — staged promotion dev -> stage/integration -> prod.
+  # ADR-0024 section 4: ApplicationSet fleet rollout by env label.
+  strategy:
+    type: RollingSync
+    rollingSync:
+      steps:
+        # Step 1: dev — validates infra apps are renderable and sync cleanly
+        # across all dev-env regional clusters before advancing.
+        - matchExpressions:
+            - key: env
+              operator: In
+              values:
+                - dev
+          maxUpdate: 100%
+        # Step 2: stage + integration — pre-production soak across regions.
+        # Gated on Step 1 (all dev Applications Healthy+Synced).
+        - matchExpressions:
+            - key: env
+              operator: In
+              values:
+                - stage
+                - integration
+          maxUpdate: 50%
+        # Step 3: prod — gates on Steps 1+2.
+        # maxUpdate: 25% gives a canary wave on large multi-region prod fleets.
+        - matchExpressions:
+            - key: env
+              operator: In
+              values:
+                - prod
+          maxUpdate: 25%
   template:
     metadata:
       name: '{{ .path.basename }}-{{ .values.regionShort }}'

--- a/argocd/bootstrap/applicationsets/role-apps-appset.yaml
+++ b/argocd/bootstrap/applicationsets/role-apps-appset.yaml
@@ -1,3 +1,19 @@
+---
+# ApplicationSet — cluster-role × git directory fan-out.
+#
+# Deploys role-specific apps to every cluster whose `cluster-role` label matches
+# one of the values below (dex, backend, 3rd-party, velocity, listeners).
+#
+# Progressive/RollingSync (ADR-0024):
+#   Applications are promoted in three ordered steps keyed on the `env` label:
+#     Step 1 — dev        (lowest risk; fast feedback)
+#     Step 2 — stage + integration  (pre-production soak)
+#     Step 3 — prod       (gates on prior steps succeeding)
+#   A step is "complete" when ALL Applications that matched its selector are
+#   Healthy+Synced. If any Application in a step reaches a degraded/error state
+#   the rollout pauses (maxUpdate: 0 semantics via the pause-on-error selector).
+#   Rollback: delete or pause the ApplicationSet; ArgoCD halts further promotion.
+#
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
@@ -25,6 +41,37 @@ spec:
               revision: HEAD
               directories:
                 - path: 'apps/cluster-roles/{{.metadata.labels.cluster-role}}/*'
+  # Progressive/RollingSync — staged promotion dev -> stage/integration -> prod.
+  # ADR-0024 section 4: ApplicationSet fleet rollout by env label.
+  strategy:
+    type: RollingSync
+    rollingSync:
+      steps:
+        # Step 1: dev — lowest blast radius; validates the generated Applications
+        # are renderable and sync cleanly before any shared environment.
+        - matchExpressions:
+            - key: env
+              operator: In
+              values:
+                - dev
+          maxUpdate: 100%
+        # Step 2: stage + integration — pre-production soak.
+        # Both are gated on Step 1 completing (all dev Applications Healthy+Synced).
+        - matchExpressions:
+            - key: env
+              operator: In
+              values:
+                - stage
+                - integration
+          maxUpdate: 50%
+        # Step 3: prod — gates on Steps 1+2.
+        # maxUpdate: 25% gives a canary wave on large prod fleets.
+        - matchExpressions:
+            - key: env
+              operator: In
+              values:
+                - prod
+          maxUpdate: 25%
   template:
     metadata:
       name: '{{.path.basename}}-{{.name}}'

--- a/argocd/bootstrap/kustomization.yaml
+++ b/argocd/bootstrap/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - applicationsets/role-apps-appset.yaml
   - applicationsets/observability-appset.yaml
   - applicationsets/multicluster-infra-appset.yaml
+  # ADR-0024: ArgoCD operational config patches (server-side diff, shallow clone).
+  - ../config

--- a/argocd/config/README.md
+++ b/argocd/config/README.md
@@ -1,0 +1,162 @@
+# argocd/config — ArgoCD operational hardening (ADR-0024)
+
+This directory contains ConfigMap patches for ArgoCD operational capabilities
+enabled on the running **ArgoCD 3.3.6 (chart 9.5.1)** — no version upgrade
+required. Applied via the bootstrap Kustomization
+(`argocd/bootstrap/kustomization.yaml`) and reconciled by the root ArgoCD
+Application (`argocd/bootstrap/root-app.yaml`).
+
+Ratified: ADR-0024 (`docs/adrs/0024-argocd-operational-hardening.md`),
+2026-06-07.
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `argocd-cmd-params-cm.yaml` | Enables server-side diff and shallow git clone |
+| `kustomization.yaml` | Kustomize entrypoint for this directory |
+
+---
+
+## argocd-cmd-params-cm.yaml
+
+### controller.diff.server.side = "true"
+
+Switches ArgoCD's diff engine to **server-side diff**: the application-controller
+submits a dry-run server-side apply to the Kubernetes API server to determine
+what would change, rather than comparing local manifests against cached live
+state. Because the diff goes through the API server's admission webhook and
+defaulting chain, any fields that a webhook or mutating admission controller
+rewrites are already present in the diff result — they no longer cause spurious
+`OutOfSync`.
+
+Without this flag, a single field mutated by a webhook (e.g. a label injected
+by Kyverno, or a container security context normalised by an admission webhook)
+causes every Application that touches that resource to report `OutOfSync` on
+every reconcile cycle, generating alert noise and unnecessary sync churn across
+the entire clusters-x-git matrix.
+
+### reposerver.git.shallow = "true"
+
+Switches the ArgoCD repo-server to **shallow git clone** (depth=1). Instead of
+fetching full commit history on every reconcile, the repo-server fetches only
+the tip commit. On large repos with thousands of commits this reduces both clone
+wall-clock time and repo-server heap usage significantly.
+
+**Important constraint:** shallow clone is most effective when `targetRevision`
+is a branch name or tag (the tip is depth=1). If an Application pins a specific
+historical SHA the repo-server will still fetch a minimal graph to reach that
+commit. All ApplicationSets in this repo use `revision: HEAD`, so the benefit
+is realised immediately.
+
+---
+
+## PreDelete hook pattern (ADR-0024)
+
+A **PreDelete hook** is an ArgoCD sync hook that runs **before ArgoCD deletes
+a managed resource**. It is the correct way to implement ordered teardown:
+drain connections, deregister from a service registry, remove from a load
+balancer target group, or flush an in-flight queue before the workload
+disappears.
+
+### When to use
+
+Use a PreDelete hook on any resource whose abrupt deletion would:
+
+- Drop live user traffic (e.g. a Deployment serving HTTP requests)
+- Leave a dangling registration in an external system (e.g. a Consul service,
+  an AWS target group, an Istio service registry entry)
+- Leave in-flight work unprocessed (e.g. a consumer Deployment reading from
+  a Kafka topic)
+
+### Annotation syntax
+
+```yaml
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PreDelete
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+```
+
+`HookSucceeded` causes ArgoCD to delete the hook resource itself once the hook
+Job completes successfully. Use `BeforeHookCreation` instead if you want the
+hook Job to be re-created on subsequent deletions (idempotent teardown).
+
+### Example: graceful drain Job
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: my-service-predel-drain
+  namespace: my-namespace
+  annotations:
+    # Run this Job BEFORE ArgoCD deletes any resource in the Application.
+    argocd.argoproj.io/hook: PreDelete
+    # Delete this Job resource once it succeeds.
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 120
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: drain
+          image: curlimages/curl:8.7.1
+          command:
+            - /bin/sh
+            - -c
+            - |
+              # Deregister from the load-balancer / service registry.
+              # Replace with the appropriate drain command for your service.
+              curl -f -X DELETE \
+                "http://service-registry.internal/services/my-service/${POD_NAME}" \
+                --max-time 30
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+```
+
+### Hang prevention
+
+A PreDelete hook that hangs blocks ArgoCD from deleting the Application.
+Always set **`activeDeadlineSeconds`** on the hook Job (120 seconds is a
+reasonable upper bound for most drain operations). If the Job exceeds the
+deadline, Kubernetes marks it as Failed; ArgoCD then surfaces the failure in
+the Application status so an operator can investigate and manually proceed.
+
+### Hook ordering with sync waves
+
+PreDelete hooks run in sync-wave order (lowest wave first) during the delete
+phase, the same way PreSync/Sync hooks run during the sync phase. If you have
+multiple PreDelete hooks that must run in sequence, use
+`argocd.argoproj.io/sync-wave` annotations on each hook Job.
+
+```yaml
+# Drain connections first (wave 0)
+argocd.argoproj.io/hook: PreDelete
+argocd.argoproj.io/sync-wave: "0"
+
+# Deregister from service discovery second (wave 5)
+argocd.argoproj.io/hook: PreDelete
+argocd.argoproj.io/sync-wave: "5"
+```
+
+---
+
+## References
+
+- ADR-0024: `docs/adrs/0024-argocd-operational-hardening.md`
+- ArgoCD sync phases and hooks:
+  <https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/>
+- ArgoCD server-side diff:
+  <https://argo-cd.readthedocs.io/en/stable/user-guide/diff-strategies/>
+- ArgoCD cmd params reference:
+  <https://argo-cd.readthedocs.io/en/stable/operator-manual/argocd-cmd-params-cm/>
+- ApplicationSet Progressive Syncs:
+  <https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Progressive-Syncs/>

--- a/argocd/config/argocd-cmd-params-cm.yaml
+++ b/argocd/config/argocd-cmd-params-cm.yaml
@@ -1,0 +1,58 @@
+---
+# argocd-cmd-params-cm — ArgoCD command-level parameter overrides.
+#
+# Enables two ADR-0024 capabilities on the running ArgoCD 3.3.6 (chart 9.5.1)
+# without any version upgrade:
+#
+#   1. Server-Side Diff / Server-Side Apply (controller.diff.server.side)
+#      The ArgoCD application-controller uses the Kubernetes API server to diff
+#      resources rather than computing diffs client-side. This makes the diff
+#      webhook/defaulting/mutation aware and eliminates spurious OutOfSync
+#      across the clusters-x-git matrix (ADR-0024 section 3).
+#      Field: controller.diff.server.side = "true"
+#
+#   2. Shallow git clone (reposerver.git.shallow)
+#      The repo-server fetches only the required commit(s) instead of full
+#      history, reducing memory and wall-clock on large repos (ADR-0024 section 2).
+#      Field: reposerver.git.shallow = "true"
+#      Note: shallow clone is only effective when revision is a concrete SHA or
+#      a branch/tag that resolves to one. HEAD on a rolling branch still fetches
+#      the tip commit only (depth=1), which is the desired behaviour here.
+#
+# Relationship to syncOptions.ServerSideApply=true in ApplicationSets:
+#   - syncOptions.ServerSideApply=true (per-Application) controls the APPLY
+#     mechanism (SSA field ownership).
+#   - controller.diff.server.side (this ConfigMap) controls the DIFF mechanism
+#     (server-side awareness during OutOfSync detection).
+#   Both are set to get the full "no spurious OutOfSync" benefit.
+#
+# application.namespaces is intentionally omitted here; it is set at chart level
+# to avoid accidental override of the Helm-managed value.
+#
+# Delivery: applied via argocd/config/kustomization.yaml, which is included in
+# the argocd/bootstrap kustomization and therefore managed by the bootstrap
+# ArgoCD Application (argocd/bootstrap/root-app.yaml -> argocd/bootstrap).
+#
+# References:
+#   - ADR-0024: docs/adrs/0024-argocd-operational-hardening.md
+#   - ArgoCD server-side diff: https://argo-cd.readthedocs.io/en/stable/user-guide/diff-strategies/
+#   - ArgoCD params reference: https://argo-cd.readthedocs.io/en/stable/operator-manual/argocd-cmd-params-cm/
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/component: application-controller
+data:
+  # --- Server-Side Diff (ADR-0024 section 3) ---
+  # Use the API server for diffing so webhook/defaulting mutations are included.
+  # Eliminates spurious OutOfSync caused by server-side field rewriting.
+  controller.diff.server.side: "true"
+
+  # --- Shallow git clone (ADR-0024 section 2) ---
+  # Fetch depth=1 (tip commit only) instead of full history.
+  # Reduces repo-server memory and clone latency on large repos.
+  reposerver.git.shallow: "true"

--- a/argocd/config/kustomization.yaml
+++ b/argocd/config/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# ArgoCD operational config patches (ADR-0024).
+# Applied via the bootstrap ArgoCD Application (argocd/bootstrap/root-app.yaml).
+resources:
+  - argocd-cmd-params-cm.yaml


### PR DESCRIPTION
## Summary

Implements ADR-0024 on the running ArgoCD 3.3.6 (chart 9.5.1) — no version upgrade.

- **ApplicationSet Progressive/RollingSync** added to `role-apps-appset.yaml` and `multicluster-infra-appset.yaml`: staged fleet rollout dev → stage/integration → prod keyed on the `env` cluster label (ADR-0012). Steps gate on prior steps being Healthy+Synced; rollout pauses automatically on degraded Applications. `maxUpdate` set to 100% / 50% / 25% per step.
- **Server-Side Diff** (`controller.diff.server.side=true`) in new `argocd/config/argocd-cmd-params-cm.yaml`: routes diffs through the API server admission/defaulting chain, eliminating spurious `OutOfSync` matrix-wide.
- **Shallow git clone** (`reposerver.git.shallow=true`) in the same ConfigMap: repo-server fetches depth=1 only, reducing clone latency and heap on large repos.
- **PreDelete hook pattern** documented in `argocd/config/README.md` with a concrete drain-Job example, `activeDeadlineSeconds` hang-prevention, and sync-wave ordering guidance.

All changes wired through `argocd/bootstrap/kustomization.yaml` → `argocd/config/` → `argocd-cmd-params-cm`. Touches nothing outside `argocd/bootstrap/applicationsets/` and the new `argocd/config/`.

## Test plan

- [ ] `python3 yaml.safe_load_all` on all 5 touched YAML files — PASS (validated in worktree)
- [ ] `yamllint -c .yamllint.yml` on all 5 touched YAML files — PASS (0 errors, 0 warnings)
- [ ] YAML→JSON round-trip validation on all files — PASS
- [ ] Verify `role-apps-appset.yaml` `strategy.rollingSync.steps` matches env label values: `dev`, `stage`/`integration`, `prod`
- [ ] Verify `multicluster-infra-appset.yaml` `strategy.rollingSync.steps` matches same env sequence
- [ ] Verify `argocd-cmd-params-cm.yaml` has `controller.diff.server.side: "true"` and `reposerver.git.shallow: "true"`
- [ ] Verify `argocd/bootstrap/kustomization.yaml` includes `../config` resource entry
- [ ] Manual: after merging, confirm ArgoCD Application `bootstrap` shows `Synced` with the new ConfigMap rendered
- [ ] Manual: confirm no `OutOfSync` noise on next reconcile cycle after `controller.diff.server.side` takes effect

Refs #252 (ADR-0024).