### PR TITLE
feat(ingress): Envoy Gateway secondary L7 GatewayClass (ADR-0025)

### DIFF
--- a/apps/infra/envoy-gateway/Chart.lock
+++ b/apps/infra/envoy-gateway/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: gateway-helm
+  repository: oci://docker.io/envoyproxy
+  version: v1.8.0
+digest: sha256:96e75ce5669e4635ce22b53b1d38b127560472972eb059306ea7aff50a65e13d
+generated: "2026-06-07T21:32:42.220346+02:00"

--- a/apps/infra/envoy-gateway/Chart.yaml
+++ b/apps/infra/envoy-gateway/Chart.yaml
@@ -6,14 +6,15 @@ version: 1.0.0
 # Pin to chart version 1.8.0 (appVersion "v1.8.0").
 # Upstream: https://github.com/envoyproxy/gateway/releases/tag/v1.8.0
 # OCI source: oci://docker.io/envoyproxy/gateway-helm:v1.8.0
-# Chart digest: sha256:  (resolve at dependency update time; pin in Chart.lock)
+# Chart digest: sha256:828b0bf1dd0a8312665590802d7e3d0d360560d44ac8afd9f4ce6ed72564c56d
 appVersion: "v1.8.0"
 type: application
 
 dependencies:
   # Pinned to v1.8.0 — do NOT use "latest" or a range in production.
   # Updated: 2026-06-07 — initial pin at v1.8.0
-  - name: gateway
+  # Chart digest: sha256:828b0bf1dd0a8312665590802d7e3d0d360560d44ac8afd9f4ce6ed72564c56d
+  - name: gateway-helm
     version: "v1.8.0"
     repository: oci://docker.io/envoyproxy
     alias: envoyGateway

--- a/apps/infra/envoy-gateway/Chart.yaml
+++ b/apps/infra/envoy-gateway/Chart.yaml
@@ -1,0 +1,39 @@
+apiVersion: v2
+name: envoy-gateway
+description: Envoy Gateway - secondary L7 GatewayClass alongside Cilium (ADR-0025)
+version: 1.0.0
+# appVersion tracks the upstream envoy-gateway Helm chart appVersion (Envoy Gateway v1.8.x).
+# Pin to chart version 1.8.0 (appVersion "v1.8.0").
+# Upstream: https://github.com/envoyproxy/gateway/releases/tag/v1.8.0
+# OCI source: oci://docker.io/envoyproxy/gateway-helm:v1.8.0
+# Chart digest: sha256:  (resolve at dependency update time; pin in Chart.lock)
+appVersion: "v1.8.0"
+type: application
+
+dependencies:
+  # Pinned to v1.8.0 — do NOT use "latest" or a range in production.
+  # Updated: 2026-06-07 — initial pin at v1.8.0
+  - name: gateway
+    version: "v1.8.0"
+    repository: oci://docker.io/envoyproxy
+    alias: envoyGateway
+    condition: envoyGateway.enabled
+
+maintainers:
+  - name: Platform Team
+    email: platform@example.com
+
+keywords:
+  - gateway-api
+  - envoy
+  - l7
+  - rate-limiting
+  - traffic-management
+  - wasm
+  - ext-proc
+  - circuit-breaking
+
+annotations:
+  category: Networking
+  platform: Kubernetes
+  adr: "0025"

--- a/apps/infra/envoy-gateway/README.md
+++ b/apps/infra/envoy-gateway/README.md
@@ -1,0 +1,83 @@
+# envoy-gateway — Secondary L7 GatewayClass (ADR-0025)
+
+## Overview
+
+Envoy Gateway v1.8.x deployed as a **secondary GatewayClass** alongside Cilium.
+
+**Cilium stays the CNI and primary GatewayClass** (`io.cilium/gateway-controller`).
+Envoy Gateway is a separate control-plane that provisions its own Envoy proxy
+data-plane pods. It is NOT a CNI and does NOT replace Cilium's networking layer.
+
+## Why
+
+Cilium Gateway API lacks several capabilities needed by platform services:
+
+| Capability | Cilium Gateway API | Envoy Gateway |
+|---|---|---|
+| Global rate-limiting (cross-pod shared counter, Redis-backed) | No | Yes (`BackendTrafficPolicy`) |
+| External processing (`ext_proc` gRPC filter) | No | Yes (`EnvoyExtensionPolicy`) |
+| WASM HTTP filters | No | Yes (`EnvoyExtensionPolicy`) |
+| Circuit-breaking per upstream | No | Yes (`BackendTrafficPolicy`) |
+| Per-route retry budgets | Partial | Yes |
+
+ADR-0025 documents the full decision record and trade-offs.
+
+## GatewayClass separation
+
+| GatewayClass | controllerName | Data-plane |
+|---|---|---|
+| `cilium` | `io.cilium/gateway-controller` | Cilium eBPF |
+| `envoy-gateway` | `gateway.envoyproxy.io/gatewayclass-controller` | Envoy proxy pods |
+
+Workloads choose the class that fits their needs. The two classes are
+fully independent and can run on the same cluster simultaneously.
+
+## What is NOT in scope (ADR-0025)
+
+- **AWS Load Balancer Controller + Gateway API (AWS-LBC-GW)** — AWS-native L4/L7
+  integration; candidate for future ADR once GA.
+- **GAMMA (Gateway API for Mesh Management and Administration)** — east-west mesh
+  traffic via Gateway API; not required in the current platform topology.
+
+## Contents
+
+```
+apps/infra/envoy-gateway/
+├── Chart.yaml                            # Helm chart, depends on oci://docker.io/envoyproxy/gateway-helm:v1.8.0
+├── values.yaml                           # Controller config + Gateway API object values
+├── README.md                             # This file
+└── templates/
+    ├── _helpers.tpl                      # Shared label/name helpers
+    ├── gatewayclass.yaml                 # GatewayClass (cluster-scoped)
+    ├── gateway.yaml                      # Example Gateway (namespace-scoped)
+    ├── backendtrafficpolicy.yaml         # Global rate-limit example
+    ├── networkpolicy.yaml                # Controller pod network isolation
+    └── servicemonitor.yaml               # Prometheus scrape config
+```
+
+## ArgoCD wiring
+
+The `infra-appset.yaml` ApplicationSet (`argocd/bootstrap/applicationsets/infra-appset.yaml`)
+uses a Git directory generator on `apps/infra/*`. Adding this directory is
+sufficient — no manual Application YAML is needed.
+
+## Validation
+
+```bash
+cd apps/infra/envoy-gateway
+
+# Lint
+helm lint .
+
+# Render (no chart dependencies needed for template validation)
+helm template envoy-gateway . --set envoyGateway.enabled=false \
+  | python3 -c "import sys, yaml; list(yaml.safe_load_all(sys.stdin))" && echo "YAML OK"
+```
+
+## Upgrading
+
+1. Update `dependencies[0].version` in `Chart.yaml` to the new `v1.8.x` patch.
+2. Run `helm dep update` to refresh `Chart.lock` and the pinned digest.
+3. Update `appVersion` to match.
+4. Validate with `helm lint` + `helm template`.
+5. Raise a PR; ArgoCD will apply after merge.

--- a/apps/infra/envoy-gateway/templates/_helpers.tpl
+++ b/apps/infra/envoy-gateway/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "envoy-gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "envoy-gateway.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version label.
+*/}}
+{{- define "envoy-gateway.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "envoy-gateway.labels" -}}
+helm.sh/chart: {{ include "envoy-gateway.chart" . }}
+{{ include "envoy-gateway.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "envoy-gateway.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "envoy-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/apps/infra/envoy-gateway/templates/backendtrafficpolicy.yaml
+++ b/apps/infra/envoy-gateway/templates/backendtrafficpolicy.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.backendTrafficPolicy.enabled }}
+---
+# BackendTrafficPolicy — global rate-limiting example.
+# This is the primary ADR-0025 capability rationale: Cilium Gateway API does not
+# support global (cross-pod, shared-counter) rate-limiting natively; Envoy Gateway
+# exposes it via this CRD backed by a Redis rate-limit service.
+#
+# Rate-limit rule below: 1000 requests/minute per distinct x-forwarded-for value
+# (i.e., per remote IP as seen by an upstream LB).
+#
+# For ext-proc, WASM, and circuit-breaking examples see docs/adrs/0025-*.md.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: {{ .Values.backendTrafficPolicy.name }}
+  namespace: {{ .Values.exampleGateway.namespace }}
+  labels:
+    {{- include "envoy-gateway.labels" . | nindent 4 }}
+spec:
+  # Attach to the example Gateway defined in gateway.yaml.
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ .Values.exampleGateway.name }}
+  rateLimit:
+    type: {{ .Values.backendTrafficPolicy.rateLimit.type }}
+    global:
+      rules:
+        {{- range .Values.backendTrafficPolicy.rateLimit.global.rules }}
+        - clientSelectors:
+            {{- range .clientSelectors }}
+            - headers:
+                {{- range .headers }}
+                - name: {{ .name }}
+                  type: {{ .type }}
+                {{- end }}
+            {{- end }}
+          limit:
+            requests: {{ .limit.requests }}
+            unit: {{ .limit.unit }}
+        {{- end }}
+{{- end }}

--- a/apps/infra/envoy-gateway/templates/gateway.yaml
+++ b/apps/infra/envoy-gateway/templates/gateway.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.exampleGateway.enabled }}
+---
+# Example Gateway — demonstrates an Envoy-backed multi-protocol listener.
+# Uses gatewayClassName: {{ .Values.exampleGateway.gatewayClassName }} which resolves
+# to the GatewayClass above (controllerName: gateway.envoyproxy.io/gatewayclass-controller).
+# This is intentionally namespace-scoped to {{ .Values.exampleGateway.namespace }}.
+# Move to a workload chart once a real service adopts this GatewayClass.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.exampleGateway.name }}
+  namespace: {{ .Values.exampleGateway.namespace }}
+  labels:
+    {{- include "envoy-gateway.labels" . | nindent 4 }}
+spec:
+  gatewayClassName: {{ .Values.exampleGateway.gatewayClassName }}
+  listeners:
+    {{- range .Values.exampleGateway.listeners }}
+    - name: {{ .name }}
+      protocol: {{ .protocol }}
+      port: {{ .port }}
+      {{- if .tls }}
+      tls:
+        mode: {{ .tls.mode }}
+        certificateRefs:
+          {{- range .tls.certificateRefs }}
+          - name: {{ .name }}
+            kind: {{ .kind | default "Secret" }}
+          {{- end }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/apps/infra/envoy-gateway/templates/gatewayclass.yaml
+++ b/apps/infra/envoy-gateway/templates/gatewayclass.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.gatewayClass.enabled }}
+---
+# GatewayClass — cluster-scoped; one per controller implementation.
+# controllerName "gateway.envoyproxy.io/gatewayclass-controller" is distinct
+# from Cilium's "io.cilium/gateway-controller" — both coexist without conflict.
+# Reference: ADR-0025; Gateway API spec §4.1.
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: {{ .Values.gatewayClass.name }}
+  labels:
+    {{- include "envoy-gateway.labels" . | nindent 4 }}
+  annotations:
+    # Human-readable description of why this GatewayClass exists alongside Cilium.
+    gateway.networking.k8s.io/description: {{ .Values.gatewayClass.description | quote }}
+spec:
+  controllerName: {{ .Values.gatewayClass.controllerName }}
+  {{- if .Values.gatewayClass.parametersRef }}
+  {{- if .Values.gatewayClass.parametersRef.name }}
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: {{ .Values.gatewayClass.parametersRef.name }}
+    namespace: {{ .Release.Namespace }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/apps/infra/envoy-gateway/templates/networkpolicy.yaml
+++ b/apps/infra/envoy-gateway/templates/networkpolicy.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.networkPolicy.enabled }}
+---
+# NetworkPolicy for the Envoy Gateway controller pods.
+# Restricts ingress/egress to the minimum required for operation and observability.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "envoy-gateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "envoy-gateway.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "envoy-gateway.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+
+  ingress:
+    # Allow Prometheus scraping of controller metrics (port 19001).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - protocol: TCP
+          port: 19001
+
+    # Allow health/readiness probes from kubelet (any namespace).
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 8081
+
+  egress:
+    # Allow DNS resolution.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+
+    # Allow Kubernetes API server access (controller watches Gateway/HTTPRoute resources).
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 443
+
+    # Allow controller to communicate with Envoy proxy data-plane pods
+    # (xDS port 18000 used for ADS/xDS config delivery).
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/managed-by: envoy-gateway
+      ports:
+        - protocol: TCP
+          port: 18000
+        # gRPC metrics from Envoy proxy -> controller
+        - protocol: TCP
+          port: 18001
+{{- end }}

--- a/apps/infra/envoy-gateway/templates/servicemonitor.yaml
+++ b/apps/infra/envoy-gateway/templates/servicemonitor.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.serviceMonitor.enabled }}
+---
+# ServiceMonitor — scrapes the Envoy Gateway controller metrics endpoint.
+# Requires kube-prometheus-stack CRDs to be installed (managed by observability chart).
+# Port 19001 is the default metrics port for Envoy Gateway v1.8.x.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "envoy-gateway.fullname" . }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  labels:
+    {{- include "envoy-gateway.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "envoy-gateway.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      path: /metrics
+      scheme: http
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+        - sourceLabels: [__meta_kubernetes_pod_node_name]
+          targetLabel: node
+        - sourceLabels: [__meta_kubernetes_pod_label_app_kubernetes_io_version]
+          targetLabel: version
+{{- end }}

--- a/apps/infra/envoy-gateway/values.yaml
+++ b/apps/infra/envoy-gateway/values.yaml
@@ -9,25 +9,42 @@
 envoyGateway:
   enabled: true
 
+  # ---------------------------------------------------------------------------
+  # Digest-pinned images (security remediation — wave 2 infra-team).
+  # Resolved 2026-06-07 via registry v2 API (Docker-Content-Digest header).
+  #
+  # To refresh controller digest:
+  #   TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:envoyproxy/gateway:pull" \
+  #     | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+  #   curl -sI -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+  #     -H "Authorization: Bearer $TOKEN" \
+  #     https://registry-1.docker.io/v2/envoyproxy/gateway/manifests/v1.8.0 | grep docker-content-digest
+  #
+  # To refresh proxy digest:
+  #   TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:envoyproxy/envoy:pull" \
+  #     | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+  #   curl -sI -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+  #     -H "Authorization: Bearer $TOKEN" \
+  #     https://registry-1.docker.io/v2/envoyproxy/envoy/manifests/v1.33.0 | grep docker-content-digest
+  # ---------------------------------------------------------------------------
+
+  # global.images overrides are the upstream chart's canonical image override mechanism.
+  # The :tag@sha256:<digest> format is Kubernetes-native — tag is human-readable,
+  # the digest governs what Kubernetes actually pulls.
+  global:
+    images:
+      envoyGateway:
+        # Controller image — v1.8.0, multi-arch manifest list digest.
+        image: "docker.io/envoyproxy/gateway:v1.8.0@sha256:a9b4c4d8a402e8c007b74f2796587a6fb33d8baba46094f17c8a6f233e46d609"
+        pullPolicy: IfNotPresent
+      envoyProxy:
+        # Proxy image — v1.33.0 (Envoy version bundled with Envoy Gateway v1.8.0),
+        # multi-arch manifest list digest.
+        image: "docker.io/envoyproxy/envoy:v1.33.0@sha256:56da5afd7df364350ff92de4fb49a9b09957c17295f2899f0a31cd12c28770c2"
+        pullPolicy: IfNotPresent
+
   # Replica count — 2 for HA; increase for high-throughput environments.
   replicaCount: 2
-
-  # Image — upstream chart pulls envoyproxy/gateway; digest pinned in Chart.lock
-  # after `helm dep update`.
-  image:
-    repository: docker.io/envoyproxy/gateway
-    tag: "v1.8.0"
-    # digest: sha256:  (populate after image is available in registry)
-    pullPolicy: IfNotPresent
-
-  # Envoy proxy image used for the data-plane pods provisioned by Gateway resources.
-  envoy:
-    image:
-      repository: docker.io/envoyproxy/envoy
-      # Envoy Gateway v1.8.0 ships with Envoy 1.33.x; pin to the exact tag the
-      # upstream chart defaults to — override only after intentional testing.
-      tag: "v1.33.0"
-      pullPolicy: IfNotPresent
 
   # Resource requests/limits for the Envoy Gateway controller pods.
   resources:

--- a/apps/infra/envoy-gateway/values.yaml
+++ b/apps/infra/envoy-gateway/values.yaml
@@ -1,0 +1,158 @@
+# Envoy Gateway values
+# Upstream chart: oci://docker.io/envoyproxy/gateway-helm:v1.8.0
+# Provenance: ADR-0025 — secondary L7 GatewayClass alongside Cilium.
+# Cilium remains the CNI and primary GatewayClass (io.cilium/gateway-controller).
+# Envoy Gateway provides a SEPARATE Envoy data-plane (not a CNI) for capabilities
+# that Cilium Gateway API currently lacks: global rate-limiting, ext-proc, WASM filters,
+# and circuit-breaking via BackendTrafficPolicy.
+
+envoyGateway:
+  enabled: true
+
+  # Replica count — 2 for HA; increase for high-throughput environments.
+  replicaCount: 2
+
+  # Image — upstream chart pulls envoyproxy/gateway; digest pinned in Chart.lock
+  # after `helm dep update`.
+  image:
+    repository: docker.io/envoyproxy/gateway
+    tag: "v1.8.0"
+    # digest: sha256:  (populate after image is available in registry)
+    pullPolicy: IfNotPresent
+
+  # Envoy proxy image used for the data-plane pods provisioned by Gateway resources.
+  envoy:
+    image:
+      repository: docker.io/envoyproxy/envoy
+      # Envoy Gateway v1.8.0 ships with Envoy 1.33.x; pin to the exact tag the
+      # upstream chart defaults to — override only after intentional testing.
+      tag: "v1.33.0"
+      pullPolicy: IfNotPresent
+
+  # Resource requests/limits for the Envoy Gateway controller pods.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  # Security context — hardened per platform baseline.
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    fsGroup: 65534
+    seccompProfile:
+      type: RuntimeDefault
+
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+
+  # Pod anti-affinity so controller replicas land on different nodes.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                    - envoy-gateway
+            topologyKey: kubernetes.io/hostname
+
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+
+  priorityClassName: system-cluster-critical
+
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+
+  # Prometheus metrics — scraped by the ServiceMonitor below.
+  metrics:
+    enabled: true
+    port: 19001
+
+  logging:
+    level: info
+
+# -----------------------------------------------------------------------
+# Gateway API objects managed by this chart's templates (not by the
+# upstream envoy-gateway dependency — those are separate CRDs/controller).
+# -----------------------------------------------------------------------
+
+# GatewayClass — the single cluster-scoped object that declares this
+# controller.  controllerName MUST differ from Cilium's
+# "io.cilium/gateway-controller" to avoid conflicts.
+gatewayClass:
+  enabled: true
+  name: envoy-gateway
+  # controllerName must match the Envoy Gateway controller deployment.
+  # Cilium uses io.cilium/gateway-controller — this MUST be different.
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  description: >-
+    Envoy Gateway secondary L7 GatewayClass (ADR-0025). Provides global
+    rate-limiting, ext-proc, WASM filters, and circuit-breaking via
+    BackendTrafficPolicy. Cilium remains the CNI and primary GatewayClass.
+  parametersRef: {}  # Optional: reference an EnvoyProxy resource for customisation
+
+# Example Gateway — demonstrates how teams declare an Envoy-backed listener.
+# Remove or move to a workload chart once a real workload adopts this class.
+exampleGateway:
+  enabled: true
+  name: envoy-l7
+  namespace: envoy-gateway
+  gatewayClassName: envoy-gateway
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+    - name: https
+      protocol: HTTPS
+      port: 443
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: envoy-l7-tls
+            kind: Secret
+
+# BackendTrafficPolicy — global rate-limit example (the primary ADR-0025 rationale).
+# Attaches to the exampleGateway above.
+backendTrafficPolicy:
+  enabled: true
+  name: global-rate-limit-example
+  # Rate-limit: 1000 req/min per distinct remote IP address.
+  # Backed by the envoy-gateway rate-limit service (Redis-backed by default).
+  rateLimit:
+    type: Global
+    global:
+      rules:
+        - clientSelectors:
+            - headers:
+                - name: x-forwarded-for
+                  type: Distinct
+          limit:
+            requests: 1000
+            unit: Minute
+
+# NetworkPolicy — restrict controller pod traffic.
+networkPolicy:
+  enabled: true
+
+# ServiceMonitor — scrape Envoy Gateway controller metrics into Prometheus.
+serviceMonitor:
+  enabled: true
+  namespace: observability
+  interval: 30s
+  scrapeTimeout: 10s
+  labels:
+    prometheus: kube-prometheus


### PR DESCRIPTION
Implements ADR-0025. Envoy Gateway v1.8.x as a SECOND GatewayClass alongside Cilium (Cilium stays CNI) for global rate-limit/ext-proc/WASM/circuit-breaking — capabilities Cilium Gateway API lacks. Distinct controllerName. Refs #252.

## Summary

- Adds `apps/infra/envoy-gateway/` Helm chart (9 files) — zero changes outside this directory
- GatewayClass `envoy-gateway` with `controllerName: gateway.envoyproxy.io/gatewayclass-controller` — distinct from Cilium's `io.cilium/gateway-controller`
- Envoy Gateway v1.8.0 upstream chart pinned (`oci://docker.io/envoyproxy/gateway-helm:v1.8.0`)
- `BackendTrafficPolicy` global rate-limit example (1000 req/min per remote IP, Redis-backed) — the primary ADR-0025 capability rationale
- `NetworkPolicy` restricts controller pods (ingress: metrics port 19001 from `observability` NS; egress: DNS, K8s API, xDS port 18000 to proxy pods)
- `ServiceMonitor` scrapes metrics into `observability` namespace (port 19001, 30s interval)
- ArgoCD auto-wired via `infra-appset.yaml` Git directory generator (`apps/infra/*`) — no Application YAML needed

## Not in scope (per ADR-0025)

- AWS-LBC-GW (Gateway API via AWS Load Balancer Controller) — future ADR candidate
- GAMMA (Gateway API for mesh east-west) — not required in current topology

## Test plan

- [ ] `helm lint apps/infra/envoy-gateway/` — 0 charts failed
- [ ] `helm template` renders 5 objects: GatewayClass, Gateway, BackendTrafficPolicy, NetworkPolicy, ServiceMonitor
- [ ] `python3 yaml.safe_load_all` on rendered output — all 5 documents parse
- [ ] JSON round-trip (kubeconform simulation) — OK
- [ ] Confirm `gatewayClass.controllerName` differs from `io.cilium/gateway-controller`
- [ ] Confirm no files touched outside `apps/infra/envoy-gateway/`