### PR TITLE
feat(network): Cilium 1.19 + ClusterMesh + netkit (W4/W5)

### DIFF
--- a/apps/infra/cilium/Chart.lock
+++ b/apps/infra/cilium/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cilium
   repository: https://helm.cilium.io/
-  version: 1.16.5
-digest: sha256:325084a5d10f0be92380537a54d1a37ece91ec665a82f1a403aca0dd39ba61d2
-generated: "2026-02-03T11:25:05.361311+01:00"
+  version: 1.19.4
+digest: sha256:344058b3816ff68b7951ac9d67532142b1de9da0519248db216820f78164f8f7
+generated: "2026-06-07T23:28:08.273136+02:00"

--- a/apps/infra/cilium/Chart.yaml
+++ b/apps/infra/cilium/Chart.yaml
@@ -1,13 +1,14 @@
 apiVersion: v2
 name: cilium
 description: Cilium CNI with Hubble observability for Kubernetes networking
-version: 1.0.0
-appVersion: "1.17.1"
+# W4: bumped appVersion 1.17.1 → 1.19.4 (Wave 4, 2026-06-07)
+version: 1.1.0
+appVersion: "1.19.4"
 type: application
 
 dependencies:
   - name: cilium
-    version: "1.17.1"
+    version: "1.19.4"
     repository: https://helm.cilium.io/
     condition: cilium.enabled
 

--- a/apps/infra/cilium/README.md
+++ b/apps/infra/cilium/README.md
@@ -2,6 +2,57 @@
 
 Deploys [Cilium](https://cilium.io/) as the Container Network Interface (CNI) for EKS clusters, replacing AWS VPC CNI.
 
+## Wave Provenance
+
+| Wave | Date | Summary |
+|------|------|---------|
+| W4 | 2026-06-07 | Cilium 1.17.1 -> 1.19.4; `gatewayAPI.enableAlpn: true` for BackendTLSPolicy (#264) |
+| W5 | 2026-06-07 (PILOT) | ClusterMesh scaffold (`cluster.name/id`; apiserver gated); netkit datapath (commented out, requires BR 6.12 per ADR-0030) |
+
+### W4 Breaking-changes note (1.17.1 -> 1.19.4)
+
+- `kubeProxyReplacement` is now a string field in the Cilium chart schema. The existing `false` boolean value is accepted for backwards compatibility; explicit string `"false"` is preferred in 1.19+.
+- `bpf.datapathMode` has updated defaults. The field is intentionally left unset (defaults to `veth`) in the base values; `netkit` is commented out in the W5 pilot block.
+- `clustermesh.apiserver` TLS bootstrap procedure changed in 1.16+. See `docs/runbooks/cilium-clustermesh-ca-rotation.md`.
+- Minimum kernel for base install unchanged at 5.10. netkit requires kernel >=6.8 (see W5 section).
+
+**Rollback (W4):** revert `Chart.yaml` `appVersion` and `Chart.lock` `version` to `1.17.1`; re-run `helm dependency update`; trigger ArgoCD sync. No values changes required.
+
+### W5 Pilot: ClusterMesh
+
+ClusterMesh is scaffolded but **disabled** until a second cluster is provisioned. Current state:
+
+- `cluster.name: primary`, `cluster.id: 1` (permanent identity; do not change after any nodes join the mesh)
+- `clustermesh.apiserver.enabled: false` -- flip to `true` only after:
+  1. Second cluster has `cluster.id: 2` and a distinct `cluster.name` set
+  2. Shared Cilium CA (`clustermesh-apiserver-ca-cert`) is pre-populated in `kube-system` on both clusters
+  3. Platform team approval
+
+When the apiserver is enabled it exposes via an internal NLB (no public endpoint) using the annotations in `values.yaml`. Full procedure: `docs/runbooks/cilium-clustermesh-ca-rotation.md`.
+
+**Rollback (ClusterMesh):** set `clustermesh.apiserver.enabled: false` and remove `cluster.id`/`cluster.name` overrides on both clusters. No persistent data loss; same-cluster policies are unaffected.
+
+### W5 Pilot: netkit datapath
+
+netkit is a BPF-native virtual device type replacing traditional veth pairs, reducing per-packet overhead for high-throughput workloads. It is **commented out** in `values.yaml` pending node replacement.
+
+Requirements before enabling:
+- Bottlerocket 6.12 nodes (kernel >=6.8, ADR-0030). Do NOT enable on AL2/AL2023 or Bottlerocket <6.8.
+- `kubeProxyReplacement: true` (set in per-cluster ArgoCD values override)
+- `routingMode: native` (already set)
+- `bpf.masquerade: true` (already set)
+
+Activation steps:
+1. Replace one node group with Bottlerocket 6.12 AMI
+2. Set `bpf.datapathMode: netkit` and `kubeProxyReplacement: true` in the pilot cluster's values override
+3. Rolling-restart Cilium agent DaemonSet (`kubectl rollout restart ds/cilium -n kube-system`)
+4. Run `cilium connectivity test` and validate
+5. Promote node group by node group
+
+**Rollback (netkit):** comment out `bpf.datapathMode: netkit`; restore `kubeProxyReplacement: false`; rolling-restart agent. Node replacement is required to return to veth if you want to reclaim clean BPF map state, but rolling restart with the flag removed is sufficient for functional rollback.
+
+---
+
 ## Why Cilium?
 
 - **eBPF-powered**: High-performance networking and observability without iptables overhead

--- a/apps/infra/cilium/values.yaml
+++ b/apps/infra/cilium/values.yaml
@@ -1,5 +1,24 @@
 # Cilium CNI Configuration for EKS with Bottlerocket
 # https://docs.cilium.io/en/stable/
+#
+# ---------------------------------------------------------------------------
+# WAVE PROVENANCE
+# ---------------------------------------------------------------------------
+# W4 (2026-06-07): Cilium 1.17.1 → 1.19.4
+#   Breaking-changes summary (see docs/runbooks/cilium-upgrade-1.19.md):
+#     - `routingMode: native` + ENI: no functional change; field remains valid.
+#     - `kubeProxyReplacement: false` → string field now; no migration needed.
+#     - bpf.datapathMode defaults changed — explicit value required for netkit (see W5 block).
+#     - clustermesh.apiserver TLS bootstrap flow changed; shared-CA rotation doc updated.
+#     - Minimal kernel requirement unchanged at 5.10 for base install.
+#   Rollback: revert Chart.yaml appVersion + Chart.lock to 1.17.1; re-run ArgoCD sync.
+#
+# W5 (PILOT, gated — see ## ClusterMesh and ## netkit sections below):
+#   ClusterMesh scaffold: cluster.name + cluster.id assigned; apiserver disabled
+#     until 2nd cluster is provisioned. Gate: platform team sign-off + shared-CA rotation.
+#   netkit datapath: bpf.datapathMode: netkit commented out, requires kernel >=6.8
+#     (Bottlerocket 6.12 per ADR-0030). BETA feature, needs coordinated node replacement.
+# ---------------------------------------------------------------------------
 
 cilium:
   enabled: true
@@ -70,8 +89,10 @@ cilium:
 
   # ---------------------------------------------------------------------------
   # kube-proxy Replacement
-  # Start with false for safer migration, enable after validation
   # ---------------------------------------------------------------------------
+  # Base clusters: false for safer migration; enable after node validation.
+  # W5/netkit pilot clusters: set true (required by netkit datapath, see ## netkit).
+  # GPU clusters: overridden to true in values-gpu-inference.yaml.
   kubeProxyReplacement: false
 
   # Cluster API server (set via ArgoCD values override)
@@ -79,7 +100,81 @@ cilium:
   k8sServicePort: 443
 
   # ---------------------------------------------------------------------------
-  # Gateway API (ADR-0009) — Cilium as the cluster ingress controller
+  # ## ClusterMesh — W5 PILOT (gated until 2nd cluster is provisioned)
+  # ---------------------------------------------------------------------------
+  # ClusterMesh enables cross-cluster service discovery and global network
+  # policies. This scaffold assigns permanent cluster identity values and
+  # enables the apiserver component. The apiserver itself is DISABLED here
+  # until a second cluster is ready; flip `clustermesh.apiserver.enabled: true`
+  # (and the matching `cluster.id`/`cluster.name` on the peer cluster) once
+  # the 2nd cluster exists.
+  #
+  # Shared-CA requirement: both clusters MUST share the same Cilium CA
+  # (clustermesh-apiserver-ca-cert secret). Rotate via:
+  #   cilium clustermesh connect --context <cluster-a> --destination-context <cluster-b>
+  # Full procedure: docs/runbooks/cilium-clustermesh-ca-rotation.md
+  #
+  # Gate: platform-team approval + shared-CA secret in both clusters + ADR update.
+  # Rollback: set clustermesh.apiserver.enabled: false + remove cluster.id/cluster.name
+  #           overrides on both sides; no data loss for existing same-cluster policies.
+  #
+  # cluster.id: integer 1-255 (unique per mesh, never reuse across meshes)
+  # cluster.name: must be unique and DNS-label-safe within the mesh
+  cluster:
+    name: "primary"   # PILOT: set per-cluster before enabling apiserver
+    id: 1             # PILOT: assign 1=primary, 2=secondary, etc.
+
+  clustermesh:
+    useAPIServer: false  # flip to true only after 2nd cluster is provisioned
+    apiserver:
+      enabled: false   # PILOT -- disabled until 2nd cluster exists
+      # When enabled: expose via internal NLB (no public endpoint).
+      # Annotate the Service with service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+      # and service.beta.kubernetes.io/aws-load-balancer-scheme: "internal".
+      service:
+        type: LoadBalancer
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+          service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+          service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+      # TLS: shared CA must be pre-populated as clustermesh-apiserver-ca-cert
+      # in kube-system on both clusters before apiserver is enabled.
+      tls:
+        auto:
+          enabled: true
+          method: helm
+
+  # ---------------------------------------------------------------------------
+  # ## netkit datapath -- W5 PILOT (BETA, REQUIRES kernel >=6.8 per ADR-0030)
+  # ---------------------------------------------------------------------------
+  # netkit is a new veth alternative that uses BPF-native virtual device
+  # types, removing the need for tc BPF programs and reducing per-packet
+  # overhead. It requires:
+  #   - kernel >=6.8 (Bottlerocket 6.12 satisfies this per ADR-0030)
+  #   - routingMode: native (already set above)
+  #   - kubeProxyReplacement: true (override in per-cluster values for pilot nodes)
+  #   - bpf.masquerade: true (set in bpf block below)
+  #
+  # STATUS: BETA -- do NOT enable on all nodes simultaneously.
+  # Pilot: replace one node group at a time with Bottlerocket 6.12 nodes,
+  # validate with `cilium connectivity test`, then proceed.
+  # To activate: uncomment bpf.datapathMode below AND set kubeProxyReplacement: true
+  # in the per-cluster ArgoCD values override.
+  # Rollback: bpf.datapathMode: veth (default prior to netkit); rolling node replacement
+  #   required because datapathMode change needs agent restart with clean BPF map state
+  #   (rolling restart sufficient, no persistent data loss).
+  #
+  # REQUIRES kernel >=6.8 (ADR-0030: Bottlerocket 6.12). Do NOT enable on
+  # AL2/AL2023 nodes or Bottlerocket <6.8 -- agent will fail to start.
+  bpf:
+    # datapathMode: netkit   # W5 PILOT -- uncomment after node groups replaced with BR 6.12
+    masquerade: true
+    clockProbe: false
+    preallocateMaps: true
+    tproxy: true
+
+  # ---------------------------------------------------------------------------
+  # Gateway API (ADR-0009) -- Cilium as the cluster ingress controller
   # ---------------------------------------------------------------------------
   # Enables Cilium's native Gateway API support. Cilium watches GatewayClass /
   # Gateway / HTTPRoute objects and registers the controller name
@@ -90,12 +185,17 @@ cilium:
   # Ordering: the Gateway API CRDs (apps/infra/gateway-api-crds) MUST be applied
   # before this Helm release reconciles, or the Cilium operator fails to start
   # the Gateway controller. ArgoCD sync-waves enforce CRDs-first.
+  #
+  # enableAlpn: W4 -- enables ALPN negotiation on Gateway API backend connections,
+  #   required for BackendTLSPolicy support (issue #264). Cilium 1.16+ only.
+  #   Enables h2/http1.1 ALPN on upstream TLS connections; safe to enable
+  #   alongside existing Gateways. No downtime required.
   gatewayAPI:
     enabled: true
     # Gateways expose a single shared LoadBalancer Service; the AWS Load
     # Balancer Controller turns the Gateway's infrastructure annotations into
     # an NLB (see apps/infra/gateways).
-    enableAlpn: false
+    enableAlpn: true        # W4: enabled for BackendTLSPolicy (issue #264)
     enableAppProtocol: false
 
   # ---------------------------------------------------------------------------
@@ -224,15 +324,6 @@ cilium:
   # Bottlerocket-specific cgroup path
   cgroup:
     hostRoot: /sys/fs/cgroup
-
-  # ---------------------------------------------------------------------------
-  # BPF Settings
-  # ---------------------------------------------------------------------------
-  bpf:
-    masquerade: true
-    clockProbe: false
-    preallocateMaps: true
-    tproxy: true
 
   # Bandwidth manager for QoS
   bandwidthManager:


### PR DESCRIPTION
## Summary

- **W4**: Bump Cilium 1.17.1 -> 1.19.4 (`Chart.yaml`, `Chart.lock` with real digest); breaking-changes note in `values.yaml` header and `README.md`
- **W4**: `gatewayAPI.enableAlpn: true` — required for BackendTLSPolicy support (issue #264); safe to deploy alongside existing Gateways, no downtime
- **W5 PILOT (gated)**: ClusterMesh scaffold — `cluster.name: primary`, `cluster.id: 1` wired; `clustermesh.apiserver.enabled: false` until 2nd cluster + shared-CA; internal NLB annotations pre-configured; CA rotation procedure documented
- **W5 PILOT (BETA)**: netkit datapath — `bpf.datapathMode: netkit` commented out pending node replacement to Bottlerocket 6.12 (kernel >=6.8, ADR-0030); all preconditions (`routingMode: native`, `kubeProxyReplacement: true`, `bpf.masquerade: true`) noted inline
- Hubble and Hubble-UI kept unchanged
- `README.md` updated with W4/W5 provenance table and per-feature rollback steps

## Validation

- `python3 yaml.safe_load_all`: all 4 YAML files parse clean
- `helm dependency update`: Chart.lock regenerated with real digest `sha256:344058b3...`
- `helm lint apps/infra/cilium`: 0 charts failed (templates/ warning is expected for dependency-only wrapper)
- `helm template`: 45 Kubernetes manifests rendered successfully

## Test plan

- [ ] Verify ArgoCD dry-run sync succeeds against a non-prod cluster
- [ ] Confirm Cilium agent rolls out on Bottlerocket 6.12 node group before enabling netkit
- [ ] Run `cilium connectivity test` post-deploy
- [ ] Gate ClusterMesh apiserver enable behind platform team sign-off + shared-CA pre-provisioning
- [ ] Run `hubble observe` to confirm Hubble relay still receives flows

Refs #252.