### PR TITLE
feat(policy): Kyverno platform-labels taxonomy policy (ADR-0028)

### DIFF
--- a/apps/infra/kyverno/README.md
+++ b/apps/infra/kyverno/README.md
@@ -7,6 +7,8 @@ Kubernetes Native Policy Management. Complements Gatekeeper + Pod Security Admis
 **Enabled** (v1.18.1). Policies are in **Enforce** mode (graduated from Audit — W3/ADR-0020).
 See [Rollback](#rollback) below if enforcement must be reverted.
 
+`require-platform-labels` (ADR-0028) is in **Audit / observe** mode — see [ADR-0028 graduation path](#adr-0028-platform-label-policy-graduation-path) below.
+
 See [ADR-0020](../../../docs/adrs/0020-kyverno-and-vap-policy-engine.md) for rationale.
 
 ## Enforcement History
@@ -15,12 +17,13 @@ See [ADR-0020](../../../docs/adrs/0020-kyverno-and-vap-policy-engine.md) for rat
 |------|-------|-----|
 | Initial deploy | All policies set to Audit | #266 |
 | W3 graduation | Audit → Enforce (post-soak, zero unexpected violations) | W3/ADR-0020 |
+| ADR-0028 stream 3 | `require-platform-labels` added in Audit/observe mode | feat/adr-0028-kyverno-labels |
 
 ## Policy split (ADR-0020)
 
 | Layer | What it owns | Why |
 |-------|-------------|-----|
-| **Kyverno** | verifyImages (keyless cosign), mutate securityContext, generate default-deny NetworkPolicy | Verify/mutate/generate — things VAP and Rego handle poorly |
+| **Kyverno** | verifyImages (keyless cosign), mutate securityContext, generate default-deny NetworkPolicy, require platform taxonomy labels | Verify/mutate/generate — things VAP and Rego handle poorly |
 | **VAP (native CEL)** | Block `:latest`, require resource limits | Simple in-process CEL checks, no webhook, lower latency |
 | **Gatekeeper** | 4 existing ConstraintTemplates (kept) | Mature, audited — no rewrite risk |
 | **PSA** | `restricted` baseline | Node-level Pod Security Admission |
@@ -40,6 +43,7 @@ See [ADR-0020](../../../docs/adrs/0020-kyverno-and-vap-policy-engine.md) for rat
 | `verify-images.yaml` | ClusterPolicy | Keyless cosign image signature verification. Fulcio issuer = GitHub Actions OIDC. mutateDigest rewrites tag to verified digest. **Enforce** (W3). |
 | `mutate-security-context.yaml` | ClusterPolicy | Injects `runAsNonRoot: true`, `seccompProfile: RuntimeDefault`, `capabilities.drop: [ALL]` into containers that do not already set these fields. |
 | `generate-default-deny-netpol.yaml` | ClusterPolicy | Generates a `default-deny-all` NetworkPolicy into every new namespace (excluding system/infra namespaces). Synchronized back if deleted. |
+| `require-platform-labels.yaml` | ClusterPolicy | Validates Pods, Services, Deployments, and Argo Rollouts carry `platform.system`, `platform.component`, `platform.owner` labels (ADR-0028). **Audit** (observe phase — see graduation path below). |
 
 ### ValidatingAdmissionPolicy (`templates/vap/`)
 
@@ -60,6 +64,10 @@ This is the verification layer that ADR-0016's cosign signing requires.
 ClusterPolicy verify-images-keyless-cosign:
   validationFailureAction: Enforce
 
+ClusterPolicy require-platform-labels:
+  validationFailureAction: Audit    # observe phase — ADR-0028 stream 3
+  failurePolicy: Ignore             # fail-open during soak
+
 ValidatingAdmissionPolicy platform-pod-baseline:
   failurePolicy: Fail
 
@@ -69,6 +77,78 @@ ValidatingAdmissionPolicyBinding platform-pod-baseline-binding:
 values.yaml admissionController:
   forceFailurePolicyIgnore.enabled: false   # webhook is fail-closed
 ```
+
+## ADR-0028 platform label policy graduation path
+
+`require-platform-labels` implements ADR-0028 implementation note 2: observe
+existing workloads for missing `platform.system` / `platform.component` /
+`platform.owner` labels before blocking admission.
+
+### Current state: Audit / observe
+
+- `validationFailureAction: Audit` — violations written to `PolicyReport` /
+  `ClusterPolicyReport` only; admission is not blocked.
+- `failurePolicy: Ignore` — webhook unavailability does not block admission.
+- `background: true` — existing resources are scanned on a background cycle
+  and violations appear in `ClusterPolicyReport`.
+
+### Monitoring violations during observe phase
+
+```bash
+# All policy report violations cluster-wide
+kubectl get clusterpolicyreport -o json \
+  | jq '.items[].results[] | select(.policy=="require-platform-labels")'
+
+# Per-namespace PolicyReport
+kubectl get policyreport -A \
+  | grep require-platform-labels
+
+# Detailed violation list for a namespace
+kubectl describe policyreport -n <namespace> <name>
+```
+
+Grafana: filter `kyverno_policy_results_total{policy="require-platform-labels",result="fail"}`.
+
+### Graduation to Enforce (next phase)
+
+Criteria before promoting to Enforce:
+1. Zero `require-platform-labels` violations in `PolicyReport` /
+   `ClusterPolicyReport` for one full sprint (typically two weeks).
+2. All teams have confirmed their Helm charts propagate the three required
+   labels on Pods, Services, Deployments, and Rollouts.
+3. ADR-0028 Terragrunt stream (stream 1) is merged — AWS tags confirmed
+   consistent, so the taxonomy is live on both planes.
+
+When criteria are met, apply these two changes and open a PR:
+
+1. `apps/infra/kyverno/templates/policies/require-platform-labels.yaml`
+   ```yaml
+   spec:
+     validationFailureAction: Enforce   # was: Audit
+     failurePolicy: Fail                # was: Ignore
+   ```
+
+2. Update the Enforcement History table in this README with the graduation
+   date and PR number.
+
+### Required labels (ADR-0028)
+
+| K8s Label | Description | Example |
+|-----------|-------------|---------|
+| `platform.system` | Logical service/system boundary | `auth`, `payment` |
+| `platform.component` | Architectural tier/role | `compute`, `database`, `cache` |
+| `platform.owner` | Engineering team responsible | `team-sec`, `team-data` |
+
+`platform.env` and `platform.managed-by` are optional at the resource level
+(they are typically injected by the ArgoCD ApplicationSet or Helm values layer).
+
+### Namespace exclusions
+
+The policy excludes the following namespaces from validation (these are system
+or infra namespaces that do not carry workload labels):
+
+`kube-system`, `kube-public`, `kube-node-lease`, `kyverno`, `cert-manager`,
+`gatekeeper-system`, `external-secrets`, `argocd`, `monitoring`
 
 ## Rollback
 
@@ -140,6 +220,7 @@ kubectl describe policyreport -n <namespace> <name>
 ## References
 
 - [ADR-0020](../../../docs/adrs/0020-kyverno-and-vap-policy-engine.md) — policy engine decision
+- [ADR-0028](../../../docs/adrs/0028-unified-platform-tagging-and-labeling-taxonomy.md) — platform tagging taxonomy (require-platform-labels)
 - ADR-0016 — cosign signing (verified here at admission, not in ArgoCD)
 - ADR-0003 — Cilium (generated NetworkPolicy pairs with Cilium baseline)
 - [Kyverno docs](https://kyverno.io/docs/)

--- a/apps/infra/kyverno/templates/policies/require-platform-labels.yaml
+++ b/apps/infra/kyverno/templates/policies/require-platform-labels.yaml
@@ -1,0 +1,227 @@
+---
+# ClusterPolicy — require platform taxonomy labels (OBSERVE / Audit mode)
+#
+# ADR-0028: Unified Platform Tagging and Labeling Taxonomy
+#
+# Purpose: Alert on any Pod, Service, Deployment, or Argo Rollout that is
+# missing the required platform taxonomy labels:
+#   platform.system    — logical service boundary (e.g. "auth", "payment")
+#   platform.component — architectural tier/role   (e.g. "compute", "database")
+#   platform.owner     — engineering team owner    (e.g. "team-sec", "team-data")
+#
+# Keys platform.env and platform.managed-by are OPTIONAL — they may be injected
+# by the ArgoCD ApplicationSet or Helm values layer rather than per-resource.
+#
+# Phase: OBSERVE (Audit mode)
+#   validationFailureAction: Audit — violations are recorded in PolicyReport /
+#   ClusterPolicyReport and surfaced as Grafana/Alertmanager alerts, but
+#   admission is NOT blocked. This gives teams time to retrofit labels before
+#   the policy is promoted to Enforce.
+#
+#   TODO(platform): promote validationFailureAction to Enforce in the next
+#   phase (after a clean Audit window — target: one sprint after all workloads
+#   show zero violations in PolicyReports). Update enforcement history table
+#   in README.md and this header comment when promoting.
+#
+# failurePolicy: Ignore — if the Kyverno webhook is unavailable, admission
+# proceeds without evaluation (fail-open for this observe-phase policy only).
+# Flip to Fail when promoting to Enforce.
+#
+# Namespace exclusions: system and infra namespaces that do not carry
+# workload labels are excluded so they do not flood PolicyReports with
+# expected-empty violations. Exclusion list mirrors the webhook
+# namespaceSelector in values.yaml plus gatekeeper-system and monitoring.
+#
+# Pattern: the (pattern) anchor requires the key to be present AND non-empty.
+# A key with an empty value ("") does NOT satisfy the pattern "?*".
+# "?*" = one or more characters — blank or whitespace-only values are rejected.
+#
+# References:
+#   https://kyverno.io/docs/policy-types/cluster-policy/validate/
+#   https://kyverno.io/docs/writing-policies/validate/#patterns
+#   ADR-0028 — unified platform tagging and labeling taxonomy
+#   ADR-0020 — Kyverno + VAP policy engine (parent framework)
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-platform-labels
+  annotations:
+    policies.kyverno.io/title: Require platform taxonomy labels
+    policies.kyverno.io/category: Platform Governance
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod,Service,Deployment,Rollout
+    policies.kyverno.io/description: >-
+      Validates that Pods, Services, Deployments, and Argo Rollouts carry
+      the three required platform taxonomy labels (platform.system,
+      platform.component, platform.owner) as defined in ADR-0028. Runs in
+      Audit/observe mode — violations are recorded in PolicyReports but do
+      not block admission. Promote to Enforce after a clean soak window.
+    adr: ADR-0028
+spec:
+  # OBSERVE phase — record violations without blocking admission.
+  # TODO(platform): change to Enforce after clean Audit window; also flip
+  # failurePolicy below from Ignore to Fail when promoting.
+  validationFailureAction: Audit
+
+  # Fail-open during the observe phase; tighten to Fail at Enforce promotion.
+  failurePolicy: Ignore
+
+  # Scan existing resources for violations (background PolicyReport).
+  background: true
+
+  rules:
+    # -----------------------------------------------------------------------
+    # Rule 1 — Pods must carry the three required platform labels
+    # -----------------------------------------------------------------------
+    - name: require-platform-labels-pods
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      # Exclude system and infra namespaces — they do not carry workload labels
+      # and are not subject to the platform taxonomy requirement.
+      exclude:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              namespaces:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+                - kyverno
+                - cert-manager
+                - gatekeeper-system
+                - external-secrets
+                - argocd
+                - monitoring
+      validate:
+        message: >-
+          Pod is missing required platform taxonomy labels (ADR-0028).
+          Every workload Pod must carry: platform.system, platform.component,
+          and platform.owner with non-empty values. See
+          docs/adrs/0028-unified-platform-tagging-and-labeling-taxonomy.md.
+        pattern:
+          metadata:
+            labels:
+              # (pattern) anchor — key must be present AND value must be
+              # at least one character (non-empty). Blank values are rejected.
+              platform.system: "?*"
+              platform.component: "?*"
+              platform.owner: "?*"
+
+    # -----------------------------------------------------------------------
+    # Rule 2 — Services must carry the three required platform labels
+    # -----------------------------------------------------------------------
+    - name: require-platform-labels-services
+      match:
+        any:
+          - resources:
+              kinds:
+                - Service
+      exclude:
+        any:
+          - resources:
+              kinds:
+                - Service
+              namespaces:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+                - kyverno
+                - cert-manager
+                - gatekeeper-system
+                - external-secrets
+                - argocd
+                - monitoring
+      validate:
+        message: >-
+          Service is missing required platform taxonomy labels (ADR-0028).
+          Every workload Service must carry: platform.system, platform.component,
+          and platform.owner with non-empty values. See
+          docs/adrs/0028-unified-platform-tagging-and-labeling-taxonomy.md.
+        pattern:
+          metadata:
+            labels:
+              platform.system: "?*"
+              platform.component: "?*"
+              platform.owner: "?*"
+
+    # -----------------------------------------------------------------------
+    # Rule 3 — Deployments must carry the three required platform labels
+    #          (spec.template labels are validated separately via Pod rule;
+    #           this validates the Deployment object itself so kubectl describe
+    #           and kube-state-metrics expose the correct label set)
+    # -----------------------------------------------------------------------
+    - name: require-platform-labels-deployments
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+      exclude:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+              namespaces:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+                - kyverno
+                - cert-manager
+                - gatekeeper-system
+                - external-secrets
+                - argocd
+                - monitoring
+      validate:
+        message: >-
+          Deployment is missing required platform taxonomy labels (ADR-0028).
+          Every workload Deployment must carry: platform.system, platform.component,
+          and platform.owner with non-empty values on both the Deployment and its
+          pod template. See
+          docs/adrs/0028-unified-platform-tagging-and-labeling-taxonomy.md.
+        pattern:
+          metadata:
+            labels:
+              platform.system: "?*"
+              platform.component: "?*"
+              platform.owner: "?*"
+
+    # -----------------------------------------------------------------------
+    # Rule 4 — Argo Rollouts must carry the three required platform labels
+    # -----------------------------------------------------------------------
+    - name: require-platform-labels-rollouts
+      match:
+        any:
+          - resources:
+              kinds:
+                - Rollout
+      exclude:
+        any:
+          - resources:
+              kinds:
+                - Rollout
+              namespaces:
+                - kube-system
+                - kube-public
+                - kube-node-lease
+                - kyverno
+                - cert-manager
+                - gatekeeper-system
+                - external-secrets
+                - argocd
+                - monitoring
+      validate:
+        message: >-
+          Argo Rollout is missing required platform taxonomy labels (ADR-0028).
+          Every workload Rollout must carry: platform.system, platform.component,
+          and platform.owner with non-empty values. See
+          docs/adrs/0028-unified-platform-tagging-and-labeling-taxonomy.md.
+        pattern:
+          metadata:
+            labels:
+              platform.system: "?*"
+              platform.component: "?*"
+              platform.owner: "?*"


### PR DESCRIPTION
ADR-0028 stream 3: Kyverno ClusterPolicy validating required platform.system/component/owner labels on Pods/Services in Audit/observe mode (system-ns excluded), with documented promote-to-Enforce path. Refs #252 / ADR-0028.

## Summary

- Adds `apps/infra/kyverno/templates/policies/require-platform-labels.yaml`: a `ClusterPolicy` with 4 rules covering Pod, Service, Deployment, and Argo Rollout resources
- `validationFailureAction: Audit` (observe phase — no admission blocking)
- `failurePolicy: Ignore` (fail-open during soak; tighten to `Fail` at Enforce promotion)
- `background: true` — background scan writes violations to `PolicyReport` / `ClusterPolicyReport`
- Namespace exclusions: `kube-system`, `kube-public`, `kube-node-lease`, `kyverno`, `cert-manager`, `gatekeeper-system`, `external-secrets`, `argocd`, `monitoring`
- Pattern `"?*"` enforces key-present AND non-empty value
- Updates `apps/infra/kyverno/README.md`: new policy row, enforcement-history entry, full ADR-0028 graduation path section (observe→enforce criteria, required-labels table, exclusion list, monitoring queries)

## Test plan

- [ ] `helm lint apps/infra/kyverno` — 0 chart(s) failed
- [ ] `helm template kyverno apps/infra/kyverno` — `require-platform-labels` ClusterPolicy renders with `validationFailureAction: Audit` and `failurePolicy: Ignore`
- [ ] `python3 -c "import yaml; yaml.safe_load(open(...))"` — YAML parses cleanly, all 4 rules confirmed with correct exclusions and `?*` patterns
- [ ] No existing policy files modified (verify-images, mutate-security-context, generate-default-deny-netpol untouched)
- [ ] README graduation path section present and links to ADR-0028