### PR TITLE
feat(ecr): ECR Pull-Through Cache (ADR-0029)

### DIFF
--- a/docs/adrs/0029-ecr-pull-through-cache.md
+++ b/docs/adrs/0029-ecr-pull-through-cache.md
@@ -1,0 +1,161 @@
+# ADR-0029: ECR Pull-Through Cache for public upstream registries
+
+- Status: **Accepted** — proposal, doc-verified; ratified, not yet implemented.
+- Ratified: 2026-06-08 by platform owner.
+- platform-design status: **pending** — the `ecr-pull-through-cache` module and
+  the shared-account terragrunt unit land in this PR, but nothing is applied yet.
+- Date: 2026-06-08
+- Authors: platform-team
+- Related issues: epic #252
+- Supersedes: (none)
+- Superseded by: (none)
+- Related: ADR-0008 (External Secrets Operator), ADR-0016 (supply-chain hardening).
+
+## Context
+
+Cluster and CI workloads pull base/tooling images directly from **public upstream
+registries** — **Docker Hub** (`registry-1.docker.io`), **Quay** (`quay.io`),
+**GHCR** (`ghcr.io`), **`registry.k8s.io`**, and **`public.ecr.aws`**. This
+couples our availability to theirs and exposes two recurring failure modes:
+
+1. **Docker Hub anonymous/free rate-limits** throttle image pulls. On a busy node
+   fleet (Karpenter scale-up, ADR-0007) a burst of cold pulls hits the limit and
+   pods get stuck in `ImagePullBackOff` — a self-inflicted outage on a third
+   party's throttle.
+2. **External-registry outages / network reachability**: when an upstream is down
+   or unreachable, *new* image pulls fail even though the same image was pulled
+   minutes earlier on another node. There is no local durable copy.
+
+There is no account-local, durable, scanned mirror of these public images today,
+and no single place to attach Docker Hub credentials or image scanning for them.
+
+## Decision
+
+Adopt **Amazon ECR Pull-Through Cache (PTC)** to mirror the public upstreams into
+this account's **private** ECR registry, fronted by a **repository creation
+template** that auto-configures each cached repository:
+
+- **One `aws_ecr_pull_through_cache_rule` per upstream**, each mapping a stable
+  local **prefix** to its upstream registry URL:
+  - `ecr-public` → `public.ecr.aws`
+  - `docker-hub` → `registry-1.docker.io`
+  - `quay` → `quay.io`
+  - `ghcr` → `ghcr.io`
+  - `k8s` → `registry.k8s.io`
+  - (`gitlab` → `registry.gitlab.com` is supported and available behind the same
+    variable when needed.)
+- **Docker Hub upstream credential** in **Secrets Manager** under the
+  AWS-required `ecr-pullthroughcache/` name prefix. The value is a **placeholder**
+  in code; the real username + **read-only access token** are injected
+  **out-of-band** (External Secrets Operator, ADR-0008) and never committed.
+- **`aws_ecr_repository_creation_template`** (`prefix = "ROOT"`,
+  `applied_for = ["PULL_THROUGH_CACHE"]`) that auto-creates each cached repo on
+  first pull with **KMS (CMK) encryption**, **immutable tags**, and a
+  **lifecycle policy** (retain last N tagged, expire untagged after M days). KMS
+  encryption + resource tags require a **custom IAM role**, which the module
+  provisions and ECR assumes to create the repositories.
+- **`aws_ecr_registry_scanning_configuration`** so cached repositories are
+  **scanned** (scan-on-push under BASIC, or continuous Inspector scanning under
+  ENHANCED) over the cache prefixes.
+
+**Callers reference cached images** as:
+
+```text
+<acct>.dkr.ecr.<region>.amazonaws.com/<upstream-prefix>/<image>
+# e.g. <acct>.dkr.ecr.eu-west-1.amazonaws.com/docker-hub/library/nginx:1.27
+```
+
+The module is deployed in the **shared-services account** (which already hosts the
+central ECR registry per `account.hcl`), in the primary region.
+
+A reviewer can check conformance by confirming: a PTC rule exists per upstream;
+the Docker Hub rule has a `credential_arn` pointing at an `ecr-pullthroughcache/`
+secret; a `ROOT` repository creation template applies for `PULL_THROUGH_CACHE`
+with KMS encryption + immutable tags + a lifecycle policy and a custom role; and
+the registry scanning configuration covers the cache prefixes.
+
+## Alternatives considered
+
+### Alternative A: Status quo — pull straight from public registries
+Keep pulling images directly from Docker Hub / Quay / GHCR / k8s / ECR Public.
+Rejected because: it leaves us exposed to **Docker Hub rate-limits** and
+**upstream outages**, with no durable local copy and no central place to attach
+credentials or scanning. Scale-up storms turn a third-party throttle into our
+`ImagePullBackOff`.
+
+### Alternative B: Manually mirror images into per-image private ECR repos
+Run a job that `docker pull`/`docker push`-mirrors each needed image into a
+hand-managed private repo.
+Rejected because: it is **toil** — every new image/tag needs a pipeline change,
+mirrors drift from upstream, and it duplicates exactly what PTC does natively
+(on-demand, transparent, with auto-created repos).
+
+### Alternative C: Run a self-hosted pull-through proxy (e.g. a registry mirror)
+Stand up and operate a registry mirror (Harbor proxy cache, registry mirror, etc.).
+Rejected because: it adds an **operational component** (HA, storage, upgrades,
+its own credentials and scanning) to solve a problem ECR already solves natively
+with IAM-scoped access, KMS encryption, and Inspector scanning — more moving
+parts for no added benefit on AWS.
+
+## Consequences
+
+### Positive
+- **Rate-limit immunity**: after the first pull, images are served from private
+  ECR — no anonymous Docker Hub throttle on scale-up.
+- **Outage resilience**: a durable account-local copy survives upstream outages.
+- **Scanned + encrypted by default**: cached repos auto-created with KMS
+  encryption, immutable tags, lifecycle, and registry scanning.
+- **One place** for Docker Hub credentials and image policy across the estate.
+
+### Negative
+- Cached images are **mirrors of upstream `latest`-style tags at first pull** —
+  consumers should pin digests/immutable tags to avoid surprise drift.
+- The Docker Hub credential must be **provisioned and rotated** out-of-band; a
+  missing/expired token silently degrades the Docker Hub rule back toward
+  anonymous rate-limits.
+
+### Risks
+- A mis-scoped credential secret or custom IAM role over-grants. Mitigated by the
+  least-privilege role (only ECR create/replicate + scoped KMS) and storing the
+  credential via ESO (ADR-0008), never in git.
+- The **registry scanning configuration is a singleton per registry** — two
+  owners conflict. Mitigated by the `create_registry_scanning_configuration`
+  toggle so exactly one unit owns it.
+- Stale cache vs. moving upstream tags. Mitigated by the lifecycle policy +
+  recommending digest/immutable-tag pinning for consumers.
+
+## Implementation notes
+
+- Files / modules touched: new `terraform/modules/ecr-pull-through-cache`
+  (`aws_ecr_pull_through_cache_rule` per upstream, the
+  `ecr-pullthroughcache/` Secrets Manager credential, the
+  `aws_ecr_repository_creation_template`, the custom IAM role, and the
+  `aws_ecr_registry_scanning_configuration`), plus a shared-account terragrunt
+  unit `terragrunt/shared/eu-west-1/ecr-pull-through-cache`.
+- Migration: deploy the rules + template + scanning, inject the Docker Hub token
+  via ESO, then repoint workload/CI image references from public registries to
+  the `<acct>.dkr.ecr.<region>.amazonaws.com/<prefix>/…` form.
+- Rollback: cached repos and rules can be removed; consumers fall back to direct
+  public pulls (reverting to the status quo).
+- CI/test: terraform-checks (`fmt`, `validate`, `terraform test` with a mock
+  provider) over the module; no apply in CI for this account.
+
+Effort: **M**.
+
+## References
+
+- Using pull through cache rules (supported upstreams, Docker Hub credential):
+  <https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache.html>
+- ECR repository creation templates:
+  <https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-creation-templates.html>
+- ECR enhanced/basic scanning:
+  <https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html>
+- Terraform: `aws_ecr_pull_through_cache_rule`, `aws_ecr_repository_creation_template`,
+  `aws_ecr_registry_scanning_configuration` (hashicorp/aws ~> 6.0)
+- Related: ADR-0008 (External Secrets Operator — delivers the Docker Hub token),
+  ADR-0016 (Tier-1 supply-chain hardening), ADR-0007 (Karpenter — scale-up pull bursts)
+
+---
+*Proposal — doc-verified 2026-06-08 (official AWS / Terraform AWS provider docs) —
+2026 platform modernization; grounded in infra@572b54d / argocd@c364c6c. Accepted,
+ratified 2026-06-08 by platform owner; not yet implemented in platform-design.*

--- a/terraform/modules/ecr-pull-through-cache/README.md
+++ b/terraform/modules/ecr-pull-through-cache/README.md
@@ -1,0 +1,123 @@
+# ecr-pull-through-cache
+
+ECR **Pull-Through Cache (PTC)** for public upstream registries — mirrors
+Docker Hub, Quay, GHCR, `registry.k8s.io`, `public.ecr.aws` (and optionally
+GitLab) into this account's **private** ECR registry. Implements **ADR-0029**.
+
+Defeats **Docker Hub rate-limits** and **external-registry outages**: once an
+image is pulled through the cache, subsequent pulls are served from your private
+ECR — no upstream round-trip, no anonymous rate-limit, no dependency on the
+upstream being reachable.
+
+## How callers consume it
+
+Reference the upstream image under the local cache prefix:
+
+```text
+<acct>.dkr.ecr.<region>.amazonaws.com/<prefix>/<upstream-image>
+```
+
+| Upstream | Default prefix | Example pull |
+|---|---|---|
+| Docker Hub (`registry-1.docker.io`) | `docker-hub` | `…/docker-hub/library/nginx:1.27` |
+| Quay (`quay.io`) | `quay` | `…/quay/prometheus/prometheus:v3.0.0` |
+| GHCR (`ghcr.io`) | `ghcr` | `…/ghcr/external-secrets/external-secrets:v0.10.0` |
+| `registry.k8s.io` | `k8s` | `…/k8s/kube-state-metrics/kube-state-metrics:v2.13.0` |
+| `public.ecr.aws` | `ecr-public` | `…/ecr-public/karpenter/controller:1.0.0` |
+
+The repository under each prefix is **created automatically on first pull** by
+the repository creation template — no pre-provisioning of individual repos.
+
+## What this module creates
+
+| Resource | Purpose |
+|---|---|
+| `aws_ecr_pull_through_cache_rule` (per upstream) | Maps a local prefix → upstream registry URL |
+| `aws_secretsmanager_secret` + `_version` (`ecr-pullthroughcache/…`) | Docker Hub upstream credential (placeholder; real value injected out-of-band) |
+| `aws_ecr_repository_creation_template` (`ROOT`, `PULL_THROUGH_CACHE`) | Auto-config for cached repos: KMS encryption, immutable tags, lifecycle |
+| `aws_iam_role` + `aws_iam_role_policy` | Custom role ECR assumes to create cached repos (required for KMS + tags) |
+| `aws_ecr_registry_scanning_configuration` | Scan cached repos on push (`SCAN_ON_PUSH` / `CONTINUOUS_SCAN`) |
+
+## Docker Hub credential (required)
+
+AWS requires an **upstream credential** for the Docker Hub PTC rule, stored in
+Secrets Manager under a name that **must** start with `ecr-pullthroughcache/`.
+This module creates the secret with a **placeholder** value:
+
+```json
+{ "username": "REPLACE_ME", "accessToken": "REPLACE_ME" }
+```
+
+The real Docker Hub username + a **read-only access token** are injected
+**out-of-band** (External Secrets Operator / a secure pipeline — ADR-0008). The
+`secret_version` uses `ignore_changes = [secret_string]` so Terraform never
+clobbers the rotated value. **Never commit real credentials.**
+
+## Usage
+
+```hcl
+module "ecr_pull_through_cache" {
+  source = "../../terraform/modules/ecr-pull-through-cache"
+
+  kms_key_arn = module.kms.key_arns["ecr"]
+
+  # Defaults already include ecr-public, docker-hub, quay, ghcr, k8s.
+  # Override only to add/remove upstreams (e.g. add GitLab):
+  upstreams = {
+    ecr-public = { upstream_registry_url = "public.ecr.aws" }
+    docker-hub = { upstream_registry_url = "registry-1.docker.io", requires_credential = true }
+    quay       = { upstream_registry_url = "quay.io" }
+    ghcr       = { upstream_registry_url = "ghcr.io" }
+    k8s        = { upstream_registry_url = "registry.k8s.io" }
+  }
+
+  tags = {
+    Environment = "shared"
+    ManagedBy   = "terraform"
+  }
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Default |
+|---|---|---|---|
+| `upstreams` | Map of `prefix → { upstream_registry_url, requires_credential }` | `map(object)` | docker-hub/quay/ghcr/k8s/ecr-public |
+| `kms_key_arn` | CMK for cached-repo encryption (drives the custom role) | `string` | `null` |
+| `create_repository_creation_template` | Auto-config cached repos | `bool` | `true` |
+| `create_registry_scanning_configuration` | Manage registry scanning (singleton) | `bool` | `true` |
+| `scan_type` | `BASIC` or `ENHANCED` | `string` | `ENHANCED` |
+| `image_tag_mutability` | `MUTABLE` / `IMMUTABLE` | `string` | `IMMUTABLE` |
+| `max_image_count` | Tagged images retained per repo | `number` | `50` |
+| `untagged_expiry_days` | Untagged image expiry | `number` | `7` |
+| `dockerhub_secret_placeholder` | Placeholder JSON for the credential (sensitive) | `string` | `REPLACE_ME` JSON |
+| `recovery_window_in_days` | Secret recovery window | `number` | `7` |
+| `tags` | Tags for all resources | `map(string)` | `{}` |
+
+## Outputs
+
+| Name | Description |
+|---|---|
+| `pull_through_cache_prefixes` | `upstream key → local ECR prefix` |
+| `pull_through_cache_rules` | `upstream key → { prefix, upstream_registry_url, registry_id }` |
+| `dockerhub_credential_secret_arns` | `upstream key → credential secret ARN` |
+| `repository_creation_template_role_arn` | IAM role ARN (or null) |
+| `scanning_configuration_registry_id` | Registry ID for scanning (or null) |
+
+## Notes
+
+- The **registry scanning configuration is a singleton per registry**. If another
+  unit already manages it, set `create_registry_scanning_configuration = false`
+  to avoid a conflict.
+- The repository creation template `prefix = "ROOT"` applies to **all** cached
+  repositories created by PTC in this registry.
+- `scan_on_push` for cached repos is delivered via the **registry scanning
+  configuration** (not the repository creation template), per AWS.
+
+## References
+
+- [Using pull through cache rules](https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache.html)
+- `aws_ecr_pull_through_cache_rule`, `aws_ecr_repository_creation_template`,
+  `aws_ecr_registry_scanning_configuration` (hashicorp/aws ~> 6.0)
+- ADR-0029 — `docs/adrs/0029-ecr-pull-through-cache.md`
+- Related: ADR-0008 (External Secrets Operator), ADR-0016 (supply-chain hardening)

--- a/terraform/modules/ecr-pull-through-cache/ecr-pull-through-cache.tftest.hcl
+++ b/terraform/modules/ecr-pull-through-cache/ecr-pull-through-cache.tftest.hcl
@@ -1,0 +1,120 @@
+mock_provider "aws" {}
+
+variables {
+  kms_key_arn = "arn:aws:kms:eu-west-1:111111111111:key/00000000-0000-0000-0000-000000000000"
+  tags = {
+    Environment = "shared"
+    Team        = "platform"
+    ManagedBy   = "terraform"
+  }
+}
+
+run "creates_a_rule_per_upstream" {
+  command = plan
+
+  assert {
+    condition     = length(aws_ecr_pull_through_cache_rule.this) == length(var.upstreams)
+    error_message = "Should create one pull-through cache rule per upstream"
+  }
+}
+
+run "default_upstreams_present" {
+  command = plan
+
+  assert {
+    condition     = aws_ecr_pull_through_cache_rule.this["ecr-public"].upstream_registry_url == "public.ecr.aws"
+    error_message = "ecr-public upstream should map to public.ecr.aws"
+  }
+
+  assert {
+    condition     = aws_ecr_pull_through_cache_rule.this["k8s"].upstream_registry_url == "registry.k8s.io"
+    error_message = "k8s upstream should map to registry.k8s.io"
+  }
+
+  assert {
+    condition     = aws_ecr_pull_through_cache_rule.this["quay"].upstream_registry_url == "quay.io"
+    error_message = "quay upstream should map to quay.io"
+  }
+
+  assert {
+    condition     = aws_ecr_pull_through_cache_rule.this["ghcr"].upstream_registry_url == "ghcr.io"
+    error_message = "ghcr upstream should map to ghcr.io"
+  }
+}
+
+run "dockerhub_credential_secret_created_with_required_prefix" {
+  command = plan
+
+  assert {
+    condition     = aws_secretsmanager_secret.dockerhub["docker-hub"].name == "ecr-pullthroughcache/docker-hub"
+    error_message = "Docker Hub credential secret name must start with the AWS-required ecr-pullthroughcache/ prefix"
+  }
+
+  assert {
+    condition     = length(aws_secretsmanager_secret.dockerhub) == 1
+    error_message = "Only Docker Hub (requires_credential = true) should get an upstream credential secret by default"
+  }
+}
+
+run "repository_creation_template_uses_kms_and_role" {
+  command = plan
+
+  assert {
+    condition     = length(aws_ecr_repository_creation_template.this) == 1
+    error_message = "Repository creation template should be created by default"
+  }
+
+  assert {
+    condition     = contains(aws_ecr_repository_creation_template.this[0].applied_for, "PULL_THROUGH_CACHE")
+    error_message = "Repository creation template must be applied for PULL_THROUGH_CACHE"
+  }
+
+  assert {
+    condition     = aws_ecr_repository_creation_template.this[0].encryption_configuration[0].encryption_type == "KMS"
+    error_message = "Cached repositories should be KMS-encrypted when a kms_key_arn is provided"
+  }
+
+  assert {
+    condition     = length(aws_iam_role.template) == 1
+    error_message = "A custom IAM role is required for KMS-encrypted / tagged cached repositories"
+  }
+}
+
+run "immutable_tags_by_default" {
+  command = plan
+
+  assert {
+    condition     = aws_ecr_repository_creation_template.this[0].image_tag_mutability == "IMMUTABLE"
+    error_message = "Cached repositories should use immutable image tags by default"
+  }
+}
+
+run "scanning_configuration_managed_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(aws_ecr_registry_scanning_configuration.this) == 1
+    error_message = "Registry scanning configuration should be managed by default"
+  }
+
+  assert {
+    condition     = aws_ecr_registry_scanning_configuration.this[0].scan_type == "ENHANCED"
+    error_message = "Default scan_type should be ENHANCED"
+  }
+}
+
+run "rejects_unsupported_upstream" {
+  command = plan
+
+  variables {
+    upstreams = {
+      bogus = {
+        upstream_registry_url = "registry.example.com"
+      }
+    }
+  }
+
+  expect_failures = [
+    var.upstreams,
+  ]
+}

--- a/terraform/modules/ecr-pull-through-cache/main.tf
+++ b/terraform/modules/ecr-pull-through-cache/main.tf
@@ -1,0 +1,215 @@
+# -----------------------------------------------------------------------------
+# ECR Pull-Through Cache (ADR-0029)
+# -----------------------------------------------------------------------------
+# Mirrors public upstream registries (Docker Hub, Quay, GHCR, registry.k8s.io,
+# public.ecr.aws, GitLab) into this account's private ECR registry to defeat
+# Docker Hub rate-limits and external-registry outages. Cached repositories are
+# auto-created on first pull by the repository creation template with KMS
+# encryption, immutable tags, a lifecycle policy, and scan-on-push.
+#
+# Callers pull as:
+#   <acct>.dkr.ecr.<region>.amazonaws.com/<prefix>/<upstream-image>
+# e.g.  <acct>.dkr.ecr.eu-west-1.amazonaws.com/docker-hub/library/nginx:1.27
+# -----------------------------------------------------------------------------
+
+locals {
+  # Upstreams that need an upstream credential (e.g. Docker Hub).
+  credentialed_upstreams = {
+    for k, v in var.upstreams : k => v if try(v.requires_credential, false)
+  }
+
+  # The custom IAM role is mandatory for the repository creation template when
+  # it uses KMS encryption and/or resource tags (AWS requirement).
+  create_template_role = var.create_repository_creation_template
+
+  # ecr_repository_prefix values managed by the creation template + scanning.
+  cache_prefixes = [for k, v in var.upstreams : "${k}/*"]
+}
+
+# -----------------------------------------------------------------------------
+# Upstream credentials (Docker Hub) — Secrets Manager, ecr-pullthroughcache/ prefix
+# -----------------------------------------------------------------------------
+# AWS requires the secret name to start with `ecr-pullthroughcache/`. The value
+# is a placeholder here; the real Docker Hub username + access token are injected
+# out-of-band (ESO / secure pipeline) and ignored on subsequent applies.
+resource "aws_secretsmanager_secret" "dockerhub" {
+  for_each = local.credentialed_upstreams
+
+  name        = "ecr-pullthroughcache/${each.key}"
+  description = "Upstream credential for ECR Pull-Through Cache rule '${each.key}' (${each.value.upstream_registry_url})"
+  kms_key_id  = var.kms_key_arn
+
+  recovery_window_in_days = var.recovery_window_in_days
+
+  tags = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "dockerhub" {
+  for_each = local.credentialed_upstreams
+
+  secret_id     = aws_secretsmanager_secret.dockerhub[each.key].id
+  secret_string = var.dockerhub_secret_placeholder
+
+  lifecycle {
+    # Real credentials are rotated out-of-band; do not clobber them.
+    ignore_changes = [secret_string]
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Pull-through cache rules — one per upstream
+# -----------------------------------------------------------------------------
+resource "aws_ecr_pull_through_cache_rule" "this" {
+  for_each = var.upstreams
+
+  ecr_repository_prefix = each.key
+  upstream_registry_url = each.value.upstream_registry_url
+
+  credential_arn = try(each.value.requires_credential, false) ? aws_secretsmanager_secret.dockerhub[each.key].arn : null
+}
+
+# -----------------------------------------------------------------------------
+# IAM role used by the repository creation template
+# -----------------------------------------------------------------------------
+# Required whenever the creation template applies KMS encryption or resource
+# tags. ECR assumes this role to create the cached repository on first pull.
+locals {
+  template_assume_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "EcrPtcAssume"
+        Effect    = "Allow"
+        Action    = "sts:AssumeRole"
+        Principal = { Service = "pullthroughcache.ecr.amazonaws.com" }
+      },
+    ]
+  })
+
+  template_permissions_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(
+      [
+        {
+          Sid    = "CreateCachedRepositories"
+          Effect = "Allow"
+          Action = [
+            "ecr:CreateRepository",
+            "ecr:ReplicateImage",
+            "ecr:BatchImportUpstreamImage",
+            "ecr:TagResource",
+            "ecr:PutLifecyclePolicy",
+            "ecr:SetRepositoryPolicy",
+          ]
+          Resource = "*"
+        },
+      ],
+      var.kms_key_arn != null ? [
+        {
+          Sid    = "KmsForCachedRepositories"
+          Effect = "Allow"
+          Action = [
+            "kms:Decrypt",
+            "kms:Encrypt",
+            "kms:GenerateDataKey",
+            "kms:CreateGrant",
+            "kms:DescribeKey",
+          ]
+          Resource = var.kms_key_arn
+        },
+      ] : []
+    )
+  })
+}
+
+resource "aws_iam_role" "template" {
+  count = local.create_template_role ? 1 : 0
+
+  name               = "ecr-ptc-repo-creation"
+  assume_role_policy = local.template_assume_policy
+  description        = "Role assumed by ECR Pull-Through Cache to create cached repositories (ADR-0029)."
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy" "template" {
+  count = local.create_template_role ? 1 : 0
+
+  name   = "ecr-ptc-repo-creation"
+  role   = aws_iam_role.template[0].id
+  policy = local.template_permissions_policy
+}
+
+# -----------------------------------------------------------------------------
+# Repository creation template — auto-configures cached repos on first pull
+# -----------------------------------------------------------------------------
+# `prefix = "ROOT"` applies to every cached repository created by PTC across all
+# the rules above. KMS encryption + resource tags drive the custom_role_arn.
+resource "aws_ecr_repository_creation_template" "this" {
+  count = var.create_repository_creation_template ? 1 : 0
+
+  prefix      = "ROOT"
+  description = "Auto-config for ECR Pull-Through Cache repositories (ADR-0029)"
+  applied_for = ["PULL_THROUGH_CACHE"]
+
+  image_tag_mutability = var.image_tag_mutability
+  custom_role_arn      = aws_iam_role.template[0].arn
+
+  encryption_configuration {
+    encryption_type = var.kms_key_arn != null ? "KMS" : "AES256"
+    kms_key         = var.kms_key_arn
+  }
+
+  lifecycle_policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last ${var.max_image_count} tagged images"
+        selection = {
+          tagStatus      = "tagged"
+          tagPatternList = ["*"]
+          countType      = "imageCountMoreThan"
+          countNumber    = var.max_image_count
+        }
+        action = { type = "expire" }
+      },
+      {
+        rulePriority = 2
+        description  = "Expire untagged images after ${var.untagged_expiry_days} days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = var.untagged_expiry_days
+        }
+        action = { type = "expire" }
+      },
+    ]
+  })
+
+  resource_tags = var.tags
+}
+
+# -----------------------------------------------------------------------------
+# Registry scanning configuration — scan cached repos on push
+# -----------------------------------------------------------------------------
+# The registry scanning configuration is a singleton per registry. We scan the
+# cache prefixes on push (BASIC) or continuously (ENHANCED/Inspector).
+resource "aws_ecr_registry_scanning_configuration" "this" {
+  count = var.create_registry_scanning_configuration ? 1 : 0
+
+  scan_type = var.scan_type
+
+  dynamic "rule" {
+    for_each = toset(local.cache_prefixes)
+
+    content {
+      scan_frequency = var.scan_type == "ENHANCED" ? "CONTINUOUS_SCAN" : "SCAN_ON_PUSH"
+
+      repository_filter {
+        filter      = rule.value
+        filter_type = "WILDCARD"
+      }
+    }
+  }
+}

--- a/terraform/modules/ecr-pull-through-cache/outputs.tf
+++ b/terraform/modules/ecr-pull-through-cache/outputs.tf
@@ -1,0 +1,34 @@
+# -----------------------------------------------------------------------------
+# ecr-pull-through-cache — outputs (ADR-0029)
+# -----------------------------------------------------------------------------
+
+output "pull_through_cache_prefixes" {
+  description = "Map of upstream key to its local ECR repository prefix. Callers pull as <acct>.dkr.ecr.<region>.amazonaws.com/<prefix>/<image>."
+  value       = { for k, r in aws_ecr_pull_through_cache_rule.this : k => r.ecr_repository_prefix }
+}
+
+output "pull_through_cache_rules" {
+  description = "Map of upstream key to { prefix, upstream_registry_url, registry_id } for the created PTC rules."
+  value = {
+    for k, r in aws_ecr_pull_through_cache_rule.this : k => {
+      prefix                = r.ecr_repository_prefix
+      upstream_registry_url = r.upstream_registry_url
+      registry_id           = r.registry_id
+    }
+  }
+}
+
+output "dockerhub_credential_secret_arns" {
+  description = "Map of credentialed-upstream key to the Secrets Manager secret ARN holding its upstream credential (value injected out-of-band)."
+  value       = { for k, s in aws_secretsmanager_secret.dockerhub : k => s.arn }
+}
+
+output "repository_creation_template_role_arn" {
+  description = "ARN of the IAM role assumed by ECR PTC to create cached repositories, or null when the creation template is disabled."
+  value       = try(aws_iam_role.template[0].arn, null)
+}
+
+output "scanning_configuration_registry_id" {
+  description = "Registry ID the scanning configuration applies to, or null when scanning configuration is not managed by this module."
+  value       = try(aws_ecr_registry_scanning_configuration.this[0].registry_id, null)
+}

--- a/terraform/modules/ecr-pull-through-cache/variables.tf
+++ b/terraform/modules/ecr-pull-through-cache/variables.tf
@@ -1,0 +1,140 @@
+# -----------------------------------------------------------------------------
+# ecr-pull-through-cache — input variables (ADR-0029)
+# -----------------------------------------------------------------------------
+
+variable "upstreams" {
+  description = <<-EOT
+    Map of upstream public registries to mirror via ECR Pull-Through Cache.
+    The map key is the local `ecr_repository_prefix` callers pull under
+    (e.g. `docker-hub`, `quay`, `ghcr`, `k8s`, `ecr-public`). Callers then
+    reference images as
+    `<acct>.dkr.ecr.<region>.amazonaws.com/<prefix>/<upstream-image>`.
+
+    Fields:
+      - upstream_registry_url: the upstream registry endpoint
+          (public.ecr.aws, registry-1.docker.io, quay.io, ghcr.io,
+           registry.k8s.io, registry.gitlab.com).
+      - requires_credential: true for registries that AWS requires an upstream
+          credential for (Docker Hub). When true, a Secrets Manager secret named
+          `ecr-pullthroughcache/<key>` is created and wired as `credential_arn`.
+  EOT
+
+  type = map(object({
+    upstream_registry_url = string
+    requires_credential   = optional(bool, false)
+  }))
+
+  default = {
+    ecr-public = {
+      upstream_registry_url = "public.ecr.aws"
+    }
+    docker-hub = {
+      upstream_registry_url = "registry-1.docker.io"
+      requires_credential   = true
+    }
+    quay = {
+      upstream_registry_url = "quay.io"
+    }
+    ghcr = {
+      upstream_registry_url = "ghcr.io"
+    }
+    k8s = {
+      upstream_registry_url = "registry.k8s.io"
+    }
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.upstreams : contains(
+        [
+          "public.ecr.aws",
+          "registry-1.docker.io",
+          "quay.io",
+          "ghcr.io",
+          "registry.k8s.io",
+          "registry.gitlab.com",
+        ],
+        v.upstream_registry_url
+      )
+    ])
+    error_message = "upstream_registry_url must be a supported ECR PTC upstream: public.ecr.aws, registry-1.docker.io, quay.io, ghcr.io, registry.k8s.io, registry.gitlab.com."
+  }
+}
+
+variable "kms_key_arn" {
+  description = "ARN of the KMS CMK used to encrypt cache repositories created by the repository creation template. Required because the template uses KMS encryption and resource tags, which force a custom IAM role."
+  type        = string
+  default     = null
+}
+
+variable "create_repository_creation_template" {
+  description = "Whether to create an aws_ecr_repository_creation_template that auto-configures cached repos (KMS encryption, lifecycle, immutable tags) on first pull."
+  type        = bool
+  default     = true
+}
+
+variable "create_registry_scanning_configuration" {
+  description = "Whether to manage the registry-level scanning configuration so cached repositories are scanned on push. The registry scanning config is a singleton per registry; disable if another unit already owns it."
+  type        = bool
+  default     = true
+}
+
+variable "scan_type" {
+  description = "ECR registry scan type for cached repositories. ENHANCED uses Amazon Inspector; BASIC uses the built-in scanner."
+  type        = string
+  default     = "ENHANCED"
+
+  validation {
+    condition     = contains(["BASIC", "ENHANCED"], var.scan_type)
+    error_message = "scan_type must be either BASIC or ENHANCED."
+  }
+}
+
+variable "image_tag_mutability" {
+  description = "Tag mutability for cached repositories created by the template."
+  type        = string
+  default     = "IMMUTABLE"
+
+  validation {
+    condition     = contains(["MUTABLE", "IMMUTABLE"], var.image_tag_mutability)
+    error_message = "image_tag_mutability must be MUTABLE or IMMUTABLE."
+  }
+}
+
+variable "max_image_count" {
+  description = "Maximum number of tagged images to retain per cached repository before the lifecycle policy expires the oldest."
+  type        = number
+  default     = 50
+}
+
+variable "untagged_expiry_days" {
+  description = "Number of days after which untagged images in cached repositories are expired."
+  type        = number
+  default     = 7
+}
+
+variable "dockerhub_secret_placeholder" {
+  description = <<-EOT
+    Placeholder value seeded into the Docker Hub upstream credential secret.
+    The real value (JSON { "username": "...", "accessToken": "..." }) MUST be
+    injected out-of-band (e.g. via External Secrets Operator / a secure
+    pipeline) and is NOT stored in version control. The lifecycle
+    ignore_changes on secret_string prevents Terraform from clobbering the
+    rotated value on subsequent applies.
+  EOT
+  type        = string
+  default     = "{\"username\":\"REPLACE_ME\",\"accessToken\":\"REPLACE_ME\"}"
+  sensitive   = true
+}
+
+variable "recovery_window_in_days" {
+  description = "Recovery window for the Docker Hub credential Secrets Manager secret. 0 forces immediate deletion (use only in ephemeral/test accounts)."
+  type        = number
+  default     = 7
+}
+
+variable "tags" {
+  description = "Tags applied to all resources created by this module."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/ecr-pull-through-cache/versions.tf
+++ b/terraform/modules/ecr-pull-through-cache/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terragrunt/shared/eu-west-1/ecr-pull-through-cache/terragrunt.hcl
+++ b/terragrunt/shared/eu-west-1/ecr-pull-through-cache/terragrunt.hcl
@@ -1,0 +1,83 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# ECR Pull-Through Cache — Shared-services Account, eu-west-1 (ADR-0029)
+# ---------------------------------------------------------------------------------------------------------------------
+# Mirrors public upstream registries (Docker Hub, Quay, GHCR, registry.k8s.io,
+# public.ecr.aws) into the shared account's private ECR registry to defeat
+# Docker Hub rate-limits and external-registry outages. The shared account
+# already hosts the central ECR registry (see shared/account.hcl), so the cache
+# lives here and is reachable by workload accounts via the registry's
+# cross-account access model.
+#
+# Implements ADR-0029. Cached repos are auto-created on first pull with KMS
+# encryption, immutable tags, lifecycle, and scan-on-push.
+#
+# NOTE: the real Docker Hub credential (username + read-only access token) is
+# injected out-of-band into the `ecr-pullthroughcache/docker-hub` secret via
+# External Secrets Operator (ADR-0008) — never committed here.
+# ---------------------------------------------------------------------------------------------------------------------
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/ecr-pull-through-cache"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  account_name = local.account_vars.locals.account_name
+  aws_region   = local.region_vars.locals.aws_region
+  environment  = local.account_vars.locals.environment
+  owner        = local.account_vars.locals.owner
+  cost_center  = local.account_vars.locals.cost_center
+}
+
+# CMK for cached-repository encryption. Mirrors the cloudtrail/aws-config wiring
+# convention: consume `key_arns["<purpose>"]` from the per-region kms unit.
+# Add an `ecr` key to the kms _envcommon inventory before applying for real.
+dependency "kms" {
+  config_path = "../kms"
+
+  mock_outputs = {
+    key_arns = {
+      ecr = "arn:aws:kms:eu-west-1:000000000000:key/mock-ecr-key"
+    }
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+inputs = {
+  # Public upstreams to mirror. Docker Hub requires an upstream credential.
+  upstreams = {
+    ecr-public = { upstream_registry_url = "public.ecr.aws" }
+    docker-hub = { upstream_registry_url = "registry-1.docker.io", requires_credential = true }
+    quay       = { upstream_registry_url = "quay.io" }
+    ghcr       = { upstream_registry_url = "ghcr.io" }
+    k8s        = { upstream_registry_url = "registry.k8s.io" }
+  }
+
+  kms_key_arn = dependency.kms.outputs.key_arns["ecr"]
+
+  # Cached repos: immutable tags, retain last 50 tagged, expire untagged after 7d.
+  image_tag_mutability = "IMMUTABLE"
+  max_image_count      = 50
+  untagged_expiry_days = 7
+
+  # Enhanced (Inspector) continuous scanning over the cache prefixes.
+  scan_type                              = "ENHANCED"
+  create_registry_scanning_configuration = true
+
+  tags = {
+    Environment = local.environment
+    Account     = local.account_name
+    Owner       = local.owner
+    CostCenter  = local.cost_center
+    ManagedBy   = "terragrunt"
+    ADR         = "0029"
+  }
+}


### PR DESCRIPTION
New ADR-0029 + impl: ECR Pull-Through Cache for docker.io/quay.io/ghcr.io/registry.k8s.io/public.ecr.aws — defeats Docker Hub rate-limits + external-registry outages; auto-created scanned cache repos; Docker Hub creds via Secrets Manager. terraform validate clean (no apply). Refs #252.