### PR TITLE
fix(ingress): gateways namespace + BackendTLSPolicy CA (W9)

### DIFF
--- a/apps/infra/gateways/README.md
+++ b/apps/infra/gateways/README.md
@@ -21,7 +21,7 @@ ingress** for platform services.
 | `grafana-backend-ca` | `Certificate` | Self-signed CA cert for the Grafana backend TLS chain |
 | `grafana-backend-ca-issuer` | `ClusterIssuer` | CA-type issuer signing backend serving certs |
 | `grafana-backend-serving` | `Certificate` | TLS serving cert for the Grafana backend pod |
-| `grafana-backend-ca-cm` | `ConfigMap` | CA cert bundle used by BackendTLSPolicy for peer validation |
+| `grafana-backend-ca-cm` | `ConfigMap` | CA cert bundle used by BackendTLSPolicy for peer validation (populated by cert-manager cainjector) |
 | `grafana` | `BackendTLSPolicy` | Encrypts the gateway->Grafana backend hop (refs #252) |
 
 Both Gateways use `gatewayClassName: cilium` (from
@@ -53,21 +53,63 @@ Grafana backend (ADR-0009 follow-on, refs #252):
    ClusterIssuer and stored in `grafana-backend-ca-secret`.
 2. A CA-type `ClusterIssuer` (`grafana-backend-ca-issuer`) signs the Grafana
    serving cert (`grafana-backend-serving-secret`).
-3. The CA cert is projected into `grafana-backend-ca-cm` ConfigMaps in both
-   the `gateways` and `monitoring` namespaces (BackendTLSPolicy requires the
-   ConfigMap in the same namespace as the targetRef Service).
-4. `BackendTLSPolicy/grafana` (namespace: `monitoring`) targets the
+3. Two `grafana-backend-ca-cm` ConfigMaps are created (one in `gateways`, one
+   in `observability`). Both carry the annotation:
+
+   ```
+   cert-manager.io/inject-ca-from: gateways/grafana-backend-ca
+   ```
+
+   cert-manager's **cainjector** watches for this annotation and automatically
+   injects `ca.crt` from the named Certificate's CA bundle into each ConfigMap
+   as soon as the Certificate is issued. Both ConfigMaps stay in sync on
+   CA renewal -- no manual bootstrap or ESO sync job is required.
+   Prerequisite: `apps/infra/cert-manager` must have `cainjector.enabled: true`
+   (this is the default; confirmed in `apps/infra/cert-manager/values.yaml`).
+
+4. `BackendTLSPolicy/grafana` (namespace: `observability`) targets the
    `kube-prometheus-stack-grafana` Service, instructs Cilium to use SNI
    `grafana.platform.internal`, and validates the backend cert against the CA.
 
-**Bootstrap required**: after cert-manager issues `grafana-backend-ca`, copy
-`ca.crt` from `grafana-backend-ca-secret` into both `grafana-backend-ca-cm`
-ConfigMaps (or use an ESO ExternalSecret -- see the inline comment in
-`templates/backendtlspolicy-grafana.yaml`).
+### Grafana HTTPS flip (follow-up in apps/infra/observability)
 
-**Grafana config required**: the Grafana Deployment must be switched to HTTPS
-(mount `grafana-backend-serving-secret` and set `grafana.ini` `[server]
-protocol=https`). Wire this in `apps/infra/observability`.
+The BackendTLSPolicy is wired and the CA ConfigMaps are populated, but Grafana
+still serves plaintext HTTP/80. To complete the fully encrypted backend hop:
+
+1. In `apps/infra/observability/prometheus-stack/values.yaml`, configure the
+   Grafana subchart to mount `grafana-backend-serving-secret` and enable HTTPS:
+
+   ```yaml
+   grafana:
+     extraSecretMounts:
+       - name: grafana-backend-tls
+         secretName: grafana-backend-serving-secret
+         mountPath: /etc/grafana/tls
+         readOnly: true
+     grafana.ini:
+       server:
+         protocol: https
+         cert_file: /etc/grafana/tls/tls.crt
+         cert_key: /etc/grafana/tls/tls.key
+   ```
+
+2. In this chart's `values.yaml`, change the Grafana HTTPRoute backend port from
+   `80` to `443` (`httpRoutes[grafana].backend.port: 443`).
+3. Add `sectionName: https` to the BackendTLSPolicy `targetRefs[0]` in
+   `templates/backendtlspolicy-grafana.yaml` to pin the policy to the HTTPS port.
+
+This is a follow-up change scoped to `apps/infra/observability`; the gateway
+and BackendTLSPolicy resources in this chart do not need structural modification.
+
+## HTTPRoute namespace
+
+The Grafana HTTPRoute backend targets `kube-prometheus-stack-grafana` in the
+`observability` namespace (migrated from `monitoring` per ADR-0026 / PR #255).
+If you see `503` responses from Grafana, verify the Service namespace:
+
+```bash
+kubectl get svc kube-prometheus-stack-grafana -n observability
+```
 
 ## Adding a platform UI
 
@@ -117,8 +159,10 @@ kubectl get gateway -n gateways
 kubectl get certificate gw-external-tls -n gateways
 kubectl get httproute -A
 # BackendTLSPolicy (v1.4.0+ Standard channel):
-kubectl get backendtlspolicy -n monitoring
+kubectl get backendtlspolicy -n observability
 kubectl get certificate grafana-backend-ca -n gateways
-kubectl get certificate grafana-backend-serving -n monitoring
-kubectl get configmap grafana-backend-ca-cm -n monitoring
+kubectl get certificate grafana-backend-serving -n observability
+kubectl get configmap grafana-backend-ca-cm -n observability
+# Confirm cainjector populated ca.crt (should not be empty):
+kubectl get configmap grafana-backend-ca-cm -n observability -o jsonpath='{.data.ca\.crt}' | head -1
 ```

--- a/apps/infra/gateways/templates/backendtlspolicy-grafana.yaml
+++ b/apps/infra/gateways/templates/backendtlspolicy-grafana.yaml
@@ -28,11 +28,13 @@
 #
 # 4. grafana-backend-ca-cm ConfigMap (wave 3)
 #    BackendTLSPolicy spec.validation.caCertificateRefs requires a ConfigMap
-#    (group: "", kind: ConfigMap) containing the key ca.crt. This resource
-#    is populated by an ExternalSecret or a manual copy of ca.crt from the CA
-#    Secret. In this mock platform the ca.crt value below is a placeholder;
-#    in production use an ESO ExternalSecret (cluster-secret-store) to sync
-#    grafana-backend-ca-secret.ca.crt into this ConfigMap automatically.
+#    (group: "", kind: ConfigMap) containing the key ca.crt. The ConfigMap is
+#    bootstrapped empty and populated automatically by cert-manager's cainjector
+#    via the annotation `cert-manager.io/inject-ca-from: gateways/grafana-backend-ca`
+#    (the <namespace>/<Certificate-name> reference). cainjector watches for this
+#    annotation and injects ca.crt from the named Certificate's CA bundle as soon
+#    as the Certificate is issued -- no manual copy or ESO sync required.
+#    Prerequisite: apps/infra/cert-manager with cainjector.enabled=true (default).
 #
 # 5. grafana BackendTLSPolicy (wave 4)
 #    Targets the kube-prometheus-stack-grafana Service in the observability
@@ -141,15 +143,14 @@ spec:
 # (group: "", kind: ConfigMap) with key `ca.crt`. The ConfigMap must be in
 # the same namespace as the targetRef Service (observability -- see step 4b).
 # This copy in the `gateways` namespace is kept for operational convenience
-# (kubectl inspection, ESO sync source).
+# (kubectl inspection, cross-namespace CA bundle reference).
 #
-# Bootstrap procedure (run once after cert-manager issues the CA):
-#   kubectl get secret grafana-backend-ca-secret -n gateways \
-#     -o jsonpath='{.data.ca\.crt}' | base64 -d | \
-#   kubectl create configmap grafana-backend-ca-cm \
-#     --from-file=ca.crt=/dev/stdin -n gateways --dry-run=client -o yaml | \
-#   kubectl apply -f -
-# In production: use an ESO ExternalSecret targeting cluster-secret-store.
+# CA injection: cert-manager's cainjector populates `ca.crt` automatically once
+# grafana-backend-ca is issued. The annotation below instructs cainjector to watch
+# the Certificate `grafana-backend-ca` in the `gateways` namespace and inject its
+# CA bundle into this ConfigMap. No manual bootstrap or ESO sync is needed.
+# Both ConfigMaps (4a + 4b) stay in sync automatically on CA renewal.
+# Prerequisite: apps/infra/cert-manager cainjector.enabled=true (see values.yaml).
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -157,12 +158,10 @@ metadata:
   namespace: {{ .Values.namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "3"
-    # PLACEHOLDER -- sync actual ca.crt from Secret grafana-backend-ca-secret
-    # before BackendTLSPolicy can enforce TLS validation.
-data:
-  # Placeholder -- replace with the real CA cert after cert-manager issues
-  # the grafana-backend-ca Certificate (see bootstrap comment above).
-  ca.crt: ""
+    # cert-manager cainjector: inject ca.crt from the named Certificate as soon
+    # as it is issued. Format: <namespace>/<Certificate-name>.
+    cert-manager.io/inject-ca-from: {{ .Values.namespace }}/grafana-backend-ca
+data: {}
 
 ---
 # Step 4b -- CA ConfigMap in observability namespace (required by BackendTLSPolicy)
@@ -172,8 +171,9 @@ data:
 # (migrated from `monitoring` per ADR-0026 / PR #255), so this ConfigMap must
 # also be in `observability`.
 #
-# In production: use a Kyverno ClusterPolicy or ESO ExternalSecret to keep
-# both ConfigMaps (gateways + observability) in sync with the CA Secret.
+# CA injection: same cainjector mechanism as step 4a. cainjector injects ca.crt
+# from `gateways/grafana-backend-ca` into this ConfigMap automatically.
+# Both ConfigMaps receive the same CA bundle and stay in sync on cert renewal.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -181,11 +181,10 @@ metadata:
   namespace: observability
   annotations:
     argocd.argoproj.io/sync-wave: "3"
-    # PLACEHOLDER -- mirrors grafana-backend-ca-cm in the gateways namespace.
-    # Sync actual ca.crt from Secret grafana-backend-ca-secret.ca.crt.
-data:
-  # Placeholder -- replace with the real CA cert (same value as step 4a).
-  ca.crt: ""
+    # cert-manager cainjector: inject ca.crt from Certificate grafana-backend-ca
+    # in the gateways namespace. Kept in sync automatically on CA renewal.
+    cert-manager.io/inject-ca-from: {{ .Values.namespace }}/grafana-backend-ca
+data: {}
 
 ---
 # Step 5 -- BackendTLSPolicy
@@ -223,5 +222,5 @@ spec:
       - group: ""
         kind: ConfigMap
         # ConfigMap must be in the same namespace as the targetRef Service.
-        # Populated from grafana-backend-ca-secret.ca.crt (step 4b above).
+        # Populated automatically by cert-manager cainjector (step 4b above).
         name: grafana-backend-ca-cm

--- a/apps/infra/gateways/values.yaml
+++ b/apps/infra/gateways/values.yaml
@@ -42,13 +42,18 @@ internal:
 # Hostnames use the placeholder *.platform.internal domain (matches the
 # gw-external TLS cert); swap for the real domain once DNS is wired.
 httpRoutes:
-  # Grafana — modeled by apps/infra/observability/prometheus-stack
-  # (kube-prometheus-stack grafana subchart, Service on port 80 in `monitoring`).
+  # Grafana — kube-prometheus-stack grafana subchart (apps/infra/observability/
+  # prometheus-stack). Service `kube-prometheus-stack-grafana` lives in the
+  # `observability` namespace (migrated from `monitoring` per ADR-0026 / PR #255).
+  # Port 80 routes plaintext HTTP to the Gateway listener; BackendTLSPolicy
+  # (templates/backendtlspolicy-grafana.yaml) encrypts the gateway->backend hop
+  # independently of the HTTPRoute port. Follow-up: once Grafana is switched to
+  # HTTPS in apps/infra/observability, change port here to 443 (see README.md).
   - name: grafana
     hostname: grafana.platform.internal
     backend:
       name: kube-prometheus-stack-grafana
-      namespace: monitoring
+      namespace: observability
       port: 80
   # ArgoCD UI — the GitOps control plane Service (argocd-server) in `argocd`.
   - name: argocd


### PR DESCRIPTION
## Summary

- **HTTPRoute-grafana namespace**: `values.yaml` backend namespace corrected `monitoring` → `observability` (`kube-prometheus-stack-grafana` Service lives in `observability` per ADR-0026 / PR #255)
- **BackendTLSPolicy CA ConfigMap**: replaced empty `ca.crt: ""` placeholder in both `grafana-backend-ca-cm` ConfigMaps (namespaces `gateways` + `observability`) with cert-manager cainjector annotation `cert-manager.io/inject-ca-from: gateways/grafana-backend-ca`; cainjector populates `ca.crt` automatically on Certificate issuance and keeps both copies in sync on renewal — no manual bootstrap or ESO sync job required (prerequisite: `cainjector.enabled: true`, confirmed in `apps/infra/cert-manager/values.yaml`)
- **README**: documents cainjector mechanism, adds Grafana HTTPS flip follow-up steps scoped to `apps/infra/observability`, fixes verify commands to reference `observability` namespace

## Test plan

- [x] `helm lint apps/infra/gateways/` — 0 failures
- [x] `helm template` — 11 documents rendered, all valid
- [x] `python3 yaml.safe_load_all` — 11 documents parsed without error
- [x] `grep monitoring` in rendered output — zero hits (all occurrences are comments only, noting the ADR-0026 migration provenance)
- [ ] Cluster smoke: `kubectl get configmap grafana-backend-ca-cm -n observability -o jsonpath='{.data.ca\.crt}'` must be non-empty after ArgoCD sync

Refs #252