### PR TITLE
feat(policy): Kyverno + VAP policy engine (ADR-0020)

### DIFF
--- a/apps/infra/kyverno/Chart.lock
+++ b/apps/infra/kyverno/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: kyverno
+  repository: https://kyverno.github.io/kyverno
+  version: 3.4.4
+digest: sha256:e54c86d1a1779c651960f0e624f6ab00c40aea30351d7aec0829c38453046bd3
+generated: "2026-06-07T21:07:25.34176+02:00"

--- a/apps/infra/kyverno/Chart.yaml
+++ b/apps/infra/kyverno/Chart.yaml
@@ -1,15 +1,16 @@
 apiVersion: v2
 name: kyverno
-description: Kyverno - Kubernetes Native Policy Management
-version: 1.0.0
-appVersion: "1.13.4"
+description: Kyverno - Kubernetes Native Policy Management (ADR-0020)
+version: 1.1.0
+appVersion: "1.18.1"
 type: application
 
 dependencies:
-  # Kyverno - Kubernetes native policy engine
-  # https://kyverno.io/docs/
+  # Kyverno - CNCF Graduated (2026-03-16). v1.18.1 — matches ADR-0020.
+  # Chart 3.4.x ships Kyverno 1.18.x.
+  # https://github.com/kyverno/kyverno/releases
   - name: kyverno
-    version: "3.3.7"
+    version: "3.4.4"
     repository: https://kyverno.github.io/kyverno
     condition: kyverno.enabled
 
@@ -23,8 +24,11 @@ keywords:
   - validation
   - mutation
   - generation
+  - image-verification
+  - cosign
   - kubernetes
 
 annotations:
   category: Security
   platform: Kubernetes
+  adr: ADR-0020

--- a/apps/infra/kyverno/README.md
+++ b/apps/infra/kyverno/README.md
@@ -1,101 +1,102 @@
-# Kyverno
+# Kyverno — ADR-0020
 
-Kubernetes Native Policy Management engine for validating, mutating, and generating resources.
-
-## Overview
-
-Kyverno is a policy engine designed specifically for Kubernetes. Unlike OPA Gatekeeper, policies are written as Kubernetes resources (no Rego required).
-
-## Features
-
-- **Validate**: Block non-compliant resources
-- **Mutate**: Modify resources on creation/update
-- **Generate**: Create resources automatically
-- **Verify Images**: Validate container image signatures
-- **Cleanup**: Automatically delete resources based on policies
+Kubernetes Native Policy Management. Complements Gatekeeper + Pod Security Admission.
 
 ## Status
 
-**Disabled by default.** Enable by setting `kyverno.enabled: true` in values.yaml.
+**Enabled** (v1.18.1). All policies start in **Audit** mode.
+Promote to **Enforce** after a clean audit window in each environment.
 
-## Comparison with OPA Gatekeeper
+See [ADR-0020](../../../docs/adrs/0020-kyverno-and-vap-policy-engine.md) for rationale.
 
-| Feature | Kyverno | Gatekeeper |
-|---------|---------|------------|
-| Policy Language | YAML (native K8s) | Rego |
-| Learning Curve | Lower | Higher |
-| Mutation Support | Native | Experimental |
-| Generation | Yes | No |
-| Image Verification | Built-in | External |
-| Policy Reports | Native | Requires add-on |
+## Policy split (ADR-0020)
 
-**Recommendation**: Choose one policy engine. If already using Gatekeeper, evaluate migration vs running both.
+| Layer | What it owns | Why |
+|-------|-------------|-----|
+| **Kyverno** | verifyImages (keyless cosign), mutate securityContext, generate default-deny NetworkPolicy | Verify/mutate/generate — things VAP and Rego handle poorly |
+| **VAP (native CEL)** | Block `:latest`, require resource limits | Simple in-process CEL checks, no webhook, lower latency |
+| **Gatekeeper** | 4 existing ConstraintTemplates (kept) | Mature, audited — no rewrite risk |
+| **PSA** | `restricted` baseline | Node-level Pod Security Admission |
 
-## Quick Start
+## What is deployed
 
-1. Enable Kyverno:
-   ```yaml
-   # values.yaml
-   kyverno:
-     enabled: true
-   ```
+### Kyverno engine (`kyverno/`)
 
-2. Deploy a sample policy:
-   ```yaml
-   apiVersion: kyverno.io/v1
-   kind: ClusterPolicy
-   metadata:
-     name: require-labels
-   spec:
-     validationFailureAction: Audit
-     rules:
-       - name: check-team-label
-         match:
-           any:
-             - resources:
-                 kinds:
-                   - Pod
-         validate:
-           message: "Label 'team' is required"
-           pattern:
-             metadata:
-               labels:
-                 team: "?*"
-   ```
+- Chart: `kyverno/kyverno` at **v3.4.4** (app v1.18.1)
+- 3-replica admission controller, 2-replica background/cleanup/reports controllers
+- Image verification cache enabled (~60 min TTL) to limit Rekor round-trips
 
-3. Check policy reports:
-   ```bash
-   kubectl get policyreport -A
-   kubectl get clusterpolicyreport
-   ```
+### Policies (`templates/policies/`)
 
-## Architecture
+| File | Kind | Purpose |
+|------|------|---------|
+| `verify-images.yaml` | ClusterPolicy | Keyless cosign image signature verification. Fulcio issuer = GitHub Actions OIDC. mutateDigest rewrites tag to verified digest. Audit then Enforce. |
+| `mutate-security-context.yaml` | ClusterPolicy | Injects `runAsNonRoot: true`, `seccompProfile: RuntimeDefault`, `capabilities.drop: [ALL]` into containers that do not already set these fields. |
+| `generate-default-deny-netpol.yaml` | ClusterPolicy | Generates a `default-deny-all` NetworkPolicy into every new namespace (excluding system/infra namespaces). Synchronized back if deleted. |
+
+### ValidatingAdmissionPolicy (`templates/vap/`)
+
+| File | Kind | Purpose |
+|------|------|---------|
+| `block-latest-require-limits.yaml` | ValidatingAdmissionPolicy + Binding | Block `:latest` image tags; require `resources.limits.cpu` and `resources.limits.memory`. In-process CEL, no webhook. Audit then Deny. |
+
+## Why image verification is here and NOT in ArgoCD
+
+ArgoCD can only verify GnuPG-signed git commits. It cannot verify cosign or
+OCI image signatures. Image-signature enforcement belongs at admission, where
+Kyverno's `verifyImages` checks the OCI signature before the pod is admitted.
+This is the verification layer that ADR-0016's cosign signing requires.
+
+## Rollout
+
+All policies and the VAP binding start in Audit mode (no blocking):
 
 ```
-                    +-----------------------+
-                    |   Admission Webhook   |
-                    |   (Validate/Mutate)   |
-                    +-----------+-----------+
-                                |
-        +-----------------------+-----------------------+
-        |                       |                       |
-+-------v-------+       +-------v-------+       +-------v-------+
-|  Background   |       |   Cleanup     |       |   Reports     |
-|  Controller   |       |  Controller   |       |  Controller   |
-| (Generate)    |       | (TTL cleanup) |       | (PolicyReport)|
-+---------------+       +---------------+       +---------------+
+ClusterPolicy:                    validationFailureAction: Audit
+ValidatingAdmissionPolicy:        failurePolicy: Ignore
+ValidatingAdmissionPolicyBinding: validationActions: [Audit]
+```
+
+Promotion checklist (per environment):
+
+1. Monitor `kubectl get policyreport -A` and `kubectl get clusterpolicyreport` for violations.
+2. Investigate and remediate violating workloads.
+3. After a clean audit window (no unexpected violations), promote:
+   - ClusterPolicy: `validationFailureAction: Enforce`
+   - Webhook failurePolicy in `values.yaml`: `Fail`
+   - VAP Binding: `validationActions: [Deny]` (or `[Deny, Warn]`)
+   - VAP Policy: `failurePolicy: Fail`
+
+## ArgoCD
+
+The `argocd-application.yaml` in this directory wires Kyverno as an ArgoCD
+Application at sync-wave 5 (after cert-manager, before workloads). Apply with:
+
+```bash
+kubectl apply -f apps/infra/kyverno/argocd-application.yaml
 ```
 
 ## Monitoring
 
-Kyverno exposes Prometheus metrics:
+Kyverno exposes Prometheus metrics (scraped by kube-prometheus-stack):
 
-- `kyverno_policy_results_total` - Policy evaluation results
-- `kyverno_admission_review_duration_seconds` - Webhook latency
-- `kyverno_controller_reconcile_total` - Controller reconciliation
+- `kyverno_policy_results_total` — policy evaluation results by action/policy/result
+- `kyverno_admission_review_duration_seconds` — admission webhook latency
+- `kyverno_controller_reconcile_total` — background controller reconciliation
 
-## Resources
+Check policy reports:
 
-- [Documentation](https://kyverno.io/docs/)
-- [Policy Library](https://kyverno.io/policies/)
-- [Helm Chart](https://github.com/kyverno/kyverno/tree/main/charts/kyverno)
+```bash
+kubectl get policyreport -A
+kubectl get clusterpolicyreport
+kubectl describe policyreport -n <namespace> <name>
+```
+
+## References
+
+- [ADR-0020](../../../docs/adrs/0020-kyverno-and-vap-policy-engine.md) — policy engine decision
+- ADR-0016 — cosign signing (verified here at admission, not in ArgoCD)
+- ADR-0003 — Cilium (generated NetworkPolicy pairs with Cilium baseline)
+- [Kyverno docs](https://kyverno.io/docs/)
+- [Kyverno image verification](https://kyverno.io/docs/policy-types/cluster-policy/verify-images/)
+- [ValidatingAdmissionPolicy (GA 1.30)](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/)

--- a/apps/infra/kyverno/argocd-application.yaml
+++ b/apps/infra/kyverno/argocd-application.yaml
@@ -1,0 +1,86 @@
+---
+# ArgoCD Application for Kyverno — ADR-0020
+#
+# Deploys Kyverno (v1.18.x) as a complement to Gatekeeper + PSA.
+# Kyverno owns: verifyImages (keyless cosign), mutate securityContext,
+#               generate default-deny NetworkPolicy.
+# VAP (in-process CEL) owns: block :latest, require resource limits.
+# Gatekeeper stays — its 4 ConstraintTemplates are not replaced.
+#
+# Sync wave 5: after cert-manager (wave 0-1) and before application
+# workloads; admission webhooks must be ready before workloads land.
+#
+# Usage:
+#   kubectl apply -f argocd-application.yaml
+#
+# ADR-0020: docs/adrs/0020-kyverno-and-vap-policy-engine.md
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kyverno
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: kyverno
+    app.kubernetes.io/component: policy-engine
+    team: platform
+  annotations:
+    # Wave 5 — after cert-manager (cert injection for webhooks), before workloads.
+    argocd.argoproj.io/sync-wave: "5"
+    adr: ADR-0020
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/100rd/platform-design.git
+    targetRevision: HEAD
+    path: apps/infra/kyverno
+
+    helm:
+      valueFiles:
+        - values.yaml
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kyverno
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+
+  # Ignore caBundle fields injected by cert-manager into webhook configurations.
+  ignoreDifferences:
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      jsonPointers:
+        - /webhooks/0/clientConfig/caBundle
+        - /webhooks/1/clientConfig/caBundle
+        - /webhooks/2/clientConfig/caBundle
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      jsonPointers:
+        - /webhooks/0/clientConfig/caBundle
+        - /webhooks/1/clientConfig/caBundle
+        - /webhooks/2/clientConfig/caBundle
+    # Ignore replica count drift (HPA / Kyverno auto-scaling)
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas

--- a/apps/infra/kyverno/templates/policies/generate-default-deny-netpol.yaml
+++ b/apps/infra/kyverno/templates/policies/generate-default-deny-netpol.yaml
@@ -1,0 +1,99 @@
+---
+# ClusterPolicy — generate default-deny NetworkPolicy per new namespace
+#
+# ADR-0020: Kyverno generates a default-deny NetworkPolicy into each new
+# namespace so every namespace starts with a deny-all posture without
+# operators having to remember to create it manually.
+#
+# Generated resource:
+#   kind: NetworkPolicy
+#   name: default-deny-all
+#   spec: podSelector: {} + policyTypes: [Ingress, Egress]
+#   Blocks all ingress and egress by default; workloads add their own
+#   NetworkPolicies (or Cilium NetworkPolicies) on top.
+#
+# Sync: Kyverno's background controller reconciles the generated policy
+# back if someone deletes it (synchronize: true).
+#
+# Exclusions: kube-system, kube-public, kube-node-lease, kyverno,
+# cert-manager, external-secrets, argocd, monitoring, observability —
+# these need cluster-level connectivity and must not be locked down by
+# a blanket deny.
+#
+# failureAction: Audit — start in Audit; promote to Enforce after clean window.
+#   TODO(ops): promote validationFailureAction to Enforce in prod.
+#
+# Kyverno JMESPath expressions are wrapped in backtick raw-string Helm actions
+# so Helm passes them through verbatim instead of interpreting them as Go templates.
+#
+# References:
+#   https://kyverno.io/docs/policy-types/cluster-policy/generate/
+#   ADR-0020 section: generate — default-deny NetworkPolicy per new namespace
+#   ADR-0003 — Cilium baseline NetworkPolicy
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: generate-default-deny-netpol
+  annotations:
+    policies.kyverno.io/title: Generate default-deny NetworkPolicy per namespace
+    policies.kyverno.io/category: Network Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Namespace
+    policies.kyverno.io/description: >-
+      Generates a default-deny-all NetworkPolicy into every new namespace
+      that is not a system or infra namespace. Provides a deny-all baseline;
+      workloads must explicitly allow traffic via their own NetworkPolicies
+      or Cilium NetworkPolicies. Pairs with ADR-0003 Cilium baseline.
+    adr: ADR-0020
+spec:
+  # TODO(ops): change to Enforce after a clean Audit window in each env.
+  validationFailureAction: Audit
+
+  background: true  # Background controller reconciles generated resources
+
+  rules:
+    - name: generate-default-deny-all
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+      # Exclude system and infra namespaces that need open connectivity.
+      exclude:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+              names:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+                - kyverno
+                - cert-manager
+                - external-secrets
+                - argocd
+                - monitoring
+                - observability
+
+      generate:
+        # synchronize: true — Kyverno re-creates the policy if deleted.
+        # Set to false if namespaces need to opt out by deleting the policy.
+        synchronize: true
+        apiVersion: networking.k8s.io/v1
+        kind: NetworkPolicy
+        name: default-deny-all
+        # Generated into the namespace that triggered this rule.
+        namespace: "{{`{{ request.object.metadata.name }}`}}"
+        data:
+          metadata:
+            labels:
+              app.kubernetes.io/managed-by: kyverno
+              policy.kyverno.io/policy-name: generate-default-deny-netpol
+          spec:
+            # Empty podSelector matches all pods in the namespace.
+            podSelector: {}
+            policyTypes:
+              - Ingress
+              - Egress
+            # No ingress or egress rules — all traffic denied by default.
+            # Workloads add their own NetworkPolicies on top of this baseline.

--- a/apps/infra/kyverno/templates/policies/mutate-security-context.yaml
+++ b/apps/infra/kyverno/templates/policies/mutate-security-context.yaml
@@ -1,0 +1,118 @@
+---
+# ClusterPolicy — mutate securityContext (secure-by-default injection)
+#
+# ADR-0020: Kyverno mutates workloads to be secure by default.
+# Injects hardened securityContext into every container that does not already
+# set the fields, so teams get safe defaults without opting in manually.
+#
+# Injected fields (only when absent — + prefix = strategic merge / add-if-missing):
+#   runAsNonRoot: true          — prevent UID 0
+#   seccompProfile.type: RuntimeDefault — enable default seccomp filter
+#   capabilities.drop: [ALL]   — drop all Linux capabilities
+#
+# The mutation uses patchStrategicMerge + the + (add-if-missing) operator so
+# it does NOT overwrite values that workloads explicitly set. Workloads that
+# need elevated capabilities must set them explicitly (override is preserved).
+#
+# failureAction: Audit — start in Audit; promote to Enforce after clean window.
+#   TODO(ops): promote validationFailureAction to Enforce in prod.
+#
+# Kyverno JMESPath expressions are wrapped in backtick raw-string Helm actions
+# so Helm passes them through verbatim instead of interpreting them as Go templates.
+#
+# References:
+#   https://kyverno.io/docs/policy-types/cluster-policy/mutate/
+#   ADR-0020 section: mutate — inject runAsNonRoot/seccompProfile/drop-ALL
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: mutate-securitycontext-defaults
+  annotations:
+    policies.kyverno.io/title: Inject hardened securityContext defaults
+    policies.kyverno.io/category: Pod Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Injects secure securityContext defaults (runAsNonRoot, RuntimeDefault
+      seccomp, drop ALL capabilities) into containers that do not already
+      set these fields. Workloads that explicitly set these fields are not
+      overwritten (strategic merge preserves explicit values).
+    adr: ADR-0020
+spec:
+  # TODO(ops): change to Enforce after a clean Audit window in each env.
+  validationFailureAction: Audit
+
+  background: true  # Apply mutations to existing resources during background scan
+
+  rules:
+    # -----------------------------------------------------------------------
+    # Rule 1 — inject pod-level seccompProfile when absent
+    # -----------------------------------------------------------------------
+    - name: inject-pod-seccomp
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      # Only patch when pod-level seccompProfile is not already present.
+      preconditions:
+        all:
+          - key: "{{`{{ request.object.spec.securityContext.seccompProfile.type || '' }}`}}"
+            operator: Equals
+            value: ""
+      mutate:
+        patchStrategicMerge:
+          spec:
+            securityContext:
+              +(seccompProfile):
+                type: RuntimeDefault
+
+    # -----------------------------------------------------------------------
+    # Rule 2 — inject container-level securityContext defaults when absent
+    # -----------------------------------------------------------------------
+    - name: inject-container-security-defaults
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      mutate:
+        foreach:
+          - list: "request.object.spec.containers"
+            patchStrategicMerge:
+              spec:
+                containers:
+                  - name: "{{`{{ element.name }}`}}"
+                    securityContext:
+                      # + means "add only if key is absent"; existing value wins.
+                      +(runAsNonRoot): true
+                      +(capabilities):
+                        drop:
+                          - ALL
+
+    # -----------------------------------------------------------------------
+    # Rule 3 — same injection for initContainers (when present)
+    # -----------------------------------------------------------------------
+    - name: inject-init-container-security-defaults
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      preconditions:
+        all:
+          - key: "{{`{{ request.object.spec.initContainers | length(@) }}`}}"
+            operator: GreaterThanOrEquals
+            value: "1"
+      mutate:
+        foreach:
+          - list: "request.object.spec.initContainers"
+            patchStrategicMerge:
+              spec:
+                initContainers:
+                  - name: "{{`{{ element.name }}`}}"
+                    securityContext:
+                      +(runAsNonRoot): true
+                      +(capabilities):
+                        drop:
+                          - ALL

--- a/apps/infra/kyverno/templates/policies/verify-images.yaml
+++ b/apps/infra/kyverno/templates/policies/verify-images.yaml
@@ -1,0 +1,89 @@
+---
+# ImageValidatingPolicy — keyless cosign image verification
+#
+# ADR-0020: Image-signature enforcement belongs at ADMISSION, not in ArgoCD.
+# ArgoCD can only verify GnuPG-signed git commits; it cannot verify cosign /
+# OCI image signatures. This policy is the verification layer ADR-0016 requires.
+#
+# Kyverno v1.18 promotes ImageValidatingPolicy to the Stable API
+# (kyverno.io/v1). It supersedes the older spec.rules[].verifyImages form
+# for new policies.
+#
+# Design:
+#   issuer  — https://token.actions.githubusercontent.com  (GitHub Actions OIDC)
+#   subject — glob matching CI workflow path for this org
+#   rekor   — https://rekor.sigstore.dev  (public Sigstore transparency log)
+#   mutateDigest: true — rewrites tag reference to the verified digest so the
+#     admitted pod is pinned to the exact verified image (not just the tag).
+#   failureAction: Audit — start in Audit; flip to Enforce after clean window.
+#     TODO(ops): promote validationFailureAction to Enforce once audit shows
+#       no false positives in prod.
+#
+# Scope: all Pods in all namespaces except system / infra namespaces.
+# Exclusions (kyverno / cert-manager / argocd / ...) are handled by the
+# webhook namespaceSelector in values.yaml.
+#
+# References:
+#   https://kyverno.io/docs/policy-types/cluster-policy/verify-images/
+#   ADR-0020 section: verifyImages (ImageValidatingPolicy on v1.18)
+#   ADR-0016 — cosign signing
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-images-keyless-cosign
+  annotations:
+    policies.kyverno.io/title: Verify container image signatures (keyless cosign)
+    policies.kyverno.io/category: Supply Chain Security
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Verifies that every container image in a Pod carries a valid keyless
+      cosign signature issued by GitHub Actions (Fulcio issuer) and recorded
+      in the Rekor transparency log. Pairs with ADR-0016 cosign signing.
+      mutateDigest rewrites the tag reference to the verified digest.
+    adr: ADR-0020
+spec:
+  # TODO(ops): change to Enforce after a clean Audit window in each env.
+  validationFailureAction: Audit
+
+  # Image verification is admission-time only; background scan not applicable.
+  background: false
+
+  rules:
+    - name: check-image-signature
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      verifyImages:
+        - imageReferences:
+            # Match all images. Restrict to your registry prefix once stable.
+            # e.g.: "*.dkr.ecr.*.amazonaws.com/*" or "ghcr.io/100rd/*"
+            - "*"
+
+          # Rewrite the admitted tag reference to the verified digest.
+          # Ensures the pod runs the exact image that was signed, not a
+          # later push to the same tag.
+          mutateDigest: true
+
+          # Reject pods where the digest cannot be resolved.
+          verifyDigest: true
+
+          attestors:
+            - count: 1
+              entries:
+                - keyless:
+                    # Fulcio OIDC identity — GitHub Actions OIDC provider.
+                    # issuer must exactly match the token issuer from ADR-0016.
+                    issuer: https://token.actions.githubusercontent.com
+
+                    # Subject glob: matches all workflow paths under the org.
+                    # Tighten to a specific repo/workflow path once rollout is
+                    # stable, e.g.:
+                    #   "https://github.com/100rd/your-repo/.github/workflows/*"
+                    subject: "https://github.com/100rd/*"
+
+                    # Rekor public transparency log — inclusion proof required.
+                    rekor:
+                      url: https://rekor.sigstore.dev

--- a/apps/infra/kyverno/templates/policies/verify-images.yaml
+++ b/apps/infra/kyverno/templates/policies/verify-images.yaml
@@ -1,13 +1,17 @@
 ---
-# ImageValidatingPolicy — keyless cosign image verification
+# ClusterPolicy — keyless cosign image verification (verifyImages rule)
 #
 # ADR-0020: Image-signature enforcement belongs at ADMISSION, not in ArgoCD.
 # ArgoCD can only verify GnuPG-signed git commits; it cannot verify cosign /
 # OCI image signatures. This policy is the verification layer ADR-0016 requires.
 #
-# Kyverno v1.18 promotes ImageValidatingPolicy to the Stable API
-# (kyverno.io/v1). It supersedes the older spec.rules[].verifyImages form
-# for new policies.
+# NOTE on API evolution:
+#   Kyverno v1.18 promotes ImageValidatingPolicy (kyverno.io/v1alpha1 → Stable)
+#   as a first-class alternative to ClusterPolicy with a verifyImages rule.
+#   This resource uses the ClusterPolicy / spec.rules[].verifyImages form
+#   (kyverno.io/v1) which remains fully supported and is the stable path for
+#   Kyverno <1.18 clusters. For new clusters on v1.18+ the ImageValidatingPolicy
+#   kind (kyverno.io/v1) is the preferred approach.
 #
 # Design:
 #   issuer  — https://token.actions.githubusercontent.com  (GitHub Actions OIDC)
@@ -19,13 +23,21 @@
 #     TODO(ops): promote validationFailureAction to Enforce once audit shows
 #       no false positives in prod.
 #
-# Scope: all Pods in all namespaces except system / infra namespaces.
+# Scope: first-party images in our ECR registry (*.dkr.ecr.*.amazonaws.com/*).
+#   Third-party / upstream images (registry.k8s.io, quay.io, ghcr.io, etc.)
+#   are NOT included — they are not signed by our GitHub Actions identity and
+#   would generate spurious Audit findings or block admission when promoted
+#   to Enforce. Upstream images are covered separately by vulnerability
+#   scanning (Trivy) and digest-pinning (Gatekeeper block-latest-tag policy).
+#   public.ecr.aws (AWS-managed pause/CNI images) is also excluded for the
+#   same reason.
+#
 # Exclusions (kyverno / cert-manager / argocd / ...) are handled by the
 # webhook namespaceSelector in values.yaml.
 #
 # References:
 #   https://kyverno.io/docs/policy-types/cluster-policy/verify-images/
-#   ADR-0020 section: verifyImages (ImageValidatingPolicy on v1.18)
+#   ADR-0020 section: verifyImages (ClusterPolicy with verifyImages rule)
 #   ADR-0016 — cosign signing
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
@@ -37,9 +49,12 @@ metadata:
     policies.kyverno.io/severity: high
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Verifies that every container image in a Pod carries a valid keyless
-      cosign signature issued by GitHub Actions (Fulcio issuer) and recorded
-      in the Rekor transparency log. Pairs with ADR-0016 cosign signing.
+      Verifies that every first-party container image (our ECR registry:
+      *.dkr.ecr.*.amazonaws.com/*) carries a valid keyless cosign signature
+      issued by GitHub Actions (Fulcio issuer) and recorded in the Rekor
+      transparency log. Third-party/upstream images (registry.k8s.io, quay.io,
+      public.ecr.aws, ghcr.io, etc.) are out of scope — they are not signed by
+      our CI identity. Pairs with ADR-0016 cosign signing.
       mutateDigest rewrites the tag reference to the verified digest.
     adr: ADR-0020
 spec:
@@ -58,9 +73,17 @@ spec:
                 - Pod
       verifyImages:
         - imageReferences:
-            # Match all images. Restrict to your registry prefix once stable.
-            # e.g.: "*.dkr.ecr.*.amazonaws.com/*" or "ghcr.io/100rd/*"
-            - "*"
+            # Scope to first-party ECR images only.
+            # Pattern covers all accounts and all regions:
+            #   <account>.dkr.ecr.<region>.amazonaws.com/<repo>[:<tag>|@sha256:...]
+            # Explicitly excludes:
+            #   - public.ecr.aws        (AWS-managed pause, CNI images)
+            #   - registry.k8s.io       (upstream Kubernetes images)
+            #   - quay.io / ghcr.io     (upstream third-party images)
+            # Those registries are not signed by our GitHub Actions identity;
+            # including them would cause spurious Audit hits today and block
+            # admission when this policy is promoted to Enforce.
+            - "*.dkr.ecr.*.amazonaws.com/*"
 
           # Rewrite the admitted tag reference to the verified digest.
           # Ensures the pod runs the exact image that was signed, not a

--- a/apps/infra/kyverno/templates/vap/block-latest-require-limits.yaml
+++ b/apps/infra/kyverno/templates/vap/block-latest-require-limits.yaml
@@ -1,0 +1,134 @@
+---
+# ValidatingAdmissionPolicy — block :latest tag + require resource limits
+#
+# ADR-0020: Simple validations that need no webhook belong in native
+# ValidatingAdmissionPolicy (VAP), which runs in-process via CEL.
+# No admission webhook, no controller on the request path, lower latency.
+#
+# VAP went GA in Kubernetes 1.30. This manifest demonstrates the
+# Kyverno-owns-verify/mutate/generate vs VAP-owns-simple-validate split.
+#
+# Policies encoded here:
+#   1. Block images tagged :latest (any container or initContainer).
+#   2. Require CPU and memory limits on every container.
+#
+# These checks intentionally complement Gatekeeper's block-latest-tag and
+# require-resource-limits ConstraintTemplates. ADR-0020 routes new simple
+# CEL checks to VAP (in-process, no webhook) while Gatekeeper retains its
+# existing mature templates.
+#
+# Binding: validationActions: [Audit] initially.
+#   TODO(ops): change to [Deny] once audit shows no false positives in prod.
+#   [Audit, Warn] is also useful — surfaces violations as API warnings without
+#   blocking, good for a graduated rollout.
+#
+# References:
+#   https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/
+#   ADR-0020 section: VAP — block :latest, require limits (CEL in-process)
+
+# -----------------------------------------------------------------------
+# ValidatingAdmissionPolicy — CEL rules
+# -----------------------------------------------------------------------
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: platform-pod-baseline
+  annotations:
+    adr: ADR-0020
+    description: >-
+      Block :latest image tags and require CPU/memory limits on all containers.
+      In-process CEL validation (no webhook). Owned by VAP layer per ADR-0020.
+spec:
+  # failurePolicy: controls what happens when the CEL expression itself errors
+  # (e.g. a type error against an unusual object). Fail = block on expression
+  # error (safe default for prod). Ignore = allow through on expression error.
+  # TODO(ops): switch to Fail in prod once expressions are validated in Audit.
+  failurePolicy: Ignore
+
+  matchConstraints:
+    resourceRules:
+      # Cover Pods directly
+      - apiGroups:   [""]
+        apiVersions: ["v1"]
+        operations:  ["CREATE", "UPDATE"]
+        resources:   ["pods"]
+      # Cover Pod controllers so teams get feedback at the controller level too.
+      - apiGroups:   ["apps"]
+        apiVersions: ["v1"]
+        operations:  ["CREATE", "UPDATE"]
+        resources:   ["deployments", "statefulsets", "daemonsets", "replicasets"]
+      - apiGroups:   ["batch"]
+        apiVersions: ["v1"]
+        operations:  ["CREATE", "UPDATE"]
+        resources:   ["jobs", "cronjobs"]
+
+  validations:
+    # -----------------------------------------------------------------------
+    # Rule 1 — Block :latest image tags
+    # Applies only to Pod objects; controller objects pass through (pod
+    # admission check catches them at pod creation time).
+    # -----------------------------------------------------------------------
+    - expression: >-
+        object.kind != 'Pod' ||
+        (
+          object.spec.containers.all(c,
+            c.image.contains(':') && !c.image.endsWith(':latest')
+          ) &&
+          (
+            !has(object.spec.initContainers) ||
+            object.spec.initContainers.all(c,
+              c.image.contains(':') && !c.image.endsWith(':latest')
+            )
+          )
+        )
+      message: >-
+        All container images must specify an explicit tag or digest and must not
+        use ':latest'. Pin images to a specific version or SHA digest.
+      reason: Invalid
+
+    # -----------------------------------------------------------------------
+    # Rule 2 — Require CPU and memory limits on every container
+    # -----------------------------------------------------------------------
+    - expression: >-
+        object.kind != 'Pod' ||
+        object.spec.containers.all(c,
+          has(c.resources) &&
+          has(c.resources.limits) &&
+          has(c.resources.limits.cpu) &&
+          has(c.resources.limits.memory)
+        )
+      message: >-
+        All containers must declare both CPU and memory limits under
+        resources.limits. Add 'resources.limits.cpu' and
+        'resources.limits.memory' to every container spec.
+      reason: Invalid
+
+---
+# -----------------------------------------------------------------------
+# ValidatingAdmissionPolicyBinding — wires the policy to a scope
+# -----------------------------------------------------------------------
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: platform-pod-baseline-binding
+  annotations:
+    adr: ADR-0020
+spec:
+  policyName: platform-pod-baseline
+
+  # Scope: all namespaces except low-level system namespaces.
+  matchResources:
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - kube-public
+            - kube-node-lease
+
+  # TODO(ops): change to [Deny] (or [Deny, Warn]) after audit window shows
+  # no false positives. Warn surfaces violations as API server warnings
+  # without blocking — useful for graduated rollout.
+  validationActions:
+    - Audit

--- a/apps/infra/kyverno/values.yaml
+++ b/apps/infra/kyverno/values.yaml
@@ -1,21 +1,27 @@
-# Kyverno Configuration
+# Kyverno Configuration — ADR-0020
 # https://kyverno.io/docs/
 #
-# DISABLED BY DEFAULT - Set kyverno.enabled to true to deploy
+# ADR-0020: Kyverno complements Gatekeeper + PSA.
+#   - Kyverno owns: verifyImages (keyless cosign), mutate securityContext,
+#     generate default-deny NetworkPolicy.
+#   - ValidatingAdmissionPolicy (VAP) owns: block :latest, require resource limits
+#     (CEL in-process, no webhook).
+#   - Gatekeeper stays — its 4 ConstraintTemplates are not replaced.
 #
-# Note: If you have OPA Gatekeeper deployed, consider which policy engine
-# to use. Running both is possible but may add complexity.
+# Rollout: all policies start in Audit mode.
+# Promote to Enforce after a clean audit window in each environment.
 
 kyverno:
-  # Disabled by default - enable when ready to use
-  enabled: false
+  enabled: true
 
-  # CRDs are managed by the Kyverno Helm chart (installCRDs: true)
-  # Unlike other tools, Kyverno CRDs are tightly coupled with the controller version
+  # CRDs are managed by the Kyverno Helm chart (installCRDs: true default).
+  # Kyverno CRDs are tightly coupled with the controller version.
   crds:
     install: true
 
-  # Admission controller configuration
+  # -----------------------------------------------------------------------
+  # Admission controller — the hot path for validate / mutate / verifyImages
+  # -----------------------------------------------------------------------
   admissionController:
     replicas: 3
 
@@ -27,7 +33,6 @@ kyverno:
         cpu: 500m
         memory: 512Mi
 
-    # Security context
     container:
       securityContext:
         allowPrivilegeEscalation: false
@@ -40,19 +45,27 @@ kyverno:
           drop:
             - ALL
 
-    # Anti-affinity for HA
+    # Spread across nodes for HA; admission path must not become a SPOF
     antiAffinity:
       enabled: true
 
-    # Tolerate system node taints
+    # Allow scheduling on system-component nodes (CriticalAddonsOnly taint)
     tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
 
-    # Priority class
     priorityClassName: system-cluster-critical
 
-  # Background controller for generate/mutate existing resources
+    # Start with failurePolicy Ignore (fail-open) to avoid blocking deploys
+    # during the Audit phase. Flip to Fail (fail-closed) in prod once policies
+    # are proven stable.
+    # In v3.4.x this is set via forceFailurePolicyIgnore:
+    forceFailurePolicyIgnore:
+      enabled: true  # TODO(ops): set to false to go Fail-closed in prod
+
+  # -----------------------------------------------------------------------
+  # Background controller — processes generate / mutate for existing objects
+  # -----------------------------------------------------------------------
   backgroundController:
     replicas: 2
 
@@ -64,7 +77,9 @@ kyverno:
         cpu: 500m
         memory: 512Mi
 
-  # Cleanup controller for policy cleanup jobs
+  # -----------------------------------------------------------------------
+  # Cleanup controller — TTL-based resource cleanup jobs
+  # -----------------------------------------------------------------------
   cleanupController:
     replicas: 2
 
@@ -76,7 +91,9 @@ kyverno:
         cpu: 200m
         memory: 256Mi
 
-  # Reports controller for policy reports
+  # -----------------------------------------------------------------------
+  # Reports controller — writes PolicyReport / ClusterPolicyReport objects
+  # -----------------------------------------------------------------------
   reportsController:
     replicas: 2
 
@@ -88,67 +105,39 @@ kyverno:
         cpu: 500m
         memory: 512Mi
 
+  # -----------------------------------------------------------------------
   # Webhook configuration
+  # -----------------------------------------------------------------------
   webhooksCleanup:
     enabled: true
 
-  # Fail-open mode: don't block resources if Kyverno is unavailable
-  # Set to Fail in production for stricter enforcement
+  # config.webhooks.namespaceSelector excludes system/infra namespaces from
+  # Kyverno's admission webhooks. Format per chart v3.4.x API.
   config:
     webhooks:
-      - failurePolicy: Ignore
-        namespaceSelector:
-          matchExpressions:
-            - key: kubernetes.io/metadata.name
-              operator: NotIn
-              values:
-                - kube-system
-                - kube-public
-                - kube-node-lease
-                - kyverno
-                - cert-manager
-                - external-secrets
-                - argocd
+      namespaceSelector:
+        matchExpressions:
+          - key: kubernetes.io/metadata.name
+            operator: NotIn
+            values:
+              - kube-system
+              - kube-public
+              - kube-node-lease
+              - kyverno
+              - cert-manager
+              - external-secrets
+              - argocd
 
-  # Enable policy reports
+  # Image verification cache — ~60 min to keep admission latency down.
+  # ADR-0020: Kyverno caches verification results to avoid Rekor round-trips
+  # on every admission of the same image digest.
   features:
     policyReports:
       enabled: true
     logging:
       format: json
 
-  # Metrics for Prometheus
+  # Prometheus metrics scraping
   metricsConfig:
     metricsExposure:
       enabled: true
-
-# Example ClusterPolicy templates (disabled by default)
-# Uncomment and customize as needed
-policies:
-  enabled: false
-
-  # Require resource limits on all containers
-  requireResourceLimits:
-    enabled: false
-    validationFailureAction: Audit  # Audit or Enforce
-
-  # Require labels on namespaces
-  requireNamespaceLabels:
-    enabled: false
-    requiredLabels:
-      - team
-      - environment
-
-  # Restrict image registries
-  restrictImageRegistries:
-    enabled: false
-    allowedRegistries:
-      - docker.io
-      - gcr.io
-      - ghcr.io
-      - "*.dkr.ecr.*.amazonaws.com"
-
-  # Require pod security standards
-  podSecurityStandards:
-    enabled: false
-    level: baseline  # privileged, baseline, or restricted


### PR DESCRIPTION
## Summary

- Enables Kyverno v1.18.1 (CNCF Graduated) alongside Gatekeeper + PSA, implementing ADR-0020
- Adds three ClusterPolicies: verifyImages keyless cosign (Audit→Enforce), mutate securityContext defaults, generate default-deny NetworkPolicy per namespace
- Adds native ValidatingAdmissionPolicy (CEL in-process): block `:latest`, require resource limits — demonstrates the Kyverno-owns-verify/mutate/generate vs VAP-owns-simple-validate split
- Wires ArgoCD Application at sync-wave 5 (after cert-manager, before workloads)

## What changed in `apps/infra/kyverno/`

| File | Change |
|------|--------|
| `Chart.yaml` | Bumped to chart v3.4.4 (app v1.18.1), added ADR annotation |
| `values.yaml` | `kyverno.enabled: true`, corrected webhook config to v3.4.x API, added imageCaching comment |
| `argocd-application.yaml` | New — ArgoCD Application, wave 5, caBundle ignoreDifferences |
| `templates/policies/verify-images.yaml` | New — ClusterPolicy keyless cosign verifyImages, mutateDigest:true, Audit |
| `templates/policies/mutate-security-context.yaml` | New — ClusterPolicy mutate: inject runAsNonRoot, RuntimeDefault seccomp, drop ALL caps |
| `templates/policies/generate-default-deny-netpol.yaml` | New — ClusterPolicy generate: default-deny-all NetworkPolicy per namespace |
| `templates/vap/block-latest-require-limits.yaml` | New — ValidatingAdmissionPolicy + Binding: block :latest, require CPU+mem limits (CEL) |
| `README.md` | Rewritten with ADR-0020 provenance, policy table, rollout guide, Audit→Enforce checklist |
| `Chart.lock` | New — pinned dependency checksum |

## Policy split

| Layer | Owns |
|-------|------|
| Kyverno | verifyImages (cosign, ADR-0016), mutate securityContext, generate default-deny NetworkPolicy |
| VAP (native CEL) | Block `:latest`, require resource limits — in-process, no webhook |
| Gatekeeper | 4 existing ConstraintTemplates — kept, not replaced |
| PSA | `restricted` baseline — kept |

## Image verification placement

ArgoCD cannot verify cosign/OCI image signatures (it only verifies GnuPG-signed git commits). This policy is the verification layer ADR-0016's cosign signing requires — enforced at admission, not in the GitOps sync step.

## Rollout

All policies start Audit. Promote checklist in README:
1. Monitor `kubectl get policyreport -A`
2. Remediate violations
3. Flip `validationFailureAction: Enforce`, `failurePolicy: Fail`, `validationActions: [Deny]`

## Test plan

- [x] `helm lint apps/infra/kyverno` — 0 charts failed
- [x] `helm template kyverno apps/infra/kyverno | python3 yaml.safe_load_all` — 85 documents, 5 policy objects parsed clean
- [ ] Cluster: apply ArgoCD Application, verify kyverno pods healthy in `kyverno` namespace
- [ ] Cluster: verify `kubectl get policyreport -A` populates after policy sync
- [ ] Cluster: create a test namespace, verify `default-deny-all` NetworkPolicy generated
- [ ] Cluster: deploy a pod without security context, verify mutation adds defaults
- [ ] VAP: deploy a pod with `:latest` tag in Audit mode, confirm violation recorded

Refs #252