### PR TITLE
fix(adr-0028): restore helm/app default render + YACE tag propagation

### DIFF
--- a/apps/infra/observability/yace/values.yaml
+++ b/apps/infra/observability/yace/values.yaml
@@ -83,6 +83,25 @@ yet-another-cloudwatch-exporter:
     apiVersion: v1alpha1
     sts-region: eu-central-1
     discovery:
+      # ADR-0028 Stream 4: exportedTagsOnMetrics is a DISCOVERY-LEVEL key (sibling of jobs),
+      # a map keyed by lowercase service alias. It surfaces AWS resource tags as
+      # tag_platform_* Prometheus labels on every metric from the matching discovery job.
+      exportedTagsOnMetrics:
+        s3:
+          - "platform:system"
+          - "platform:component"
+          - "platform:env"
+          - "platform:owner"
+        rds:
+          - "platform:system"
+          - "platform:component"
+          - "platform:env"
+          - "platform:owner"
+        dynamodb:
+          - "platform:system"
+          - "platform:component"
+          - "platform:env"
+          - "platform:owner"
       jobs:
         # NOTE: AWS/EKS is intentionally absent - YACE v0.61.2 does not support
         # it as a discovery service (not in its known-services list). EKS
@@ -144,14 +163,7 @@ yet-another-cloudwatch-exporter:
             # Remove to discover ALL buckets (raises CW API cost).
             - key: "platform:system"
               value: ".*"
-          exportedTagsOnMetrics:
-            # Translate AWS resource tags → Prometheus label tag_platform_<key>.
-            # e.g. AWS tag platform:system="auth" → label tag_platform_system="auth"
-            AWS/S3:
-              - "platform:system"
-              - "platform:component"
-              - "platform:env"
-              - "platform:owner"
+          # exportedTagsOnMetrics handled at discovery level above (alias: s3).
           metrics:
             - name: BucketSizeBytes
               statistics: [Average]
@@ -174,12 +186,7 @@ yet-another-cloudwatch-exporter:
           searchTags:
             - key: "platform:system"
               value: ".*"
-          exportedTagsOnMetrics:
-            AWS/RDS:
-              - "platform:system"
-              - "platform:component"
-              - "platform:env"
-              - "platform:owner"
+          # exportedTagsOnMetrics handled at discovery level above (alias: rds).
           metrics:
             - name: CPUUtilization
               statistics: [Average, Maximum]
@@ -205,12 +212,7 @@ yet-another-cloudwatch-exporter:
           searchTags:
             - key: "platform:system"
               value: ".*"
-          exportedTagsOnMetrics:
-            AWS/DynamoDB:
-              - "platform:system"
-              - "platform:component"
-              - "platform:env"
-              - "platform:owner"
+          # exportedTagsOnMetrics handled at discovery level above (alias: dynamodb).
           metrics:
             - name: ConsumedReadCapacityUnits
               statistics: [Sum, Average]

--- a/helm/app/templates/_helpers.tpl
+++ b/helm/app/templates/_helpers.tpl
@@ -33,14 +33,16 @@ Optional (has a default):
   platform.managedBy  — orchestration tool; defaults to "argocd"
 */}}
 {{- define "app.validatePlatformLabels" -}}
+{{- if .Values.platform.strict -}}
 {{- if not .Values.platform.system -}}
-{{- fail "platform.system is required (ADR-0028). Set it to the logical service name, e.g. auth, payment, analytics." -}}
+{{- fail "platform.system is required (ADR-0028, strict mode). Set it to the logical service name, e.g. auth, payment, analytics." -}}
 {{- end -}}
 {{- if not .Values.platform.component -}}
-{{- fail "platform.component is required (ADR-0028). Set it to the architectural tier, e.g. compute, database, cache, ingress." -}}
+{{- fail "platform.component is required (ADR-0028, strict mode). Set it to the architectural tier, e.g. compute, database, cache, ingress." -}}
 {{- end -}}
 {{- if not .Values.platform.owner -}}
-{{- fail "platform.owner is required (ADR-0028). Set it to the responsible team, e.g. team-sec, team-checkout, team-data." -}}
+{{- fail "platform.owner is required (ADR-0028, strict mode). Set it to the responsible team, e.g. team-sec, team-checkout, team-data." -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm/app/values.yaml
+++ b/helm/app/values.yaml
@@ -393,31 +393,34 @@ migrations:
 #     owner: team-sec
 #     managedBy: argocd   # optional, already the default
 platform:
-  # REQUIRED — logical service / system boundary.
-  # Maps to: platform.system label on all K8s resources.
+  # Logical service / system boundary. Maps to platform.system label.
+  # Default "app" lets bare `helm template` / CI dry-run succeed; OVERRIDE per real release.
   # K8s label key constraint: no colon allowed; use dot notation (ADR-0028).
   # Examples: auth, payment, analytics, ingest
-  system: ""
+  system: "app"
 
-  # REQUIRED — architectural tier or role of this workload.
-  # Maps to: platform.component label on all K8s resources.
-  # Examples: compute, database, cache, ingress, worker, scheduler
-  component: ""
+  # Architectural tier or role of this workload. Maps to platform.component label.
+  # Default "compute"; OVERRIDE per real release. Examples: compute, database, cache, ingress, worker
+  component: "compute"
 
   # OPTIONAL — deployment environment. Defaults to .Release.Namespace.
   # Maps to: platform.env label on all K8s resources.
   # Examples: production, staging, dev, sandbox
   env: ""
 
-  # REQUIRED — engineering team responsible for this workload.
-  # Maps to: platform.owner label on all K8s resources.
-  # Examples: team-sec, team-checkout, team-data, team-platform
-  owner: ""
+  # Engineering team responsible for this workload. Maps to platform.owner label.
+  # Default "platform"; OVERRIDE per real release. Examples: team-sec, team-checkout, team-data
+  owner: "platform"
 
   # OPTIONAL — tool orchestrating this resource. Defaults to "argocd".
   # Maps to: platform.managed-by label on all K8s resources.
   # Override when deploying via Helm CLI directly (e.g. helm upgrade --install).
   managedBy: ""
+
+  # Opt-in strict validation (ADR-0028). Default false so default render never fails.
+  # When true: chart fails at render time if system/component/owner are empty.
+  # RECOMMENDED: set strict: true in every production Application values override.
+  strict: false
 
 # --- Labels & Annotations ---
 labels: {}


### PR DESCRIPTION
Hotfix for two ADR-0028 regressions merged in #287/#284: (1) helm/app generic chart hard-failed on bare `helm template` (empty platform.* defaults + ungated fail) — broke Kargo/ArgoCD/all consumers; now sane defaults (app/compute/platform) + opt-in `platform.strict` (default false). (2) YACE `exportedTagsOnMetrics` was per-job/wrong-keyed → tags didn't propagate; moved to discovery-level keyed by s3/rds/dynamodb. Refs #252 / ADR-0028.