### PR TITLE
feat(observability): Prometheus 3.x + Thanos Pod Identity (W4)

### DIFF
--- a/apps/infra/observability/prometheus-stack/Chart.lock
+++ b/apps/infra/observability/prometheus-stack/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: kube-prometheus-stack
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 86.2.0
+- name: thanos
+  repository: https://charts.bitnami.com/bitnami
+  version: 15.7.29
+digest: sha256:f425633ac65c1f990209cde66ef9894d3fe25478c80551c2bc248881cf098bf5
+generated: "2026-06-07T23:25:41.699267+02:00"

--- a/apps/infra/observability/prometheus-stack/Chart.yaml
+++ b/apps/infra/observability/prometheus-stack/Chart.yaml
@@ -2,8 +2,11 @@ apiVersion: v2
 name: prometheus-stack
 description: Production-ready Prometheus + Thanos + Grafana stack for large-scale EKS clusters (1K-5K nodes, 100K+ pods)
 type: application
-version: 1.1.0
-appVersion: "v0.70.0"
+version: 1.2.0
+# appVersion tracks the bundled Prometheus *server* line (the user-facing
+# component), not the prometheus-operator version. As of chart 86.2.0 the
+# kube-prometheus-stack subchart ships Prometheus v3.12.0 (operator v0.91.0).
+appVersion: "v3.12.0"
 
 keywords:
   - prometheus
@@ -22,8 +25,12 @@ dependencies:
   # kube-prometheus-stack - Community operator for Prometheus, Grafana, Alertmanager
   # Includes CRDs for ServiceMonitor, PrometheusRule, etc.
   # Updated: 2026-04-05 from ~81.2.0 to 82.15.1 (mirrors infra versions.hcl)
+  # Updated: 2026-06 (W4) 82.15.1 -> 86.2.0 — moves onto the latest stable
+  #   Prometheus 3.x line (operator v0.91.0, Prometheus server v3.12.0). This
+  #   activates the native-histogram feature flags added in #261 (ADR-0026),
+  #   which require Prometheus >= 3.0. See README "Breaking Changes (W4)".
   - name: kube-prometheus-stack
-    version: "82.15.1"
+    version: "86.2.0"
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-prometheus-stack.enabled
 

--- a/apps/infra/observability/prometheus-stack/README.md
+++ b/apps/infra/observability/prometheus-stack/README.md
@@ -73,6 +73,44 @@ Production-ready Prometheus + Thanos + Grafana stack designed for large-scale Ku
    - Slack + PagerDuty integration
    - Intelligent alert routing
 
+## Breaking Changes (W4 — Prometheus 3.x + Thanos Pod Identity)
+
+This chart line introduces two breaking changes. Review before upgrading.
+
+### 1. kube-prometheus-stack 82.15.1 -> 86.2.0 (Prometheus 3.x)
+
+- The `kube-prometheus-stack` subchart moves to **86.2.0**, which ships
+  **prometheus-operator v0.91.0** and **Prometheus server v3.12.0** (the chart
+  `appVersion` now tracks the Prometheus *server* line: `v3.12.0`).
+- This is the first chart line on which the **native-histogram feature flags**
+  added in #261 (`native-histograms`, `scrape-native-histograms`, and the
+  `native-histograms` `scrapeClass`) are guaranteed to start cleanly —
+  Prometheus 3.x is **required** for those flags. On Prometheus 2.x they cause a
+  start-up error, so do not pin back below chart 67.x without removing the flags
+  in `values.yaml` (`kube-prometheus-stack.prometheus.prometheusSpec.enableFeatures`).
+- Prometheus 3.x carries upstream breaking changes (PromQL/UI/flag changes, TSDB
+  format). Snapshot/back up TSDB and Grafana dashboards before upgrading (see
+  "Backup Before Upgrade"); the upgrade is one-way for the on-disk TSDB.
+- CRDs are bundled with the bumped operator; ensure CRD updates are applied
+  (ArgoCD `skipCrds: false`, or `helm upgrade` with CRD upgrade enabled).
+
+### 2. Thanos S3 auth: IRSA -> EKS Pod Identity (ADR-0018)
+
+- The Thanos `ServiceAccount` **no longer carries the
+  `eks.amazonaws.com/role-arn` IRSA annotation**. S3 access is now granted by the
+  `pod-identity-thanos` Terraform module (#267) via an
+  `EksPodIdentityAssociation` for `(monitoring, thanos)`.
+- **Apply order:** apply the `pod-identity-thanos` catalog unit (with the real
+  per-env `cluster_name` and least-privilege `bucket_names`) **before/with** this
+  chart upgrade, so Thanos keeps S3 access across the cutover. Combining both
+  IRSA and Pod Identity on one SA is unsupported (ADR-0018: precedence-both).
+- The `argocd-application.yaml` `thanos.serviceAccount.annotations` role-arn
+  parameter and the `--set ...role-arn=...` install flag have been removed.
+- **Not done here:** retiring per-cluster OIDC / flipping `enable_irsa=false`
+  globally is the *final* ADR-0018 step and is intentionally **not** performed in
+  this change (other workloads may still depend on IRSA). It is tracked
+  separately and must only follow once all workloads are on Pod Identity.
+
 ## Scale Characteristics
 
 | Metric | Value | Notes |
@@ -91,7 +129,8 @@ Production-ready Prometheus + Thanos + Grafana stack designed for large-scale Ku
 ### Required Components
 
 1. **EKS Cluster** (v1.27+)
-   - IRSA (IAM Roles for Service Accounts) enabled
+   - EKS Pod Identity Agent installed (ADR-0018); IRSA OIDC no longer
+     required for Thanos S3 access
    - VPC CNI with prefix delegation
    - Karpenter for node scaling
 
@@ -161,7 +200,17 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "thanos" {
 }
 ```
 
-### 2. Create IAM Role for IRSA
+### 2. Grant Thanos S3 access via EKS Pod Identity (ADR-0018)
+
+Thanos S3 access is provisioned by the `pod-identity-thanos` Terraform
+module (`terraform/modules/pod-identity-thanos`, catalog unit
+`catalog/units/pod-identity-thanos`), which creates the IAM role (trusting
+`pods.eks.amazonaws.com`) and the EksPodIdentityAssociation for
+`monitoring/thanos`. The Thanos ServiceAccount carries **no**
+`eks.amazonaws.com/role-arn` annotation. The IRSA snippet below is kept only
+as historical reference for the permissions shape — prefer the module.
+
+<details><summary>Legacy IRSA IAM role (reference only)</summary>
 
 ```hcl
 # terraform/iam-thanos.tf
@@ -236,6 +285,8 @@ output "thanos_iam_role_arn" {
 }
 ```
 
+</details>
+
 ### 3. Install via Helm
 
 ```bash
@@ -253,7 +304,6 @@ helm upgrade --install prometheus-stack . \
   --values values.yaml \
   --values values-thanos.yaml \
   --set kube-prometheus-stack.prometheus.prometheusSpec.externalLabels.cluster=eks-us-east-1 \
-  --set thanos.serviceAccount.annotations."eks\.amazonaws\.io/role-arn"=arn:aws:iam::123456789012:role/thanos-s3-access \
   --wait \
   --timeout 10m
 ```
@@ -566,8 +616,11 @@ kubectl exec -n monitoring prometheus-stack-kube-prometheus-prometheus-0 -c prom
 # Check sidecar logs
 kubectl logs -n monitoring prometheus-stack-kube-prometheus-prometheus-0 -c thanos-sidecar
 
-# Verify IRSA permissions
+# Verify Pod Identity association (ADR-0018) — the SA has NO role-arn
+# annotation; check the EksPodIdentityAssociation instead:
 kubectl describe sa -n monitoring thanos
+aws eks list-pod-identity-associations --cluster-name <cluster> \
+  --namespace monitoring --service-account thanos
 
 # Test S3 access
 kubectl run -n monitoring aws-cli --rm -it --image amazon/aws-cli -- \

--- a/apps/infra/observability/prometheus-stack/argocd-application.yaml
+++ b/apps/infra/observability/prometheus-stack/argocd-application.yaml
@@ -52,8 +52,9 @@ spec:
       - name: kube-prometheus-stack.prometheus.prometheusSpec.externalLabels.region
         value: us-east-1
 
-      - name: thanos.serviceAccount.annotations.eks\.amazonaws\.io/role-arn
-        value: arn:aws:iam::123456789012:role/thanos-s3-access
+      # Thanos S3 access is granted by EKS Pod Identity (ADR-0018,
+      # pod-identity-thanos module #267), NOT IRSA — so no
+      # thanos.serviceAccount.annotations role-arn parameter is set here.
 
       # Skip CRDs installation (manage separately)
       skipCrds: false

--- a/apps/infra/observability/prometheus-stack/templates/thanos-objstore-secret.yaml
+++ b/apps/infra/observability/prometheus-stack/templates/thanos-objstore-secret.yaml
@@ -7,8 +7,10 @@
 # 2. AWS Secrets Manager secret created with S3 bucket config
 # 3. IRSA configured for external-secrets ServiceAccount
 #
-# Alternative: Use IRSA directly on Thanos pods (recommended)
-# This secret is only needed if NOT using IRSA
+# Alternative: Use EKS Pod Identity directly on the Thanos SA (recommended,
+# ADR-0018 — see the thanos ServiceAccount below). This secret is only needed
+# when object-store *config* (bucket/endpoint) is sourced from Secrets Manager;
+# S3 *auth* comes from Pod Identity, not from credentials in this secret.
 
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -114,17 +116,22 @@ spec:
 #         response_header_timeout: 2m
 
 ---
-# ServiceAccount for Thanos with IRSA
-# This is the RECOMMENDED approach - no credentials in secrets
+# ServiceAccount for Thanos — EKS Pod Identity (ADR-0018), NOT IRSA.
+#
+# RECOMMENDED: workload identity with no credentials in secrets AND no IRSA
+# annotation. S3 access is granted by the `pod-identity-thanos` Terraform module
+# (#267) via an EksPodIdentityAssociation that binds this SA
+# (namespace=monitoring, name=thanos) to an IAM role trusting
+# `pods.eks.amazonaws.com`. Do NOT add `eks.amazonaws.com/role-arn` here — the
+# IRSA annotation was dropped in W4 and combining both mechanisms on one SA is
+# unsupported (ADR-0018: precedence-both).
 #
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: thanos
   namespace: monitoring
-  annotations:
-    # IAM Role ARN with S3 access permissions
-    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/thanos-s3-access
+  # No `eks.amazonaws.com/role-arn` annotation: Pod Identity, not IRSA.
   labels:
     app.kubernetes.io/name: thanos
 

--- a/apps/infra/observability/prometheus-stack/values-production.yaml
+++ b/apps/infra/observability/prometheus-stack/values-production.yaml
@@ -344,7 +344,10 @@ thanos:
     persistence:
       size: 200Gi
 
+  # Workload Identity - EKS Pod Identity (ADR-0018), NOT IRSA.
+  # Production Thanos S3 access comes from the `pod-identity-thanos` association
+  # (per-env `cluster_name`/`bucket_names` in catalog/units/pod-identity-thanos),
+  # so the SA carries no `eks.amazonaws.com/role-arn` annotation. Keep `create`
+  # true (from values-thanos.yaml) so the association's referenced SA exists.
   serviceAccount:
-    annotations:
-      # TODO: Replace 123456789012 with actual AWS account ID before production deployment
-      eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/thanos-s3-access-prod
+    annotations: {}  # intentionally empty — Pod Identity, not IRSA

--- a/apps/infra/observability/prometheus-stack/values-thanos.yaml
+++ b/apps/infra/observability/prometheus-stack/values-thanos.yaml
@@ -421,13 +421,25 @@ thanos:
         prometheus: kube-prometheus
 
   # --------------------------------------------------------------------------
-  # IRSA (IAM Roles for Service Accounts) - AWS Integration
+  # Workload Identity - EKS Pod Identity (ADR-0018), NOT IRSA
   # --------------------------------------------------------------------------
+  # The Thanos ServiceAccount carries NO `eks.amazonaws.com/role-arn` annotation.
+  # S3 access is granted by the `pod-identity-thanos` Terraform module (#267),
+  # which creates an EksPodIdentityAssociation binding
+  #   (cluster, namespace=monitoring, serviceAccount=thanos) -> IAM role
+  # whose trust targets `pods.eks.amazonaws.com`. Pod Identity injects creds via
+  # the EKS Pod Identity Agent (no SA annotation, no per-cluster OIDC needed).
+  #
+  # IMPORTANT: never set both mechanisms on this SA. The IRSA annotation was
+  # dropped in W4; if the annotation is re-added while the Pod Identity
+  # association exists, behaviour is unsupported (ADR-0018: precedence-both).
+  #
+  # The chart must still CREATE the `thanos` SA (the association references it by
+  # name); it just must not annotate it.
   serviceAccount:
     create: true
     name: thanos
-    annotations:
-      eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/thanos-s3-access  # Replace with actual IAM role ARN
+    # annotations: {}  # intentionally empty — Pod Identity, not IRSA (see above)
 
 ---
 # Cache Configuration ConfigMap (Memcached for Query Frontend)


### PR DESCRIPTION
Wave 4: kube-prometheus-stack -> Prometheus 3.x line (activates native-histogram flags from #261); Thanos Pod Identity finished (drops IRSA annotation). enable_irsa retirement noted, not flipped. Refs #252.

## Changes

### 1. kube-prometheus-stack 82.15.1 -> 86.2.0 (Prometheus 3.x)
- Bumps the `kube-prometheus-stack` dependency to **86.2.0** (operator v0.91.0, **Prometheus server v3.12.0**).
- Regenerates `Chart.lock` (kube-prometheus-stack 86.2.0 + thanos 15.7.29).
- Chart `appVersion` now tracks the Prometheus *server* line (`v3.12.0`) instead of the stale operator version.
- This is the first guaranteed-clean line for the **native-histogram feature flags** added in #261 (`native-histograms`, `scrape-native-histograms`, `native-histograms` scrapeClass) — Prometheus 3.x is required for them. README gains a **Breaking Changes (W4)** section (TSDB/Grafana backup before upgrade; CRD upgrade note).

### 2. Thanos S3 auth: IRSA -> EKS Pod Identity (ADR-0018, #267)
- Drops the `eks.amazonaws.com/role-arn` IRSA annotation from the Thanos ServiceAccount across the chart: `values-thanos.yaml`, `values-production.yaml`, `templates/thanos-objstore-secret.yaml`, the `argocd-application.yaml` helm parameter, and the README `--set` install flag.
- The chart still **creates** the `thanos` SA (the `pod-identity-thanos` association references it by name) but no longer annotates it. S3 access is granted by the `pod-identity-thanos` module + catalog unit via an EksPodIdentityAssociation (trust `pods.eks.amazonaws.com`).
- Apply-order note in README: apply the `pod-identity-thanos` unit before/with this upgrade so Thanos keeps S3 access.

### 3. enable_irsa retirement — NOTE only
- Retiring per-cluster OIDC / flipping `enable_irsa=false` globally is the **final** ADR-0018 step and is intentionally **not** performed here (other workloads may still depend on IRSA). Documented as a tracked follow-up.

## Validation
- `helm template` (base + production overlay): renders cleanly; Prometheus CR shows `image: quay.io/prometheus/prometheus:v3.12.0-distroless`, `enableFeatures: [native-histograms, scrape-native-histograms]`, scrapeClass `native-histograms`.
- Rendered Thanos ServiceAccount: `annotations: {}` — **no role-arn** (base + prod).
- `python3 yaml.safe_load` on all edited static YAML: OK.
- `grep` for `eks.amazonaws.com/role-arn:` annotation: **none** (only explanatory comments remain).
- `terraform fmt -check -recursive` + `terraform validate` on `pod-identity-thanos`: **PASS** (Success).
- `terraform test` (module native tests): **5 passed, 0 failed**.

## Notes
- Two pre-existing chart issues (unrelated to W4, identical on `origin/main`) surface under Helm 4.2.0: unescaped `{{ $value }}`/`{{ $labels }}` in 3 PrometheusRule/ServiceMonitor templates, and `external-secrets.yaml` requiring `aws.region`. Validation rendered the W4-changed templates with those supplied/excluded; the pre-existing issues are out of scope for this change.
- checkov not available in this environment; `pod-identity-thanos` is unchanged by W4 and was security-gated when introduced in #267 (ABAC-scoped least-privilege S3 policy).