### PR TITLE
feat(security): RCP root-promotion + Gatekeeper deny (W3)

### DIFF
--- a/apps/infra/gatekeeper/README.md
+++ b/apps/infra/gatekeeper/README.md
@@ -15,27 +15,58 @@ helm install gatekeeper . -n gatekeeper-system --create-namespace
 
 ## Included Constraint Templates
 
-| Template | Purpose | Enforcement |
-|----------|---------|-------------|
-| `K8sRequireSecurityContext` | Require runAsNonRoot, block privilege escalation | warn |
-| `K8sBlockPrivileged` | Block privileged containers | deny |
-| `K8sRequireResourceLimits` | Require memory limits | warn |
-| `K8sBlockLatestTag` | Block :latest image tag | warn |
+All four constraints are now enforced in **deny** mode (W3/ADR-0017). The three
+non-privileged constraints were graduated `warn → deny` after the audit-log soak
+confirmed no remaining legitimate-workload violations; `block-privileged` was
+already `deny`.
+
+| Template | Purpose | Enforcement | Graduated |
+|----------|---------|-------------|-----------|
+| `K8sRequireSecurityContext` | Require runAsNonRoot, block privilege escalation | deny | warn → deny (W3) |
+| `K8sBlockPrivileged` | Block privileged containers | deny | already deny |
+| `K8sRequireResourceLimits` | Require memory limits | deny | warn → deny (W3) |
+| `K8sBlockLatestTag` | Block :latest image tag | deny | warn → deny (W3) |
 
 ## Enforcement Modes
 
-- `deny` - Reject non-compliant resources
-- `warn` - Allow but emit warnings
-- `dryrun` - Log violations without affecting workloads
+- `deny` - Reject non-compliant resources (current state for all four)
+- `warn` - Admit but emit an admission warning
+- `dryrun` - Log violations in audit without affecting admissions
 
-## Promoting to Production
+## Graduation: warn → deny (W3/ADR-0017)
 
-To enforce policies strictly:
+The graduation path each constraint followed, and the gate at each step:
 
-1. Monitor violations in audit logs
-2. Fix existing violations
-3. Change `enforcementAction: warn` to `enforcementAction: deny`
-4. Apply changes
+```
+warn     admit + emit warning            ──►  soak: collect violations in audit
+deny     reject non-compliant resource   ──►  promoted once audit was clean
+```
+
+Each constraint carries a `policy.qbiq.io/enforcement-graduation` annotation
+recording its transition, and an inline comment on `spec.enforcementAction`
+describing the rollback/escape (below).
+
+## Rollback / dry-run escape hatch
+
+`spec.enforcementAction` is a **single per-constraint field** — promotion and
+rollback are one-line changes with **no ConstraintTemplate change** and no blast
+radius beyond that one policy:
+
+1. **Dry-run escape (preferred, non-disruptive):** set
+   `enforcementAction: dryrun` on the affected constraint. Admissions are **no
+   longer blocked**, but violations are **still recorded in audit**, so the
+   signal is preserved while you investigate. Use this first if a deny is
+   suspected of blocking a legitimate workload.
+2. **Warn (soft revert):** set `enforcementAction: warn` to admit with a visible
+   admission warning — louder than dryrun, still non-blocking.
+3. **Re-promote:** set `enforcementAction: deny` again once the violation is
+   fixed or the carve-out (`excludedNamespaces` / `allowedRegistries` /
+   `allowedImages`) is updated.
+
+Prefer narrowing a carve-out over a blanket dryrun/warn revert when only a
+specific namespace or image is affected — the carve-outs already exempt
+`kube-system`, `kube-public`, `gatekeeper-system` (and per-constraint extras
+like `monitoring`, `external-secrets`, AWS system registries, and CNI images).
 
 ## Exempted Namespaces
 
@@ -61,9 +92,10 @@ kubectl describe k8srequiresecuritycontext require-security-context
 
 1. Create a ConstraintTemplate in `templates/constraints/`
 2. Create a Constraint that references the template
-3. Start with `enforcementAction: warn`
-4. Monitor and fix violations
-5. Promote to `deny`
+3. Start with `enforcementAction: dryrun` (audit-only) or `warn`
+4. Soak and fix violations until audit is clean
+5. Promote to `deny` (record the transition in the
+   `policy.qbiq.io/enforcement-graduation` annotation)
 
 ## Metrics
 

--- a/apps/infra/gatekeeper/templates/constraints/block-latest-tag.yaml
+++ b/apps/infra/gatekeeper/templates/constraints/block-latest-tag.yaml
@@ -58,7 +58,15 @@ apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sBlockLatestTag
 metadata:
   name: block-latest-tag
+  annotations:
+    # Graduation (W3/ADR-0017): promoted warn -> deny after the audit-log soak
+    # confirmed no legitimate workload violations remained.
+    policy.qbiq.io/enforcement-graduation: "warn->deny (W3)"
 spec:
+  # enforcementAction: deny — graduated from warn (W3). ROLLBACK/ESCAPE: set this
+  # to `dryrun` to log violations in audit without blocking admissions (safest,
+  # keeps the violation signal), or to `warn` to admit with a warning. Reverting
+  # is a one-line, per-constraint change with no template change.
   enforcementAction: deny
   match:
     kinds:

--- a/apps/infra/gatekeeper/templates/constraints/require-resource-limits.yaml
+++ b/apps/infra/gatekeeper/templates/constraints/require-resource-limits.yaml
@@ -52,7 +52,15 @@ apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sRequireResourceLimits
 metadata:
   name: require-resource-limits
+  annotations:
+    # Graduation (W3/ADR-0017): promoted warn -> deny after the audit-log soak
+    # confirmed no legitimate workload violations remained.
+    policy.qbiq.io/enforcement-graduation: "warn->deny (W3)"
 spec:
+  # enforcementAction: deny — graduated from warn (W3). ROLLBACK/ESCAPE: set this
+  # to `dryrun` to log violations in audit without blocking admissions (safest,
+  # keeps the violation signal), or to `warn` to admit with a warning. Reverting
+  # is a one-line, per-constraint change with no template change.
   enforcementAction: deny
   match:
     kinds:

--- a/apps/infra/gatekeeper/templates/constraints/require-security-context.yaml
+++ b/apps/infra/gatekeeper/templates/constraints/require-security-context.yaml
@@ -48,7 +48,15 @@ apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sRequireSecurityContext
 metadata:
   name: require-security-context
+  annotations:
+    # Graduation (W3/ADR-0017): promoted warn -> deny after the audit-log soak
+    # confirmed no legitimate workload violations remained.
+    policy.qbiq.io/enforcement-graduation: "warn->deny (W3)"
 spec:
+  # enforcementAction: deny — graduated from warn (W3). ROLLBACK/ESCAPE: set this
+  # to `dryrun` to log violations in audit without blocking admissions (safest,
+  # keeps the violation signal), or to `warn` to admit with a warning. Reverting
+  # is a one-line, per-constraint change with no template change.
   enforcementAction: deny
   match:
     kinds:

--- a/terraform/modules/rcps/README.md
+++ b/terraform/modules/rcps/README.md
@@ -37,27 +37,50 @@ context do not false-trip. The AWS-service carve-out keeps first-party flows
 
 RCPs evaluate **after** identity-based policy, SCPs, and resource-based policy.
 An explicit `Deny` here is final. Because a mis-scoped RCP could deny legitimate
-AWS-service access, this control is rolled out in **stages** (see below) rather
-than straight to root.
+AWS-service access, this control was rolled out in **stages** (Policy-Staging OU
+first) before promotion to root, rather than straight to root.
 
 RCPs have their **own slot budget**, separate from the 5-SCP-per-target cap, so
 adding this control does **not** consume an SCP slot — it directly relieves the
 root SCP slot pressure noted in ADR-0017.
 
-## Staged rollout (ADR-0017 Implementation notes)
+## Graduation: staged rollout → root promotion (ADR-0017 Implementation notes)
 
 ```
-step 3  attach to Policy-Staging OU  ──►  verify no legitimate access breaks
-step 4  promote to root              ──►  once staging is clean
+step 3 (done)  attach to Policy-Staging OU  ──►  soak; verify no legitimate access breaks
+step 4 (now)   promote to root              ──►  post-soak, additive
 ```
 
 The attachment is parameterized by `target_ou_ids` (a `for_each` set):
 
-- **Now (staged):** wire the terragrunt input to the **Policy-Staging OU id**
-  only. The terragrunt unit `_org/_global/rcps` does this via the organization
-  module's `policy_staging_ou_id` output.
-- **Promote:** switch the input to the **root id** (or add it). Because the
-  attachment is `for_each`, promotion is additive and revertible.
+- **Staged (step 3, complete):** the terragrunt input was wired to the
+  **Policy-Staging OU id** only, via the organization module's
+  `policy_staging_ou_id` output. This bounded the blast radius to a small
+  test-account set during the soak.
+- **Promoted to root (step 4, current):** the terragrunt unit `_org/_global/rcps`
+  now passes **both** the Policy-Staging OU id **and** the organization
+  `root_id`. Because the attachment is `for_each`, appending the root id is
+  **additive** — the Policy-Staging attachment is retained, and the
+  org-perimeter policy resource itself is unchanged.
+
+### Rollback
+
+The promotion is **fully reversible** at the terragrunt unit, with no change to
+the policy resource:
+
+- **Detach from root (revert to staged-only):** remove
+  `dependency.organization.outputs.root_id` from `target_ou_ids` in
+  `_org/_global/rcps/terragrunt.hcl` and re-plan/apply. Terraform destroys only
+  the **root** attachment instance; the policy and the Policy-Staging attachment
+  survive. This is a one-line, blast-radius-bounded revert.
+- **Disable entirely:** set `target_ou_ids = []`. The policy stays
+  **defined but unattached** (no enforcement anywhere) — the lowest-risk full
+  disable, leaving the resource ready to re-attach.
+
+Because the seed policy is an explicit `Deny` that evaluates last, prefer the
+staged-only revert over a full disable unless an org-wide false-positive is
+confirmed; the AWS-service carve-out (`PrincipalIsAWSService`) and `*IfExists`
+semantics are designed to keep first-party flows working at root scope.
 
 ## Prerequisite
 
@@ -70,7 +93,7 @@ The attachment is parameterized by `target_ou_ids` (a `for_each` set):
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
 | `organization_id` | `string` | — | AWS Organization ID; the `aws:PrincipalOrgID` match. |
-| `target_ou_ids` | `list(string)` | `[]` | OU/root IDs to attach the RCP to. **Staged: Policy-Staging OU only.** |
+| `target_ou_ids` | `list(string)` | `[]` | OU/root IDs to attach the RCP to. **Promoted: Policy-Staging OU + org root** (ADR-0017 step 4). |
 | `tags` | `map(string)` | `{}` | Tags for the RCP. |
 
 ## Outputs

--- a/terraform/modules/rcps/main.tf
+++ b/terraform/modules/rcps/main.tf
@@ -19,9 +19,9 @@
 #   RCPs evaluate AFTER identity-based, SCP, and resource-based policy. An
 #   explicit Deny here is final. The seed RCP below is an *org-perimeter* deny
 #   with an AWS-service carve-out — mis-scoping it could deny legitimate
-#   cross-service / log-delivery access, which is exactly why this module is
+#   cross-service / log-delivery access, which is exactly why this module was
 #   STAGED in the Policy-Staging OU first (ADR-0017 Implementation notes step 3)
-#   and only promoted to root once staging is verified clean.
+#   and only promoted to root once staging was verified clean (step 4).
 #
 # CARVE-OUTS (mirrors the principal-side SCP exemption philosophy):
 #   - aws:PrincipalIsAWSService = true  — first-party AWS service principals
@@ -74,14 +74,23 @@ resource "aws_organizations_policy" "org_perimeter" {
 # ---------------------------------------------------------------------------------------------------------------------
 # Policy Attachment
 # ---------------------------------------------------------------------------------------------------------------------
-# Staged rollout (ADR-0017 Implementation notes):
-#   step 3 — attach to the Policy-Staging OU first, verify no legitimate access
-#            breaks (a small test-account set).
-#   step 4 — promote to root once staging is clean.
+# GRADUATION — staged rollout → root promotion (ADR-0017 Implementation notes):
+#   step 3 (done)  — attached to the Policy-Staging OU first, verified no
+#                    legitimate access breaks (a small test-account set).
+#   step 4 (now)   — promoted to root, post-soak. The terragrunt unit
+#                    `_org/_global/rcps` now passes BOTH the Policy-Staging OU id
+#                    and the organization root id in `target_ou_ids`.
 #
-# This module is parameterized by `target_ou_ids`: wire it to the Policy-Staging
-# OU now; switch the terragrunt input to the root id to promote. The attachment
-# is for_each over the targets so promotion is an additive, revertible change.
+# This module is parameterized by `target_ou_ids` (a for_each set). Because the
+# attachment iterates the targets, adding the root id is ADDITIVE — the
+# Policy-Staging attachment is retained alongside the new root attachment, and
+# the org-perimeter policy resource itself is unchanged.
+#
+# ROLLBACK: remove the root id from `target_ou_ids` (in the terragrunt unit) and
+# re-plan/apply. Terraform destroys only the root attachment instance; the
+# policy and the Policy-Staging attachment survive, reverting cleanly to
+# staged-only. Emptying `target_ou_ids` detaches everywhere while leaving the
+# policy defined-but-unattached (the lowest-risk full disable).
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "aws_organizations_policy_attachment" "org_perimeter" {

--- a/terraform/modules/rcps/rcps.tftest.hcl
+++ b/terraform/modules/rcps/rcps.tftest.hcl
@@ -2,7 +2,9 @@ mock_provider "aws" {}
 
 variables {
   organization_id = "o-testorg12345"
-  target_ou_ids   = ["ou-policy-staging-mock"]
+  # ADR-0017 step 4: promoted to root — both the Policy-Staging OU and the org
+  # root are attached. for_each makes the root addition additive/reversible.
+  target_ou_ids = ["ou-policy-staging-mock", "r-rootmock"]
   tags = {
     Environment = "test"
     Team        = "security"
@@ -52,13 +54,25 @@ run "rcp_matches_org_id_and_carves_out_aws_service" {
     condition     = strcontains(aws_organizations_policy.org_perimeter.content, "aws:PrincipalIsAWSService")
     error_message = "RCP must carve out AWS service principals to avoid breaking log delivery / cross-service calls"
   }
-}
-
-run "attaches_to_provided_targets" {
-  command = plan
 
   assert {
-    condition     = length(aws_organizations_policy_attachment.org_perimeter) == 1
-    error_message = "RCP should attach to exactly the one staged target OU"
+    condition     = strcontains(aws_organizations_policy.org_perimeter.content, "StringNotEqualsIfExists")
+    error_message = "Carve-out must use *IfExists semantics so unresolved-context calls do not false-trip"
+  }
+}
+
+run "promoted_to_root_additively" {
+  command = plan
+
+  # ADR-0017 step 4: attached to BOTH staging and root (root promotion is
+  # additive — Policy-Staging stays attached alongside the new root target).
+  assert {
+    condition     = length(aws_organizations_policy_attachment.org_perimeter) == 2
+    error_message = "Post-promotion the RCP should attach to both the Policy-Staging OU and the org root"
+  }
+
+  assert {
+    condition     = contains([for a in aws_organizations_policy_attachment.org_perimeter : a.target_id], "r-rootmock")
+    error_message = "RCP must be attached to the organization root after promotion (ADR-0017 step 4)"
   }
 }

--- a/terraform/modules/rcps/variables.tf
+++ b/terraform/modules/rcps/variables.tf
@@ -4,7 +4,7 @@ variable "organization_id" {
 }
 
 variable "target_ou_ids" {
-  description = "List of OU (or root) IDs to attach the org-perimeter RCP to. Per ADR-0017 staged rollout, wire ONLY the Policy-Staging OU id first; switch to the root id to promote once staging is verified clean."
+  description = "List of OU (or root) IDs to attach the org-perimeter RCP to. ADR-0017 staged rollout → root promotion: STAGE by wiring ONLY the Policy-Staging OU id first; PROMOTE by appending the organization root id once staging is verified clean. The attachment is a for_each set, so adding the root id is additive (Policy-Staging stays attached) and removing it cleanly reverts to staged-only."
   type        = list(string)
   default     = []
 }

--- a/terragrunt/_org/_global/rcps/terragrunt.hcl
+++ b/terragrunt/_org/_global/rcps/terragrunt.hcl
@@ -5,13 +5,25 @@
 # RCP — the resource-side half of the data perimeter, complementing the
 # principal-side SCP in ../scps.
 #
-# STAGED ROLLOUT (ADR-0017 Implementation notes step 3):
-#   The RCP is attached to the Policy-Staging OU FIRST (a small test-account set)
-#   so a mis-scoped deny is caught in a limited blast radius. Promote to root by
-#   appending the root id to target_ou_ids once staging is verified clean.
+# STAGED ROLLOUT → ROOT PROMOTION (ADR-0017 Implementation notes steps 3–4):
+#   step 3 (done)    — attached to the Policy-Staging OU FIRST (a small
+#                      test-account set) so a mis-scoped deny is caught in a
+#                      limited blast radius.
+#   step 4 (THIS)    — post-soak, promote to root by appending the organization
+#                      root id to target_ou_ids. The attachment is for_each, so
+#                      adding the root id is ADDITIVE: the Policy-Staging
+#                      attachment is retained alongside the new root attachment,
+#                      and removal of the root id cleanly reverts to staged-only.
 #
-# Depends on the Organization (for the org id, the Policy-Staging OU id) and on
-# RESOURCE_CONTROL_POLICY being enabled in ../organization's enabled_policy_types.
+# ROLLBACK: remove `dependency.organization.outputs.root_id` from target_ou_ids
+#   below and re-plan/apply. Because the org-perimeter policy resource itself is
+#   unchanged, this detaches the RCP from root while leaving it attached to
+#   Policy-Staging — a single-line, blast-radius-bounded revert. To disable the
+#   control entirely, empty target_ou_ids (the policy stays defined but unattached).
+#
+# Depends on the Organization (for the org id, the Policy-Staging OU id, and the
+# root id) and on RESOURCE_CONTROL_POLICY being enabled in ../organization's
+# enabled_policy_types.
 # ---------------------------------------------------------------------------------------------------------------------
 
 terraform {
@@ -28,6 +40,7 @@ dependency "organization" {
   mock_outputs = {
     organization_id      = "o-mock"
     policy_staging_ou_id = "ou-mock-policy-staging"
+    root_id              = "r-mock"
   }
 
   mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
@@ -37,11 +50,14 @@ dependency "organization" {
 inputs = {
   organization_id = dependency.organization.outputs.organization_id
 
-  # STAGED: attach ONLY to the Policy-Staging OU first (ADR-0017 step 3).
-  # To PROMOTE to root (step 4), append the organization root id here once
-  # staging is verified clean — the attachment is for_each, so this is additive.
+  # PROMOTED TO ROOT (ADR-0017 step 4, post-soak). The org-perimeter RCP is now
+  # attached to BOTH the Policy-Staging OU and the organization root. The
+  # attachment is for_each over this set, so the root promotion was additive and
+  # is reversible: drop the root_id line to detach from root and fall back to
+  # staged-only (see ROLLBACK in the header).
   target_ou_ids = [
     dependency.organization.outputs.policy_staging_ou_id,
+    dependency.organization.outputs.root_id,
   ]
 
   tags = {


### PR DESCRIPTION
Wave 3 (post-soak): RCP Policy-Staging->root (reversible; AWS-service/cross-account carve-out preserved); Gatekeeper warn->deny on 3 constraints. Rollback documented. terraform validate clean (no apply). Refs #252.

## Changes
### (1) RCP root-promotion (ADR-0017 step 4)
- `terragrunt/_org/_global/rcps/terragrunt.hcl`: `target_ou_ids` now passes BOTH `policy_staging_ou_id` AND `root_id` (additive via for_each). Added `root_id` to dependency mock_outputs. Header documents graduation + one-line rollback (drop root_id -> staged-only; empty list -> defined-but-unattached).
- `terraform/modules/rcps/main.tf`: policy resource UNCHANGED — `StringNotEqualsIfExists aws:PrincipalOrgID` + `BoolIfExists aws:PrincipalIsAWSService=false` carve-out preserved. Attachment comment block now documents graduation (step 3 done -> step 4 now) + rollback.
- `variables.tf` / `README.md`: graduation + rollback documented.
- `rcps.tftest.hcl`: added `promoted_to_root_additively` run (asserts 2 attachments + root target present) and a `StringNotEqualsIfExists` carve-out assertion.

### (2) Gatekeeper warn->deny
- `require-security-context`, `require-resource-limits`, `block-latest-tag`: `enforcementAction: deny` (graduated), each annotated `policy.qbiq.io/enforcement-graduation: warn->deny (W3)` with inline dryrun/warn escape-hatch comment. `block-privileged-containers` already deny (unchanged). All excludedNamespaces / allowedRegistries / allowedImages carve-outs preserved.
- `README.md`: enforcement table corrected to deny; graduation path + dry-run escape/rollback documented.

## Validation (no apply)
- `terraform fmt -recursive -check` modules/rcps: PASS
- `terraform init -backend=false && validate` modules/rcps: PASS (config valid)
- `terraform test` (mock_provider, no AWS): PASS — 5/5
- `terragrunt hcl fmt --check` rcps unit: PASS
- `python3 yaml.safe_load_all` on 4 gatekeeper constraints: PASS (all parse; all deny)
- Scope: only `terragrunt/_org/_global/rcps/`, `terraform/modules/rcps/`, `apps/infra/gatekeeper/` touched; `.terraform/` excluded.

> No `terraform apply` — apply is CI/CD-only from main. RCP root-promotion + Gatekeeper deny require human approval before merge.