### PR TITLE
docs(adr): reconcile index (0029-0032) + deferred Backstage 0034

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -190,6 +190,45 @@ until wired in. Tracked under epic
 | #252 | Observability target architecture (LGTM: Prometheus 3 + Thanos, Loki, Tempo, Alloy; one RED source; no Mimir/Coroot) | Accepted | PLANNED | [ADR-0026](docs/adrs/0026-observability-target-architecture.md) |
 | #252 | Kubernetes cost allocation via OpenCost + AWS CUR/Athena (amortized, discount-aware; optional Kubecost Free) | Accepted | PLANNED | [ADR-0027](docs/adrs/0027-kubernetes-cost-opencost-cur.md) |
 
+### Batch-B ADRs (0029–0032) — implemented 2026-06-08
+
+ADRs 0029–0032 were proposed, doc-verified, and implemented this session
+(2026-06-08) under epic [#252](https://github.com/100rd/platform-design/issues/252).
+Their modules and Helm templates are `synced` in-repo; no live AWS resources have
+been applied yet.
+
+| ADR | Title | Implementation status |
+|-----|-------|-----------------------|
+| [ADR-0029](docs/adrs/0029-ecr-pull-through-cache.md) | ECR Pull-Through Cache for public upstream registries | synced (module) — not applied |
+| [ADR-0030](docs/adrs/0030-bottlerocket-node-os.md) | Bottlerocket as the EKS node operating system | synced (module) / pending (manifests) |
+| [ADR-0031](docs/adrs/0031-secret-rotation.md) | Automated secret rotation via Secrets Manager rotation Lambda + ESO auto-refresh | synced (module) — not applied |
+| [ADR-0032](docs/adrs/0032-db-migrations-gitops.md) | DB migrations via ArgoCD PreSync Jobs | synced (helm) — not applied |
+
+### ADR-0034 Backstage IDP — Proposed, Deferred (on hold)
+
+[ADR-0034](docs/adrs/0034-backstage-idp.md) records the **Backstage Internal
+Developer Platform** decision, tracked by epic
+[#252](https://github.com/100rd/platform-design/issues/252). Backstage is a strong
+strategic fit — it would provide a Software Catalog and a Golden Path Scaffolder
+template that generates services pre-wired to the platform ADRs. The decision is
+**deferred / on hold** as of 2026-06-08 by the platform owner because Backstage is
+a self-owned Node.js application (not a Helm-install), and taking on the operational
+commitment without a dedicated owner would result in degradation.
+
+**Agreed Phase 1 scope** (when hold is lifted):
+
+- Software Catalog (`catalog-info.yaml` registration for all services).
+- ONE Golden Path Scaffolder template generating a new service conforming to the
+  platform ADRs: generic Helm/app chart + ArgoCD/Kargo promotion (ADR-0006,
+  ADR-0021) + Kyverno keyless-signed images (ADR-0020) + EKS Pod Identity
+  (ADR-0018) + observability wiring (ADR-0026).
+- Three plugins only: ArgoCD (sync status), Kubernetes (pod/rollout health),
+  OpenCost (per-service cost, ADR-0027).
+- TechDocs deferred to Phase 2.
+
+**Revisit trigger**: a dedicated Backstage owner is assigned and the platform
+backlog (ADRs 0017–0027) matures toward `synced`.
+
 ### Candidates / revisit (considered, NOT accepted)
 
 Recorded in ADR-0025's alternatives — tracked, not adopted:
@@ -221,10 +260,12 @@ Add new GATE umbrellas in pull-requests when initiating any multi-issue effort t
 ## Cross-cutting decisions
 
 ADRs live in `docs/adrs/` — see the [index](docs/adrs/README.md) for the full
-catalog (0001–0027) with each ADR's **platform-design status**. ADRs 0017–0027 are
-the **2026 modernization** set: research-backed + doc-verified 2026-06-07, all
+catalog (0001–0032, 0034) with each ADR's **platform-design status**. ADRs 0017–0027
+are the **2026 modernization** set: research-backed + doc-verified 2026-06-07, all
 ratified **Accepted** (implementation `pending` / PLANNED, tracked by Phase 8 above).
-The two native foundation ADRs:
+ADRs 0029–0032 are the **Batch-B** set: implemented 2026-06-08 (`synced` in modules /
+charts). ADR-0034 (Backstage) is **Proposed — Deferred (on hold)** — see Phase 8
+above. The two native foundation ADRs:
 - [ADR-0001 OU split](docs/adrs/0001-ou-split.md) — explains why `Prod` / `NonProd` aliases were preserved instead of renaming to canonical `Production` / `Non-Production`.
 - [ADR-0002 TF-only state backend bootstrap](docs/adrs/0002-tf-only-state-backend.md) — bootstrap chicken-and-egg resolution.
 

--- a/docs/adrs/0034-backstage-idp.md
+++ b/docs/adrs/0034-backstage-idp.md
@@ -1,0 +1,170 @@
+# ADR-0034: Backstage as the Internal Developer Platform
+
+- Status: **Proposed — Deferred (on hold)**
+- Deferred: 2026-06-08 by platform owner — revisit when a dedicated owner is
+  assigned and the platform backlog matures.
+- platform-design status: **pending** — no Backstage installation or catalog
+  config exists in this repo.
+- Date: 2026-06-08
+- Authors: platform-team
+- Related issues: epic [#252](https://github.com/100rd/platform-design/issues/252)
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+The platform now has a well-defined set of standards encoded in ADRs: the generic
+Helm/app chart (ADR-0006, ADR-0014), ArgoCD/Kargo promotion (ADR-0006, ADR-0021),
+Kyverno keyless-signed images (ADR-0020), EKS Pod Identity (ADR-0018), and the
+observability wiring (ADR-0026). At the same time, onboarding a new service
+requires developers to stitch these pieces together manually — there is no
+single pane that shows what services exist, who owns them, and how to scaffold a
+new one that conforms to the ADRs from day one.
+
+Backstage is the CNCF-graduated Internal Developer Platform adopted by many
+platform-engineering organisations for exactly this: a **Software Catalog**
+(register and browse services, their owners, dependencies, and ADR compliance)
+and **Golden Path Scaffolder templates** (generate a service that is already
+wired to the platform's patterns).
+
+The strategic fit is strong. However, Backstage is **not a Helm-install-and-forget
+tool**: it is a self-owned Node.js application that requires a dedicated
+engineering owner to maintain the app itself, its plugins, and its
+`catalog-info.yaml` conventions across the organisation. As of 2026-06-08, no
+such owner has been assigned, and taking on the operational commitment without one
+would result in an abandoned or degraded portal within months.
+
+## Decision
+
+**Backstage as the Internal Developer Platform is deferred / on hold.**
+
+The decision to adopt Backstage is strategically sound and is not rejected; it is
+placed on hold until:
+
+1. A **dedicated owner** (team or engineer) is assigned to operate Backstage as a
+   product — managing the Node.js app, plugin upgrades, and catalog hygiene.
+2. The **platform backlog matures** such that the Golden Path Scaffolder template
+   can reference a stable, implemented set of ADRs rather than tracking pending
+   items.
+
+### Agreed Phase 1 scope (to execute when the hold is lifted)
+
+When revisited, the Phase 1 implementation is bounded to:
+
+- **Software Catalog**: register all existing services via `catalog-info.yaml`
+  files (Kind: Component, System, API). No manual imports; catalog populated
+  from SCM discovery.
+- **ONE Golden Path Scaffolder template**: generates a new service pre-wired to:
+  - the generic Helm/app chart (ADR-0006),
+  - ArgoCD + Kargo GitOps promotion (ADR-0006, ADR-0021),
+  - Kyverno keyless-signed images (ADR-0020),
+  - EKS Pod Identity for AWS access (ADR-0018),
+  - observability wiring — metrics, structured logs, traces (ADR-0026).
+- **Three plugins** (no more in Phase 1): ArgoCD plugin (sync status),
+  Kubernetes plugin (pod/rollout health), OpenCost plugin (per-service cost
+  — ADR-0027).
+- **TechDocs deferred to Phase 2**: Backstage-rendered docs are desirable but
+  add maintenance surface; defer until Phase 1 is stable.
+
+A reviewer can check Phase 1 conformance by confirming: `catalog-info.yaml` files
+exist for all services, the scaffolder template generates a repo that passes
+the platform CI supply-chain gates (ADR-0016), and the three plugins are
+registered and returning data.
+
+## Alternatives considered
+
+### Alternative A: Self-hosted Backstage (chosen — if hold is lifted)
+
+Deploy Backstage on the platform EKS cluster, managed as a first-class
+GitOps-delivered application (ArgoCD ApplicationSet, ADR-0006). The operator
+owns the Node.js app, its Docker image, and plugin upgrades.
+
+**Chosen for Phase 1 if the hold is lifted** — full control, no vendor lock-in,
+aligns with the estate's self-hosted-first posture.
+
+### Alternative B: Managed Backstage (Roadie / Spotify Portal)
+
+SaaS-hosted Backstage. Eliminates the Node.js operational burden; the vendor
+manages upgrades and infrastructure.
+
+Rejected (for now) because: adds an external SaaS dependency and ongoing
+subscription cost. Revisit if the dedicated-owner constraint cannot be met
+and the catalog value is urgent enough to justify the spend.
+
+### Alternative C: Lighter SaaS IDP (Port / Cortex)
+
+Port and Cortex offer catalog + scorecard + self-service without the Node.js
+self-hosting burden. Both are SaaS-native.
+
+Deferred: the strategic preference is Backstage (CNCF-graduated, open ecosystem,
+no lock-in). Port/Cortex become relevant if the self-hosted and managed-Backstage
+paths are both ruled out.
+
+## Consequences
+
+### Positive
+- Phase 1 scope is deliberately small (catalog + one template + three plugins) —
+  reduces the ramp-up for the dedicated owner and delivers immediate value
+  without sprawl.
+- Golden Path template encodes ADR conformance at creation time, not as a
+  post-hoc audit.
+- OpenCost plugin (ADR-0027) surfaces per-service cost in the catalog, closing
+  the FinOps loop.
+
+### Negative
+- Until the hold is lifted, developers must onboard services manually against
+  the ADR checklist. The gap in self-service UX remains.
+- Backstage's Node.js runtime adds a non-Kubernetes workload to the platform
+  maintenance surface once adopted.
+
+### Risks
+- **Ownership risk**: the primary non-technical risk. Mitigated by making the
+  hold condition explicit — no deployment until an owner is formally assigned.
+- **Scope creep after lift**: Phase 1 scope must be enforced; TechDocs and
+  additional plugins inflate the maintenance surface quickly. Mitigated by the
+  Phase 1 boundary defined above.
+- **Plugin compatibility drift**: Backstage's plugin ecosystem moves fast;
+  pinning plugin versions and gating upgrades in CI mitigates breakage.
+
+## Implementation notes
+
+- When the hold is lifted, start from the
+  [Backstage `@backstage/create-app` scaffold](https://backstage.io/docs/getting-started/)
+  and deploy via the generic Helm/app chart (ADR-0006) under a dedicated
+  `backstage` ArgoCD Application.
+- `catalog-info.yaml` convention: adopt the
+  [Backstage System model](https://backstage.io/docs/features/software-catalog/system-model)
+  (Domain → System → Component → API).
+- The Scaffolder template repository lives in the platform-design org and is
+  itself catalog-registered.
+- Secrets (GitHub token for SCM discovery, plugin API tokens) delivered via
+  ESO from Secrets Manager (ADR-0008).
+- CI gate: the generated scaffolder output must pass `helm lint`,
+  `kubeconform`, and the Tier-1 supply-chain scan (ADR-0016).
+
+Effort (Phase 1, when hold is lifted): **XL** — dominated by Node.js app setup
+and catalog population, not by the template itself.
+
+## References
+
+- Backstage getting started: <https://backstage.io/docs/getting-started/>
+- Backstage Software Catalog: <https://backstage.io/docs/features/software-catalog/>
+- Backstage Scaffolder: <https://backstage.io/docs/features/software-templates/>
+- Backstage ArgoCD plugin: <https://backstage.io/docs/integrations/argocd/>
+- Backstage Kubernetes plugin: <https://backstage.io/docs/features/kubernetes/>
+- Roadie (managed Backstage): <https://roadie.io/>
+- Port (alternative SaaS IDP): <https://www.getport.io/>
+- Cortex (alternative SaaS IDP): <https://www.cortex.io/>
+- Related: ADR-0006 (ArgoCD GitOps — delivery of Backstage itself),
+  ADR-0008 (ESO — secrets for plugins),
+  ADR-0016 (Tier-1 supply-chain hardening — gates on generated repos),
+  ADR-0018 (EKS Pod Identity — Backstage AWS access),
+  ADR-0020 (Kyverno — keyless signing wired by the Golden Path template),
+  ADR-0021 (Kargo — promotion wired by the Golden Path template),
+  ADR-0026 (Observability — wired by the Golden Path template),
+  ADR-0027 (OpenCost — plugin Phase 1),
+  epic #252.
+
+---
+*Proposal — owner discussion 2026-06-08. Status: Proposed — Deferred (on hold).
+Revisit trigger: dedicated Backstage owner assigned + platform backlog matures.*

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -24,6 +24,11 @@ session tags + ESO upgrade prereq in 0018, netkit unblocked on kernel 6.12 in 00
 admission-time cosign verification in 0020, OTel SLO-gating in 0021, the supply-chain
 follow-ons in 0022).
 
+ADRs 0029–0032 are the **Batch-B infra-team ADRs**, implemented this session
+(2026-06-08) — modules / templates / charts landed in their respective PRs and
+are doc-verified 2026-06-08. ADR-0034 is **Proposed — Deferred (on hold)** by
+the platform owner pending a dedicated Backstage owner being assigned.
+
 Every ported ADR also carries a **platform-design status** (`synced` / `partial`
 / `pending`) recording whether the decision is actually wired into *this* repo —
 see the column in the index below. This makes the catalog a development driver:
@@ -68,10 +73,11 @@ decision.
 | [0026](0026-observability-target-architecture.md) | Observability target architecture (LGTM: Prometheus 3 + Thanos, Loki, Tempo, Alloy) | Accepted | pending | research-backed + doc-verified |
 | [0027](0027-kubernetes-cost-opencost-cur.md) | Kubernetes cost allocation via OpenCost + AWS CUR/Athena | Accepted | pending | research-backed + doc-verified |
 | [0028](0028-unified-platform-tagging-and-labeling-taxonomy.md) | Unified Platform Tagging and Labeling Taxonomy | Accepted | pending | native |
-| [0029](0029-ecr-pull-through-cache.md) | ECR Pull-Through Cache for public upstream registries | Accepted | pending | native |
-| [0030](0030-bottlerocket-node-os.md) | Bottlerocket as the EKS node operating system | Accepted | synced (module) / pending (manifests) | native |
-| [0031](0031-secret-rotation.md) | Automated secret rotation via Secrets Manager rotation Lambda + ESO auto-refresh | Accepted | pending | native |
-| [0032](0032-db-migrations-gitops.md) | DB migrations via ArgoCD PreSync Jobs | Accepted | pending | native |
+| [0029](0029-ecr-pull-through-cache.md) | ECR Pull-Through Cache for public upstream registries | Accepted | synced (module) | proposal — doc-verified 2026-06-08 |
+| [0030](0030-bottlerocket-node-os.md) | Bottlerocket as the EKS node operating system | Accepted | synced (module) / pending (manifests) | proposal — doc-verified 2026-06-08 |
+| [0031](0031-secret-rotation.md) | Automated secret rotation via Secrets Manager rotation Lambda + ESO auto-refresh | Accepted | synced (module) | proposal — doc-verified 2026-06-08 |
+| [0032](0032-db-migrations-gitops.md) | DB migrations via ArgoCD PreSync Jobs | Accepted | synced (helm) | proposal — doc-verified 2026-06-08 |
+| [0034](0034-backstage-idp.md) | Backstage as the Internal Developer Platform | Proposed — Deferred (on hold) | pending | proposal — doc-verified 2026-06-08 |
 
 
 
@@ -85,6 +91,8 @@ decision.
 - Source numbering does not map 1:1 onto target numbering: ported ADRs were
   renumbered sequentially from 0003 with clearer kebab titles, and the two CI/CD
   ADRs land last as 0015–0016.
+- ADR-0033 is intentionally unassigned (reserved gap between the Batch-B ADRs
+  and the Backstage proposal).
 
 ## Conventions
 


### PR DESCRIPTION
Adds index rows for the Batch-B ADRs 0029 (ECR PTC) / 0030 (Bottlerocket) / 0031 (secret rotation) / 0032 (DB migrations) and records ADR-0034 (Backstage IDP) as Proposed-Deferred (owner hold 2026-06-08) with the agreed phase-1 scope (Catalog + 1 Golden Path + plugins). Docs-only. Refs #252.