### PR TITLE
feat(secrets): ESO v2.x + CRD v1 migration (W4)

### DIFF
--- a/apps/infra/external-secrets/Chart.lock
+++ b/apps/infra/external-secrets/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: external-secrets
+  repository: https://charts.external-secrets.io
+  version: 2.6.0
+digest: sha256:18576e23abafb5305e77f03826b4f6d7f7b48adaf18934416511ea7f8d757b26
+generated: "2026-06-07T23:24:35.580027+02:00"

--- a/apps/infra/external-secrets/Chart.yaml
+++ b/apps/infra/external-secrets/Chart.yaml
@@ -1,15 +1,16 @@
 apiVersion: v2
 name: external-secrets
 description: Install the External Secrets Operator using the official chart
-version: 1.3.1
-appVersion: "v0.14.1"
+version: 1.4.0
+appVersion: "v2.6.0"
 type: application
 
 dependencies:
-  # Updated 2026-01-28 from ^0 (0.18.0) to 0.14.1
-  # Note: ESO uses 0.x Helm chart versions even for stable releases.
-  # v1beta1 API is deprecated and will be removed 2026-05-01.
-  # Migrate ExternalSecret manifests to use external-secrets.io/v1 API.
+  # Upgraded 2026-06-07 from 0.14.1 to 2.6.0.
+  # ESO v2.x moved Helm chart versioning to match app version (2.x).
+  # The v1beta1 API was removed in v2.x; all CRs must use external-secrets.io/v1.
+  # CRDs are managed by Terraform (platform-crds module) — upgrade CRDs BEFORE
+  # rolling the chart; see README.md staged upgrade procedure.
   - name: external-secrets
-    version: "0.14.1"
+    version: "2.6.0"
     repository: https://charts.external-secrets.io

--- a/apps/infra/external-secrets/README.md
+++ b/apps/infra/external-secrets/README.md
@@ -1,10 +1,104 @@
 # External Secrets Operator
 
 This chart installs the [External Secrets Operator](https://github.com/external-secrets/external-secrets)
-using the official Helm chart from the project's `deploy` directory.
+(ESO) using the official Helm chart from `https://charts.external-secrets.io`.
 
-The `Chart.yaml` declares a dependency on the upstream chart so ArgoCD can
-pull it automatically. The provided `values.yaml` enables CRD installation.
+The `Chart.yaml` declares a dependency on the upstream chart so ArgoCD can pull it
+automatically. `values.yaml` disables in-chart CRD installation because CRDs are
+managed by the Terraform `platform-crds` module.
 
-This application will be discovered by the ApplicationSet and deployed into
-each cluster as an infrastructure component.
+This application is discovered by the ApplicationSet and deployed into each cluster
+as an infrastructure component.
+
+---
+
+## Current version
+
+| Field         | Value         |
+|---------------|---------------|
+| Helm chart    | `2.6.0`       |
+| App version   | `v2.6.0`      |
+| API version   | `external-secrets.io/v1` |
+
+ESO v2.x graduated the `ExternalSecret`, `ClusterExternalSecret`, `SecretStore`,
+`ClusterSecretStore`, `PushSecret`, and Generator CRDs from `v1beta1` to `v1`.
+The `v1beta1` served version was removed in v2.x. All manifests in this repo must
+use `external-secrets.io/v1`.
+
+---
+
+## Staged upgrade procedure (CRD-first)
+
+Because CRDs are managed out-of-band (Terraform) and ArgoCD syncs the Helm chart
+separately, the upgrade must follow a strict order to avoid a window where the
+controller expects `v1` but only `v1beta1` is registered (or vice-versa).
+
+### Step 1 — Apply upgraded CRDs via Terraform
+
+```bash
+# In the platform-crds Terragrunt unit
+terragrunt plan   # confirm CRD changes
+terragrunt apply  # installs external-secrets.io/v1 alongside v1beta1
+```
+
+After this step the API server serves both `v1beta1` (deprecated, still stored) and
+`v1` (new storage version). Existing objects are not migrated yet.
+
+### Step 2 — Migrate all CR manifests from v1beta1 to v1
+
+Update every `ExternalSecret`, `ClusterExternalSecret`, `SecretStore`,
+`ClusterSecretStore`, `PushSecret`, and Generator manifest in the repo:
+
+```diff
+-apiVersion: external-secrets.io/v1beta1
++apiVersion: external-secrets.io/v1
+```
+
+No field-level changes are needed — the v1 schema is backwards-compatible with
+v1beta1 for all core fields. Commit and push the manifest changes.
+
+### Step 3 — Trigger a CRD storage migration
+
+After the CRD apply in Step 1, Kubernetes still stores objects in `v1beta1`
+internally. Run the storage migration job or wait for the operator's built-in
+migration (ESO v2 handles this automatically on first startup with the
+`--storage-version` flag enabled by default).
+
+### Step 4 — Bump this chart and sync ArgoCD
+
+Merge this PR. ArgoCD will sync the new Helm chart version (`2.6.0`). The operator
+restarts and begins serving all objects through the `v1` storage version.
+
+### Step 5 — Remove the v1beta1 CRD served version (Terraform)
+
+Once all clusters are running v2.x and no object is stored as `v1beta1`, remove the
+`v1beta1` served version from the CRD definitions in the `platform-crds` Terraform
+module and apply again.
+
+---
+
+## Rollback procedure
+
+If the v2.x upgrade fails after Step 4:
+
+1. **Revert ArgoCD sync** — set `targetRevision` back to the previous chart tag in
+   the ApplicationSet, or use `argocd app rollback external-secrets <history-id>`.
+2. **Do not downgrade CRDs** — removing the `v1` served version while objects are
+   stored as `v1` will make them unreadable. Keep both `v1` and `v1beta1` served
+   versions in the CRD until the rollback window has passed.
+3. **Check controller logs** for admission-webhook errors before re-applying traffic:
+   ```bash
+   kubectl logs -n external-secrets -l app.kubernetes.io/name=external-secrets --tail=100
+   ```
+4. After a successful rollback, re-plan the migration and address the root cause
+   before retrying.
+
+---
+
+## Auth
+
+The ESO controller uses EKS Pod Identity (ADR-0018). An
+`aws_eks_pod_identity_association` in `catalog/units/pod-identity-eso` binds the
+controller `ServiceAccount` to an IAM role. The `ServiceAccount` must not carry an
+`eks.amazonaws.com/role-arn` IRSA annotation alongside a Pod Identity association
+(precedence is undocumented by AWS; ADR-0018 forbids the combination).


### PR DESCRIPTION
## Summary

- Upgrades External Secrets Operator Helm chart dependency from `0.14.1` (appVersion `v0.14.1`) to `2.6.0` (appVersion `v2.6.0`) — the current stable v2.x release
- Adds `Chart.lock` (digest `sha256:18576e23abafb5305e77f03826b4f6d7f7b48adaf18934416511ea7f8d757b26`) generated by `helm dependency update`
- Updates README with staged upgrade procedure (CRD-first via Terraform, v1beta1 removal step, 4-step rollback), preserving existing auth section (ADR-0018 / EKS Pod Identity)

## ESO v2.x breaking change

ESO v2.x graduated CRD APIs from `external-secrets.io/v1beta1` to `external-secrets.io/v1` and removed the `v1beta1` served version. All in-cluster ExternalSecret, ClusterSecretStore, SecretStore, ClusterExternalSecret, PushSecret, and Generator manifests must use `apiVersion: external-secrets.io/v1`. See README.md Step 2 for the migration diff.

CRDs are managed by the Terraform `platform-crds` module (not this chart; `installCRDs: false` in values.yaml). The staged upgrade in README.md prescribes: apply CRDs first, migrate CR manifests, then sync this chart.

## Test plan

- [x] `helm lint` — 0 failures (INFO only: icon recommended, no templates dir)
- [x] `helm template` — renders cleanly with `helm.sh/chart: external-secrets-2.6.0`
- [x] `python3 yaml.safe_load_all` — Chart.yaml and values.yaml parse without error
- [x] No functional `v1beta1` apiVersion in any manifest under `apps/infra/external-secrets/` (prose-only references in README/comments)
- [x] Chart.lock digest pinned to `2.6.0`
- [ ] Integration: apply CRD upgrade in non-prod cluster before merging to validate Step 1 of the staged procedure

Refs #252