### PR TITLE
feat(identity): Pod Identity rollout to remaining workloads (ADR-0018)

### DIFF
--- a/apps/infra/aws-lb-controller/values.yaml
+++ b/apps/infra/aws-lb-controller/values.yaml
@@ -8,13 +8,16 @@ aws-load-balancer-controller:
   clusterName: ""  # Set via ArgoCD ApplicationSet or --set
 
   # Service account configuration
-  # Uses EKS Pod Identity (recommended for EKS 1.24+)
+  # Uses EKS Pod Identity (ADR-0018) - identity is bound by an
+  # aws_eks_pod_identity_association (catalog/units/pod-identity-lb-controller),
+  # NOT by an IRSA `eks.amazonaws.com/role-arn` annotation. Keep annotations empty:
+  # a ServiceAccount must never carry BOTH an IRSA annotation and a Pod Identity
+  # association (precedence is undocumented by AWS; ADR-0018 treats both as
+  # unsupported).
   serviceAccount:
     create: true
     name: aws-load-balancer-controller
     annotations: {}
-      # If using IRSA instead of Pod Identity:
-      # eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/AmazonEKSLoadBalancerControllerRole
 
   # Replica count for HA
   replicaCount: 2

--- a/apps/infra/external-secrets/values.yaml
+++ b/apps/infra/external-secrets/values.yaml
@@ -1,2 +1,18 @@
 # CRDs are managed by Terraform (platform-crds module) — do not install via Helm
 installCRDs: false
+
+# Subchart values for the upstream external-secrets chart (alias matches the
+# dependency name in Chart.yaml).
+external-secrets:
+  # ESO controller workload identity via EKS Pod Identity (ADR-0018). Identity is
+  # bound by an aws_eks_pod_identity_association (catalog/units/pod-identity-eso)
+  # on this controller ServiceAccount - ESO uses the identity injected into its own
+  # controller pod, NOT a SecretStore `serviceAccountRef` (ADR-0018 sub-decision).
+  #
+  # No IRSA `eks.amazonaws.com/role-arn` annotation is set: a ServiceAccount must
+  # never carry BOTH an IRSA annotation and a Pod Identity association (precedence
+  # is undocumented by AWS; ADR-0018 treats both as unsupported).
+  serviceAccount:
+    create: true
+    name: external-secrets
+    annotations: {}

--- a/apps/infra/observability/loki-stack/templates/loki-s3-secret.yaml
+++ b/apps/infra/observability/loki-stack/templates/loki-s3-secret.yaml
@@ -99,15 +99,17 @@ spec:
 #         key: /observability/loki/s3/bucket_admin
 
 ---
-# Service Account for Loki with IRSA (IAM Roles for Service Accounts)
+# Service Account for Loki - identity via EKS Pod Identity (ADR-0018).
+# Bound by an aws_eks_pod_identity_association (catalog/units/pod-identity-loki),
+# NOT by an IRSA `eks.amazonaws.com/role-arn` annotation. A ServiceAccount must
+# never carry BOTH an IRSA annotation and a Pod Identity association (precedence is
+# undocumented by AWS; ADR-0018 treats both as unsupported), so no role-arn
+# annotation is set here.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: loki
   namespace: {{ .Release.Namespace }}
-  annotations:
-    # IRSA annotation - replace with actual IAM role ARN
-    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.global.awsAccountId | default "ACCOUNT_ID" }}:role/loki-s3-access
   labels:
     app.kubernetes.io/name: {{ include "loki-stack.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/catalog/units/pod-identity-ebs-csi/terragrunt.hcl
+++ b/catalog/units/pod-identity-ebs-csi/terragrunt.hcl
@@ -1,0 +1,52 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# EKS Pod Identity — EBS CSI Driver (controller) — Catalog Unit — ADR-0018
+# ---------------------------------------------------------------------------------------------------------------------
+# Storage-driver consumer in the ADR-0018 Pod Identity rollout. Creates the
+# Pod-Identity-trust IAM role + ABAC-scoped EC2 volume-operations policy + the
+# PodIdentityAssociation for kube-system/ebs-csi-controller-sa.
+#
+# After this unit is applied, drop the IRSA role from the EBS CSI controller SA. If
+# the driver is an EKS managed addon, remove the addon's
+# `service_account_role_arn` (no SA may carry both mechanisms; ADR-0018).
+#
+# Prerequisite (assumed): the `eks-pod-identity-agent` EKS addon is installed on
+# the target cluster.
+#
+# `cluster_name` MUST be supplied per-environment (no portable default). Set
+# `kms_key_arns` to the volume-encryption CMK(s) for least-privilege (defaults to
+# "*").
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/pod-identity-ebs-csi"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  account_name = local.account_vars.locals.account_name
+  environment  = local.account_vars.locals.environment
+}
+
+inputs = {
+  project = "platform-design"
+
+  # Placeholder — override per environment with the real EKS cluster name (or wire
+  # a `dependency "eks"` and pass `dependency.eks.outputs.cluster_name`).
+  cluster_name = "platform-${local.environment}"
+
+  # The aws-ebs-csi-driver controller deploys into `kube-system` with SA
+  # `ebs-csi-controller-sa`. These are the module defaults; pinned here for clarity
+  # and to drive the ABAC kubernetes-namespace condition.
+  namespace       = "kube-system"
+  service_account = "ebs-csi-controller-sa"
+
+  # Least-privilege KMS scoping (defaults to "*" when empty). Override per
+  # environment with the real volume-encryption CMK ARN(s).
+
+  tags = {
+    ManagedBy   = "terragrunt"
+    Environment = local.environment
+    ADR         = "ADR-0018"
+    Workload    = "ebs-csi-driver"
+  }
+}

--- a/catalog/units/pod-identity-eso/terragrunt.hcl
+++ b/catalog/units/pod-identity-eso/terragrunt.hcl
@@ -1,0 +1,53 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# EKS Pod Identity — External Secrets Operator (ESO) — Catalog Unit — ADR-0018
+# ---------------------------------------------------------------------------------------------------------------------
+# Third workload in the ADR-0018 Pod Identity cutover (YACE -> observability stack
+# -> ESO -> LB controller). Creates the Pod-Identity-trust IAM role + ABAC-scoped
+# SecretsManager/KMS/ECR policy + the PodIdentityAssociation for the ESO controller
+# SA (external-secrets/external-secrets).
+#
+# ESO uses the identity bound to its OWN controller SA via this association — NOT
+# `serviceAccountRef` (ADR-0018 sub-decision). Prerequisite: ESO upgraded to v2.6.0
+# (CRDs move to v1) before migrating ESO onto Pod Identity.
+#
+# After this unit is applied, ensure the ESO controller SA does not carry
+# `eks.amazonaws.com/role-arn` (no SA may carry both mechanisms; ADR-0018).
+#
+# `cluster_name` MUST be supplied per-environment (no portable default): set it in
+# the environment overlay's inputs or via a `dependency` on the eks unit.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/pod-identity-eso"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  account_name = local.account_vars.locals.account_name
+  environment  = local.account_vars.locals.environment
+}
+
+inputs = {
+  project = "platform-design"
+
+  # Placeholder — override per environment with the real EKS cluster name (or wire
+  # a `dependency "eks"` and pass `dependency.eks.outputs.cluster_name`).
+  cluster_name = "platform-${local.environment}"
+
+  # ESO controller deploys into the `external-secrets` namespace with SA
+  # `external-secrets`. These are the module defaults; pinned here for clarity and
+  # to drive the ABAC kubernetes-namespace condition.
+  namespace       = "external-secrets"
+  service_account = "external-secrets"
+
+  # Optional least-privilege scoping (defaults to "*" when empty):
+  #   secret_arn_patterns = ["arn:aws:secretsmanager:*:*:secret:/platform/*"]
+  #   kms_key_arns        = ["arn:aws:kms:*:*:key/<secrets-cmk-id>"]
+
+  tags = {
+    ManagedBy   = "terragrunt"
+    Environment = local.environment
+    ADR         = "ADR-0018"
+    Workload    = "external-secrets"
+  }
+}

--- a/catalog/units/pod-identity-lb-controller/terragrunt.hcl
+++ b/catalog/units/pod-identity-lb-controller/terragrunt.hcl
@@ -1,0 +1,49 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# EKS Pod Identity — AWS Load Balancer Controller — Catalog Unit — ADR-0018
+# ---------------------------------------------------------------------------------------------------------------------
+# Last workload in the ADR-0018 Pod Identity cutover (YACE -> observability stack
+# -> ESO -> LB controller). Ingress-critical, so migrated last. Creates the
+# Pod-Identity-trust IAM role + ABAC-scoped ELB/EC2 policy + the
+# PodIdentityAssociation for kube-system/aws-load-balancer-controller.
+#
+# After this unit is applied, drop the IRSA `eks.amazonaws.com/role-arn` annotation
+# from the LBC ServiceAccount (apps/infra/aws-lb-controller/values.yaml) so the SA
+# does not carry both mechanisms (ADR-0018: precedence-both is unsupported).
+#
+# Prerequisite (assumed): the `eks-pod-identity-agent` EKS addon is installed on
+# the target cluster.
+#
+# `cluster_name` MUST be supplied per-environment (no portable default): set it in
+# the environment overlay's inputs or via a `dependency` on the eks unit.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/pod-identity-lb-controller"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  account_name = local.account_vars.locals.account_name
+  environment  = local.account_vars.locals.environment
+}
+
+inputs = {
+  project = "platform-design"
+
+  # Placeholder — override per environment with the real EKS cluster name (or wire
+  # a `dependency "eks"` and pass `dependency.eks.outputs.cluster_name`).
+  cluster_name = "platform-${local.environment}"
+
+  # The AWS Load Balancer Controller deploys into `kube-system` with SA
+  # `aws-load-balancer-controller`. These are the module defaults; pinned here for
+  # clarity and to drive the ABAC kubernetes-namespace condition.
+  namespace       = "kube-system"
+  service_account = "aws-load-balancer-controller"
+
+  tags = {
+    ManagedBy   = "terragrunt"
+    Environment = local.environment
+    ADR         = "ADR-0018"
+    Workload    = "aws-load-balancer-controller"
+  }
+}

--- a/catalog/units/pod-identity-loki/terragrunt.hcl
+++ b/catalog/units/pod-identity-loki/terragrunt.hcl
@@ -1,0 +1,51 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# EKS Pod Identity — Loki (S3 object storage) — Catalog Unit — ADR-0018
+# ---------------------------------------------------------------------------------------------------------------------
+# Observability-stack step in the ADR-0018 Pod Identity cutover (YACE ->
+# observability stack -> ESO -> LB controller). Creates the Pod-Identity-trust IAM
+# role + ABAC-scoped S3 object-storage policy + the PodIdentityAssociation for
+# observability/loki.
+#
+# After this unit is applied, drop the IRSA `eks.amazonaws.com/role-arn` annotation
+# from the Loki ServiceAccount
+# (apps/infra/observability/loki-stack/templates/loki-s3-secret.yaml) so the SA
+# does not carry both mechanisms (ADR-0018: precedence-both is unsupported).
+#
+# `cluster_name` MUST be supplied per-environment (no portable default). Set
+# `bucket_names` to the Loki bucket(s) for least-privilege (defaults to "*").
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/pod-identity-loki"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  account_name = local.account_vars.locals.account_name
+  environment  = local.account_vars.locals.environment
+}
+
+inputs = {
+  project = "platform-design"
+
+  # Placeholder — override per environment with the real EKS cluster name (or wire
+  # a `dependency "eks"` and pass `dependency.eks.outputs.cluster_name`).
+  cluster_name = "platform-${local.environment}"
+
+  # Loki (loki-stack chart, SimpleScalable) deploys into `observability` with SA
+  # `loki`. These are the module defaults; pinned here for clarity and to drive the
+  # ABAC kubernetes-namespace condition.
+  namespace       = "observability"
+  service_account = "loki"
+
+  # Least-privilege bucket scoping (defaults to "*" when empty). Override per
+  # environment with the real Loki bucket name(s), e.g.:
+  #   bucket_names = ["platform-design-${local.environment}-loki-chunks"]
+
+  tags = {
+    ManagedBy   = "terragrunt"
+    Environment = local.environment
+    ADR         = "ADR-0018"
+    Workload    = "loki"
+  }
+}

--- a/catalog/units/pod-identity-thanos/terragrunt.hcl
+++ b/catalog/units/pod-identity-thanos/terragrunt.hcl
@@ -1,0 +1,50 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# EKS Pod Identity — Thanos (S3 object storage) — Catalog Unit — ADR-0018
+# ---------------------------------------------------------------------------------------------------------------------
+# Observability-stack step in the ADR-0018 Pod Identity cutover (YACE ->
+# observability stack -> ESO -> LB controller). Creates the Pod-Identity-trust IAM
+# role + ABAC-scoped S3 object-storage policy + the PodIdentityAssociation for
+# monitoring/thanos.
+#
+# After this unit is applied, drop the IRSA `eks.amazonaws.com/role-arn` annotation
+# from the Thanos ServiceAccount (the kube-prometheus-stack Thanos SA template) so
+# the SA does not carry both mechanisms (ADR-0018: precedence-both is unsupported).
+#
+# `cluster_name` MUST be supplied per-environment (no portable default). Set
+# `bucket_names` to the Thanos bucket(s) for least-privilege (defaults to "*").
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/pod-identity-thanos"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  account_name = local.account_vars.locals.account_name
+  environment  = local.account_vars.locals.environment
+}
+
+inputs = {
+  project = "platform-design"
+
+  # Placeholder — override per environment with the real EKS cluster name (or wire
+  # a `dependency "eks"` and pass `dependency.eks.outputs.cluster_name`).
+  cluster_name = "platform-${local.environment}"
+
+  # Thanos (kube-prometheus-stack) creates its SA `thanos` in the `monitoring`
+  # namespace. These are the module defaults; pinned here for clarity and to drive
+  # the ABAC kubernetes-namespace condition.
+  namespace       = "monitoring"
+  service_account = "thanos"
+
+  # Least-privilege bucket scoping (defaults to "*" when empty). Override per
+  # environment with the real Thanos bucket name(s), e.g.:
+  #   bucket_names = ["platform-design-${local.environment}-thanos-metrics"]
+
+  tags = {
+    ManagedBy   = "terragrunt"
+    Environment = local.environment
+    ADR         = "ADR-0018"
+    Workload    = "thanos"
+  }
+}

--- a/terraform/modules/pod-identity-ebs-csi/README.md
+++ b/terraform/modules/pod-identity-ebs-csi/README.md
@@ -1,0 +1,49 @@
+# pod-identity-ebs-csi
+
+EKS **Pod Identity** for the **EBS CSI driver** controller — part of the
+[ADR-0018](../../../docs/adrs/0018-eks-pod-identity-as-default-workload-identity.md)
+rollout from IRSA to Pod Identity. The driver provisions/attaches/snapshots EBS
+volumes for PersistentVolumeClaims.
+
+## What it creates
+
+| Resource | Purpose |
+|---|---|
+| `aws_iam_role.this` | Controller role. **Trust targets `pods.eks.amazonaws.com`** (not an OIDC issuer), allowing **`sts:AssumeRole` + `sts:TagSession`**. |
+| `aws_iam_policy.ebs_csi` | EC2 volume lifecycle (create/attach/detach/delete/modify), snapshot lifecycle, describe, tagging, plus KMS grants for CMK-encrypted volumes. **ABAC-scoped** by `aws:PrincipalTag/kubernetes-namespace`. |
+| `aws_iam_role_policy_attachment.ebs_csi` | Attaches the policy. |
+| `aws_eks_pod_identity_association.this` | Binds `(cluster, namespace=kube-system, service_account=ebs-csi-controller-sa)` → the role. **Replaces the IRSA annotation / addon role.** |
+
+## Coexistence & caveats
+
+- **Never put both on one SA.** Drop the IRSA role from the EBS CSI controller SA
+  once this association exists. If the driver is an EKS managed addon, remove the
+  addon's `service_account_role_arn`.
+- **Least-privilege:** pass `kms_key_arns` to scope CMK-encrypted-volume grants —
+  the default `*` is for plan-time convenience only.
+- **Fargate unsupported** (and EBS volumes are not attachable to Fargate pods); the
+  controller runs on EC2/Karpenter nodes.
+- **Prerequisite:** `eks-pod-identity-agent` addon installed on the cluster.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|---|---|---|---|---|
+| `project` | Naming prefix | `string` | `"platform-design"` | no |
+| `cluster_name` | EKS cluster | `string` | — | **yes** |
+| `namespace` | Controller namespace | `string` | `"kube-system"` | no |
+| `service_account` | Controller SA | `string` | `"ebs-csi-controller-sa"` | no |
+| `kms_key_arns` | Volume-encryption CMK ARNs | `list(string)` | `[]` (→ `*`) | no |
+| `iam_path` | IAM path | `string` | `"/pod-identity/"` | no |
+| `max_session_duration` | Role max session seconds | `number` | `3600` | no |
+| `tags` | Extra tags | `map(string)` | `{}` | no |
+
+## Outputs
+
+`role_arn`, `role_name`, `policy_arn`, `association_id`, `association_arn`.
+
+## References
+
+- ADR-0018 — EKS Pod Identity as default workload identity
+- [Pod Identity ABAC session tags](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-abac.html)
+- [AmazonEBSCSIDriverPolicy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEBSCSIDriverPolicy.html)

--- a/terraform/modules/pod-identity-ebs-csi/main.tf
+++ b/terraform/modules/pod-identity-ebs-csi/main.tf
@@ -1,0 +1,208 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# EKS Pod Identity — EBS CSI Driver (controller) — ADR-0018
+# ---------------------------------------------------------------------------------------------------------------------
+# The aws-ebs-csi-driver controller provisions/attaches/snapshots EBS volumes for
+# PersistentVolumeClaims. It previously authenticated via an IRSA role; this module
+# replaces that with a Pod Identity association on the EBS CSI controller SA.
+#
+# What this module creates:
+#   1. An IAM role whose TRUST policy targets the EKS Auth service principal
+#      `pods.eks.amazonaws.com` (NOT a per-cluster OIDC issuer), allowing both
+#      `sts:AssumeRole` AND `sts:TagSession` (TagSession injects the ABAC tags).
+#   2. An EC2 volume-operations policy (create/attach/detach/delete volumes,
+#      create/delete snapshots, describe, tag) plus optional KMS grants for
+#      encrypted volumes. ABAC-scoped by the kubernetes-namespace session tag.
+#   3. An `aws_eks_pod_identity_association` binding (cluster, namespace
+#      `kube-system`, ServiceAccount `ebs-csi-controller-sa`) -> the role above.
+#
+# Coexistence (ADR-0018): IRSA stays supported for not-yet-migrated workloads. Do
+# NOT configure both an IRSA annotation AND an association on the same SA. The EBS
+# CSI controller SA must not carry `eks.amazonaws.com/role-arn` once this
+# association exists. The EBS CSI driver may be installed as an EKS managed addon,
+# in which case the addon's `service_account_role_arn` is dropped in favour of this
+# association.
+#
+# Fargate caveat: Pod Identity is NOT supported on Fargate (and EBS volumes are not
+# attachable to Fargate pods anyway). The controller runs on EC2/Karpenter nodes.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  role_name = "${var.project}-${var.cluster_name}-${var.service_account}"
+
+  default_tags = {
+    ManagedBy        = "Terraform"
+    Module           = "pod-identity-ebs-csi"
+    ADR              = "ADR-0018"
+    WorkloadIdentity = "eks-pod-identity"
+    Namespace        = var.namespace
+    ServiceAccount   = var.service_account
+  }
+  effective_tags = merge(local.default_tags, var.tags)
+
+  # KMS key ARNs for encrypted EBS volumes. Empty list -> "*" (allow any key); pin
+  # to the volume-encryption CMK(s) in production.
+  kms_key_arns = length(var.kms_key_arns) > 0 ? var.kms_key_arns : ["*"]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Trust policy — EKS Pod Identity service principal
+# ---------------------------------------------------------------------------------------------------------------------
+data "aws_iam_policy_document" "trust" {
+  statement {
+    sid     = "EksPodIdentityAssumeRole"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# EBS CSI driver permissions — EC2 volume operations (ABAC namespace-scoped)
+# ---------------------------------------------------------------------------------------------------------------------
+# Mirrors the upstream AmazonEBSCSIDriverPolicy: describe (resource discovery),
+# volume lifecycle (create/attach/detach/delete), snapshot lifecycle, and tagging,
+# plus KMS grants for CMK-encrypted volumes. Describe/CreateVolume/CreateSnapshot
+# are account/region-global EC2 actions that do not support per-resource ARNs, so
+# Resource is "*", ABAC-constrained by the kubernetes-namespace session tag.
+data "aws_iam_policy_document" "ebs_csi" {
+  # Describe — discover volumes/snapshots/instances/AZs for reconcile.
+  statement {
+    sid    = "Ec2DescribeRead"
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeInstances",
+      "ec2:DescribeSnapshots",
+      "ec2:DescribeTags",
+      "ec2:DescribeVolumes",
+      "ec2:DescribeVolumesModifications",
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+
+  # Volume lifecycle — provision/attach/detach/delete/modify EBS volumes for PVCs.
+  statement {
+    sid    = "Ec2VolumeLifecycle"
+    effect = "Allow"
+    actions = [
+      "ec2:CreateVolume",
+      "ec2:AttachVolume",
+      "ec2:DetachVolume",
+      "ec2:DeleteVolume",
+      "ec2:ModifyVolume",
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+
+  # Snapshot lifecycle — VolumeSnapshot support.
+  statement {
+    sid    = "Ec2SnapshotLifecycle"
+    effect = "Allow"
+    actions = [
+      "ec2:CreateSnapshot",
+      "ec2:DeleteSnapshot",
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+
+  # Tagging — the driver tags volumes/snapshots it creates (and is restricted by
+  # CreateAction at the EC2 level).
+  statement {
+    sid    = "Ec2Tagging"
+    effect = "Allow"
+    actions = [
+      "ec2:CreateTags",
+      "ec2:DeleteTags",
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+
+  # KMS — encrypt/decrypt + grant management for CMK-encrypted EBS volumes. Scoped
+  # to the supplied keys.
+  statement {
+    sid    = "KmsVolumeEncryption"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKeyWithoutPlaintext",
+      "kms:CreateGrant",
+      "kms:ListGrants",
+      "kms:RevokeGrant",
+      "kms:DescribeKey",
+    ]
+    resources = local.kms_key_arns
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# IAM role + policy
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_iam_role" "this" {
+  name                 = local.role_name
+  description          = "EKS Pod Identity role for the EBS CSI driver controller in namespace ${var.namespace} (ADR-0018)"
+  assume_role_policy   = data.aws_iam_policy_document.trust.json
+  max_session_duration = var.max_session_duration
+  path                 = var.iam_path
+
+  tags = local.effective_tags
+}
+
+resource "aws_iam_policy" "ebs_csi" {
+  name        = "${local.role_name}-ebs-csi"
+  description = "EBS CSI driver EC2 volume operations, ABAC-scoped to the ${var.namespace} namespace (ADR-0018)"
+  path        = var.iam_path
+  policy      = data.aws_iam_policy_document.ebs_csi.json
+
+  tags = local.effective_tags
+}
+
+resource "aws_iam_role_policy_attachment" "ebs_csi" {
+  role       = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.ebs_csi.arn
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Pod Identity association — binds (cluster, namespace, ServiceAccount) -> role
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_eks_pod_identity_association" "this" {
+  cluster_name    = var.cluster_name
+  namespace       = var.namespace
+  service_account = var.service_account
+  role_arn        = aws_iam_role.this.arn
+
+  tags = local.effective_tags
+}

--- a/terraform/modules/pod-identity-ebs-csi/outputs.tf
+++ b/terraform/modules/pod-identity-ebs-csi/outputs.tf
@@ -1,0 +1,24 @@
+output "role_arn" {
+  description = "ARN of the EBS CSI driver Pod Identity IAM role. The association binds the controller ServiceAccount to this role; no IRSA annotation is required."
+  value       = aws_iam_role.this.arn
+}
+
+output "role_name" {
+  description = "Name of the EBS CSI driver Pod Identity IAM role."
+  value       = aws_iam_role.this.name
+}
+
+output "policy_arn" {
+  description = "ARN of the ABAC-scoped EC2 volume-operations policy attached to the EBS CSI role."
+  value       = aws_iam_policy.ebs_csi.arn
+}
+
+output "association_id" {
+  description = "ID of the EKS Pod Identity association (cluster + namespace + ServiceAccount -> role)."
+  value       = aws_eks_pod_identity_association.this.association_id
+}
+
+output "association_arn" {
+  description = "ARN of the EKS Pod Identity association."
+  value       = aws_eks_pod_identity_association.this.association_arn
+}

--- a/terraform/modules/pod-identity-ebs-csi/pod-identity-ebs-csi.tftest.hcl
+++ b/terraform/modules/pod-identity-ebs-csi/pod-identity-ebs-csi.tftest.hcl
@@ -1,0 +1,97 @@
+# Mock the aws_iam_policy_document data source with a REPRESENTATIVE policy JSON so
+# the role/policy JSON validation passes at plan AND the content assertions stay
+# meaningful (bare mocks return null .json, which fails validation).
+mock_provider "aws" {
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"sts:AssumeRole\",\"sts:TagSession\",\"ec2:CreateVolume\",\"ec2:AttachVolume\",\"ec2:DescribeVolumes\"],\"Principal\":{\"Service\":\"pods.eks.amazonaws.com\"},\"Condition\":{\"StringEquals\":{\"aws:PrincipalTag/kubernetes-namespace\":\"kube-system\"}}}]}"
+    }
+  }
+}
+
+variables {
+  project      = "platform-design"
+  cluster_name = "platform-dev"
+  tags = {
+    Environment = "test"
+    Team        = "platform"
+  }
+}
+
+run "defaults_to_kube_system_ebs_csi_controller" {
+  command = plan
+
+  assert {
+    condition     = var.namespace == "kube-system"
+    error_message = "namespace should default to kube-system (where the EBS CSI controller deploys)"
+  }
+
+  assert {
+    condition     = var.service_account == "ebs-csi-controller-sa"
+    error_message = "service_account should default to ebs-csi-controller-sa"
+  }
+}
+
+run "pod_identity_association_targets_cluster_ns_sa" {
+  command = plan
+
+  assert {
+    condition     = aws_eks_pod_identity_association.this.cluster_name == "platform-dev"
+    error_message = "association must target the supplied cluster"
+  }
+
+  assert {
+    condition     = aws_eks_pod_identity_association.this.namespace == "kube-system"
+    error_message = "association must target the kube-system namespace"
+  }
+
+  assert {
+    condition     = aws_eks_pod_identity_association.this.service_account == "ebs-csi-controller-sa"
+    error_message = "association must target the ebs-csi-controller-sa ServiceAccount"
+  }
+}
+
+run "trust_policy_uses_pod_identity_principal_and_tagsession" {
+  command = plan
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.trust.json, "pods.eks.amazonaws.com")
+    error_message = "trust policy must target the pods.eks.amazonaws.com service principal"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.trust.json, "sts:TagSession")
+    error_message = "trust policy must allow sts:TagSession (required to inject ABAC session tags)"
+  }
+}
+
+run "ebs_policy_is_abac_scoped_and_covers_volume_ops" {
+  command = plan
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.ebs_csi.json, "aws:PrincipalTag/kubernetes-namespace")
+    error_message = "EBS CSI policy must be ABAC-scoped on the kubernetes-namespace session tag"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.ebs_csi.json, "ec2:CreateVolume")
+    error_message = "EBS CSI policy must allow ec2:CreateVolume (volume provisioning)"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.ebs_csi.json, "ec2:AttachVolume")
+    error_message = "EBS CSI policy must allow ec2:AttachVolume (volume attach)"
+  }
+}
+
+run "invalid_iam_path_is_rejected" {
+  command = plan
+
+  variables {
+    iam_path = "no-leading-slash"
+  }
+
+  expect_failures = [
+    var.iam_path,
+  ]
+}

--- a/terraform/modules/pod-identity-ebs-csi/variables.tf
+++ b/terraform/modules/pod-identity-ebs-csi/variables.tf
@@ -1,0 +1,69 @@
+variable "project" {
+  description = "Project name used in IAM role/policy naming (e.g. 'platform-design')."
+  type        = string
+  default     = "platform-design"
+
+  validation {
+    condition     = length(var.project) > 0
+    error_message = "project must not be empty."
+  }
+}
+
+variable "cluster_name" {
+  description = "Name of the EKS cluster the Pod Identity association is created on. Also used in IAM role naming and (optionally) as an ABAC eks-cluster-name condition."
+  type        = string
+
+  validation {
+    condition     = length(var.cluster_name) > 0
+    error_message = "cluster_name must not be empty."
+  }
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace of the EBS CSI controller ServiceAccount. Defaults to 'kube-system'. Drives the ABAC kubernetes-namespace policy condition."
+  type        = string
+  default     = "kube-system"
+  nullable    = false
+}
+
+variable "service_account" {
+  description = "Kubernetes ServiceAccount name bound to the Pod Identity role. Defaults to 'ebs-csi-controller-sa' (the aws-ebs-csi-driver controller SA)."
+  type        = string
+  default     = "ebs-csi-controller-sa"
+  nullable    = false
+}
+
+variable "kms_key_arns" {
+  description = "List of KMS CMK ARNs for encrypted EBS volumes. Empty list (default) means all keys ('*'); pin to the volume-encryption CMK(s) in production."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
+variable "iam_path" {
+  description = "IAM path for the role and policy. Useful for organising workload-identity roles (e.g. '/pod-identity/')."
+  type        = string
+  default     = "/pod-identity/"
+
+  validation {
+    condition     = can(regex("^/.*/$", var.iam_path))
+    error_message = "iam_path must begin and end with '/' (e.g. '/pod-identity/')."
+  }
+}
+
+variable "max_session_duration" {
+  description = "Maximum IAM role session duration in seconds. Pod Identity caches assumed credentials, so the default 3600s (1h) is sufficient for the EBS CSI controller's reconcile loop."
+  type        = number
+  default     = 3600
+
+  validation {
+    condition     = var.max_session_duration >= 3600 && var.max_session_duration <= 43200
+    error_message = "max_session_duration must be between 3600 and 43200 seconds (AWS IAM limits)."
+  }
+}
+
+variable "tags" {
+  description = "Additional tags merged onto every resource in this module."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/pod-identity-ebs-csi/versions.tf
+++ b/terraform/modules/pod-identity-ebs-csi/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/modules/pod-identity-eso/README.md
+++ b/terraform/modules/pod-identity-eso/README.md
@@ -1,0 +1,55 @@
+# pod-identity-eso
+
+EKS **Pod Identity** for the **External Secrets Operator (ESO)** controller — part
+of the [ADR-0018](../../../docs/adrs/0018-eks-pod-identity-as-default-workload-identity.md)
+cutover from IRSA to Pod Identity (cutover order: YACE → observability stack →
+**ESO** → LB controller).
+
+## What it creates
+
+| Resource | Purpose |
+|---|---|
+| `aws_iam_role.this` | Controller role. **Trust targets `pods.eks.amazonaws.com`** (not an OIDC issuer), allowing **`sts:AssumeRole` + `sts:TagSession`**. |
+| `aws_iam_policy.eso` | SecretsManager read + PushSecret write, KMS decrypt/data-key for the secrets CMK, and `ecr:GetAuthorizationToken` for the `ECRAuthorizationToken` generator. **ABAC-scoped** by `aws:PrincipalTag/kubernetes-namespace`. |
+| `aws_iam_role_policy_attachment.eso` | Attaches the policy. |
+| `aws_eks_pod_identity_association.this` | Binds `(cluster, namespace=external-secrets, service_account=external-secrets)` → the role. **Replaces the IRSA annotation.** |
+
+## ESO specifics (ADR-0018)
+
+- **ESO uses its OWN controller SA identity, not `serviceAccountRef`.** With Pod
+  Identity the agent injects credentials into the ESO controller pod directly.
+- **Generators adopted (no Vault):** `ECRAuthorizationToken` (short-lived ECR pull
+  creds) and `Password` → `PushSecret` (writes credentials into Secrets Manager).
+  Hence SecretsManager read+write, KMS, and ECR auth-token in one policy.
+- **Prerequisite:** upgrade ESO `0.10.5 → v2.6.0` (CRDs move to `v1`) before
+  migrating ESO onto Pod Identity.
+
+## Coexistence & caveats
+
+- **Never put both on one SA.** Drop `eks.amazonaws.com/role-arn` from the ESO
+  controller SA once this association exists.
+- **Fargate unsupported.** Verify the controller is not Fargate-scheduled.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|---|---|---|---|---|
+| `project` | Naming prefix | `string` | `"platform-design"` | no |
+| `cluster_name` | EKS cluster | `string` | — | **yes** |
+| `namespace` | ESO namespace | `string` | `"external-secrets"` | no |
+| `service_account` | ESO controller SA | `string` | `"external-secrets"` | no |
+| `secret_arn_patterns` | SecretsManager ARN scope | `list(string)` | `[]` (→ `*`) | no |
+| `kms_key_arns` | Secrets CMK ARNs | `list(string)` | `[]` (→ `*`) | no |
+| `iam_path` | IAM path | `string` | `"/pod-identity/"` | no |
+| `max_session_duration` | Role max session seconds | `number` | `3600` | no |
+| `tags` | Extra tags | `map(string)` | `{}` | no |
+
+## Outputs
+
+`role_arn`, `role_name`, `policy_arn`, `association_id`, `association_arn`.
+
+## References
+
+- ADR-0018 — EKS Pod Identity as default workload identity
+- [Pod Identity ABAC session tags](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-abac.html)
+- [ESO Generators / PushSecret](https://external-secrets.io/latest/api/generator/)

--- a/terraform/modules/pod-identity-eso/main.tf
+++ b/terraform/modules/pod-identity-eso/main.tf
@@ -1,0 +1,204 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# EKS Pod Identity — External Secrets Operator (ESO) — ADR-0018
+# ---------------------------------------------------------------------------------------------------------------------
+# Third workload in the ADR-0018 cutover order (YACE -> observability stack -> ESO
+# -> LB controller). ESO is a primary consumer of workload identity.
+#
+# ADR-0018 sub-decision — ESO + Pod Identity specifics:
+#   - ESO supports Pod Identity but CANNOT use `serviceAccountRef`. With Pod
+#     Identity the agent injects credentials into the ESO controller's pod
+#     directly, so ESO uses the identity bound to its OWN controller
+#     ServiceAccount (`external-secrets` in namespace `external-secrets`) via a
+#     PodIdentityAssociation — NOT the IRSA-style "act as this SA" indirection.
+#   - ESO Generators adopted (no Vault): `ECRAuthorizationToken` mints short-lived
+#     ECR pull creds; `Password` generator -> `PushSecret` writes credentials INTO
+#     Secrets Manager. Hence this role needs SecretsManager read+write, KMS
+#     decrypt/encrypt (CMK that encrypts those secrets), and ECR auth-token.
+#
+# What this module creates:
+#   1. An IAM role whose TRUST policy targets the EKS Auth service principal
+#      `pods.eks.amazonaws.com` (NOT a per-cluster OIDC issuer), allowing both
+#      `sts:AssumeRole` AND `sts:TagSession` (TagSession injects the ABAC tags).
+#   2. A least-privilege policy: SecretsManager get/describe/list + create/put for
+#      the PushSecret flow, KMS decrypt/generate-data-key for the encrypting CMK,
+#      and ECR GetAuthorizationToken for the ECRAuthorizationToken generator.
+#   3. An `aws_eks_pod_identity_association` binding (cluster, namespace
+#      `external-secrets`, ServiceAccount `external-secrets`) -> the role above.
+#
+# Coexistence (ADR-0018): IRSA stays supported for not-yet-migrated workloads. Do
+# NOT configure both an IRSA annotation AND an association on the same SA. ESO's
+# controller SA must not carry `eks.amazonaws.com/role-arn` once this association
+# exists.
+#
+# Fargate caveat: Pod Identity is NOT supported on Fargate. Verify the ESO
+# controller is not Fargate-scheduled before migrating.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  role_name = "${var.project}-${var.cluster_name}-${var.service_account}"
+
+  default_tags = {
+    ManagedBy        = "Terraform"
+    Module           = "pod-identity-eso"
+    ADR              = "ADR-0018"
+    WorkloadIdentity = "eks-pod-identity"
+    Namespace        = var.namespace
+    ServiceAccount   = var.service_account
+  }
+  effective_tags = merge(local.default_tags, var.tags)
+
+  # Secrets Manager ARN scope for the secrets ESO reads/writes. Defaults to all
+  # secrets in the account/region ("*"); pass `secret_arn_patterns` to narrow to a
+  # path prefix (e.g. ["arn:aws:secretsmanager:*:*:secret:/platform/*"]).
+  secret_arns = length(var.secret_arn_patterns) > 0 ? var.secret_arn_patterns : ["*"]
+
+  # KMS key ARNs ESO may decrypt/encrypt (the CMK(s) protecting those secrets).
+  # Defaults to "*"; pass `kms_key_arns` to pin to the platform secrets CMK.
+  kms_key_arns = length(var.kms_key_arns) > 0 ? var.kms_key_arns : ["*"]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Trust policy — EKS Pod Identity service principal
+# ---------------------------------------------------------------------------------------------------------------------
+# Principal is the EKS Auth service (`pods.eks.amazonaws.com`), NOT a cluster OIDC
+# issuer. `sts:TagSession` MUST accompany `sts:AssumeRole` so EKS can attach the
+# ABAC session tags it injects on every pod credential vend.
+data "aws_iam_policy_document" "trust" {
+  statement {
+    sid     = "EksPodIdentityAssumeRole"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# ESO permissions — Secrets Manager + KMS + ECR auth-token (ABAC namespace-scoped)
+# ---------------------------------------------------------------------------------------------------------------------
+# Every statement is ABAC-scoped to sessions whose `kubernetes-namespace` tag ==
+# var.namespace (the `external-secrets` namespace). EKS injects that PrincipalTag
+# on every Pod Identity session because the trust allows `sts:TagSession`. This is
+# the ADR-0018 mechanism that lets one role serve a namespace's workloads instead
+# of cutting a new role per workload.
+data "aws_iam_policy_document" "eso" {
+  # Read flow — fetch secrets into the cluster (ExternalSecret).
+  statement {
+    sid    = "SecretsManagerRead"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:ListSecretVersionIds",
+      "secretsmanager:ListSecrets",
+    ]
+    resources = local.secret_arns
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+
+  # Write flow — Password generator -> PushSecret writes credentials INTO Secrets
+  # Manager (in-cluster-originated rotation; ADR-0018, no Vault needed).
+  statement {
+    sid    = "SecretsManagerPushSecret"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:CreateSecret",
+      "secretsmanager:PutSecretValue",
+      "secretsmanager:TagResource",
+      "secretsmanager:UpdateSecret",
+    ]
+    resources = local.secret_arns
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+
+  # KMS — decrypt secrets read, generate data keys for secrets pushed. Scoped to
+  # the CMK(s) protecting the secrets.
+  statement {
+    sid    = "KmsSecretsAccess"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+      "kms:DescribeKey",
+    ]
+    resources = local.kms_key_arns
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+
+  # ECR — ECRAuthorizationToken generator mints short-lived registry pull creds.
+  # `GetAuthorizationToken` is account/region-global and does not support a
+  # per-resource ARN, so Resource is "*", ABAC-constrained by namespace.
+  statement {
+    sid    = "EcrAuthorizationToken"
+    effect = "Allow"
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# IAM role + policy
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_iam_role" "this" {
+  name                 = local.role_name
+  description          = "EKS Pod Identity role for External Secrets Operator in namespace ${var.namespace} (ADR-0018)"
+  assume_role_policy   = data.aws_iam_policy_document.trust.json
+  max_session_duration = var.max_session_duration
+  path                 = var.iam_path
+
+  tags = local.effective_tags
+}
+
+resource "aws_iam_policy" "eso" {
+  name        = "${local.role_name}-eso"
+  description = "ESO SecretsManager + KMS + ECR auth-token, ABAC-scoped to the ${var.namespace} namespace (ADR-0018)"
+  path        = var.iam_path
+  policy      = data.aws_iam_policy_document.eso.json
+
+  tags = local.effective_tags
+}
+
+resource "aws_iam_role_policy_attachment" "eso" {
+  role       = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.eso.arn
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Pod Identity association — binds (cluster, namespace, ServiceAccount) -> role
+# ---------------------------------------------------------------------------------------------------------------------
+# Replaces the IRSA `eks.amazonaws.com/role-arn` annotation on the ESO controller
+# SA. ESO uses THIS identity (its own controller SA), never `serviceAccountRef`.
+resource "aws_eks_pod_identity_association" "this" {
+  cluster_name    = var.cluster_name
+  namespace       = var.namespace
+  service_account = var.service_account
+  role_arn        = aws_iam_role.this.arn
+
+  tags = local.effective_tags
+}

--- a/terraform/modules/pod-identity-eso/outputs.tf
+++ b/terraform/modules/pod-identity-eso/outputs.tf
@@ -1,0 +1,24 @@
+output "role_arn" {
+  description = "ARN of the ESO Pod Identity IAM role. The association binds the external-secrets controller ServiceAccount to this role; no IRSA annotation is required."
+  value       = aws_iam_role.this.arn
+}
+
+output "role_name" {
+  description = "Name of the ESO Pod Identity IAM role."
+  value       = aws_iam_role.this.name
+}
+
+output "policy_arn" {
+  description = "ARN of the ABAC-scoped ESO policy (SecretsManager + KMS + ECR auth-token) attached to the role."
+  value       = aws_iam_policy.eso.arn
+}
+
+output "association_id" {
+  description = "ID of the EKS Pod Identity association (cluster + namespace + ServiceAccount -> role)."
+  value       = aws_eks_pod_identity_association.this.association_id
+}
+
+output "association_arn" {
+  description = "ARN of the EKS Pod Identity association."
+  value       = aws_eks_pod_identity_association.this.association_arn
+}

--- a/terraform/modules/pod-identity-eso/pod-identity-eso.tftest.hcl
+++ b/terraform/modules/pod-identity-eso/pod-identity-eso.tftest.hcl
@@ -1,0 +1,114 @@
+# The aws_iam_policy_document data source computes its `.json` attribute from the
+# provider; a bare mock returns null, which fails the role/policy JSON validation
+# at plan. We mock the data source with a REPRESENTATIVE policy JSON that carries
+# the same principal/actions/ABAC-tag strings the real module renders, so the
+# role/policy JSON validation passes AND the content assertions stay meaningful.
+mock_provider "aws" {
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"sts:AssumeRole\",\"sts:TagSession\",\"secretsmanager:GetSecretValue\",\"secretsmanager:PutSecretValue\",\"kms:Decrypt\",\"ecr:GetAuthorizationToken\"],\"Principal\":{\"Service\":\"pods.eks.amazonaws.com\"},\"Condition\":{\"StringEquals\":{\"aws:PrincipalTag/kubernetes-namespace\":\"external-secrets\"}}}]}"
+    }
+  }
+}
+
+variables {
+  project      = "platform-design"
+  cluster_name = "platform-dev"
+  tags = {
+    Environment = "test"
+    Team        = "platform"
+  }
+}
+
+run "defaults_to_external_secrets_controller_sa" {
+  command = plan
+
+  assert {
+    condition     = var.namespace == "external-secrets"
+    error_message = "namespace should default to external-secrets (ESO controller namespace)"
+  }
+
+  assert {
+    condition     = var.service_account == "external-secrets"
+    error_message = "service_account should default to external-secrets (ESO controller SA — ESO uses its own SA, not serviceAccountRef)"
+  }
+}
+
+run "pod_identity_association_targets_cluster_ns_sa" {
+  command = plan
+
+  assert {
+    condition     = aws_eks_pod_identity_association.this.cluster_name == "platform-dev"
+    error_message = "association must target the supplied cluster"
+  }
+
+  assert {
+    condition     = aws_eks_pod_identity_association.this.namespace == "external-secrets"
+    error_message = "association must target the external-secrets namespace"
+  }
+
+  assert {
+    condition     = aws_eks_pod_identity_association.this.service_account == "external-secrets"
+    error_message = "association must target the external-secrets ServiceAccount"
+  }
+}
+
+run "trust_policy_uses_pod_identity_principal_and_tagsession" {
+  command = plan
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.trust.json, "pods.eks.amazonaws.com")
+    error_message = "trust policy must target the pods.eks.amazonaws.com service principal"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.trust.json, "sts:AssumeRole")
+    error_message = "trust policy must allow sts:AssumeRole"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.trust.json, "sts:TagSession")
+    error_message = "trust policy must allow sts:TagSession (required to inject ABAC session tags)"
+  }
+}
+
+run "eso_policy_is_abac_scoped_and_covers_secrets_kms_ecr" {
+  command = plan
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.eso.json, "aws:PrincipalTag/kubernetes-namespace")
+    error_message = "ESO policy must be ABAC-scoped on the kubernetes-namespace session tag"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.eso.json, "secretsmanager:GetSecretValue")
+    error_message = "ESO policy must allow secretsmanager:GetSecretValue (read flow)"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.eso.json, "secretsmanager:PutSecretValue")
+    error_message = "ESO policy must allow secretsmanager:PutSecretValue (PushSecret write flow)"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.eso.json, "kms:Decrypt")
+    error_message = "ESO policy must allow kms:Decrypt (decrypt managed secrets)"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.eso.json, "ecr:GetAuthorizationToken")
+    error_message = "ESO policy must allow ecr:GetAuthorizationToken (ECRAuthorizationToken generator)"
+  }
+}
+
+run "invalid_iam_path_is_rejected" {
+  command = plan
+
+  variables {
+    iam_path = "no-leading-slash"
+  }
+
+  expect_failures = [
+    var.iam_path,
+  ]
+}

--- a/terraform/modules/pod-identity-eso/variables.tf
+++ b/terraform/modules/pod-identity-eso/variables.tf
@@ -1,0 +1,76 @@
+variable "project" {
+  description = "Project name used in IAM role/policy naming (e.g. 'platform-design')."
+  type        = string
+  default     = "platform-design"
+
+  validation {
+    condition     = length(var.project) > 0
+    error_message = "project must not be empty."
+  }
+}
+
+variable "cluster_name" {
+  description = "Name of the EKS cluster the Pod Identity association is created on. Also used in IAM role naming and (optionally) as an ABAC eks-cluster-name condition."
+  type        = string
+
+  validation {
+    condition     = length(var.cluster_name) > 0
+    error_message = "cluster_name must not be empty."
+  }
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace of the ESO controller ServiceAccount. Defaults to 'external-secrets'. Drives the ABAC kubernetes-namespace policy condition."
+  type        = string
+  default     = "external-secrets"
+  nullable    = false
+}
+
+variable "service_account" {
+  description = "Kubernetes ServiceAccount name bound to the Pod Identity role. Defaults to 'external-secrets' (the ESO chart's controller SA). ESO uses THIS identity, never serviceAccountRef."
+  type        = string
+  default     = "external-secrets"
+  nullable    = false
+}
+
+variable "secret_arn_patterns" {
+  description = "List of Secrets Manager ARN patterns ESO may read/write. Empty list (default) means all secrets ('*'); pass a path-prefixed ARN pattern to narrow (e.g. ['arn:aws:secretsmanager:*:*:secret:/platform/*'])."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
+variable "kms_key_arns" {
+  description = "List of KMS CMK ARNs ESO may decrypt/encrypt (the keys protecting the managed secrets). Empty list (default) means all keys ('*'); pin to the platform secrets CMK in production."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
+variable "iam_path" {
+  description = "IAM path for the role and policy. Useful for organising workload-identity roles (e.g. '/pod-identity/')."
+  type        = string
+  default     = "/pod-identity/"
+
+  validation {
+    condition     = can(regex("^/.*/$", var.iam_path))
+    error_message = "iam_path must begin and end with '/' (e.g. '/pod-identity/')."
+  }
+}
+
+variable "max_session_duration" {
+  description = "Maximum IAM role session duration in seconds. Pod Identity caches assumed credentials, so the default 3600s (1h) is sufficient for ESO's reconcile loop."
+  type        = number
+  default     = 3600
+
+  validation {
+    condition     = var.max_session_duration >= 3600 && var.max_session_duration <= 43200
+    error_message = "max_session_duration must be between 3600 and 43200 seconds (AWS IAM limits)."
+  }
+}
+
+variable "tags" {
+  description = "Additional tags merged onto every resource in this module."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/pod-identity-eso/versions.tf
+++ b/terraform/modules/pod-identity-eso/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/modules/pod-identity-lb-controller/README.md
+++ b/terraform/modules/pod-identity-lb-controller/README.md
@@ -1,0 +1,44 @@
+# pod-identity-lb-controller
+
+EKS **Pod Identity** for the **AWS Load Balancer Controller** — the last workload
+in the [ADR-0018](../../../docs/adrs/0018-eks-pod-identity-as-default-workload-identity.md)
+cutover (YACE → observability stack → ESO → **LB controller**). Ingress-critical,
+so migrated last.
+
+## What it creates
+
+| Resource | Purpose |
+|---|---|
+| `aws_iam_role.this` | Controller role. **Trust targets `pods.eks.amazonaws.com`** (not an OIDC issuer), allowing **`sts:AssumeRole` + `sts:TagSession`**. |
+| `aws_iam_policy.lb_controller` | The LBC least-privilege policy: ELBv2 provisioning, EC2/VPC describe, managed-SG management, and WAFv2/Shield/ACM/Cognito read. **ABAC-scoped** by `aws:PrincipalTag/kubernetes-namespace`. |
+| `aws_iam_role_policy_attachment.lb_controller` | Attaches the policy. |
+| `aws_eks_pod_identity_association.this` | Binds `(cluster, namespace=kube-system, service_account=aws-load-balancer-controller)` → the role. **Replaces the IRSA annotation.** |
+
+## Coexistence & caveats
+
+- **Never put both on one SA.** Keep the LBC SA annotations empty
+  (`apps/infra/aws-lb-controller/values.yaml`) — no `eks.amazonaws.com/role-arn`.
+- **Fargate unsupported.** Verify the controller is not Fargate-scheduled.
+- **Prerequisite:** `eks-pod-identity-agent` addon installed on the cluster.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|---|---|---|---|---|
+| `project` | Naming prefix | `string` | `"platform-design"` | no |
+| `cluster_name` | EKS cluster | `string` | — | **yes** |
+| `namespace` | Controller namespace | `string` | `"kube-system"` | no |
+| `service_account` | Controller SA | `string` | `"aws-load-balancer-controller"` | no |
+| `iam_path` | IAM path | `string` | `"/pod-identity/"` | no |
+| `max_session_duration` | Role max session seconds | `number` | `3600` | no |
+| `tags` | Extra tags | `map(string)` | `{}` | no |
+
+## Outputs
+
+`role_arn`, `role_name`, `policy_arn`, `association_id`, `association_arn`.
+
+## References
+
+- ADR-0018 — EKS Pod Identity as default workload identity
+- [Pod Identity ABAC session tags](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-abac.html)
+- [AWS Load Balancer Controller IAM policy](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/installation/)

--- a/terraform/modules/pod-identity-lb-controller/main.tf
+++ b/terraform/modules/pod-identity-lb-controller/main.tf
@@ -1,0 +1,251 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# EKS Pod Identity — AWS Load Balancer Controller — ADR-0018
+# ---------------------------------------------------------------------------------------------------------------------
+# Last workload in the ADR-0018 cutover order (YACE -> observability stack -> ESO
+# -> LB controller). Ingress-critical, so migrated last (highest blast radius).
+#
+# What this module creates:
+#   1. An IAM role whose TRUST policy targets the EKS Auth service principal
+#      `pods.eks.amazonaws.com` (NOT a per-cluster OIDC issuer), allowing both
+#      `sts:AssumeRole` AND `sts:TagSession` (TagSession injects the ABAC tags).
+#   2. The AWS Load Balancer Controller least-privilege policy: elasticloadbalancing
+#      create/modify/delete + ec2 describe + wafv2/shield/acm/cognito read, scoped
+#      by an ABAC kubernetes-namespace condition where the API supports conditions.
+#   3. An `aws_eks_pod_identity_association` binding (cluster, namespace
+#      `kube-system`, ServiceAccount `aws-load-balancer-controller`) -> the role.
+#
+# Note on ABAC scope: most LBC actions are describe/manage on ELBv2/EC2 resources
+# whose ARNs are created at runtime; the controller is a singleton in kube-system,
+# so the namespace ABAC condition pins it to the kube-system controller session.
+#
+# Coexistence (ADR-0018): IRSA stays supported for not-yet-migrated workloads. Do
+# NOT configure both an IRSA annotation AND an association on the same SA. The LBC
+# SA must not carry `eks.amazonaws.com/role-arn` once this association exists.
+#
+# Fargate caveat: Pod Identity is NOT supported on Fargate. Verify the LBC is not
+# Fargate-scheduled before migrating.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  role_name = "${var.project}-${var.cluster_name}-${var.service_account}"
+
+  default_tags = {
+    ManagedBy        = "Terraform"
+    Module           = "pod-identity-lb-controller"
+    ADR              = "ADR-0018"
+    WorkloadIdentity = "eks-pod-identity"
+    Namespace        = var.namespace
+    ServiceAccount   = var.service_account
+  }
+  effective_tags = merge(local.default_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Trust policy — EKS Pod Identity service principal
+# ---------------------------------------------------------------------------------------------------------------------
+data "aws_iam_policy_document" "trust" {
+  statement {
+    sid     = "EksPodIdentityAssumeRole"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# AWS Load Balancer Controller permissions (ABAC namespace-scoped where supported)
+# ---------------------------------------------------------------------------------------------------------------------
+# Mirrors the upstream AWS Load Balancer Controller IAM policy, condensed to the
+# action families it needs: ELBv2 provisioning, EC2/VPC describe for subnet and
+# security-group resolution, security-group management for managed SGs, and the
+# read-only integrations (WAFv2 / Shield / ACM / Cognito) the controller resolves
+# when an Ingress requests them. Every statement is ABAC-scoped to sessions whose
+# `kubernetes-namespace` tag == var.namespace (kube-system controller session).
+data "aws_iam_policy_document" "lb_controller" {
+  # EC2 / VPC describe — resolve subnets, security groups, AZs, ENIs.
+  statement {
+    sid    = "Ec2DescribeRead"
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeAccountAttributes",
+      "ec2:DescribeAddresses",
+      "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeInternetGateways",
+      "ec2:DescribeVpcs",
+      "ec2:DescribeVpcPeeringConnections",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeInstances",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DescribeTags",
+      "ec2:GetCoipPoolUsage",
+      "ec2:DescribeCoipPools",
+      "ec2:DescribeVpcEndpoints",
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+
+  # Elastic Load Balancing — describe load balancers/target groups/listeners/rules.
+  statement {
+    sid    = "ElbDescribeRead"
+    effect = "Allow"
+    actions = [
+      "elasticloadbalancing:DescribeLoadBalancers",
+      "elasticloadbalancing:DescribeLoadBalancerAttributes",
+      "elasticloadbalancing:DescribeListeners",
+      "elasticloadbalancing:DescribeListenerCertificates",
+      "elasticloadbalancing:DescribeSSLPolicies",
+      "elasticloadbalancing:DescribeRules",
+      "elasticloadbalancing:DescribeTargetGroups",
+      "elasticloadbalancing:DescribeTargetGroupAttributes",
+      "elasticloadbalancing:DescribeTargetHealth",
+      "elasticloadbalancing:DescribeTags",
+      "elasticloadbalancing:DescribeTrustStores",
+      "elasticloadbalancing:DescribeListenerAttributes",
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+
+  # Elastic Load Balancing — provision/modify/delete (Ingress -> ALB, Service -> NLB).
+  statement {
+    sid    = "ElbProvision"
+    effect = "Allow"
+    actions = [
+      "elasticloadbalancing:CreateLoadBalancer",
+      "elasticloadbalancing:CreateTargetGroup",
+      "elasticloadbalancing:CreateListener",
+      "elasticloadbalancing:DeleteListener",
+      "elasticloadbalancing:CreateRule",
+      "elasticloadbalancing:DeleteRule",
+      "elasticloadbalancing:ModifyLoadBalancerAttributes",
+      "elasticloadbalancing:SetIpAddressType",
+      "elasticloadbalancing:SetSecurityGroups",
+      "elasticloadbalancing:SetSubnets",
+      "elasticloadbalancing:DeleteLoadBalancer",
+      "elasticloadbalancing:ModifyTargetGroup",
+      "elasticloadbalancing:ModifyTargetGroupAttributes",
+      "elasticloadbalancing:DeleteTargetGroup",
+      "elasticloadbalancing:ModifyListener",
+      "elasticloadbalancing:AddListenerCertificates",
+      "elasticloadbalancing:RemoveListenerCertificates",
+      "elasticloadbalancing:ModifyRule",
+      "elasticloadbalancing:ModifyListenerAttributes",
+      "elasticloadbalancing:RegisterTargets",
+      "elasticloadbalancing:DeregisterTargets",
+      "elasticloadbalancing:AddTags",
+      "elasticloadbalancing:RemoveTags",
+      "elasticloadbalancing:SetWebAcl",
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+
+  # Security groups — manage the LBC-managed SGs that front load balancers.
+  statement {
+    sid    = "SecurityGroupManage"
+    effect = "Allow"
+    actions = [
+      "ec2:CreateSecurityGroup",
+      "ec2:DeleteSecurityGroup",
+      "ec2:AuthorizeSecurityGroupIngress",
+      "ec2:RevokeSecurityGroupIngress",
+      "ec2:CreateTags",
+      "ec2:DeleteTags",
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+
+  # Read-only integrations the controller resolves for Ingress annotations.
+  statement {
+    sid    = "IntegrationsRead"
+    effect = "Allow"
+    actions = [
+      "wafv2:GetWebACL",
+      "wafv2:GetWebACLForResource",
+      "wafv2:AssociateWebACL",
+      "wafv2:DisassociateWebACL",
+      "shield:GetSubscriptionState",
+      "shield:DescribeProtection",
+      "shield:CreateProtection",
+      "shield:DeleteProtection",
+      "acm:ListCertificates",
+      "acm:DescribeCertificate",
+      "cognito-idp:DescribeUserPoolClient",
+      "iam:ListServerCertificates",
+      "iam:GetServerCertificate",
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# IAM role + policy
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_iam_role" "this" {
+  name                 = local.role_name
+  description          = "EKS Pod Identity role for the AWS Load Balancer Controller in namespace ${var.namespace} (ADR-0018)"
+  assume_role_policy   = data.aws_iam_policy_document.trust.json
+  max_session_duration = var.max_session_duration
+  path                 = var.iam_path
+
+  tags = local.effective_tags
+}
+
+resource "aws_iam_policy" "lb_controller" {
+  name        = "${local.role_name}-lb-controller"
+  description = "AWS Load Balancer Controller ELB/EC2 permissions, ABAC-scoped to the ${var.namespace} namespace (ADR-0018)"
+  path        = var.iam_path
+  policy      = data.aws_iam_policy_document.lb_controller.json
+
+  tags = local.effective_tags
+}
+
+resource "aws_iam_role_policy_attachment" "lb_controller" {
+  role       = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.lb_controller.arn
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Pod Identity association — binds (cluster, namespace, ServiceAccount) -> role
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_eks_pod_identity_association" "this" {
+  cluster_name    = var.cluster_name
+  namespace       = var.namespace
+  service_account = var.service_account
+  role_arn        = aws_iam_role.this.arn
+
+  tags = local.effective_tags
+}

--- a/terraform/modules/pod-identity-lb-controller/outputs.tf
+++ b/terraform/modules/pod-identity-lb-controller/outputs.tf
@@ -1,0 +1,24 @@
+output "role_arn" {
+  description = "ARN of the AWS Load Balancer Controller Pod Identity IAM role. The association binds the controller ServiceAccount to this role; no IRSA annotation is required."
+  value       = aws_iam_role.this.arn
+}
+
+output "role_name" {
+  description = "Name of the AWS Load Balancer Controller Pod Identity IAM role."
+  value       = aws_iam_role.this.name
+}
+
+output "policy_arn" {
+  description = "ARN of the ABAC-scoped ELB/EC2 policy attached to the controller role."
+  value       = aws_iam_policy.lb_controller.arn
+}
+
+output "association_id" {
+  description = "ID of the EKS Pod Identity association (cluster + namespace + ServiceAccount -> role)."
+  value       = aws_eks_pod_identity_association.this.association_id
+}
+
+output "association_arn" {
+  description = "ARN of the EKS Pod Identity association."
+  value       = aws_eks_pod_identity_association.this.association_arn
+}

--- a/terraform/modules/pod-identity-lb-controller/pod-identity-lb-controller.tftest.hcl
+++ b/terraform/modules/pod-identity-lb-controller/pod-identity-lb-controller.tftest.hcl
@@ -1,0 +1,97 @@
+# Mock the aws_iam_policy_document data source with a REPRESENTATIVE policy JSON so
+# the role/policy JSON validation passes at plan AND the content assertions stay
+# meaningful (bare mocks return null .json, which fails validation).
+mock_provider "aws" {
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"sts:AssumeRole\",\"sts:TagSession\",\"elasticloadbalancing:CreateLoadBalancer\",\"ec2:DescribeSubnets\"],\"Principal\":{\"Service\":\"pods.eks.amazonaws.com\"},\"Condition\":{\"StringEquals\":{\"aws:PrincipalTag/kubernetes-namespace\":\"kube-system\"}}}]}"
+    }
+  }
+}
+
+variables {
+  project      = "platform-design"
+  cluster_name = "platform-dev"
+  tags = {
+    Environment = "test"
+    Team        = "platform"
+  }
+}
+
+run "defaults_to_kube_system_lb_controller" {
+  command = plan
+
+  assert {
+    condition     = var.namespace == "kube-system"
+    error_message = "namespace should default to kube-system (where the LB controller deploys)"
+  }
+
+  assert {
+    condition     = var.service_account == "aws-load-balancer-controller"
+    error_message = "service_account should default to aws-load-balancer-controller"
+  }
+}
+
+run "pod_identity_association_targets_cluster_ns_sa" {
+  command = plan
+
+  assert {
+    condition     = aws_eks_pod_identity_association.this.cluster_name == "platform-dev"
+    error_message = "association must target the supplied cluster"
+  }
+
+  assert {
+    condition     = aws_eks_pod_identity_association.this.namespace == "kube-system"
+    error_message = "association must target the kube-system namespace"
+  }
+
+  assert {
+    condition     = aws_eks_pod_identity_association.this.service_account == "aws-load-balancer-controller"
+    error_message = "association must target the aws-load-balancer-controller ServiceAccount"
+  }
+}
+
+run "trust_policy_uses_pod_identity_principal_and_tagsession" {
+  command = plan
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.trust.json, "pods.eks.amazonaws.com")
+    error_message = "trust policy must target the pods.eks.amazonaws.com service principal"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.trust.json, "sts:TagSession")
+    error_message = "trust policy must allow sts:TagSession (required to inject ABAC session tags)"
+  }
+}
+
+run "lb_controller_policy_is_abac_scoped_and_covers_elb_ec2" {
+  command = plan
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.lb_controller.json, "aws:PrincipalTag/kubernetes-namespace")
+    error_message = "LB controller policy must be ABAC-scoped on the kubernetes-namespace session tag"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.lb_controller.json, "elasticloadbalancing:CreateLoadBalancer")
+    error_message = "LB controller policy must allow elasticloadbalancing:CreateLoadBalancer"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.lb_controller.json, "ec2:DescribeSubnets")
+    error_message = "LB controller policy must allow ec2:DescribeSubnets (subnet resolution)"
+  }
+}
+
+run "invalid_iam_path_is_rejected" {
+  command = plan
+
+  variables {
+    iam_path = "no-leading-slash"
+  }
+
+  expect_failures = [
+    var.iam_path,
+  ]
+}

--- a/terraform/modules/pod-identity-lb-controller/variables.tf
+++ b/terraform/modules/pod-identity-lb-controller/variables.tf
@@ -1,0 +1,62 @@
+variable "project" {
+  description = "Project name used in IAM role/policy naming (e.g. 'platform-design')."
+  type        = string
+  default     = "platform-design"
+
+  validation {
+    condition     = length(var.project) > 0
+    error_message = "project must not be empty."
+  }
+}
+
+variable "cluster_name" {
+  description = "Name of the EKS cluster the Pod Identity association is created on. Also used in IAM role naming and (optionally) as an ABAC eks-cluster-name condition."
+  type        = string
+
+  validation {
+    condition     = length(var.cluster_name) > 0
+    error_message = "cluster_name must not be empty."
+  }
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace of the AWS Load Balancer Controller ServiceAccount. Defaults to 'kube-system'. Drives the ABAC kubernetes-namespace policy condition."
+  type        = string
+  default     = "kube-system"
+  nullable    = false
+}
+
+variable "service_account" {
+  description = "Kubernetes ServiceAccount name bound to the Pod Identity role. Defaults to 'aws-load-balancer-controller' (the LBC chart's controller SA)."
+  type        = string
+  default     = "aws-load-balancer-controller"
+  nullable    = false
+}
+
+variable "iam_path" {
+  description = "IAM path for the role and policy. Useful for organising workload-identity roles (e.g. '/pod-identity/')."
+  type        = string
+  default     = "/pod-identity/"
+
+  validation {
+    condition     = can(regex("^/.*/$", var.iam_path))
+    error_message = "iam_path must begin and end with '/' (e.g. '/pod-identity/')."
+  }
+}
+
+variable "max_session_duration" {
+  description = "Maximum IAM role session duration in seconds. Pod Identity caches assumed credentials, so the default 3600s (1h) is sufficient for the controller's reconcile loop."
+  type        = number
+  default     = 3600
+
+  validation {
+    condition     = var.max_session_duration >= 3600 && var.max_session_duration <= 43200
+    error_message = "max_session_duration must be between 3600 and 43200 seconds (AWS IAM limits)."
+  }
+}
+
+variable "tags" {
+  description = "Additional tags merged onto every resource in this module."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/pod-identity-lb-controller/versions.tf
+++ b/terraform/modules/pod-identity-lb-controller/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/modules/pod-identity-loki/README.md
+++ b/terraform/modules/pod-identity-loki/README.md
@@ -1,0 +1,48 @@
+# pod-identity-loki
+
+EKS **Pod Identity** for **Loki** (S3 object storage) — part of the observability
+step in the [ADR-0018](../../../docs/adrs/0018-eks-pod-identity-as-default-workload-identity.md)
+cutover (YACE → **observability stack** → ESO → LB controller). Replaces Loki's
+IRSA `loki-s3-access` role.
+
+## What it creates
+
+| Resource | Purpose |
+|---|---|
+| `aws_iam_role.this` | Loki role. **Trust targets `pods.eks.amazonaws.com`** (not an OIDC issuer), allowing **`sts:AssumeRole` + `sts:TagSession`**. |
+| `aws_iam_policy.loki_s3` | S3 list + object CRUD scoped to Loki's bucket ARNs, plus KMS decrypt/data-key for SSE-KMS buckets. **ABAC-scoped** by `aws:PrincipalTag/kubernetes-namespace`. |
+| `aws_iam_role_policy_attachment.loki_s3` | Attaches the policy. |
+| `aws_eks_pod_identity_association.this` | Binds `(cluster, namespace=observability, service_account=loki)` → the role. **Replaces the IRSA annotation.** |
+
+## Coexistence & caveats
+
+- **Never put both on one SA.** The Loki SA drops its `eks.amazonaws.com/role-arn`
+  annotation (`apps/infra/observability/loki-stack/templates/loki-s3-secret.yaml`)
+  once this association exists.
+- **Least-privilege:** pass `bucket_names` (and `kms_key_arns` for SSE-KMS) — the
+  default `*` is for plan-time convenience only.
+- **Fargate unsupported.** Verify Loki pods are not Fargate-scheduled.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|---|---|---|---|---|
+| `project` | Naming prefix | `string` | `"platform-design"` | no |
+| `cluster_name` | EKS cluster | `string` | — | **yes** |
+| `namespace` | Loki namespace | `string` | `"observability"` | no |
+| `service_account` | Loki SA | `string` | `"loki"` | no |
+| `bucket_names` | Loki S3 bucket names | `list(string)` | `[]` (→ `*`) | no |
+| `kms_key_arns` | SSE-KMS CMK ARNs | `list(string)` | `[]` (→ `*`) | no |
+| `aws_partition` | ARN partition | `string` | `"aws"` | no |
+| `iam_path` | IAM path | `string` | `"/pod-identity/"` | no |
+| `max_session_duration` | Role max session seconds | `number` | `3600` | no |
+| `tags` | Extra tags | `map(string)` | `{}` | no |
+
+## Outputs
+
+`role_arn`, `role_name`, `policy_arn`, `association_id`, `association_arn`.
+
+## References
+
+- ADR-0018 — EKS Pod Identity as default workload identity
+- [Pod Identity ABAC session tags](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-abac.html)

--- a/terraform/modules/pod-identity-loki/main.tf
+++ b/terraform/modules/pod-identity-loki/main.tf
@@ -1,0 +1,164 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# EKS Pod Identity — Loki (S3 object storage) — ADR-0018
+# ---------------------------------------------------------------------------------------------------------------------
+# Part of the observability-stack step in the ADR-0018 cutover order (YACE ->
+# observability stack -> ESO -> LB controller). Loki (SimpleScalable mode) stores
+# chunks/index/ruler/admin in S3 and previously authenticated via an IRSA role
+# (`loki-s3-access`); this module replaces that with a Pod Identity association.
+#
+# What this module creates:
+#   1. An IAM role whose TRUST policy targets the EKS Auth service principal
+#      `pods.eks.amazonaws.com` (NOT a per-cluster OIDC issuer), allowing both
+#      `sts:AssumeRole` AND `sts:TagSession` (TagSession injects the ABAC tags).
+#   2. An S3 object-storage policy scoped to Loki's bucket(s): list on the bucket
+#      ARNs, object CRUD on the bucket object ARNs, plus KMS decrypt/data-key for
+#      SSE-KMS buckets. ABAC-scoped by the kubernetes-namespace session tag.
+#   3. An `aws_eks_pod_identity_association` binding (cluster, namespace
+#      `observability`, ServiceAccount `loki`) -> the role above.
+#
+# Coexistence (ADR-0018): IRSA stays supported for not-yet-migrated workloads. Do
+# NOT configure both an IRSA annotation AND an association on the same SA. The Loki
+# SA must drop its `eks.amazonaws.com/role-arn` annotation once this association
+# exists (apps/infra/observability/loki-stack/templates/loki-s3-secret.yaml).
+#
+# Fargate caveat: Pod Identity is NOT supported on Fargate. Verify Loki pods are
+# not Fargate-scheduled before migrating.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  role_name = "${var.project}-${var.cluster_name}-${var.service_account}"
+
+  default_tags = {
+    ManagedBy        = "Terraform"
+    Module           = "pod-identity-loki"
+    ADR              = "ADR-0018"
+    WorkloadIdentity = "eks-pod-identity"
+    Namespace        = var.namespace
+    ServiceAccount   = var.service_account
+  }
+  effective_tags = merge(local.default_tags, var.tags)
+
+  # Bucket-level ARNs (for ListBucket / GetBucketLocation) and object-level ARNs
+  # (for object CRUD). Empty `bucket_names` falls back to "*" so the module plans
+  # without a real bucket list; pass the Loki bucket names in production.
+  bucket_arns = length(var.bucket_names) > 0 ? [for b in var.bucket_names : "arn:${var.aws_partition}:s3:::${b}"] : ["*"]
+  object_arns = length(var.bucket_names) > 0 ? [for b in var.bucket_names : "arn:${var.aws_partition}:s3:::${b}/*"] : ["*"]
+
+  # KMS key ARNs for SSE-KMS buckets. Empty list -> "*" (allow any key); pin to the
+  # bucket CMK in production.
+  kms_key_arns = length(var.kms_key_arns) > 0 ? var.kms_key_arns : ["*"]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Trust policy — EKS Pod Identity service principal
+# ---------------------------------------------------------------------------------------------------------------------
+data "aws_iam_policy_document" "trust" {
+  statement {
+    sid     = "EksPodIdentityAssumeRole"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Loki S3 object-storage permissions (ABAC namespace-scoped)
+# ---------------------------------------------------------------------------------------------------------------------
+data "aws_iam_policy_document" "loki_s3" {
+  # Bucket-level — list objects + locate region. Scoped to Loki's bucket ARNs.
+  statement {
+    sid    = "S3BucketList"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+    resources = local.bucket_arns
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+
+  # Object-level — chunk/index/ruler/admin object CRUD. Scoped to bucket/* ARNs.
+  statement {
+    sid    = "S3ObjectCrud"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts",
+    ]
+    resources = local.object_arns
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+
+  # KMS — SSE-KMS encrypt/decrypt for the bucket CMK. Scoped to the supplied keys.
+  statement {
+    sid    = "KmsBucketAccess"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+    resources = local.kms_key_arns
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# IAM role + policy
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_iam_role" "this" {
+  name                 = local.role_name
+  description          = "EKS Pod Identity role for Loki S3 object storage in namespace ${var.namespace} (ADR-0018)"
+  assume_role_policy   = data.aws_iam_policy_document.trust.json
+  max_session_duration = var.max_session_duration
+  path                 = var.iam_path
+
+  tags = local.effective_tags
+}
+
+resource "aws_iam_policy" "loki_s3" {
+  name        = "${local.role_name}-loki-s3"
+  description = "Loki S3 object-storage access, ABAC-scoped to the ${var.namespace} namespace (ADR-0018)"
+  path        = var.iam_path
+  policy      = data.aws_iam_policy_document.loki_s3.json
+
+  tags = local.effective_tags
+}
+
+resource "aws_iam_role_policy_attachment" "loki_s3" {
+  role       = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.loki_s3.arn
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Pod Identity association — binds (cluster, namespace, ServiceAccount) -> role
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_eks_pod_identity_association" "this" {
+  cluster_name    = var.cluster_name
+  namespace       = var.namespace
+  service_account = var.service_account
+  role_arn        = aws_iam_role.this.arn
+
+  tags = local.effective_tags
+}

--- a/terraform/modules/pod-identity-loki/outputs.tf
+++ b/terraform/modules/pod-identity-loki/outputs.tf
@@ -1,0 +1,24 @@
+output "role_arn" {
+  description = "ARN of the Loki Pod Identity IAM role. The association binds the observability/loki ServiceAccount to this role; no IRSA annotation is required."
+  value       = aws_iam_role.this.arn
+}
+
+output "role_name" {
+  description = "Name of the Loki Pod Identity IAM role."
+  value       = aws_iam_role.this.name
+}
+
+output "policy_arn" {
+  description = "ARN of the ABAC-scoped S3 object-storage policy attached to the Loki role."
+  value       = aws_iam_policy.loki_s3.arn
+}
+
+output "association_id" {
+  description = "ID of the EKS Pod Identity association (cluster + namespace + ServiceAccount -> role)."
+  value       = aws_eks_pod_identity_association.this.association_id
+}
+
+output "association_arn" {
+  description = "ARN of the EKS Pod Identity association."
+  value       = aws_eks_pod_identity_association.this.association_arn
+}

--- a/terraform/modules/pod-identity-loki/pod-identity-loki.tftest.hcl
+++ b/terraform/modules/pod-identity-loki/pod-identity-loki.tftest.hcl
@@ -1,0 +1,98 @@
+# Mock the aws_iam_policy_document data source with a REPRESENTATIVE policy JSON so
+# the role/policy JSON validation passes at plan AND the content assertions stay
+# meaningful (bare mocks return null .json, which fails validation).
+mock_provider "aws" {
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"sts:AssumeRole\",\"sts:TagSession\",\"s3:GetObject\",\"s3:PutObject\",\"s3:ListBucket\"],\"Principal\":{\"Service\":\"pods.eks.amazonaws.com\"},\"Condition\":{\"StringEquals\":{\"aws:PrincipalTag/kubernetes-namespace\":\"observability\"}}}]}"
+    }
+  }
+}
+
+variables {
+  project      = "platform-design"
+  cluster_name = "platform-dev"
+  bucket_names = ["platform-design-loki-chunks", "platform-design-loki-ruler"]
+  tags = {
+    Environment = "test"
+    Team        = "platform"
+  }
+}
+
+run "defaults_to_observability_loki" {
+  command = plan
+
+  assert {
+    condition     = var.namespace == "observability"
+    error_message = "namespace should default to observability (where the loki-stack chart deploys)"
+  }
+
+  assert {
+    condition     = var.service_account == "loki"
+    error_message = "service_account should default to loki"
+  }
+}
+
+run "pod_identity_association_targets_cluster_ns_sa" {
+  command = plan
+
+  assert {
+    condition     = aws_eks_pod_identity_association.this.cluster_name == "platform-dev"
+    error_message = "association must target the supplied cluster"
+  }
+
+  assert {
+    condition     = aws_eks_pod_identity_association.this.namespace == "observability"
+    error_message = "association must target the observability namespace"
+  }
+
+  assert {
+    condition     = aws_eks_pod_identity_association.this.service_account == "loki"
+    error_message = "association must target the loki ServiceAccount"
+  }
+}
+
+run "trust_policy_uses_pod_identity_principal_and_tagsession" {
+  command = plan
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.trust.json, "pods.eks.amazonaws.com")
+    error_message = "trust policy must target the pods.eks.amazonaws.com service principal"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.trust.json, "sts:TagSession")
+    error_message = "trust policy must allow sts:TagSession (required to inject ABAC session tags)"
+  }
+}
+
+run "s3_policy_is_abac_scoped_and_covers_object_crud" {
+  command = plan
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.loki_s3.json, "aws:PrincipalTag/kubernetes-namespace")
+    error_message = "Loki S3 policy must be ABAC-scoped on the kubernetes-namespace session tag"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.loki_s3.json, "s3:PutObject")
+    error_message = "Loki S3 policy must allow s3:PutObject (chunk/index writes)"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.loki_s3.json, "s3:ListBucket")
+    error_message = "Loki S3 policy must allow s3:ListBucket (bucket listing)"
+  }
+}
+
+run "invalid_iam_path_is_rejected" {
+  command = plan
+
+  variables {
+    iam_path = "no-leading-slash"
+  }
+
+  expect_failures = [
+    var.iam_path,
+  ]
+}

--- a/terraform/modules/pod-identity-loki/variables.tf
+++ b/terraform/modules/pod-identity-loki/variables.tf
@@ -1,0 +1,83 @@
+variable "project" {
+  description = "Project name used in IAM role/policy naming (e.g. 'platform-design')."
+  type        = string
+  default     = "platform-design"
+
+  validation {
+    condition     = length(var.project) > 0
+    error_message = "project must not be empty."
+  }
+}
+
+variable "cluster_name" {
+  description = "Name of the EKS cluster the Pod Identity association is created on. Also used in IAM role naming and (optionally) as an ABAC eks-cluster-name condition."
+  type        = string
+
+  validation {
+    condition     = length(var.cluster_name) > 0
+    error_message = "cluster_name must not be empty."
+  }
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace of the Loki ServiceAccount. Defaults to 'observability' (where the loki-stack chart deploys). Drives the ABAC kubernetes-namespace policy condition."
+  type        = string
+  default     = "observability"
+  nullable    = false
+}
+
+variable "service_account" {
+  description = "Kubernetes ServiceAccount name bound to the Pod Identity role. Defaults to 'loki' (the loki-stack chart's SA)."
+  type        = string
+  default     = "loki"
+  nullable    = false
+}
+
+variable "bucket_names" {
+  description = "List of S3 bucket names Loki uses for chunks/index/ruler/admin storage. Empty list (default) falls back to '*' so the module plans without a real bucket list; pass the Loki bucket names in production for least-privilege."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
+variable "kms_key_arns" {
+  description = "List of KMS CMK ARNs for SSE-KMS-encrypted Loki buckets. Empty list (default) means all keys ('*'); pin to the bucket CMK in production."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
+variable "aws_partition" {
+  description = "AWS partition for ARN construction ('aws', 'aws-us-gov', or 'aws-cn')."
+  type        = string
+  default     = "aws"
+  nullable    = false
+}
+
+variable "iam_path" {
+  description = "IAM path for the role and policy. Useful for organising workload-identity roles (e.g. '/pod-identity/')."
+  type        = string
+  default     = "/pod-identity/"
+
+  validation {
+    condition     = can(regex("^/.*/$", var.iam_path))
+    error_message = "iam_path must begin and end with '/' (e.g. '/pod-identity/')."
+  }
+}
+
+variable "max_session_duration" {
+  description = "Maximum IAM role session duration in seconds. Pod Identity caches assumed credentials, so the default 3600s (1h) is sufficient for Loki's S3 access."
+  type        = number
+  default     = 3600
+
+  validation {
+    condition     = var.max_session_duration >= 3600 && var.max_session_duration <= 43200
+    error_message = "max_session_duration must be between 3600 and 43200 seconds (AWS IAM limits)."
+  }
+}
+
+variable "tags" {
+  description = "Additional tags merged onto every resource in this module."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/pod-identity-loki/versions.tf
+++ b/terraform/modules/pod-identity-loki/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/modules/pod-identity-thanos/README.md
+++ b/terraform/modules/pod-identity-thanos/README.md
@@ -1,0 +1,51 @@
+# pod-identity-thanos
+
+EKS **Pod Identity** for **Thanos** (S3 object storage) — part of the observability
+step in the [ADR-0018](../../../docs/adrs/0018-eks-pod-identity-as-default-workload-identity.md)
+cutover (YACE → **observability stack** → ESO → LB controller). Replaces Thanos's
+IRSA `thanos-s3-access` role.
+
+## What it creates
+
+| Resource | Purpose |
+|---|---|
+| `aws_iam_role.this` | Thanos role. **Trust targets `pods.eks.amazonaws.com`** (not an OIDC issuer), allowing **`sts:AssumeRole` + `sts:TagSession`**. |
+| `aws_iam_policy.thanos_s3` | S3 list + object CRUD scoped to Thanos's bucket ARNs, plus KMS decrypt/data-key for SSE-KMS buckets. **ABAC-scoped** by `aws:PrincipalTag/kubernetes-namespace`. |
+| `aws_iam_role_policy_attachment.thanos_s3` | Attaches the policy. |
+| `aws_eks_pod_identity_association.this` | Binds `(cluster, namespace=monitoring, service_account=thanos)` → the role. **Replaces the IRSA annotation.** |
+
+## Coexistence & caveats
+
+- **Never put both on one SA.** The Thanos SA (kube-prometheus-stack template)
+  drops its `eks.amazonaws.com/role-arn` annotation once this association exists.
+  > NOTE: the Thanos SA template lives inside `apps/infra/observability/prometheus-stack/`,
+  > which is out of scope for the change that introduced this module; the
+  > annotation drop there is tracked separately. This module + unit provide the
+  > Pod Identity side so the SA can be migrated when prometheus-stack is touched.
+- **Least-privilege:** pass `bucket_names` (and `kms_key_arns` for SSE-KMS) — the
+  default `*` is for plan-time convenience only.
+- **Fargate unsupported.** Verify Thanos pods are not Fargate-scheduled.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|---|---|---|---|---|
+| `project` | Naming prefix | `string` | `"platform-design"` | no |
+| `cluster_name` | EKS cluster | `string` | — | **yes** |
+| `namespace` | Thanos namespace | `string` | `"monitoring"` | no |
+| `service_account` | Thanos SA | `string` | `"thanos"` | no |
+| `bucket_names` | Thanos S3 bucket names | `list(string)` | `[]` (→ `*`) | no |
+| `kms_key_arns` | SSE-KMS CMK ARNs | `list(string)` | `[]` (→ `*`) | no |
+| `aws_partition` | ARN partition | `string` | `"aws"` | no |
+| `iam_path` | IAM path | `string` | `"/pod-identity/"` | no |
+| `max_session_duration` | Role max session seconds | `number` | `3600` | no |
+| `tags` | Extra tags | `map(string)` | `{}` | no |
+
+## Outputs
+
+`role_arn`, `role_name`, `policy_arn`, `association_id`, `association_arn`.
+
+## References
+
+- ADR-0018 — EKS Pod Identity as default workload identity
+- [Pod Identity ABAC session tags](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-abac.html)

--- a/terraform/modules/pod-identity-thanos/main.tf
+++ b/terraform/modules/pod-identity-thanos/main.tf
@@ -1,0 +1,165 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# EKS Pod Identity — Thanos (S3 object storage) — ADR-0018
+# ---------------------------------------------------------------------------------------------------------------------
+# Part of the observability-stack step in the ADR-0018 cutover order (YACE ->
+# observability stack -> ESO -> LB controller). Thanos (store/compactor/sidecar)
+# reads and writes long-term metrics blocks in S3 and previously authenticated via
+# an IRSA role (`thanos-s3-access`); this module replaces that with a Pod Identity
+# association.
+#
+# What this module creates:
+#   1. An IAM role whose TRUST policy targets the EKS Auth service principal
+#      `pods.eks.amazonaws.com` (NOT a per-cluster OIDC issuer), allowing both
+#      `sts:AssumeRole` AND `sts:TagSession` (TagSession injects the ABAC tags).
+#   2. An S3 object-storage policy scoped to Thanos's bucket(s): list on the bucket
+#      ARNs, object CRUD on the bucket object ARNs, plus KMS decrypt/data-key for
+#      SSE-KMS buckets. ABAC-scoped by the kubernetes-namespace session tag.
+#   3. An `aws_eks_pod_identity_association` binding (cluster, namespace
+#      `monitoring`, ServiceAccount `thanos`) -> the role above.
+#
+# Coexistence (ADR-0018): IRSA stays supported for not-yet-migrated workloads. Do
+# NOT configure both an IRSA annotation AND an association on the same SA. The
+# Thanos SA must drop its `eks.amazonaws.com/role-arn` annotation once this
+# association exists (the kube-prometheus-stack Thanos SA template).
+#
+# Fargate caveat: Pod Identity is NOT supported on Fargate. Verify Thanos pods are
+# not Fargate-scheduled before migrating.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  role_name = "${var.project}-${var.cluster_name}-${var.service_account}"
+
+  default_tags = {
+    ManagedBy        = "Terraform"
+    Module           = "pod-identity-thanos"
+    ADR              = "ADR-0018"
+    WorkloadIdentity = "eks-pod-identity"
+    Namespace        = var.namespace
+    ServiceAccount   = var.service_account
+  }
+  effective_tags = merge(local.default_tags, var.tags)
+
+  # Bucket-level ARNs (for ListBucket / GetBucketLocation) and object-level ARNs
+  # (for object CRUD). Empty `bucket_names` falls back to "*" so the module plans
+  # without a real bucket list; pass the Thanos bucket name(s) in production.
+  bucket_arns = length(var.bucket_names) > 0 ? [for b in var.bucket_names : "arn:${var.aws_partition}:s3:::${b}"] : ["*"]
+  object_arns = length(var.bucket_names) > 0 ? [for b in var.bucket_names : "arn:${var.aws_partition}:s3:::${b}/*"] : ["*"]
+
+  # KMS key ARNs for SSE-KMS buckets. Empty list -> "*" (allow any key); pin to the
+  # bucket CMK in production.
+  kms_key_arns = length(var.kms_key_arns) > 0 ? var.kms_key_arns : ["*"]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Trust policy — EKS Pod Identity service principal
+# ---------------------------------------------------------------------------------------------------------------------
+data "aws_iam_policy_document" "trust" {
+  statement {
+    sid     = "EksPodIdentityAssumeRole"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Thanos S3 object-storage permissions (ABAC namespace-scoped)
+# ---------------------------------------------------------------------------------------------------------------------
+data "aws_iam_policy_document" "thanos_s3" {
+  # Bucket-level — list blocks + locate region. Scoped to Thanos's bucket ARNs.
+  statement {
+    sid    = "S3BucketList"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+    resources = local.bucket_arns
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+
+  # Object-level — metrics block CRUD. Scoped to bucket/* ARNs.
+  statement {
+    sid    = "S3ObjectCrud"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts",
+    ]
+    resources = local.object_arns
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+
+  # KMS — SSE-KMS encrypt/decrypt for the bucket CMK. Scoped to the supplied keys.
+  statement {
+    sid    = "KmsBucketAccess"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+    resources = local.kms_key_arns
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/kubernetes-namespace"
+      values   = [var.namespace]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# IAM role + policy
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_iam_role" "this" {
+  name                 = local.role_name
+  description          = "EKS Pod Identity role for Thanos S3 object storage in namespace ${var.namespace} (ADR-0018)"
+  assume_role_policy   = data.aws_iam_policy_document.trust.json
+  max_session_duration = var.max_session_duration
+  path                 = var.iam_path
+
+  tags = local.effective_tags
+}
+
+resource "aws_iam_policy" "thanos_s3" {
+  name        = "${local.role_name}-thanos-s3"
+  description = "Thanos S3 object-storage access, ABAC-scoped to the ${var.namespace} namespace (ADR-0018)"
+  path        = var.iam_path
+  policy      = data.aws_iam_policy_document.thanos_s3.json
+
+  tags = local.effective_tags
+}
+
+resource "aws_iam_role_policy_attachment" "thanos_s3" {
+  role       = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.thanos_s3.arn
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Pod Identity association — binds (cluster, namespace, ServiceAccount) -> role
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_eks_pod_identity_association" "this" {
+  cluster_name    = var.cluster_name
+  namespace       = var.namespace
+  service_account = var.service_account
+  role_arn        = aws_iam_role.this.arn
+
+  tags = local.effective_tags
+}

--- a/terraform/modules/pod-identity-thanos/outputs.tf
+++ b/terraform/modules/pod-identity-thanos/outputs.tf
@@ -1,0 +1,24 @@
+output "role_arn" {
+  description = "ARN of the Thanos Pod Identity IAM role. The association binds the monitoring/thanos ServiceAccount to this role; no IRSA annotation is required."
+  value       = aws_iam_role.this.arn
+}
+
+output "role_name" {
+  description = "Name of the Thanos Pod Identity IAM role."
+  value       = aws_iam_role.this.name
+}
+
+output "policy_arn" {
+  description = "ARN of the ABAC-scoped S3 object-storage policy attached to the Thanos role."
+  value       = aws_iam_policy.thanos_s3.arn
+}
+
+output "association_id" {
+  description = "ID of the EKS Pod Identity association (cluster + namespace + ServiceAccount -> role)."
+  value       = aws_eks_pod_identity_association.this.association_id
+}
+
+output "association_arn" {
+  description = "ARN of the EKS Pod Identity association."
+  value       = aws_eks_pod_identity_association.this.association_arn
+}

--- a/terraform/modules/pod-identity-thanos/pod-identity-thanos.tftest.hcl
+++ b/terraform/modules/pod-identity-thanos/pod-identity-thanos.tftest.hcl
@@ -1,0 +1,98 @@
+# Mock the aws_iam_policy_document data source with a REPRESENTATIVE policy JSON so
+# the role/policy JSON validation passes at plan AND the content assertions stay
+# meaningful (bare mocks return null .json, which fails validation).
+mock_provider "aws" {
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"sts:AssumeRole\",\"sts:TagSession\",\"s3:GetObject\",\"s3:PutObject\",\"s3:ListBucket\"],\"Principal\":{\"Service\":\"pods.eks.amazonaws.com\"},\"Condition\":{\"StringEquals\":{\"aws:PrincipalTag/kubernetes-namespace\":\"monitoring\"}}}]}"
+    }
+  }
+}
+
+variables {
+  project      = "platform-design"
+  cluster_name = "platform-dev"
+  bucket_names = ["platform-design-thanos-metrics"]
+  tags = {
+    Environment = "test"
+    Team        = "platform"
+  }
+}
+
+run "defaults_to_monitoring_thanos" {
+  command = plan
+
+  assert {
+    condition     = var.namespace == "monitoring"
+    error_message = "namespace should default to monitoring (where the kube-prometheus-stack Thanos SA is created)"
+  }
+
+  assert {
+    condition     = var.service_account == "thanos"
+    error_message = "service_account should default to thanos"
+  }
+}
+
+run "pod_identity_association_targets_cluster_ns_sa" {
+  command = plan
+
+  assert {
+    condition     = aws_eks_pod_identity_association.this.cluster_name == "platform-dev"
+    error_message = "association must target the supplied cluster"
+  }
+
+  assert {
+    condition     = aws_eks_pod_identity_association.this.namespace == "monitoring"
+    error_message = "association must target the monitoring namespace"
+  }
+
+  assert {
+    condition     = aws_eks_pod_identity_association.this.service_account == "thanos"
+    error_message = "association must target the thanos ServiceAccount"
+  }
+}
+
+run "trust_policy_uses_pod_identity_principal_and_tagsession" {
+  command = plan
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.trust.json, "pods.eks.amazonaws.com")
+    error_message = "trust policy must target the pods.eks.amazonaws.com service principal"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.trust.json, "sts:TagSession")
+    error_message = "trust policy must allow sts:TagSession (required to inject ABAC session tags)"
+  }
+}
+
+run "s3_policy_is_abac_scoped_and_covers_object_crud" {
+  command = plan
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.thanos_s3.json, "aws:PrincipalTag/kubernetes-namespace")
+    error_message = "Thanos S3 policy must be ABAC-scoped on the kubernetes-namespace session tag"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.thanos_s3.json, "s3:PutObject")
+    error_message = "Thanos S3 policy must allow s3:PutObject (block writes)"
+  }
+
+  assert {
+    condition     = strcontains(data.aws_iam_policy_document.thanos_s3.json, "s3:ListBucket")
+    error_message = "Thanos S3 policy must allow s3:ListBucket (block listing)"
+  }
+}
+
+run "invalid_iam_path_is_rejected" {
+  command = plan
+
+  variables {
+    iam_path = "no-leading-slash"
+  }
+
+  expect_failures = [
+    var.iam_path,
+  ]
+}

--- a/terraform/modules/pod-identity-thanos/variables.tf
+++ b/terraform/modules/pod-identity-thanos/variables.tf
@@ -1,0 +1,83 @@
+variable "project" {
+  description = "Project name used in IAM role/policy naming (e.g. 'platform-design')."
+  type        = string
+  default     = "platform-design"
+
+  validation {
+    condition     = length(var.project) > 0
+    error_message = "project must not be empty."
+  }
+}
+
+variable "cluster_name" {
+  description = "Name of the EKS cluster the Pod Identity association is created on. Also used in IAM role naming and (optionally) as an ABAC eks-cluster-name condition."
+  type        = string
+
+  validation {
+    condition     = length(var.cluster_name) > 0
+    error_message = "cluster_name must not be empty."
+  }
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace of the Thanos ServiceAccount. Defaults to 'monitoring' (where the kube-prometheus-stack Thanos SA is created). Drives the ABAC kubernetes-namespace policy condition."
+  type        = string
+  default     = "monitoring"
+  nullable    = false
+}
+
+variable "service_account" {
+  description = "Kubernetes ServiceAccount name bound to the Pod Identity role. Defaults to 'thanos' (the kube-prometheus-stack Thanos SA)."
+  type        = string
+  default     = "thanos"
+  nullable    = false
+}
+
+variable "bucket_names" {
+  description = "List of S3 bucket names Thanos uses for long-term metrics blocks. Empty list (default) falls back to '*' so the module plans without a real bucket list; pass the Thanos bucket name(s) in production for least-privilege."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
+variable "kms_key_arns" {
+  description = "List of KMS CMK ARNs for SSE-KMS-encrypted Thanos buckets. Empty list (default) means all keys ('*'); pin to the bucket CMK in production."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
+variable "aws_partition" {
+  description = "AWS partition for ARN construction ('aws', 'aws-us-gov', or 'aws-cn')."
+  type        = string
+  default     = "aws"
+  nullable    = false
+}
+
+variable "iam_path" {
+  description = "IAM path for the role and policy. Useful for organising workload-identity roles (e.g. '/pod-identity/')."
+  type        = string
+  default     = "/pod-identity/"
+
+  validation {
+    condition     = can(regex("^/.*/$", var.iam_path))
+    error_message = "iam_path must begin and end with '/' (e.g. '/pod-identity/')."
+  }
+}
+
+variable "max_session_duration" {
+  description = "Maximum IAM role session duration in seconds. Pod Identity caches assumed credentials, so the default 3600s (1h) is sufficient for Thanos's S3 access."
+  type        = number
+  default     = 3600
+
+  validation {
+    condition     = var.max_session_duration >= 3600 && var.max_session_duration <= 43200
+    error_message = "max_session_duration must be between 3600 and 43200 seconds (AWS IAM limits)."
+  }
+}
+
+variable "tags" {
+  description = "Additional tags merged onto every resource in this module."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/pod-identity-thanos/versions.tf
+++ b/terraform/modules/pod-identity-thanos/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
Implements ADR-0018 rollout (after YACE #254). PodIdentityAssociation + ABAC IAM roles for ESO, AWS LB Controller, Loki, Thanos, EBS-CSI; drops IRSA annotations (coexistence, Pod Identity precedence). terraform validate clean (no apply). Refs #252.

## Modules added (mirror `pod-identity-yace`)

| Module | SA (ns) | Least-privilege policy | ABAC |
|---|---|---|---|
| `pod-identity-eso` | external-secrets/external-secrets | SecretsManager read+PushSecret, KMS, `ecr:GetAuthorizationToken` (Generators) | `kubernetes-namespace` |
| `pod-identity-lb-controller` | kube-system/aws-load-balancer-controller | elasticloadbalancing provision/describe, ec2/VPC describe, SG manage, WAFv2/Shield/ACM/Cognito read | `kubernetes-namespace` |
| `pod-identity-loki` | observability/loki | S3 list + object CRUD + KMS (SSE-KMS) | `kubernetes-namespace` |
| `pod-identity-thanos` | monitoring/thanos | S3 list + object CRUD + KMS (SSE-KMS) | `kubernetes-namespace` |
| `pod-identity-ebs-csi` | kube-system/ebs-csi-controller-sa | ec2 volume lifecycle + snapshot + describe + tag + KMS grants | `kubernetes-namespace` |

Each: trust `pods.eks.amazonaws.com` with `sts:AssumeRole`+`sts:TagSession`; one IAM role + ABAC-scoped policy + `aws_eks_pod_identity_association`; `versions.tf` (TF ~>1.11, aws ~>6.0); README; mock-provider `.tftest.hcl` (5 runs each). Plus 5 matching `catalog/units/pod-identity-*/terragrunt.hcl` (parameterized, no qbiq; `cluster_name` per-environment).

## IRSA annotation drops (coexistence — never both on one SA)

- `apps/infra/aws-lb-controller/values.yaml` — SA `annotations: {}`, IRSA hint removed; Pod Identity documented.
- `apps/infra/external-secrets/values.yaml` — added `external-secrets.serviceAccount` (create+name, `annotations: {}`); ESO uses its own controller SA, not `serviceAccountRef`.
- `apps/infra/observability/loki-stack/templates/loki-s3-secret.yaml` — dropped `eks.amazonaws.com/role-arn` from the `loki` SA.

> **Thanos SA annotation note:** the live Thanos SA template lives in `apps/infra/observability/prometheus-stack/` (out of scope for this change). The `pod-identity-thanos` module + unit are provided so the SA can be migrated when prometheus-stack is next touched. **EBS-CSI** has no standalone Helm app values in `apps/infra` (it's an EKS addon / controller SA), so only the module + unit are added.

## Validation (no apply)

- `terraform fmt -recursive`: clean (no reformat).
- per-module `terraform init -backend=false && terraform validate`: **all 5 "Success! The configuration is valid."**
- `terraform test` (mock_provider): **25/25 pass** (5 runs × 5 modules) — trust principal+TagSession, ABAC namespace scoping, per-policy action coverage, association target, iam_path validation.
- `python3 yaml.safe_load` on edited app values + structural parse of the Loki template: **clean**; confirmed Loki SA has no role-arn and ESO/LBC SA annotations are empty.
- **checkov:** not installed in this environment (CLI/pip/pipx absent) — flagged for CI. IAM policies are ABAC least-privilege; S3/KMS/secret ARNs parameterized (default `*` for plan-time only).
- Fargate unsupported / `eks-pod-identity-agent` prerequisite documented per module.

**No `terraform apply` run.** IRSA stays for unmigrated workloads.