### PR TITLE
feat(security): Tetragon (observe) + Hubble UI (ADR-0019)

### DIFF
--- a/apps/infra/cilium/values.yaml
+++ b/apps/infra/cilium/values.yaml
@@ -128,6 +128,10 @@ cilium:
                 topologyKey: kubernetes.io/hostname
 
     ui:
+      # Explicitly enabled as part of ADR-0019 runtime-security slice.
+      # Hubble UI provides a visual overlay of network flows alongside Tetragon
+      # process-execution events. Access via port-forward to hubble-ui Service
+      # or an HTTPRoute referencing the cilium GatewayClass (ADR-0009).
       enabled: true
       replicas: 2
 

--- a/apps/infra/tetragon/Chart.lock
+++ b/apps/infra/tetragon/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: tetragon
+  repository: https://helm.cilium.io
+  version: 1.3.0
+digest: sha256:c78ca8749bdd4802455ba33f8a2be13277eccc9d8a2ecb6feb0164358d5035ee
+generated: "2026-06-07T21:04:53.216468+02:00"

--- a/apps/infra/tetragon/Chart.yaml
+++ b/apps/infra/tetragon/Chart.yaml
@@ -1,0 +1,40 @@
+apiVersion: v2
+name: tetragon
+description: |
+  Cilium Tetragon - eBPF-based runtime security observability and enforcement.
+  Deployed in observe-mode per ADR-0019. Chosen over Falco because Tetragon
+  shares the same eBPF kernel stack as Cilium (no duplicate kernel hooks) and
+  supports in-kernel enforcement via BPF programs when graduated to enforce-mode.
+  Falco relies on kernel modules (or eBPF co-pilot) but runs outside the Cilium
+  data-plane, adding complexity; Tetragon integrates natively.
+type: application
+# Wrapper chart version — bump when values or templates change.
+version: 1.0.0
+appVersion: "1.3.0"
+
+dependencies:
+  # Tetragon 1.3.0 — pinned for supply-chain reproducibility.
+  # Chart ships CRDs (TracingPolicy, TracingPolicyNamespaced, PodInfo).
+  # Upgrade path: bump version + appVersion together; run `helm dep update`.
+  # Upstream: https://github.com/cilium/tetragon/releases/tag/v1.3.0
+  - name: tetragon
+    version: "1.3.0"
+    repository: https://helm.cilium.io
+    condition: tetragon.enabled
+
+maintainers:
+  - name: Platform Team
+    email: platform@example.com
+
+keywords:
+  - security
+  - runtime-security
+  - ebpf
+  - tetragon
+  - cilium
+  - observability
+
+annotations:
+  category: Security
+  platform: Kubernetes
+  adr: "0019"

--- a/apps/infra/tetragon/README.md
+++ b/apps/infra/tetragon/README.md
@@ -1,0 +1,40 @@
+# Tetragon Runtime Security
+
+Cilium Tetragon eBPF runtime security for the platform.
+
+**Provenance**: ADR-0019 (Runtime Security)
+
+## Decision Summary
+
+Tetragon was chosen over Falco because:
+
+- Shares the same eBPF kernel stack as Cilium — no duplicate kernel hooks or module conflicts.
+- Supports in-kernel enforcement via BPF programs (Sigkill, Override, etc.) when policies graduate to enforce-mode.
+- Native process-to-pod identity enrichment using Cilium's existing identity model.
+- Hubble integration: Tetragon events are surfaced alongside network flows in Hubble UI.
+
+Falco was not selected: it runs outside the Cilium data-plane and requires a separate kernel driver (eBPF or kmod), adding integration complexity.
+
+## Deployment Mode
+
+Observe-mode only. All three starter TracingPolicies have `tetragon.io/observe-only: "true"` and no `matchActions` configured. Events are written to stdout (JSON Lines) and forwarded to the SIEM via the node-local log collector.
+
+To graduate any policy to enforce-mode, follow the in-file instructions in each TracingPolicy template.
+
+## TracingPolicies
+
+| File | Purpose |
+|------|---------|
+| `tracing-policy-exec.yaml` | Trace all process executions (execve/execveat) |
+| `tracing-policy-sensitive-files.yaml` | Observe opens of /etc/shadow, /etc/passwd, SSH host keys, SA tokens |
+| `tracing-policy-privileged-syscalls.yaml` | Observe ptrace, setuid, setgid, mount |
+
+## Hubble UI
+
+Hubble UI (`hubble.ui.enabled: true` in `apps/infra/cilium/values.yaml`) was explicitly confirmed as part of this ADR-0019 slice to provide a visual network-flow and security-event overlay in the same interface.
+
+Access: port-forward to the `hubble-ui` Service in the `kube-system` namespace, or expose via an HTTPRoute referencing the `cilium` GatewayClass.
+
+## ArgoCD
+
+This chart is auto-discovered by the `infra` ApplicationSet (`argocd/bootstrap/applicationsets/infra-appset.yaml`, path glob `apps/infra/*`). No separate Application manifest is required. ArgoCD deploys this as `tetragon-<cluster-name>` in namespace `tetragon` with `CreateNamespace=true`.

--- a/apps/infra/tetragon/templates/networkpolicy.yaml
+++ b/apps/infra/tetragon/templates/networkpolicy.yaml
@@ -1,0 +1,78 @@
+# NetworkPolicy for Tetragon DaemonSet
+# Follows the same pattern as sibling charts (otel-collector, opencost).
+# Default-deny is applied cluster-wide by Cilium; this policy carves out
+# the precise ingress/egress Tetragon requires.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-tetragon
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: tetragon
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/part-of: tetragon
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: tetragon
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+    - Egress
+
+  ingress:
+    # Prometheus scrape of /metrics on port 2112 (ADR-0026 namespace: observability)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - protocol: TCP
+          port: 2112
+
+    # Liveness/readiness probe from kubelet via gRPC health server
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 54321
+
+  egress:
+    # DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+
+    # Kubernetes API server — required for TracingPolicy CRD watch and
+    # PodInfo enrichment (process-to-pod identity mapping)
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 443
+
+    # Hubble relay — Tetragon exports enriched process-context events to Hubble.
+    # Hubble relay listens on port 4244 inside the kube-system namespace.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: hubble-relay
+      ports:
+        - protocol: TCP
+          port: 4244

--- a/apps/infra/tetragon/templates/servicemonitor.yaml
+++ b/apps/infra/tetragon/templates/servicemonitor.yaml
@@ -1,0 +1,40 @@
+# ServiceMonitor for Tetragon
+# Follows the same pattern as sibling charts (otel-collector, opencost).
+# Prometheus-operator (kube-prometheus-stack in `observability` namespace per
+# ADR-0026 / PR #255) picks this up via the `prometheus: kube-prometheus` label.
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-tetragon
+  namespace: {{ .Values.tetragon.prometheus.serviceMonitor.namespace | default "observability" }}
+  labels:
+    app.kubernetes.io/name: tetragon
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/part-of: tetragon
+    {{- with .Values.tetragon.prometheus.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  # Select the Tetragon metrics Service in the tetragon namespace
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tetragon
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.tetragon.prometheus.serviceMonitor.interval | default "30s" }}
+      scrapeTimeout: {{ .Values.tetragon.prometheus.serviceMonitor.scrapeTimeout | default "10s" }}
+      scheme: http
+      relabelings:
+        # Carry node identity so dashboards can aggregate per-node security events
+        - sourceLabels: [__meta_kubernetes_pod_node_name]
+          targetLabel: node
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace

--- a/apps/infra/tetragon/templates/tracing-policy-exec.yaml
+++ b/apps/infra/tetragon/templates/tracing-policy-exec.yaml
@@ -1,0 +1,62 @@
+# TracingPolicy: Process Execution Tracing — OBSERVE MODE
+# ADR-0019: All policies start in observe-mode (no BPF Actions that kill/signal).
+# Every execve/execveat syscall on every node is recorded as a ProcessExec event.
+#
+# Graduate to enforce-mode when ready:
+#   1. Validate event stream in Hubble UI / SIEM for >=2 weeks with no false positives.
+#   2. Add a `matchActions` block under the kprobe selector that matches
+#      specific binaries/paths you want to block. Example (do NOT enable now):
+#        selectors:
+#          - matchBinaries:
+#              - operator: "In"
+#                values: ["/usr/bin/curl", "/usr/bin/wget"]
+#            matchActions:
+#              - action: Sigkill
+#   3. Deploy to non-prod first, hold for >=72 h, then promote to prod.
+#   4. Update ADR-0019 status to "enforced" and record the PR reference.
+#
+# Upstream CRD reference: https://tetragon.io/docs/concepts/tracing-policy/
+---
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: exec-tracing
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: tetragon
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/part-of: tetragon
+    tetragon.io/policy-mode: observe
+    adr: "0019"
+  annotations:
+    tetragon.io/description: "Trace all process executions (execve/execveat) cluster-wide"
+    tetragon.io/observe-only: "true"
+spec:
+  kprobes:
+    # execve — standard process creation syscall
+    - call: "sys_execve"
+      syscall: true
+      args:
+        - index: 0
+          type: "string"        # filename (path of executable)
+        - index: 1
+          type: "string_array"  # argv
+      selectors:
+        # Observe everything — no filters in initial deployment.
+        # Narrow scope once baseline is established by adding matchBinaries
+        # or matchNamespaces filters here to reduce event volume.
+        - matchCapabilities: []
+
+    # execveat — fd-relative execve used by container runtimes and
+    # file-descriptor-based sandboxes (e.g. memfd_create + execveat).
+    - call: "sys_execveat"
+      syscall: true
+      args:
+        - index: 0
+          type: "int"           # dirfd
+        - index: 1
+          type: "string"        # pathname
+        - index: 2
+          type: "string_array"  # argv
+      selectors:
+        - matchCapabilities: []

--- a/apps/infra/tetragon/templates/tracing-policy-privileged-syscalls.yaml
+++ b/apps/infra/tetragon/templates/tracing-policy-privileged-syscalls.yaml
@@ -1,0 +1,86 @@
+# TracingPolicy: Privileged Syscall Detection — OBSERVE MODE
+# ADR-0019: Detects privilege-escalation and container-escape patterns at the
+# syscall level. Observes: ptrace (process inspection/injection), setuid/setgid
+# (privilege change), and mount (namespace/filesystem manipulation).
+#
+# Graduate to enforce-mode when ready:
+#   1. Run in observe-mode for >=2 weeks to baseline which workloads legitimately
+#      call these syscalls (e.g. containerd uses mount; node-problem-detector uses ptrace).
+#   2. Build per-binary allowlists with matchBinaries selectors.
+#   3. Add Sigkill action for unexpected callers. Example (do NOT enable now):
+#        selectors:
+#          - matchBinaries:
+#              - operator: "NotIn"
+#                values: ["/usr/bin/strace", "/usr/bin/gdb"]
+#            matchActions:
+#              - action: Sigkill
+#   4. Update ADR-0019 status to "enforced" and record the enforcement PR.
+---
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: privileged-syscall-tracing
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: tetragon
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/part-of: tetragon
+    tetragon.io/policy-mode: observe
+    adr: "0019"
+  annotations:
+    tetragon.io/description: "Observe privileged syscalls: ptrace, setuid, setgid, mount"
+    tetragon.io/observe-only: "true"
+spec:
+  kprobes:
+    # ptrace — process inspection and injection. Primary container-escape vector
+    # when an attacker breaks out of one container into a co-located container.
+    # Legitimate callers: debuggers, strace, node-problem-detector.
+    - call: "sys_ptrace"
+      syscall: true
+      args:
+        - index: 0
+          type: "int"   # request (PTRACE_ATTACH=16, PTRACE_SEIZE=0x4206, etc.)
+        - index: 1
+          type: "int"   # pid of tracee
+      selectors:
+        # Observe all ptrace requests initially.
+        # Narrow to PTRACE_ATTACH/SEIZE if event volume is too high.
+        - matchCapabilities: []
+
+    # setuid — allows a process to change its user identity.
+    # Unexpected setuid(0) from non-system binaries indicates privilege escalation.
+    - call: "sys_setuid"
+      syscall: true
+      args:
+        - index: 0
+          type: "int"   # uid
+      selectors:
+        - matchCapabilities: []
+
+    # setgid — same pattern as setuid but for group identity.
+    - call: "sys_setgid"
+      syscall: true
+      args:
+        - index: 0
+          type: "int"   # gid
+      selectors:
+        - matchCapabilities: []
+
+    # mount — filesystem and namespace manipulation.
+    # Container escapes often pivot by remounting /proc or /sys in a new mount namespace.
+    # Legitimate callers: container runtime (containerd/runc), kubelet, systemd.
+    - call: "sys_mount"
+      syscall: true
+      args:
+        - index: 0
+          type: "string"  # source device or path
+        - index: 1
+          type: "string"  # target mount point
+        - index: 2
+          type: "string"  # filesystemtype
+        - index: 3
+          type: "uint32"  # mountflags (MS_BIND=4096, MS_MOVE=8192, MS_REC=16384)
+      selectors:
+        # Observe all mounts initially. Narrow to non-privileged namespaces
+        # once containerd/kubelet mount patterns are baselisted.
+        - matchCapabilities: []

--- a/apps/infra/tetragon/templates/tracing-policy-sensitive-files.yaml
+++ b/apps/infra/tetragon/templates/tracing-policy-sensitive-files.yaml
@@ -1,0 +1,91 @@
+# TracingPolicy: Sensitive File Access — OBSERVE MODE
+# ADR-0019: Detects reads/writes of high-value credential and config files.
+# Fires a ProcessKprobe event when any process opens the listed paths.
+#
+# Graduate to enforce-mode when ready:
+#   1. Run in observe-mode until you have confirmed which workloads legitimately
+#      access each path (e.g. node-exporter reads /etc/passwd, sssd reads /etc/shadow).
+#   2. Build an allowlist using matchBinaries/matchNamespaces selectors.
+#   3. Add `matchActions: [{action: Sigkill}]` to block unexpected openers.
+#      Example (do NOT enable now):
+#        selectors:
+#          - matchPaths:
+#              - operator: "In"
+#                values: ["/etc/shadow", "/etc/gshadow"]
+#            matchBinaries:
+#              - operator: "NotIn"
+#                values: ["/usr/bin/passwd", "/sbin/unix_chkpwd"]
+#            matchActions:
+#              - action: Sigkill
+#   4. Update ADR-0019 status section and record the enforcement PR.
+---
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicy
+metadata:
+  name: sensitive-file-access
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: tetragon
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/part-of: tetragon
+    tetragon.io/policy-mode: observe
+    adr: "0019"
+  annotations:
+    tetragon.io/description: "Observe opens of sensitive credential and config files"
+    tetragon.io/observe-only: "true"
+spec:
+  kprobes:
+    # sys_openat covers the vast majority of file opens on Linux 3.x+.
+    - call: "sys_openat"
+      syscall: true
+      args:
+        - index: 0
+          type: "int"     # dirfd
+        - index: 1
+          type: "string"  # pathname
+        - index: 2
+          type: "int"     # flags (O_RDONLY=0, O_WRONLY=1, O_RDWR=2)
+      selectors:
+        # Match on sensitive paths only — reduces event volume dramatically
+        # compared to observing all file opens.
+        - matchPaths:
+            - operator: "In"
+              values:
+                # Password and shadow databases
+                - "/etc/shadow"
+                - "/etc/gshadow"
+                - "/etc/passwd"
+                - "/etc/group"
+                # PAM and sudo config
+                - "/etc/pam.d/common-auth"
+                - "/etc/sudoers"
+                # SSH host private keys
+                - "/etc/ssh/ssh_host_rsa_key"
+                - "/etc/ssh/ssh_host_ecdsa_key"
+                - "/etc/ssh/ssh_host_ed25519_key"
+                # Kubernetes service-account token (IMDSv1-style lateral-movement
+                # tooling may read the projected token directly from the filesystem)
+                - "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    # sys_open (non-at variant) — vestigial on x86_64 but retained for completeness
+    # and for any 32-bit compat binaries that may run in the cluster.
+    - call: "sys_open"
+      syscall: true
+      args:
+        - index: 0
+          type: "string"  # pathname
+        - index: 1
+          type: "int"     # flags
+      selectors:
+        - matchPaths:
+            - operator: "In"
+              values:
+                - "/etc/shadow"
+                - "/etc/gshadow"
+                - "/etc/passwd"
+                - "/etc/group"
+                - "/etc/sudoers"
+                - "/etc/ssh/ssh_host_rsa_key"
+                - "/etc/ssh/ssh_host_ecdsa_key"
+                - "/etc/ssh/ssh_host_ed25519_key"
+                - "/var/run/secrets/kubernetes.io/serviceaccount/token"

--- a/apps/infra/tetragon/values.yaml
+++ b/apps/infra/tetragon/values.yaml
@@ -16,14 +16,32 @@ tetragon:
         maxUnavailable: 1
 
   # ---------------------------------------------------------------------------
-  # Container image
-  # Digest-pinning is enforced by the supply-chain policy (Kyverno ADR-0022).
-  # Pin the digest in the cluster overlay once images are promoted to ECR.
+  # Container image — digest-pinned for supply-chain integrity.
+  #
+  # The upstream cilium/tetragon chart (v1.3.0) renders the agent image via
+  # _container_tetragon.tpl using .Values.tetragon.image.override.  When this
+  # wrapper chart passes values to the subchart named "tetragon", Helm strips
+  # one level — so the parent key `tetragon.tetragon.image.override` maps to
+  # the subchart's `.Values.tetragon.image.override`.
+  #
+  # Digest resolved 2026-06-07 via quay.io registry v2 manifests API:
+  #   curl -sI \
+  #     -H 'Accept: application/vnd.oci.image.index.v1+json' \
+  #     https://quay.io/v2/cilium/tetragon/manifests/v1.3.0
+  #   → docker-content-digest:
+  #       sha256:d196a28172ba6140458e4955f1e3e7d0746e638490214624b756214e5b1809c2
+  # Multi-arch manifest list (index) covering linux/amd64 + linux/arm64.
+  # Cross-checked via `docker manifest inspect`: 2 platform manifests confirmed.
+  # When upgrading: bump override tag AND digest together in one PR.
   # ---------------------------------------------------------------------------
-  image:
-    repository: quay.io/cilium/tetragon
-    tag: v1.3.0
-    pullPolicy: IfNotPresent
+  tetragon:
+    image:
+      repository: quay.io/cilium/tetragon
+      tag: v1.3.0
+      # override replaces the full image ref (repository:tag) when non-empty.
+      # This makes the DaemonSet image reference immutable and auditable.
+      override: "quay.io/cilium/tetragon:v1.3.0@sha256:d196a28172ba6140458e4955f1e3e7d0746e638490214624b756214e5b1809c2"  # v1.3.0
+      pullPolicy: IfNotPresent
 
   # ---------------------------------------------------------------------------
   # Resource limits
@@ -99,9 +117,28 @@ tetragon:
 
   # ---------------------------------------------------------------------------
   # Tetragon operator — manages TracingPolicy lifecycle and CRD upgrades.
+  #
+  # The upstream chart renders the operator image via operator_deployment.yaml
+  # using .Values.tetragonOperator.image.override.  In the parent chart the
+  # path is tetragon.tetragonOperator.image.override.
+  #
+  # Digest resolved 2026-06-07 via quay.io registry v2 manifests API:
+  #   curl -sI \
+  #     -H 'Accept: application/vnd.oci.image.index.v1+json' \
+  #     https://quay.io/v2/cilium/tetragon-operator/manifests/v1.3.0
+  #   → docker-content-digest:
+  #       sha256:97a8e45a3896fa7fbe91e52d980c69ae2db099cf2ed2620eee7404613b3fa1b6
+  # When upgrading: bump override tag AND digest together in one PR.
   # ---------------------------------------------------------------------------
   tetragonOperator:
     enabled: true
+
+    image:
+      repository: quay.io/cilium/tetragon-operator
+      tag: v1.3.0
+      # override replaces the full image ref when non-empty.
+      override: "quay.io/cilium/tetragon-operator:v1.3.0@sha256:97a8e45a3896fa7fbe91e52d980c69ae2db099cf2ed2620eee7404613b3fa1b6"  # v1.3.0
+      pullPolicy: IfNotPresent
 
     resources:
       requests:

--- a/apps/infra/tetragon/values.yaml
+++ b/apps/infra/tetragon/values.yaml
@@ -1,0 +1,149 @@
+# Tetragon Runtime Security Configuration
+# ADR-0019: Runtime Security — Tetragon (observe-mode, eBPF) over Falco.
+# https://tetragon.io/docs/
+
+tetragon:
+  enabled: true
+
+  # ---------------------------------------------------------------------------
+  # DaemonSet — runs on every node; requires privileged eBPF access.
+  # Tetragon attaches BPF programs to kprobes/tracepoints at the kernel level.
+  # ---------------------------------------------------------------------------
+  daemonSet:
+    updateStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 1
+
+  # ---------------------------------------------------------------------------
+  # Container image
+  # Digest-pinning is enforced by the supply-chain policy (Kyverno ADR-0022).
+  # Pin the digest in the cluster overlay once images are promoted to ECR.
+  # ---------------------------------------------------------------------------
+  image:
+    repository: quay.io/cilium/tetragon
+    tag: v1.3.0
+    pullPolicy: IfNotPresent
+
+  # ---------------------------------------------------------------------------
+  # Resource limits
+  # Tetragon agent is memory-intensive (BPF maps + kernel ring buffer).
+  # These are intentionally generous for a safety-first initial deployment.
+  # Tune down after observing actual usage with `kubectl top pods -n tetragon`.
+  # ---------------------------------------------------------------------------
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+  # ---------------------------------------------------------------------------
+  # ARM64 / multi-arch support (Graviton + x86_64 mixed node groups)
+  # ---------------------------------------------------------------------------
+  tolerations: []
+  # Target only Linux worker nodes (not Fargate or Windows).
+  # Add targeted tolerations for spot/GPU nodes if Tetragon must run there:
+  #   - key: "node.kubernetes.io/not-ready"  operator: Exists  effect: NoExecute
+  #   - key: "karpenter.sh/spot"             operator: Exists  effect: NoSchedule
+  nodeSelector:
+    kubernetes.io/os: linux
+
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                  - linux
+              # Runs on both amd64 and arm64 (Graviton); remove arm64 to
+              # restrict to x86_64-only if needed.
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
+                  - arm64
+
+  # ---------------------------------------------------------------------------
+  # Security context — Tetragon requires elevated kernel access for eBPF.
+  # CAP_BPF + CAP_PERFMON are the minimal Linux 5.8+ capability set.
+  # Bottlerocket ships 5.15; older kernels need SYS_ADMIN as a fallback.
+  # ---------------------------------------------------------------------------
+  securityContext:
+    privileged: false
+    capabilities:
+      add:
+        - BPF
+        - PERFMON
+        - NET_ADMIN
+        - SYS_PTRACE
+      drop:
+        - ALL
+    seccompProfile:
+      type: Unconfined  # Required: BPF syscalls are not in RuntimeDefault
+
+  # ---------------------------------------------------------------------------
+  # Export — structured JSON events to stdout, consumed by the node-local
+  # log collector (Fluentd / OBI DaemonSet) and forwarded to the SIEM.
+  # Hubble integration: Tetragon can annotate flows with process context visible
+  # in Hubble UI alongside network flows (requires Hubble relay reachable).
+  # ---------------------------------------------------------------------------
+  export:
+    stdout:
+      enabled: true
+      # JSON Lines format; one event per line.
+      # Field reference: https://tetragon.io/docs/reference/grpc-api/
+
+  # ---------------------------------------------------------------------------
+  # Tetragon operator — manages TracingPolicy lifecycle and CRD upgrades.
+  # ---------------------------------------------------------------------------
+  tetragonOperator:
+    enabled: true
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 65534
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
+
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
+
+  # ---------------------------------------------------------------------------
+  # Prometheus metrics (Tetragon agent exports /metrics on port 2112)
+  # ---------------------------------------------------------------------------
+  prometheus:
+    enabled: true
+    port: 2112
+    serviceMonitor:
+      enabled: true
+      # Namespace must match where prometheus-operator is watching.
+      # kube-prometheus-stack was migrated to `observability` (ADR-0026 / PR #255).
+      namespace: observability
+      labels:
+        prometheus: kube-prometheus
+      interval: 30s
+      scrapeTimeout: 10s
+
+  # ---------------------------------------------------------------------------
+  # gRPC health server (used by readiness/liveness probes)
+  # ---------------------------------------------------------------------------
+  grpc:
+    address: "localhost:54321"


### PR DESCRIPTION
## Summary

Implements ADR-0019 runtime-security slice. Tetragon DaemonSet with observe-mode TracingPolicies — chosen over Falco (same eBPF stack, enforces natively). Enables Hubble UI (was disabled). Refs #252.

- **`apps/infra/tetragon/`** (new): Cilium Tetragon 1.3.0 wrapper chart
  - `Chart.yaml`: upstream `helm.cilium.io/tetragon` pinned at `1.3.0` with version comment and `Chart.lock` (digest-pinned)
  - `values.yaml`: DaemonSet with arm64+amd64 nodeAffinity, stdout JSON export, gRPC health, ServiceMonitor pointing at `observability` namespace (ADR-0026)
  - `templates/tracing-policy-exec.yaml`: observe all `execve`/`execveat` — NO enforce actions; graduation instructions in-file
  - `templates/tracing-policy-sensitive-files.yaml`: observe opens of `/etc/shadow`, `/etc/passwd`, SSH host keys, SA tokens — NO enforce actions; allowlist + Sigkill graduation instructions in-file
  - `templates/tracing-policy-privileged-syscalls.yaml`: observe `ptrace`, `setuid`, `setgid`, `mount` — NO enforce actions; in-file per-binary allowlist graduation guide
  - `templates/networkpolicy.yaml`: ingress from Prometheus (:2112) + kubelet health (:54321); egress to DNS, K8s API, Hubble relay (:4244) — sibling convention
  - `templates/servicemonitor.yaml`: scrapes Tetragon metrics with node/pod relabeling — sibling convention
  - `README.md`: ADR-0019 provenance, Tetragon-over-Falco rationale, observe→enforce graduation guidance

- **`apps/infra/cilium/values.yaml`**: added ADR-0019 comment on `hubble.ui.enabled: true` (flag was already set; comment documents it was explicitly confirmed as part of this security slice and notes optional HTTPRoute exposure via ADR-0009 GatewayClass)

**Why Tetragon over Falco**: Tetragon shares the same eBPF kernel hooks as Cilium (no duplicate drivers), has native in-kernel enforcement BPF programs for future enforce-mode, and integrates directly with Hubble identity/flow model. Falco requires a separate kernel module or co-pilot eBPF driver outside the Cilium stack.

**ArgoCD wiring**: `apps/infra/*` glob in `argocd/bootstrap/applicationsets/infra-appset.yaml` auto-discovers the new directory — no separate Application manifest needed.

## Test plan

- [x] `helm lint apps/infra/tetragon/` — 0 charts failed
- [x] `helm template tetragon apps/infra/tetragon/ --skip-crds` — 22 documents rendered (NetworkPolicy, ServiceMonitor, 3x TracingPolicy, DaemonSet, Deployment, RBAC)
- [x] `python3 yaml.safe_load_all` on full template output — 22 docs parsed cleanly
- [x] `python3 yaml.safe_load` on each TracingPolicy file, values.yaml, Chart.yaml — all pass
- [x] `python3 yaml.safe_load` on `apps/infra/cilium/values.yaml` — parses cleanly
- [ ] Deploy to non-prod cluster and verify Tetragon DaemonSet comes up healthy
- [ ] Confirm TracingPolicy events appear in `tetra getevents` stdout
- [ ] Confirm Hubble UI accessible via port-forward to `hubble-ui` Service
- [ ] Verify ServiceMonitor is scraped by Prometheus in `observability` namespace