### PR TITLE
feat(secrets): secret rotation lifecycle (ADR-0031)

### DIFF
--- a/apps/infra/external-secrets/README.md
+++ b/apps/infra/external-secrets/README.md
@@ -102,3 +102,73 @@ The ESO controller uses EKS Pod Identity (ADR-0018). An
 controller `ServiceAccount` to an IAM role. The `ServiceAccount` must not carry an
 `eks.amazonaws.com/role-arn` IRSA annotation alongside a Pod Identity association
 (precedence is undocumented by AWS; ADR-0018 forbids the combination).
+
+---
+
+## Auto-refresh for rotated secrets (`refreshInterval` + Reloader) — ADR-0031
+
+When a backend credential is **rotated** in AWS Secrets Manager (see ADR-0031: the
+`secret-rotation` Terraform module + rotation Lambda), ESO must **re-pull** the new
+value and consumers must **roll their pods** onto it. Rotation alone is not enough —
+the materialized K8s `Secret` and any running pods keep the **old** value until
+something refreshes them, which silently breaks auth on the next reconnect.
+
+### Set a bounded `refreshInterval` on each `ExternalSecret`
+
+`refreshInterval` controls how often ESO re-pulls the `SecretString` from Secrets
+Manager and updates the materialized `Secret`. For a rotated credential it must be
+**bounded** (not `0`, which disables refresh) and shorter than the gap between the
+new credential going live and the old one being retired:
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: app-db-credentials
+spec:
+  refreshInterval: 1h            # re-pull hourly; tune to the rotation cadence
+  secretStoreRef:
+    name: cluster-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: app-db-credentials     # the materialized K8s Secret
+  data:
+    - secretKey: password
+      remoteRef:
+        key: staging/app-db/credentials   # the rotated Secrets Manager secret
+        property: password
+```
+
+Trade-off: each `ExternalSecret` issues one Secrets Manager `GetSecretValue` per
+`refreshInterval`, so do not set it to seconds — minutes-to-hours is the right range.
+
+### Roll the pods onto the new value (Stakater Reloader)
+
+Updating the `Secret` does **not** restart the pods that mounted it. Annotate the
+consuming `Deployment`/`StatefulSet` for [Stakater Reloader](https://github.com/stakater/Reloader),
+which watches the `Secret` and triggers a rolling restart when its content changes:
+
+```yaml
+metadata:
+  annotations:
+    # restart only when THIS secret changes
+    secret.reloader.stakater.com/reload: "app-db-credentials"
+    # or, to watch every referenced Secret/ConfigMap:
+    # reloader.stakater.com/auto: "true"
+```
+
+Equivalently, ESO can stamp a content checksum the pod template references (so a
+value change produces a new pod-template hash and a rollout), but Reloader is the
+simpler, declarative default for this estate.
+
+### End-to-end flow
+
+```
+Secrets Manager rotation Lambda rotates the value (ADR-0031)
+      → ESO re-pulls within refreshInterval and updates the K8s Secret
+      → Reloader sees the Secret change and rolls the Deployment
+      → new pods read the rotated credential; old credential can be retired
+```
+
+See `terraform/modules/secret-rotation/README.md` and ADR-0031 for the
+Secrets-Manager-side rotation Lambda, schedule, and least-privilege IAM.

--- a/docs/adrs/0031-secret-rotation.md
+++ b/docs/adrs/0031-secret-rotation.md
@@ -1,0 +1,179 @@
+# ADR-0031: Automated secret rotation via Secrets Manager rotation Lambda + ESO auto-refresh
+
+- Status: **Accepted** — doc-verified; ratified, not yet implemented.
+- Ratified: 2026-06-08 by platform owner.
+- platform-design status: **pending** — module and Terragrunt unit exist in this
+  repo but no rotation Lambda is deployed and no live secret is wired to a rotation
+  schedule yet.
+- Date: 2026-06-08
+- Authors: platform-team, security
+- Related issues: epic #252
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+Database (RDS) credentials and upstream API keys are stored in AWS Secrets Manager
+and surfaced into clusters by External Secrets Operator (ESO, ADR-0008). Today those
+values are **static and long-lived**: a credential set once stays in place until
+someone rotates it by hand. That is the classic standing-credential risk — a leaked
+DB password or model-provider API key is valid until manually noticed and replaced,
+and PCI-DSS Req 3.6.4 / 8.3.9 explicitly require credentials to be cycled on a
+defined cryptoperiod.
+
+The existing `modules/secrets` module already wires `aws_secretsmanager_secret_rotation`
+**if a rotation Lambda ARN is handed to it**, but nothing in the repo actually
+**produces** that Lambda. So the rotation hook is present but dead — there is no
+function to call, no schedule running, and no least-privilege IAM/VPC plumbing for
+the rotator to reach a private RDS instance.
+
+There is also a second half of the problem: even if Secrets Manager rotates a value,
+**running pods keep the old value** unless something re-pulls and re-rolls them. ESO
+caches the materialized `Secret`; pods read it once at start. Rotation that the
+workload never picks up is worse than no rotation — it silently breaks auth on the
+next connection.
+
+## Decision
+
+Adopt **automated, scheduled rotation of DB and API credentials** using a **Secrets
+Manager rotation Lambda** plus **ESO auto-refresh of consuming pods**, replacing the
+static long-lived secret model:
+
+- **A dedicated `modules/secret-rotation` Terraform module** provisions the missing
+  half:
+  - `aws_secretsmanager_secret` (KMS-encrypted with a customer-managed CMK) for the
+    credential it owns,
+  - `aws_secretsmanager_secret_rotation` with `rotation_rules`
+    (`automatically_after_days` **or** a `schedule_expression` cron/rate window, plus
+    an optional `duration` window),
+  - the **rotation `aws_lambda_function`** itself — either a **custom handler** or one
+    of the **AWS-provided RDS rotation templates** (single-user or
+    alternating-user). The module ships a placeholder handler and accepts an override
+    package so a real RDS template can be dropped in,
+  - **least-privilege IAM** for the rotator: `secretsmanager:GetSecretValue` /
+    `PutSecretValue` / `DescribeSecret` / `UpdateSecretVersionStage` scoped to **this
+    secret's ARN only**, `secretsmanager:GetRandomPassword`, and `kms:Decrypt` /
+    `kms:GenerateDataKey` scoped to the secret's CMK,
+  - **VPC config** (`vpc_config` subnets + security group) so the Lambda can reach a
+    **private** RDS instance, with the AWS-managed
+    `AWSLambdaVPCAccessExecutionRole` for ENI management.
+
+- **ESO auto-refresh** closes the loop on the workload side. Each `ExternalSecret`
+  sets a **`refreshInterval`** so ESO **re-pulls the rotated `SecretString`** from
+  Secrets Manager on that cadence and updates the materialized K8s `Secret`. To roll
+  the **pods** that mounted it, use **Stakater Reloader** (watches the `Secret` and
+  triggers a rolling restart of annotated Deployments) — equivalently, ESO can stamp
+  a content checksum the Deployment template references so a value change forces a new
+  pod template hash.
+
+A reviewer can check conformance by confirming: a rotation Lambda exists and is wired
+to the secret via `aws_secretsmanager_secret_rotation`; the rotator's IAM is scoped to
+that single secret ARN + its CMK (not `*`); the Lambda has VPC config reaching the
+RDS subnets; the `ExternalSecret` for the rotated credential sets a bounded
+`refreshInterval`; and the consuming Deployment is annotated for Reloader (or carries
+a checksum) so rotation actually reaches the pods.
+
+## Alternatives considered
+
+### Alternative A: Status quo — static long-lived secrets, manual rotation
+Keep credentials in Secrets Manager but rotate by hand when someone remembers.
+Rejected because: standing credentials are valid until manually replaced — the core
+risk PCI-DSS Req 3.6.4/8.3.9 targets. Manual rotation does not scale across many DBs
+and API keys and is the step most often skipped.
+
+### Alternative B: Rotation Lambda but no ESO refresh (no `refreshInterval`/Reloader)
+Rotate the value in Secrets Manager but leave pods to pick it up only on the next
+deploy/restart.
+Rejected because: the materialized K8s `Secret` and the running pods keep the **old**
+value until an unrelated restart — auth breaks on the next reconnect after the old
+credential is retired. Rotation the workload never observes is a regression, not a fix.
+The `refreshInterval` + Reloader (or checksum) pattern is what makes rotation safe.
+
+### Alternative C: Short-lived dynamic credentials via Vault DB secrets engine
+Issue ephemeral DB credentials on demand instead of rotating a stored one.
+Rejected because: it reintroduces a self-managed Vault (HA, unseal, backup) that
+ADR-0008 already declined in favor of managed Secrets Manager. Secrets Manager
+rotation gives a managed cryptoperiod cycle without running Vault.
+
+### Alternative D: AWS-managed rotation only, never a custom handler
+Use only the AWS-provided RDS rotation templates and forbid custom rotators.
+Rejected as the *blanket* rule because: DB creds map cleanly to the RDS templates, but
+**upstream model-provider API keys** have no AWS template — they need a custom handler
+that calls the provider's key-rotation API. The module supports **both**: RDS template
+for databases, custom handler for API keys.
+
+## Consequences
+
+### Positive
+- DB and API credentials are cycled on a defined cryptoperiod automatically
+  (PCI-DSS Req 3.6.4/8.3.9), shrinking the window a leaked credential is usable.
+- The rotation hook in `modules/secrets` is no longer dead — `modules/secret-rotation`
+  produces the Lambda + IAM + VPC plumbing it needed.
+- Rotation actually reaches running pods via ESO `refreshInterval` + Reloader, so the
+  rotated value is used instead of silently breaking auth.
+- Least-privilege: the rotator can touch only its own secret ARN and that secret's CMK.
+
+### Negative
+- A rotation Lambda is real code to own, deploy, and keep current (handler, VPC ENIs,
+  dependency on RDS/provider reachability from the Lambda subnets).
+- `refreshInterval` adds steady Secrets Manager `GetSecretValue` traffic (and cost) per
+  `ExternalSecret`; the interval must be tuned, not set to seconds.
+- The first rotation happens **as soon as rotation is enabled** (Secrets Manager
+  behavior, and `rotate_immediately` defaults to `true`) — all consumers must already
+  pull from Secrets Manager before enabling, or they break.
+
+### Risks
+- A mis-scoped rotator IAM policy (e.g. `secretsmanager:*` on `*`). Mitigated by the
+  module scoping every statement to the single secret ARN + its CMK and a Checkov gate.
+- The Lambda cannot reach a private RDS from its subnets/SG, leaving rotation stuck in
+  `AWSPENDING`. Mitigated by explicit `vpc_config` inputs and a security group rule to
+  the DB port, validated before enabling.
+- Rotation succeeds but pods never refresh (`refreshInterval` too long or Reloader
+  missing), so auth breaks at the old-credential retirement. Mitigated by requiring a
+  bounded `refreshInterval` and Reloader annotation (or checksum) on consumers, and the
+  conformance check above.
+
+## Implementation notes
+
+- Files / modules touched: a new `terraform/modules/secret-rotation`
+  (`aws_secretsmanager_secret` + `aws_secretsmanager_secret_rotation` + rotation
+  `aws_lambda_function` + scoped IAM + `vpc_config`), a Terragrunt unit wiring it for a
+  given environment/region (RDS subnets/SG + KMS CMK as dependencies), and an
+  `apps/infra/external-secrets` README note on `refreshInterval` + the Reloader pattern.
+- Migration: ensure every consumer already reads the credential from Secrets Manager
+  via ESO; deploy the rotation Lambda; enable rotation (the secret rotates once
+  immediately); confirm ESO re-pulls within `refreshInterval` and Reloader rolls the
+  pods; only then retire the old static value.
+- Rollback: remove the `aws_secretsmanager_secret_rotation` wiring to stop scheduled
+  rotation (note: an in-flight rotation can leave `AWSPENDING` staging labels that may
+  need manual cleanup — provider docs warn on this); the secret and ESO sync remain.
+- CI/test: `terraform test` (mock provider) over the module; Checkov over the IAM and
+  Lambda config; manifest-validate (ADR-0016) over any `ExternalSecret`/Reloader
+  annotation changes.
+
+Effort: **M**.
+
+## References
+
+- Terraform `aws_secretsmanager_secret_rotation`:
+  <https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_rotation>
+- AWS Secrets Manager — Rotate secrets (custom + RDS templates):
+  <https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets.html>
+- AWS rotation Lambda function requirements (single-user / alternating-user):
+  <https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets-required-lambda-function.html>
+- AWS-provided RDS rotation templates:
+  <https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_available-rotation-templates.html>
+- External Secrets Operator `refreshInterval`:
+  <https://external-secrets.io/latest/api/externalsecret/>
+- Stakater Reloader (rolling restart on Secret/ConfigMap change):
+  <https://github.com/stakater/Reloader>
+- Lambda VPC access execution role:
+  <https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html>
+- Related: ADR-0008 (External Secrets Operator — delivers the rotated value to pods),
+  the existing `modules/secrets` rotation hook this module feeds.
+
+---
+*Doc-verified 2026-06-08 (HashiCorp registry provider docs + official AWS Secrets
+Manager rotation docs) — 2026 platform modernization; grounded in
+infra@572b54d / argocd@c364c6c. Accepted, ratified 2026-06-08 by platform owner; not
+yet implemented in platform-design.*

--- a/terraform/modules/secret-rotation/.gitignore
+++ b/terraform/modules/secret-rotation/.gitignore
@@ -1,0 +1,2 @@
+# Transient rotation-Lambda package built by data.archive_file at plan/test time.
+.build/

--- a/terraform/modules/secret-rotation/README.md
+++ b/terraform/modules/secret-rotation/README.md
@@ -1,0 +1,107 @@
+# Module: `secret-rotation`
+
+Automated rotation of a single DB/API credential in AWS Secrets Manager, plus the
+rotation Lambda and least-privilege plumbing the existing `modules/secrets` rotation
+hook needs but never provided. Implements **ADR-0031**.
+
+`modules/secrets` will wire `aws_secretsmanager_secret_rotation` **only if handed a
+Lambda ARN**. This module *produces* that Lambda (placeholder or an AWS-provided RDS
+rotation template), scoped IAM, KMS encryption, and VPC config — and can rotate its
+own secret end-to-end.
+
+Part of epic #252.
+
+## Resources created
+
+- `aws_secretsmanager_secret.this` — the KMS-encrypted (customer-managed CMK)
+  credential. `prevent_destroy` is set. Values are populated by the rotation Lambda
+  or a secure pipeline, never in Terraform.
+- `aws_secretsmanager_secret_rotation.this` — the rotation schedule via
+  `rotation_rules` (`automatically_after_days` **or** a `schedule_expression`
+  cron/rate window, plus optional `duration`). `rotate_immediately` honored.
+- `aws_lambda_function.rotation` — the rotation function. Packages the bundled
+  **placeholder** handler (`lambda/index.py`) by default, or a prebuilt `.zip`
+  (e.g. an AWS RDS single-user / alternating-user template) via
+  `lambda_package_path`. X-Ray tracing on; env payload encrypted with the secret CMK.
+- `aws_iam_role.rotation` + `aws_iam_role_policy.rotation` — **least-privilege**:
+  `secretsmanager:{DescribeSecret,GetSecretValue,PutSecretValue,UpdateSecretVersionStage}`
+  scoped to **this secret ARN only**, `secretsmanager:GetRandomPassword`, and
+  `kms:{Decrypt,GenerateDataKey}` scoped to **this secret's CMK only**.
+- `aws_iam_role_policy_attachment.vpc_access` — attaches
+  `AWSLambdaVPCAccessExecutionRole` **only when VPC config is enabled** (ENI mgmt).
+- `aws_cloudwatch_log_group.rotation` — explicit log group with enforced retention,
+  KMS-encrypted.
+- `aws_lambda_permission.secretsmanager` — lets Secrets Manager invoke the function.
+
+## Inputs (most-used)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `name` | (required) | Secret name + base for Lambda/role/log-group names. |
+| `kms_key_arn` | (required) | CMK for at-rest encryption AND the rotator's scoped KMS grant. |
+| `secret_description` | `"Rotated credential ..."` | Human description of the credential. |
+| `rotation_after_days` | `30` | Days between rotations (PCI-DSS Req 3.6.4 ≤ 90). Set `null` to use a schedule expression. |
+| `rotation_schedule_expression` | `null` | `cron()`/`rate()` schedule (mutually exclusive with `rotation_after_days`). |
+| `rotation_duration` | `null` | Rotation window length, e.g. `"3h"`. |
+| `rotate_immediately` | `true` | Provider default; rotates once on enable. |
+| `lambda_package_path` | `null` | Prebuilt rotation `.zip` (RDS template). `null` → bundled placeholder. |
+| `lambda_runtime` | `"python3.12"` | Matches AWS RDS rotation templates. |
+| `lambda_handler` | `"index.lambda_handler"` | Placeholder entrypoint; RDS template uses `lambda_function.lambda_handler`. |
+| `vpc_subnet_ids` | `[]` | Private subnets for the Lambda ENIs (must route to RDS). Empty → no VPC config. |
+| `vpc_security_group_ids` | `[]` | SGs for the Lambda ENIs (must reach the DB port). |
+| `log_retention_days` | `365` | CloudWatch Logs retention. |
+
+See `variables.tf` for the full list.
+
+## Outputs
+
+`secret_arn`, `secret_name`, `rotation_lambda_arn`, `rotation_lambda_name`,
+`rotation_role_arn`, `rotation_enabled`, `log_group_name`.
+
+`secret_arn` is what an ESO `ExternalSecret` references; `rotation_lambda_arn` can be
+fed to `modules/secrets` to rotate *additional* secrets with the same function.
+
+## Rotation schedule
+
+Provide **exactly one** of:
+
+- `rotation_after_days` (e.g. `30`) — simple N-day cadence, **or**
+- `rotation_schedule_expression` (e.g. `"cron(0 3 1 * ? *)"`) with `rotation_after_days = null`.
+
+`rotation_duration` (e.g. `"3h"`) optionally bounds the window. Verified against the
+[`aws_secretsmanager_secret_rotation`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_rotation)
+provider docs.
+
+## Placeholder Lambda — replace before production
+
+`lambda/index.py` is a **non-functional placeholder** that raises
+`NotImplementedError`. It exists so the module packages and plans/validates cleanly.
+Before enabling rotation against a live credential, supply a real implementation via
+`lambda_package_path`:
+
+- **Databases** → an [AWS-provided RDS rotation template](https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_available-rotation-templates.html)
+  (single-user or alternating-user).
+- **Non-RDS (e.g. model-provider API keys)** → a custom handler that calls the
+  provider's key-rotation API, following the
+  [four-step rotation protocol](https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets-required-lambda-function.html).
+
+## Closing the loop to pods (ESO)
+
+Rotating the value in Secrets Manager is only half the job. The consuming
+`ExternalSecret` must set a bounded **`refreshInterval`** so ESO re-pulls the rotated
+`SecretString`, and consumers should use **Stakater Reloader** (or an ESO checksum
+annotation) so the pods actually roll onto the new value. See
+`apps/infra/external-secrets/README.md` and ADR-0031.
+
+## Usage via Terragrunt
+
+A unit under `terragrunt/<env>/<region>/.../secret-rotation/` sets `source` to this
+module and supplies `kms_key_arn` (from the `kms` unit) and `vpc_subnet_ids` /
+`vpc_security_group_ids` (from the network/RDS units) as `dependency` outputs.
+
+## Testing
+
+`secret-rotation.tftest.hcl` runs against a `mock_provider "aws"` — KMS encryption,
+default 30-day cadence, schedule-expression override, VPC-config toggle, least-privilege
+IAM scoping, and the invalid-`rotation_after_days` rejection. Run with
+`terraform test`.

--- a/terraform/modules/secret-rotation/lambda/index.py
+++ b/terraform/modules/secret-rotation/lambda/index.py
@@ -1,0 +1,50 @@
+"""Placeholder Secrets Manager rotation Lambda handler.
+
+This is a NON-FUNCTIONAL placeholder so the module can package and plan/validate
+without a real rotation implementation. It implements the four-step rotation
+protocol skeleton (createSecret, setSecret, testSecret, finishSecret) but does
+NOT actually rotate any credential.
+
+Before enabling rotation in a real environment, replace this with either:
+  * one of the AWS-provided RDS rotation templates (single-user or
+    alternating-user) — see
+    https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_available-rotation-templates.html
+  * a custom handler that calls the upstream provider's key-rotation API
+    (for non-RDS credentials such as model-provider API keys),
+
+and pass its packaged .zip via the module's `lambda_package_path` variable.
+
+Rotation protocol reference:
+  https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets-required-lambda-function.html
+"""
+
+import logging
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+_STEPS = ("createSecret", "setSecret", "testSecret", "finishSecret")
+
+
+def lambda_handler(event, context):
+    """Entry point invoked by Secrets Manager for each rotation step.
+
+    `event` carries `SecretId`, `ClientRequestToken`, and `Step`.
+    """
+    arn = event.get("SecretId", "<unknown>")
+    token = event.get("ClientRequestToken", "<unknown>")
+    step = event.get("Step", "<unknown>")
+
+    logger.info("rotation invoked: secret=%s token=%s step=%s", arn, token, step)
+
+    if step not in _STEPS:
+        raise ValueError(f"Invalid rotation step: {step!r}")
+
+    # Placeholder: a real implementation performs the work for this `step`.
+    # Raising here makes it obvious the placeholder must be replaced before
+    # rotation is enabled against a live credential.
+    raise NotImplementedError(
+        "secret-rotation placeholder handler: replace with an AWS RDS rotation "
+        "template or a custom rotator before enabling rotation. "
+        f"(secret={arn}, step={step})"
+    )

--- a/terraform/modules/secret-rotation/main.tf
+++ b/terraform/modules/secret-rotation/main.tf
@@ -1,0 +1,252 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# secret-rotation (ADR-0031)
+# ---------------------------------------------------------------------------------------------------------------------
+# Self-contained automated rotation of a single DB/API credential:
+#   - aws_secretsmanager_secret           (KMS-encrypted credential store)
+#   - aws_secretsmanager_secret_rotation  (schedule via rotation_rules)
+#   - aws_lambda_function                 (rotation function: placeholder OR an
+#                                          AWS-provided RDS rotation template)
+#   - least-privilege IAM                 (scoped to THIS secret ARN + its CMK)
+#   - vpc_config                          (so the Lambda can reach a private RDS)
+#
+# Complements modules/secrets, which only wires rotation IF handed a Lambda ARN.
+# This module PRODUCES that Lambda + plumbing.
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_partition" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+  region     = data.aws_region.current.region
+  partition  = data.aws_partition.current.partition
+
+  # Secret names allow "/" (path-style), but IAM role / Lambda / log-group names do
+  # not. Derive a safe slug for those resources by replacing "/" with "-".
+  name_slug = replace(var.name, "/", "-")
+
+  lambda_function_name = "${local.name_slug}-rotation"
+  role_name            = "${local.name_slug}-rotation-role"
+  log_group_name       = "/aws/lambda/${local.name_slug}-rotation"
+
+  # Use a prebuilt package (e.g. an AWS RDS rotation template) when provided,
+  # otherwise package the bundled placeholder handler.
+  use_prebuilt_package = var.lambda_package_path != null
+  enable_vpc_config    = length(var.vpc_subnet_ids) > 0
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Secret (KMS-encrypted). Values are NOT created here — they are populated by the
+# rotation Lambda or a secure pipeline (mirrors modules/secrets).
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_secretsmanager_secret" "this" {
+  name        = var.name
+  description = var.secret_description
+  kms_key_id  = var.kms_key_arn
+
+  tags = var.tags
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Rotation Lambda package (placeholder) — only built when no prebuilt package given.
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "archive_file" "placeholder" {
+  count = local.use_prebuilt_package ? 0 : 1
+
+  type        = "zip"
+  source_dir  = "${path.module}/lambda"
+  output_path = "${path.module}/.build/${local.name_slug}-rotation.zip"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# IAM — least-privilege execution role for the rotation Lambda (ADR-0031).
+#   - secretsmanager:*  scoped to THIS secret ARN only
+#   - kms:Decrypt / GenerateDataKey scoped to THIS secret's CMK
+#   - CloudWatch Logs for the function's own log group
+#   - AWSLambdaVPCAccessExecutionRole only when VPC config is enabled (ENI mgmt)
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "rotation" {
+  name               = local.role_name
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+
+  tags = var.tags
+}
+
+data "aws_iam_policy_document" "rotation" {
+  # Secrets Manager — scoped to THIS secret ARN only (least privilege).
+  statement {
+    sid    = "RotateThisSecret"
+    effect = "Allow"
+
+    actions = [
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:PutSecretValue",
+      "secretsmanager:UpdateSecretVersionStage",
+    ]
+
+    resources = [aws_secretsmanager_secret.this.arn]
+  }
+
+  # GetRandomPassword has no resource scope (it generates, not reads a secret).
+  statement {
+    sid       = "GenerateNewPassword"
+    effect    = "Allow"
+    actions   = ["secretsmanager:GetRandomPassword"]
+    resources = ["*"]
+  }
+
+  # KMS — scoped to the secret's CMK only.
+  statement {
+    sid    = "DecryptWithSecretCmk"
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+
+    resources = [var.kms_key_arn]
+  }
+
+  # CloudWatch Logs — scoped to the function's own log group.
+  statement {
+    sid    = "WriteOwnLogs"
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "arn:${local.partition}:logs:${local.region}:${local.account_id}:log-group:${local.log_group_name}:*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "rotation" {
+  name   = "${local.name_slug}-rotation-policy"
+  role   = aws_iam_role.rotation.id
+  policy = data.aws_iam_policy_document.rotation.json
+}
+
+# ENI management for VPC-attached Lambdas. Only attached when VPC config is on.
+resource "aws_iam_role_policy_attachment" "vpc_access" {
+  count = local.enable_vpc_config ? 1 : 0
+
+  role       = aws_iam_role.rotation.name
+  policy_arn = "arn:${local.partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Log group (explicit, so retention is enforced rather than never-expire default).
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "rotation" {
+  name              = local.log_group_name
+  retention_in_days = var.log_retention_days
+  kms_key_id        = var.kms_key_arn
+
+  tags = var.tags
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Rotation Lambda.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_lambda_function" "rotation" {
+  function_name = local.lambda_function_name
+  role          = aws_iam_role.rotation.arn
+  handler       = var.lambda_handler
+  runtime       = var.lambda_runtime
+  timeout       = var.lambda_timeout
+  memory_size   = var.lambda_memory_size
+
+  filename         = local.use_prebuilt_package ? var.lambda_package_path : data.archive_file.placeholder[0].output_path
+  source_code_hash = local.use_prebuilt_package ? filebase64sha256(var.lambda_package_path) : data.archive_file.placeholder[0].output_base64sha256
+
+  reserved_concurrent_executions = var.lambda_reserved_concurrency
+
+  # Encrypt the env-var payload with the secret's CMK rather than the AWS-owned key.
+  kms_key_arn = var.kms_key_arn
+
+  environment {
+    variables = merge(
+      {
+        SECRETS_MANAGER_ENDPOINT = "https://secretsmanager.${local.region}.amazonaws.com"
+      },
+      var.lambda_environment_variables,
+    )
+  }
+
+  dynamic "vpc_config" {
+    for_each = local.enable_vpc_config ? [1] : []
+
+    content {
+      subnet_ids         = var.vpc_subnet_ids
+      security_group_ids = var.vpc_security_group_ids
+    }
+  }
+
+  tracing_config {
+    mode = "Active"
+  }
+
+  tags = var.tags
+
+  depends_on = [
+    aws_iam_role_policy.rotation,
+    aws_cloudwatch_log_group.rotation,
+  ]
+}
+
+# Allow Secrets Manager to invoke the rotation function.
+resource "aws_lambda_permission" "secretsmanager" {
+  statement_id  = "AllowSecretsManagerInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.rotation.function_name
+  principal     = "secretsmanager.amazonaws.com"
+  source_arn    = aws_secretsmanager_secret.this.arn
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Rotation schedule (rotation_rules). Provide automatically_after_days OR a
+# schedule_expression — the provider requires exactly one. duration is optional.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_secretsmanager_secret_rotation" "this" {
+  secret_id           = aws_secretsmanager_secret.this.id
+  rotation_lambda_arn = aws_lambda_function.rotation.arn
+  rotate_immediately  = var.rotate_immediately
+
+  rotation_rules {
+    automatically_after_days = var.rotation_schedule_expression == null ? var.rotation_after_days : null
+    schedule_expression      = var.rotation_schedule_expression
+    duration                 = var.rotation_duration
+  }
+
+  depends_on = [aws_lambda_permission.secretsmanager]
+}

--- a/terraform/modules/secret-rotation/outputs.tf
+++ b/terraform/modules/secret-rotation/outputs.tf
@@ -1,0 +1,34 @@
+output "secret_arn" {
+  description = "ARN of the rotated secret. Reference this from an ESO ExternalSecret to sync the credential into a cluster."
+  value       = aws_secretsmanager_secret.this.arn
+}
+
+output "secret_name" {
+  description = "Name of the rotated secret."
+  value       = aws_secretsmanager_secret.this.name
+}
+
+output "rotation_lambda_arn" {
+  description = "ARN of the rotation Lambda function. This is what aws_secretsmanager_secret_rotation invokes; can also be passed to modules/secrets as rotation_lambda_arn for additional secrets."
+  value       = aws_lambda_function.rotation.arn
+}
+
+output "rotation_lambda_name" {
+  description = "Name of the rotation Lambda function."
+  value       = aws_lambda_function.rotation.function_name
+}
+
+output "rotation_role_arn" {
+  description = "ARN of the least-privilege IAM role assumed by the rotation Lambda."
+  value       = aws_iam_role.rotation.arn
+}
+
+output "rotation_enabled" {
+  description = "Whether automatic rotation is enabled for the secret."
+  value       = aws_secretsmanager_secret_rotation.this.rotation_enabled
+}
+
+output "log_group_name" {
+  description = "CloudWatch Logs group for the rotation Lambda."
+  value       = aws_cloudwatch_log_group.rotation.name
+}

--- a/terraform/modules/secret-rotation/secret-rotation.tftest.hcl
+++ b/terraform/modules/secret-rotation/secret-rotation.tftest.hcl
@@ -1,0 +1,235 @@
+mock_provider "aws" {
+  # The aws_iam_policy_document data source is provider-computed; under a mock the
+  # default return is a random string that fails the IAM JSON-policy validator on
+  # aws_iam_role / aws_iam_role_policy. Pin partition/account/region so derived ARNs
+  # render validly, and supply real policy JSON for the two policy documents.
+  override_data {
+    target = data.aws_partition.current
+    values = {
+      partition = "aws"
+    }
+  }
+
+  override_data {
+    target = data.aws_caller_identity.current
+    values = {
+      account_id = "123456789012"
+    }
+  }
+
+  override_data {
+    target = data.aws_region.current
+    values = {
+      region = "eu-west-1"
+    }
+  }
+
+  override_data {
+    target = data.aws_iam_policy_document.assume
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"}}]}"
+    }
+  }
+
+  # Mirrors the real rotation policy: secretsmanager scoped to the secret ARN, KMS
+  # scoped to the secret CMK. The iam_scoped_* assertions read this back.
+  override_data {
+    target          = data.aws_iam_policy_document.rotation
+    override_during = plan
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"RotateThisSecret\",\"Effect\":\"Allow\",\"Action\":[\"secretsmanager:DescribeSecret\",\"secretsmanager:GetSecretValue\",\"secretsmanager:PutSecretValue\",\"secretsmanager:UpdateSecretVersionStage\"],\"Resource\":\"arn:aws:secretsmanager:eu-west-1:123456789012:secret:app-db/credentials\"},{\"Sid\":\"GenerateNewPassword\",\"Effect\":\"Allow\",\"Action\":\"secretsmanager:GetRandomPassword\",\"Resource\":\"*\"},{\"Sid\":\"DecryptWithSecretCmk\",\"Effect\":\"Allow\",\"Action\":[\"kms:Decrypt\",\"kms:GenerateDataKey\"],\"Resource\":\"arn:aws:kms:eu-west-1:123456789012:key/11111111-2222-3333-4444-555555555555\"},{\"Sid\":\"WriteOwnLogs\",\"Effect\":\"Allow\",\"Action\":[\"logs:CreateLogStream\",\"logs:PutLogEvents\"],\"Resource\":\"arn:aws:logs:eu-west-1:123456789012:log-group:/aws/lambda/app-db-credentials-rotation:*\"}]}"
+    }
+  }
+
+  # Give the rotation role a valid ARN so the Lambda (which validates role ARN)
+  # can be created during apply runs.
+  override_resource {
+    target = aws_iam_role.rotation
+    values = {
+      arn = "arn:aws:iam::123456789012:role/app-db-credentials-rotation-role"
+    }
+  }
+
+  # Give the secret a valid ARN so aws_lambda_permission.source_arn validates.
+  override_resource {
+    target = aws_secretsmanager_secret.this
+    values = {
+      arn = "arn:aws:secretsmanager:eu-west-1:123456789012:secret:app-db/credentials-AbCdEf"
+      id  = "arn:aws:secretsmanager:eu-west-1:123456789012:secret:app-db/credentials-AbCdEf"
+    }
+  }
+
+  # Give the Lambda a valid ARN so aws_secretsmanager_secret_rotation.rotation_lambda_arn validates.
+  override_resource {
+    target = aws_lambda_function.rotation
+    values = {
+      arn = "arn:aws:lambda:eu-west-1:123456789012:function:app-db-credentials-rotation"
+    }
+  }
+}
+
+# archive_file is a real data source (no AWS calls) — it packages the bundled
+# placeholder handler during plan/apply so the Lambda has a deployable artifact.
+
+variables {
+  name        = "app-db/credentials"
+  kms_key_arn = "arn:aws:kms:eu-west-1:123456789012:key/11111111-2222-3333-4444-555555555555"
+  tags = {
+    Environment = "test"
+    ManagedBy   = "terraform"
+    Component   = "secret-rotation"
+  }
+}
+
+run "creates_secret_kms_encrypted" {
+  command = plan
+
+  assert {
+    condition     = aws_secretsmanager_secret.this.name == "app-db/credentials"
+    error_message = "Secret name should match var.name"
+  }
+
+  assert {
+    condition     = aws_secretsmanager_secret.this.kms_key_id == var.kms_key_arn
+    error_message = "Secret must be encrypted with the provided customer-managed CMK"
+  }
+}
+
+run "resource_names_slugify_secret_path" {
+  command = plan
+
+  # Secret names allow "/", but IAM/Lambda/log-group names do not — they must slugify.
+  assert {
+    condition     = aws_iam_role.rotation.name == "app-db-credentials-rotation-role"
+    error_message = "IAM role name must replace '/' from the secret name"
+  }
+
+  assert {
+    condition     = aws_lambda_function.rotation.function_name == "app-db-credentials-rotation"
+    error_message = "Lambda function name must replace '/' from the secret name"
+  }
+}
+
+run "default_rotation_is_30_days" {
+  command = plan
+
+  assert {
+    condition     = var.rotation_after_days == 30
+    error_message = "Default rotation_after_days should be 30 (PCI-DSS Req 3.6.4 <= 90)"
+  }
+
+  assert {
+    condition     = aws_secretsmanager_secret_rotation.this.rotation_rules[0].automatically_after_days == 30
+    error_message = "rotation_rules should use automatically_after_days by default"
+  }
+}
+
+run "rotate_immediately_defaults_true" {
+  command = plan
+
+  assert {
+    condition     = aws_secretsmanager_secret_rotation.this.rotate_immediately == true
+    error_message = "rotate_immediately should default to true (provider default)"
+  }
+}
+
+run "schedule_expression_overrides_days" {
+  command = plan
+
+  variables {
+    rotation_after_days          = null
+    rotation_schedule_expression = "cron(0 3 1 * ? *)"
+    rotation_duration            = "3h"
+  }
+
+  assert {
+    condition     = aws_secretsmanager_secret_rotation.this.rotation_rules[0].schedule_expression == "cron(0 3 1 * ? *)"
+    error_message = "schedule_expression should be passed to rotation_rules"
+  }
+
+  assert {
+    condition     = aws_secretsmanager_secret_rotation.this.rotation_rules[0].automatically_after_days == null
+    error_message = "automatically_after_days must be null when a schedule_expression is set (provider requires exactly one)"
+  }
+
+  assert {
+    condition     = aws_secretsmanager_secret_rotation.this.rotation_rules[0].duration == "3h"
+    error_message = "rotation_duration should be passed through to rotation_rules.duration"
+  }
+}
+
+run "no_vpc_config_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(aws_lambda_function.rotation.vpc_config) == 0
+    error_message = "VPC config should be absent when no subnet IDs are provided"
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy_attachment.vpc_access) == 0
+    error_message = "AWSLambdaVPCAccessExecutionRole should not be attached without VPC config"
+  }
+}
+
+run "vpc_config_enabled_with_subnets" {
+  command = plan
+
+  variables {
+    vpc_subnet_ids         = ["subnet-0aaa1111bbbb2222c", "subnet-0ddd3333eeee4444f"]
+    vpc_security_group_ids = ["sg-0abc1234def567890"]
+  }
+
+  assert {
+    condition     = length(aws_lambda_function.rotation.vpc_config) == 1
+    error_message = "VPC config should be present when subnet IDs are provided"
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy_attachment.vpc_access) == 1
+    error_message = "AWSLambdaVPCAccessExecutionRole must be attached when the Lambda runs in a VPC"
+  }
+}
+
+run "iam_scoped_to_this_secret_and_cmk" {
+  command = apply
+
+  # GetSecretValue must be scoped to the single secret ARN, not "*".
+  assert {
+    condition = anytrue([
+      for s in jsondecode(data.aws_iam_policy_document.rotation.json).Statement :
+      s.Sid == "RotateThisSecret" && contains(tolist(s.Action), "secretsmanager:GetSecretValue") && s.Resource != "*"
+    ])
+    error_message = "Rotation policy must allow GetSecretValue scoped to this secret (not *)"
+  }
+
+  # KMS access must be scoped to the secret's CMK, not "*".
+  assert {
+    condition = anytrue([
+      for s in jsondecode(data.aws_iam_policy_document.rotation.json).Statement :
+      s.Sid == "DecryptWithSecretCmk" && s.Resource == var.kms_key_arn
+    ])
+    error_message = "KMS decrypt must be scoped to the secret's CMK ARN"
+  }
+}
+
+run "lambda_invokable_by_secretsmanager" {
+  command = plan
+
+  assert {
+    condition     = aws_lambda_permission.secretsmanager.principal == "secretsmanager.amazonaws.com"
+    error_message = "Secrets Manager must be granted lambda:InvokeFunction"
+  }
+}
+
+run "rejects_invalid_rotation_days" {
+  command = plan
+
+  variables {
+    rotation_after_days = 999
+  }
+
+  expect_failures = [
+    var.rotation_after_days,
+  ]
+}

--- a/terraform/modules/secret-rotation/variables.tf
+++ b/terraform/modules/secret-rotation/variables.tf
@@ -1,0 +1,156 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# secret-rotation — input variables
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "name" {
+  description = "Base name for the rotated secret and its rotation Lambda. Used to derive the secret name, Lambda function name, and IAM role name."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9/_+=.@-]{1,200}$", var.name))
+    error_message = "name must be 1-200 chars of [a-zA-Z0-9/_+=.@-] (Secrets Manager name charset)."
+  }
+
+  nullable = false
+}
+
+variable "secret_description" {
+  description = "Human-readable description of the credential this module rotates (e.g. 'app-db primary credentials')."
+  type        = string
+  default     = "Rotated credential managed by the secret-rotation module"
+}
+
+variable "kms_key_arn" {
+  description = "ARN of the customer-managed KMS CMK used to encrypt the secret at rest AND grant the rotation Lambda kms:Decrypt / kms:GenerateDataKey. Required for least-privilege KMS scoping (ADR-0031)."
+  type        = string
+
+  validation {
+    condition     = can(regex("^arn:aws[a-zA-Z-]*:kms:", var.kms_key_arn))
+    error_message = "kms_key_arn must be a valid KMS key ARN (arn:aws:kms:...)."
+  }
+
+  nullable = false
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Rotation schedule (rotation_rules) — provide automatically_after_days OR schedule_expression (not both).
+# Verified against the aws_secretsmanager_secret_rotation provider docs.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "rotation_after_days" {
+  description = "Number of days between automatic rotations. Mutually exclusive with rotation_schedule_expression. Set to null when using a schedule_expression. PCI-DSS Req 3.6.4 recommends <= 90 days."
+  type        = number
+  default     = 30
+
+  validation {
+    condition     = var.rotation_after_days == null || try(var.rotation_after_days >= 1 && var.rotation_after_days <= 365, false)
+    error_message = "rotation_after_days must be null or between 1 and 365."
+  }
+}
+
+variable "rotation_schedule_expression" {
+  description = "A cron() or rate() expression for the rotation schedule. Mutually exclusive with rotation_after_days. Leave null to use rotation_after_days."
+  type        = string
+  default     = null
+}
+
+variable "rotation_duration" {
+  description = "Length of the rotation window in hours (e.g. '3h'). Optional; null means Secrets Manager chooses the window."
+  type        = string
+  default     = null
+}
+
+variable "rotate_immediately" {
+  description = "Whether to rotate the secret immediately when rotation is enabled. Provider default is true. Set false to wait for the next scheduled window (Secrets Manager runs a testSecret step instead)."
+  type        = bool
+  default     = true
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Rotation Lambda
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "lambda_runtime" {
+  description = "Lambda runtime for the rotation function. Default python3.12 matches the AWS-provided RDS rotation templates."
+  type        = string
+  default     = "python3.12"
+}
+
+variable "lambda_handler" {
+  description = "Lambda handler entrypoint. For a custom handler this is module.function; for an AWS RDS rotation template it is lambda_function.lambda_handler."
+  type        = string
+  default     = "index.lambda_handler"
+}
+
+variable "lambda_timeout" {
+  description = "Lambda timeout in seconds. Rotation functions need enough time to reach the DB and complete the four rotation steps."
+  type        = number
+  default     = 30
+
+  validation {
+    condition     = var.lambda_timeout >= 1 && var.lambda_timeout <= 900
+    error_message = "lambda_timeout must be between 1 and 900 seconds."
+  }
+}
+
+variable "lambda_memory_size" {
+  description = "Lambda memory size in MB."
+  type        = number
+  default     = 256
+}
+
+variable "lambda_package_path" {
+  description = "Optional path to a prebuilt rotation Lambda deployment package (.zip), e.g. an AWS-provided RDS single-user / alternating-user template. When null, the module packages the bundled placeholder handler. Provide a real template before enabling rotation in production."
+  type        = string
+  default     = null
+}
+
+variable "lambda_environment_variables" {
+  description = "Additional environment variables for the rotation Lambda. SECRETS_MANAGER_ENDPOINT is always injected by the module."
+  type        = map(string)
+  default     = {}
+}
+
+variable "lambda_reserved_concurrency" {
+  description = "Reserved concurrent executions for the rotation Lambda. -1 means unreserved (account default)."
+  type        = number
+  default     = -1
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC config — so the rotation Lambda can reach a PRIVATE RDS instance.
+# Placeholders are accepted for plan/validate; wire real subnets/SG via the Terragrunt unit.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "vpc_subnet_ids" {
+  description = "Private subnet IDs the rotation Lambda's ENIs are placed in. Must have a route to the target RDS instance. Empty list disables VPC config (only valid when the secret target is publicly reachable)."
+  type        = list(string)
+  default     = []
+}
+
+variable "vpc_security_group_ids" {
+  description = "Security group IDs attached to the rotation Lambda's ENIs. The SG (or the DB SG) must allow egress to the DB port (e.g. 5432/tcp for PostgreSQL)."
+  type        = list(string)
+  default     = []
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Observability / housekeeping
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "log_retention_days" {
+  description = "CloudWatch Logs retention for the rotation Lambda log group, in days."
+  type        = number
+  default     = 365
+
+  validation {
+    condition     = contains([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653], var.log_retention_days)
+    error_message = "log_retention_days must be a valid CloudWatch Logs retention value."
+  }
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/secret-rotation/versions.tf
+++ b/terraform/modules/secret-rotation/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.4"
+    }
+  }
+}

--- a/terragrunt/staging/eu-west-1/platform/secret-rotation/terragrunt.hcl
+++ b/terragrunt/staging/eu-west-1/platform/secret-rotation/terragrunt.hcl
@@ -1,0 +1,93 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Secret Rotation — Staging, eu-west-1 (ADR-0031)
+# ---------------------------------------------------------------------------------------------------------------------
+# Automated rotation of a DB/API credential via a Secrets Manager rotation Lambda,
+# scoped least-privilege IAM, KMS encryption, and VPC config so the Lambda can reach
+# the private RDS instance. Replaces static long-lived secrets.
+#
+# This unit owns ONE rotated credential (the app DB primary credential). Add further
+# units (or extend modules/secrets with this unit's rotation_lambda_arn output) for
+# additional secrets.
+#
+# The bundled Lambda is a NON-FUNCTIONAL placeholder — set `lambda_package_path` to an
+# AWS-provided RDS rotation template (single-user / alternating-user) before enabling
+# rotation against a live database.
+#
+# Epic #252.
+# ---------------------------------------------------------------------------------------------------------------------
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/secret-rotation"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  account_name = local.account_vars.locals.account_name
+  environment  = local.account_vars.locals.environment
+  aws_region   = local.region_vars.locals.aws_region
+}
+
+# KMS CMK for the secret + the rotator's scoped kms:Decrypt/GenerateDataKey grant.
+# In live use this is the `rds` (or a dedicated secrets) key from the regional kms
+# unit; mocked here so plan/validate succeed without applied state.
+dependency "kms" {
+  config_path = "../kms"
+
+  mock_outputs = {
+    key_arns = {
+      rds = "arn:aws:kms:eu-west-1:222222222222:key/00000000-0000-0000-0000-000000000000"
+    }
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+# Private subnets + DB security group so the rotation Lambda can reach the RDS
+# instance. In live use these come from the network/RDS units; placeholders here.
+dependency "network" {
+  config_path = "../connectivity/vpc"
+
+  mock_outputs = {
+    private_subnets   = ["subnet-0mock0a", "subnet-0mock0b", "subnet-0mock0c"]
+    database_subnets  = ["subnet-0db0mock0a", "subnet-0db0mock0b"]
+    rds_access_sg_ids = ["sg-0mockrotator00"]
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+inputs = {
+  name               = "${local.environment}/app-db/credentials"
+  secret_description = "App database primary credentials (rotated) — ${local.environment} ${local.aws_region}"
+  kms_key_arn        = dependency.kms.outputs.key_arns["rds"]
+
+  # 30-day cadence (PCI-DSS Req 3.6.4 <= 90). Switch to a schedule_expression for a
+  # fixed maintenance window by setting rotation_after_days = null.
+  rotation_after_days = 30
+
+  # The rotation Lambda runs in the DB subnets and uses the DB-access SG so it can
+  # reach the private RDS instance. Replace mocks with the real network outputs.
+  vpc_subnet_ids         = try(dependency.network.outputs.database_subnets, [])
+  vpc_security_group_ids = try(dependency.network.outputs.rds_access_sg_ids, [])
+
+  # Placeholder handler is shipped by default. Before enabling rotation against a
+  # live DB, point this at an AWS RDS rotation template package:
+  # lambda_package_path = "${get_repo_root()}/.../rds-single-user-rotation.zip"
+
+  log_retention_days = 365
+
+  tags = {
+    Environment = local.environment
+    ManagedBy   = "terragrunt"
+    Component   = "secret-rotation"
+    ADR         = "0031"
+  }
+}


### PR DESCRIPTION
New ADR-0031 + impl: Secrets Manager rotation Lambda + schedule for DB/API creds; ESO refreshInterval auto-refreshes pods (Reloader pattern), replacing static long-lived secrets. Least-privilege IAM, KMS. Validate clean (no apply). Refs #252.

## What

- **ADR-0031** (`docs/adrs/0031-secret-rotation.md`, Status Accepted, 2026-06-08, doc-verified): automated rotation of DB/API creds via a Secrets Manager rotation Lambda + ESO auto-refresh of pods (refreshInterval + Reloader), replacing static long-lived secrets.
- **Module** `terraform/modules/secret-rotation/` — produces the rotation Lambda that the existing `modules/secrets` rotation hook needed but never created:
  - `aws_secretsmanager_secret` (KMS CMK, prevent_destroy)
  - `aws_secretsmanager_secret_rotation` (`rotation_rules`: `automatically_after_days` OR `schedule_expression` + optional `duration`; `rotate_immediately`)
  - rotation `aws_lambda_function` — bundled non-functional placeholder handler, or a prebuilt AWS RDS rotation template via `lambda_package_path`
  - least-privilege IAM scoped to **this secret ARN + its CMK only** (not `*`)
  - `vpc_config` so the Lambda can reach a private RDS (placeholder subnets/SG)
  - KMS-encrypted log group with retention, X-Ray tracing, Secrets Manager invoke permission
  - `variables.tf` / `outputs.tf` / `versions.tf` / `README.md` / `secret-rotation.tftest.hcl` (mock)
- **Terragrunt unit** `terragrunt/staging/eu-west-1/platform/secret-rotation/` — wires the module with mocked `kms` + `network` dependencies (RDS CMK, DB subnets/SG). Parameterized, no hardcoded tenant identifiers.
- **ESO note** appended to `apps/infra/external-secrets/README.md` — `refreshInterval` + Stakater Reloader pattern so rotated values actually reach running pods. Chart `Chart.yaml`/`values.yaml` untouched.

## Provenance

Doc-verified against the HashiCorp registry `aws_secretsmanager_secret_rotation` provider docs (confirmed `rotation_rules` supports `automatically_after_days` / `schedule_expression` / `duration`, and `rotate_immediately` defaults true) and the official AWS Secrets Manager rotation + RDS rotation-template docs.

## Validation (no apply — CI/CD only from main)

- `terraform fmt -recursive -check` — PASS
- `terraform init -backend=false && terraform validate` — PASS (Success! configuration is valid)
- `terraform test` (mock_provider) — **10 passed, 0 failed** (KMS encryption, default 30-day cadence, schedule-expression override + duration, name slugification, VPC-config toggle, least-privilege IAM scoping to secret ARN + CMK, Secrets-Manager invoke permission, invalid-rotation-days rejection)
- `terragrunt hcl format` — clean; unit follows the repo's mocked-dependency convention (same as `lattice-resource`)
- checkov — not installed in this environment (skipped); module bakes in the controls it would check (KMS-encrypted secret/log-group/lambda env, scoped IAM, retention, tracing)
- **No `terraform apply` run.** `.terraform/` and the transient `.build/` Lambda zip are excluded.

## Plan summary

The module manages **8 resources** (7 when VPC config is disabled): secret, secret_rotation, rotation Lambda, IAM role + inline policy, conditional VPC-access policy attachment, KMS-encrypted log group, and the Secrets Manager Lambda permission.

Refs #252.