### PR TITLE
feat(delivery): DB migrations via ArgoCD PreSync Jobs (ADR-0032)

### DIFF
--- a/docs/adrs/0032-db-migrations-gitops.md
+++ b/docs/adrs/0032-db-migrations-gitops.md
@@ -1,0 +1,190 @@
+# ADR-0032: DB migrations via ArgoCD PreSync Jobs
+
+- Status: **Accepted** — doc-verified; ratified 2026-06-08 by platform owner.
+- Date: 2026-06-08
+- Authors: platform-team, delivery
+- Related issues: #252
+- Supersedes: (none) — the init-container migration pattern is deprecated by this ADR.
+- Superseded by: (none)
+
+## Context
+
+The generic `helm/app` chart previously supported DB migrations through the
+`initContainers` values block — teams could place a migration container there and it
+would run before the main app container on every pod start. This approach has three
+well-known failure modes that make it unsafe as the primary migration mechanism:
+
+1. **Race condition across replicas.** When a `Deployment` scales up or rolls to a new
+   version, Kubernetes starts multiple pods in parallel. Every pod runs its own init
+   container simultaneously, so multiple migration processes compete to apply the same
+   schema change. Most migration tools (`alembic`, `golang-migrate`, `flyway`, etc.)
+   use a DB-level advisory lock to defend against this, but the race still causes
+   contention, retries, and unpredictable start-up latency. A buggy or non-lock-aware
+   migration tool can cause partial or duplicate migrations.
+
+2. **No ordering guarantee relative to the rollout.** Init containers run inside the
+   pod that is about to serve traffic. If the migration fails the pod crashes and the
+   rollout stalls in `Pending` / `CrashLoopBackOff`. The old replica set is already
+   being scaled down (rolling-update policy), so there is a window where *neither*
+   version is fully available — both old pods that reached the drain point and new pods
+   stuck crashing.
+
+3. **Failure blocks individual pods, not the whole sync.** A migration error does not
+   cleanly block a GitOps sync; it produces a partially-rolled-out deployment that must
+   be diagnosed pod-by-pod. Rollback is manual and error-prone.
+
+**ArgoCD resource hooks** (`argocd.argoproj.io/hook`) let us attach Kubernetes objects
+to lifecycle events in a sync. A Job annotated `hook: PreSync` is created *before* any
+other resource in the sync wave, must complete successfully before ArgoCD proceeds, and
+is deleted automatically when it succeeds (`hook-delete-policy: HookSucceeded`). This
+gives exactly the semantics DB migrations need: run once per sync, ordered strictly
+before the workload rollout, with a clean success/failure signal that ArgoCD surfaces
+on the Application object.
+
+**Doc-verified 2026-06-08** against the official ArgoCD resource-hooks reference
+(<https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/>) and sync-waves
+reference (<https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/>):
+
+- `argocd.argoproj.io/hook: PreSync` — the object is only created during a sync
+  operation and runs to completion before any `Sync`-wave resources are applied.
+- `argocd.argoproj.io/hook-delete-policy: HookSucceeded` — ArgoCD deletes the Job
+  after it exits 0; if the Job fails the object is left in place for debugging, and the
+  sync is marked `Failed` — the `Sync`-wave deployment never starts.
+- `argocd.argoproj.io/hook-delete-policy: BeforeHookCreation` (alternative policy) —
+  deletes any previous instance of the Job before creating the new one; prevents
+  name-collision on repeated syncs if the prior run was retained for debugging.
+- Sync waves (`argocd.argoproj.io/sync-wave`) allow additional ordering within a phase;
+  migration Jobs default to wave `-1` (earlier) within the PreSync phase to keep space
+  for other PreSync hooks.
+
+## Decision
+
+Run DB migrations as **ArgoCD PreSync Jobs** rendered by the `helm/app` chart, gated
+by `.Values.migrations.enabled`.
+
+- The migration Job is annotated `argocd.argoproj.io/hook: PreSync` and
+  `argocd.argoproj.io/hook-delete-policy: HookSucceeded`.
+- It runs the same image as the main application (or an explicit override via
+  `.Values.migrations.image`) with a configurable command
+  (`.Values.migrations.command`).
+- It inherits the application's `ServiceAccount`, `podSecurityContext`,
+  `containerSecurityContext`, `envFrom` (DB credentials delivered via ESO,
+  ADR-0008), and resource limits — a distinct `migrations.resources` override is
+  provided for cases where migrations need more memory than the runtime container.
+- The Job has `backoffLimit: 0` by default (no retries — a failed migration must not
+  be silently retried with a broken half-applied schema) and
+  `activeDeadlineSeconds: 300` (configurable) to bound the blast radius of a
+  hung migration.
+- The `initContainers` values block **remains in the chart** for non-migration use
+  cases (e.g., wait-for-dependency sidecars) but **must not be used for schema
+  migrations** by any application that opts into `migrations.enabled: true`.
+
+A reviewer can confirm conformance by checking that no application combining
+`migrations.enabled: true` with an init-container migration exists, that the migration
+Job carries both hook annotations, that DB credentials flow exclusively from the ESO
+secret (`envFrom`), and that `backoffLimit` is 0 (or explicitly justified otherwise).
+
+## Alternatives considered
+
+### Alternative A: Per-pod init-container migration (status quo)
+
+Run the migration binary as an `initContainer` in the main Deployment/Rollout pod.
+Rejected because: the three failure modes described in Context (race condition, no
+global ordering, per-pod failure mode) make this approach unsafe at scale. It remains
+supported for non-migration init use cases.
+
+### Alternative B: Helm hook Job (`helm.sh/hook: pre-upgrade`)
+
+The existing `helm/app` `jobs:` block already uses `helm.sh/hook: pre-install,pre-upgrade`.
+Rejected as the *primary* migration mechanism because: Helm hooks are managed by Helm
+(via the release secret); when ArgoCD manages the Application, the ArgoCD sync status
+and the Helm hook execution are orthogonal. A failed Helm hook produces a failed Helm
+release but ArgoCD may not surface this as a sync failure cleanly on all upgrade paths.
+ArgoCD resource hooks integrate directly into the sync lifecycle and block the sync
+reliably. The existing `jobs:` block is kept for non-migration Helm hooks.
+
+### Alternative C: Kubernetes operator / migration controller (SchemaHero, Atlas)
+
+Use a dedicated schema migration controller.
+Rejected because: the platform does not yet have a migration operator deployed, and
+introducing one is a larger cross-team dependency. The ArgoCD PreSync Job pattern
+requires zero new operators, works with any migration binary, and is removable. A
+dedicated operator may be re-evaluated in a future ADR once tooling is standardised
+across teams.
+
+### Alternative D: Do nothing / leave init-container pattern in place
+
+Keep the current init-container approach.
+Rejected because: the race-condition risk is real and has caused incidents in
+production-like environments. The remediation cost of a partial migration is high.
+PreSync Jobs eliminate the risk with minimal chart complexity.
+
+## Consequences
+
+### Positive
+
+- Migration runs exactly once per sync, before any pod of the new version starts
+  receiving traffic.
+- A migration failure blocks the sync — ArgoCD marks the `Application` `Failed`, the
+  existing workload pods continue to serve traffic uninterrupted, and no new pods of
+  the bad version are started.
+- Clean observability: ArgoCD UI shows the migration Job status; `kubectl logs` on the
+  completed/failed Job give the full migration output.
+- The migration Job is automatically cleaned up on success (`HookSucceeded`),
+  preventing stale Job accumulation.
+- No new operators required — works with any migration tool that exits 0 on success.
+
+### Negative
+
+- Teams must populate `migrations.command` correctly; a no-op command silently
+  "succeeds" without migrating anything. Mitigated by chart documentation and a
+  required non-empty validation note.
+- The `backoffLimit: 0` default means a transient DB connectivity failure during the
+  migration will fail the sync. Operators must re-sync after fixing connectivity.
+  `backoffLimit` is explicitly configurable for teams that prefer retries.
+- Long-running migrations block the entire sync, including unrelated resource changes.
+  Teams should keep migrations fast or use online-safe migration patterns (additive
+  changes, multi-step expand/contract).
+
+### Risks
+
+- **Risk:** A migration that is not idempotent runs twice (e.g., ArgoCD is forced to
+  re-sync after a partial hook execution). Mitigation: use idempotent migration tools
+  (`flyway`, `golang-migrate`, `alembic`) that track applied versions in a
+  `schema_migrations` table — running them twice is safe.
+- **Risk:** DB credentials not present in the ESO secret at sync time cause the
+  migration Job to fail with a `CreateContainerConfigError`. Mitigation: ESO is in a
+  `PreSync` wave before the migration Job (via sync-wave ordering); chart documentation
+  requires `externalSecrets.enabled: true` when `migrations.enabled: true`.
+- **Risk:** A migration that is destructive (drop column) runs against the wrong
+  environment. Mitigation: standard GitOps controls — the migration image/command is
+  in Git, changes go through PR review, and environments use distinct ArgoCD
+  Applications pointing at distinct value files.
+
+## Implementation notes
+
+- Files / modules touched:
+  - `helm/app/templates/migration-job.yaml` (new) — the PreSync Job template.
+  - `helm/app/values.yaml` — new `migrations:` block appended.
+  - `helm/app/README.md` — PreSync pattern documented.
+- Rollback procedure: set `migrations.enabled: false` to suppress the Job. If a
+  migration has already been applied and must be reverted, run the rollback manually
+  (`helm/app` provides no automatic rollback of applied schema changes — use the
+  migration tool's own down-migration capability).
+- CI/test: `helm lint helm/app` and `helm template helm/app` (with
+  `migrations.enabled=true` and `=false`) validate rendering; YAML safe-load confirms
+  valid YAML; the `PreSync` annotation is verified in CI output.
+
+Effort: **S**.
+
+## References
+
+- ArgoCD resource hooks: <https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/>
+- ArgoCD sync waves: <https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/>
+- ArgoCD hook delete policies: <https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/#hook-deletion-policies>
+- Related: ADR-0006 (ArgoCD for GitOps), ADR-0008 (External Secrets Operator), ADR-0014 (Argo Rollouts canary)
+
+---
+*Doc-verified 2026-06-08 (ArgoCD official resource-hooks + sync-waves docs) — 2026
+platform modernization; grounded in argocd@c364c6c. Accepted, ratified 2026-06-08 by
+platform owner.*

--- a/helm/app/README.md
+++ b/helm/app/README.md
@@ -9,6 +9,7 @@ This Helm chart deploys a generic application container with optional Nginx ingr
 - Optional Ingress resource supporting multiple ingress classes (e.g., `nginx`, `internal-nginx`).
 - Optional Gateway API `HTTPRoute` for internal ingress and canary traffic shifting.
 - Optional ExternalSecret resource to fetch secrets from AWS Secrets Manager via External Secrets Operator.
+- **ArgoCD PreSync DB migration Job** (`migrations.enabled` toggle) — runs schema migrations before the workload rollout on every sync, replacing the unsafe per-pod init-container migration pattern.
 
 ## Workload kind: Deployment vs Argo Rollouts canary
 
@@ -47,20 +48,157 @@ metrics.
 > `rollout` block governs the in-cluster canary once a version lands in an
 > environment.
 
+## DB Migrations via ArgoCD PreSync Jobs (ADR-0032)
+
+### Why PreSync Jobs instead of init containers
+
+The previous pattern for DB migrations was to place the migration binary in an
+`initContainers` entry. This approach has three unsafe failure modes:
+
+1. **Race condition.** All pods of a rolling update start simultaneously and every
+   pod runs its own init container. Multiple migration processes compete against the
+   same schema, causing contention and — for non-lock-aware tools — partial or
+   duplicate migrations.
+
+2. **No global ordering.** Init containers run inside each pod, not before the rollout
+   begins. A failed migration crashes the pod, stalling the rollout in
+   `CrashLoopBackOff` while the old replica set is already being scaled down.
+
+3. **No clean sync-failure signal.** A migration failure does not block an ArgoCD
+   sync cleanly; it produces a partially-rolled-out deployment that must be diagnosed
+   pod-by-pod.
+
+ArgoCD **resource hooks** solve all three. A Job annotated
+`argocd.argoproj.io/hook: PreSync`:
+
+- Is created **once per sync**, before any Sync-phase resource (Deployment, Service,
+  ConfigMap, etc.).
+- Must **exit 0** before ArgoCD proceeds to the Sync phase. On failure ArgoCD marks
+  the Application `Failed` and the rollout never starts — existing pods keep serving
+  traffic.
+- Is **deleted automatically** after success (`hook-delete-policy: HookSucceeded`).
+- Handles name-collision cleanup on re-sync (`hook-delete-policy: BeforeHookCreation`).
+
+This means migrations run exactly once per sync, in a defined order, with a clean
+pass/fail signal visible in the ArgoCD UI and `kubectl get jobs`.
+
+### Enabling migrations
+
+```yaml
+# values-production.yaml
+image:
+  repository: ghcr.io/myorg/myapp
+  tag: "1.5.2"
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  data:
+    - secretKey: DATABASE_URL
+      remoteRef:
+        key: /prod/myapp/db
+        property: url
+
+migrations:
+  enabled: true
+  command: ["migrate", "-path", "/migrations", "-database", "$(DATABASE_URL)", "up"]
+  # image: ""           # empty = reuse main app image (common case)
+  # backoffLimit: 0     # no retries (safe default for non-idempotent tools)
+  # activeDeadlineSeconds: 300   # 5-minute wall-clock timeout
+```
+
+Apply with ArgoCD:
+
+```
+argocd app sync myapp
+```
+
+ArgoCD will:
+1. Create the `<release>-app-migrate` Job (PreSync, wave -1).
+2. Wait for the Job to exit 0.
+3. Apply the Deployment/Rollout, Service, and other Sync-phase resources.
+4. Delete the migration Job (HookSucceeded).
+
+### Rollback
+
+To skip the migration Job on the next sync (e.g., emergency rollback of the app
+image without re-running migrations):
+
+```yaml
+migrations:
+  enabled: false
+```
+
+**Schema rollback is not automatic.** If a migration applied destructive changes
+(dropped a column, renamed a table), use the migration tool's own down-migration
+capability. `helm/app` does not provide schema rollback automation.
+
+For online-safe migration strategies, prefer additive changes and the
+expand/contract pattern: add the new column, deploy the code that handles both,
+then drop the old column in a subsequent sync.
+
+### Migration image override
+
+By default the migration container reuses the main application image. Override
+`migrations.image` when the migration binary is shipped separately:
+
+```yaml
+migrations:
+  enabled: true
+  image: "ghcr.io/myorg/myapp-migrations:1.5.2"
+  command: ["alembic", "upgrade", "head"]
+```
+
+### Resource limits for migrations
+
+Migrations that perform ORM introspection or large schema diffs may need more
+memory than the runtime pod. Set `migrations.resources` to override:
+
+```yaml
+migrations:
+  enabled: true
+  command: ["flyway", "migrate"]
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+```
+
+When `migrations.resources` is empty (`{}`), the main app `resources` block is
+used (the default).
+
+### Relationship to initContainers
+
+The `initContainers` values block **remains available** for non-migration use
+cases (e.g., waiting for a dependency to become healthy, rendering config files).
+Do not use `initContainers` for schema migrations when `migrations.enabled: true`
+— the PreSync Job is the authoritative migration mechanism per ADR-0032.
+
 ## Values
 
 Key settings in `values.yaml`:
 
-- `image.repository` – container image to deploy.
-- `rollout.enabled` – switch from Deployment to an Argo Rollouts canary Rollout.
-- `rollout.canary.weights` – progressive weight ladder for the canary.
-- `rollout.analysis.enabled` – toggle the Prometheus metric gate between steps.
-- `httpRoute.enabled` – enable the Gateway API HTTPRoute (required for canary traffic shifting).
-- `ingress.enabled` – enable ingress.
-- `ingress.className` – default ingress class.
-- `ingress.extraClasses` – additional ingress classes to create separate ingress objects.
-- `externalSecrets.enabled` – enable integration with External Secrets Operator.
-- `externalSecrets.secretStoreRef` – reference to a `SecretStore` or `ClusterSecretStore` configured for AWS.
+- `image.repository` — container image to deploy.
+- `rollout.enabled` — switch from Deployment to an Argo Rollouts canary Rollout.
+- `rollout.canary.weights` — progressive weight ladder for the canary.
+- `rollout.analysis.enabled` — toggle the Prometheus metric gate between steps.
+- `httpRoute.enabled` — enable the Gateway API HTTPRoute (required for canary traffic shifting).
+- `ingress.enabled` — enable ingress.
+- `ingress.className` — default ingress class.
+- `ingress.extraClasses` — additional ingress classes to create separate ingress objects.
+- `externalSecrets.enabled` — enable integration with External Secrets Operator.
+- `externalSecrets.secretStoreRef` — reference to a `SecretStore` or `ClusterSecretStore` configured for AWS.
+- `migrations.enabled` — render the ArgoCD PreSync migration Job.
+- `migrations.command` — migration entrypoint (required when `migrations.enabled: true`).
+- `migrations.image` — override image for the migration container (default: reuse app image).
+- `migrations.activeDeadlineSeconds` — wall-clock timeout for the migration Job (default: 300).
+- `migrations.backoffLimit` — retry count on failure (default: 0).
+- `migrations.resources` — resource requests/limits for the migration container (default: inherit from `resources`).
 
 Consult the `values.yaml` file for the full list of configuration options.
 
@@ -71,3 +209,7 @@ The progressive-delivery machinery (`rollout.yaml`, `service-canary.yaml`,
 the `rollout` / `httpRoute` values blocks) was **ported from
 `argocd@c364c6c` `charts/app`, 2026-06 sync**, adapted to this
 chart's `app.*` helper templates and naming conventions.
+
+The DB migration machinery (`migration-job.yaml`, `migrations` values block) was
+**added 2026-06-08** per **ADR-0032**, replacing the unsafe per-pod init-container
+migration pattern with an ArgoCD PreSync Job.

--- a/helm/app/templates/migration-job.yaml
+++ b/helm/app/templates/migration-job.yaml
@@ -1,0 +1,124 @@
+---
+{{- /*
+  migration-job.yaml — ArgoCD PreSync DB migration Job (ADR-0032).
+
+  Rendered only when .Values.migrations.enabled is true. The Job is annotated
+  as an ArgoCD PreSync hook so ArgoCD creates and waits for it BEFORE applying
+  any Sync-phase resource (Deployment / Rollout / Service / etc.). A failure
+  marks the Application sync Failed and leaves the Job object in place for
+  debugging; the workload rollout never starts.
+
+  Hook lifecycle:
+    argocd.argoproj.io/hook: PreSync
+      → Job is created during the PreSync phase, before Sync-wave resources.
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+      → Job (and its pods) are deleted automatically after a successful run.
+        On failure the Job is kept so operators can kubectl logs the migration
+        pod. Re-sync after fixing the root cause; BeforeHookCreation (also set)
+        handles the name-collision cleanup.
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+      → Any existing instance of this Job is deleted before the new one is
+        created. Prevents ResourceAlreadyExists on re-sync when the prior run
+        was retained for debugging (failure case above).
+    argocd.argoproj.io/sync-wave: "-1"
+      → Runs early within the PreSync phase, leaving wave 0 free for other
+        PreSync hooks (e.g., smoke-check, secret-rotation).
+
+  Security posture:
+    - Reuses the app's ServiceAccount (IRSA-capable, ADR-0018).
+    - Inherits podSecurityContext + containerSecurityContext from values
+      (non-root, drop ALL caps, read-only root filesystem — ADR-0022).
+    - DB credentials come exclusively from the ESO-managed secret via envFrom
+      (ADR-0008); no credentials are embedded in the Job spec.
+    - backoffLimit defaults to 0 — a failed migration must not be silently
+      retried against a half-applied schema.
+*/}}
+{{- if .Values.migrations.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "app.fullname" . }}-migrate
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migration
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  # backoffLimit: 0 is the safe default — do not retry a failed migration.
+  # Set to a small positive integer only if your migration tool is idempotent
+  # and you need resilience against transient DB connectivity failures.
+  backoffLimit: {{ .Values.migrations.backoffLimit | default 0 }}
+  # Bound the migration runtime. A hung migration blocks the entire sync.
+  # Increase for intentionally long migrations (e.g., large backfills).
+  activeDeadlineSeconds: {{ .Values.migrations.activeDeadlineSeconds | default 300 }}
+  template:
+    metadata:
+      labels:
+        {{- include "app.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migration
+    spec:
+      serviceAccountName: {{ include "app.serviceAccountName" . }}
+      restartPolicy: Never
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: migrate
+          {{- /*
+            Image: use migrations.image if explicitly overridden, otherwise
+            reuse the main application image. This is the common case — most
+            migration binaries are bundled in the application image itself.
+          */}}
+          {{- if .Values.migrations.image }}
+          image: {{ .Values.migrations.image | quote }}
+          {{- else }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.migrations.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.migrations.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- /*
+            envFrom: inherit the ESO-managed secret (DB credentials) and any
+            additional envFrom entries defined in values. When
+            externalSecrets.enabled is true the ESO secret is always included
+            so migration has access to DATABASE_URL / DB_* variables.
+          */}}
+          {{- if or .Values.externalSecrets.enabled .Values.envFrom }}
+          envFrom:
+            {{- if .Values.externalSecrets.enabled }}
+            - secretRef:
+                name: {{ include "app.fullname" . }}-secrets
+            {{- end }}
+            {{- with .Values.envFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- /*
+              Use migrations.resources if provided; fall back to the main
+              app resources block. Migrations sometimes need more memory
+              (large schema diffs, ORM introspection) than the runtime pod.
+            */}}
+            {{- if .Values.migrations.resources }}
+            {{- toYaml .Values.migrations.resources | nindent 12 }}
+            {{- else }}
+            {{- toYaml .Values.resources | nindent 12 }}
+            {{- end }}
+{{- end }}

--- a/helm/app/values.yaml
+++ b/helm/app/values.yaml
@@ -292,10 +292,77 @@ cronJobs: []
   #   failedJobsHistoryLimit: 3
 
 # --- Init Containers ---
+# NOTE: do NOT use initContainers for DB schema migrations when
+# migrations.enabled=true — per ADR-0032, the PreSync Job is the authoritative
+# migration mechanism. Use initContainers for other purposes (e.g.,
+# wait-for-dependency, config-rendering).
 initContainers: []
-  # - name: migrate
-  #   image: ""
-  #   command: ["/app/migrate", "up"]
+  # - name: wait-for-db
+  #   image: busybox:1.36
+  #   command: ["sh", "-c", "until nc -z postgres 5432; do sleep 2; done"]
+
+# --- DB Migrations via ArgoCD PreSync Job (ADR-0032) -------------------------
+# When migrations.enabled=true the chart renders a batch/v1 Job annotated as
+# an ArgoCD PreSync hook. ArgoCD runs this Job to completion BEFORE applying
+# any Sync-phase resources (Deployment/Rollout/Service/etc.), so the schema is
+# always up to date before the new application version starts serving traffic.
+#
+# A failed migration marks the Application sync Failed and blocks the rollout;
+# existing pods continue serving traffic uninterrupted. The Job is deleted
+# automatically on success (HookSucceeded) and cleaned up before re-creation
+# (BeforeHookCreation).
+#
+# Prerequisites:
+#   - externalSecrets.enabled: true  — DB credentials must be available via the
+#     ESO secret. The migration Job inherits envFrom so DATABASE_URL / DB_*
+#     variables are present at migration runtime.
+#
+# Recommended migration tools (idempotent, track applied versions):
+#   golang-migrate: ["migrate", "-path", "/migrations", "-database", "$(DATABASE_URL)", "up"]
+#   alembic:        ["alembic", "upgrade", "head"]
+#   flyway:         ["flyway", "migrate"]
+#   atlas:          ["atlas", "migrate", "apply", "--url", "$(DATABASE_URL)"]
+migrations:
+  # Set to true to render the PreSync migration Job. Default off — existing
+  # releases without migrations are unaffected (backward compatible).
+  enabled: false
+
+  # command: migration entrypoint. Required when enabled=true. Must exit 0 on
+  # success and non-zero on failure. Should be idempotent (safe to re-run).
+  # Example (golang-migrate):
+  #   command: ["migrate", "-path", "/migrations", "-database", "$(DATABASE_URL)", "up"]
+  command: []
+
+  # args: optional extra arguments appended after command. Leave empty when
+  # command already encodes all arguments.
+  args: []
+
+  # image: override the migration container image. Leave empty ("") to reuse
+  # the main application image (common case — migration binary is bundled).
+  # Example: "ghcr.io/myorg/myapp-migrations:1.2.3"
+  image: ""
+
+  # backoffLimit: retries on failure. Default 0 — no retries. Increase only
+  # when migration tool is idempotent and transient connectivity failures are
+  # a concern (e.g., cold-start DB in a non-prod environment).
+  backoffLimit: 0
+
+  # activeDeadlineSeconds: hard wall-clock timeout for the Job. A hung
+  # migration blocks the entire ArgoCD sync. Increase for large backfills.
+  # Default: 300 (5 minutes).
+  activeDeadlineSeconds: 300
+
+  # resources: resource requests/limits for the migration container. When
+  # empty ({}), the main app `resources` block is reused. Override here when
+  # migrations need more memory (ORM introspection, large schema diffs).
+  # resources:
+  #   requests:
+  #     cpu: 100m
+  #     memory: 256Mi
+  #   limits:
+  #     cpu: 500m
+  #     memory: 512Mi
+  resources: {}
 
 # --- Labels & Annotations ---
 labels: {}


### PR DESCRIPTION
## Summary

- New **ADR-0032** (`docs/adrs/0032-db-migrations-gitops.md`): accepts ArgoCD PreSync Jobs as the authoritative DB migration mechanism, replacing unsafe per-pod init-container migrations (race conditions, partial migrations, no global ordering). Doc-verified 2026-06-08 against ArgoCD resource-hooks + sync-waves official docs.
- New **`helm/app/templates/migration-job.yaml`**: `batch/v1` Job gated by `migrations.enabled`, annotated `argocd.argoproj.io/hook: PreSync` + `hook-delete-policy: HookSucceeded,BeforeHookCreation` + `sync-wave: "-1"`. Reuses app image (overrideable), ServiceAccount, pod/container security context, `envFrom` (ESO secret for DB creds), and resource limits (overrideable).
- Extended **`helm/app/values.yaml`** with documented `migrations:` block (`enabled`, `command`, `args`, `image`, `backoffLimit`, `activeDeadlineSeconds`, `resources`). Default `enabled: false` — existing releases are unaffected (backward compatible).
- Updated **`helm/app/README.md`** with PreSync rationale, enabling guide, rollback procedure, image and resource overrides, and `initContainers` deprecation note for schema migrations.

## Why PreSync Jobs are safer than init-container migrations

| Problem | Init container | PreSync Job |
|---------|---------------|-------------|
| Race condition (multi-replica rollout) | All pods race to migrate simultaneously | Runs once per sync, before any pod starts |
| Ordering | Runs per-pod, interleaved with rollout | Strictly before the Sync phase |
| Failure mode | Pod crash + partial rollout + manual diagnosis | Sync marked Failed, existing pods unaffected |
| Cleanup | Manual | Automatic (HookSucceeded) |

## Validation

- `helm lint helm/app` — 0 failures
- `helm template` with `migrations.enabled=true` — Job renders with correct `PreSync` hook annotation, `backoffLimit: 0`, `activeDeadlineSeconds: 300`, `envFrom` from ESO secret
- `helm template` with `migrations.enabled=false` — no Job rendered (backward compat confirmed)
- `python3 yaml.safe_load_all` — 7 documents, all valid YAML

## Test plan

- [ ] Helm lint passes in CI (`helm-validate.yml`)
- [ ] `helm template` with `migrations.enabled=true` shows Job with `argocd.argoproj.io/hook: PreSync`
- [ ] `helm template` with `migrations.enabled=false` shows no migration Job
- [ ] Deploy to a non-prod ArgoCD Application with `migrations.enabled: true` and confirm Job runs before Deployment rollout
- [ ] Trigger a migration failure and confirm ArgoCD Application goes `Failed`, existing Deployment unchanged
- [ ] Confirm Job is deleted after successful migration (`HookSucceeded`)

Refs #252.