### PR TITLE
fix(org): reconcile member_accounts map (dr account-ID + 4 missing accounts)

### DIFF
--- a/terragrunt/_org/account.hcl
+++ b/terragrunt/_org/account.hcl
@@ -18,12 +18,37 @@ locals {
   organization_id   = "" # Populated after org creation
 
   # Member accounts
+  # Account-to-OU placement is managed here (see docs/ou-structure.md). Account IDs
+  # mirror each account's own terragrunt/<name>/account.hcl — keep them in sync.
   member_accounts = {
+    # Infrastructure OU — shared platform tooling (networking hub, shared services)
     network = {
       account_id = "555555555555"
       email      = "aws+network@example.com"
       ou         = "Infrastructure"
     }
+    shared = {
+      account_id = "999999999999"
+      email      = "aws+shared@example.com"
+      ou         = "Infrastructure"
+    }
+    # Security OU — audit and security-tooling accounts
+    security = {
+      account_id = "777777777777"
+      email      = "aws+security@example.com"
+      ou         = "Security"
+    }
+    "log-archive" = {
+      account_id = "888888888888"
+      email      = "aws+log-archive@example.com"
+      ou         = "Security"
+    }
+    "third-party" = {
+      account_id = "121212121212"
+      email      = "aws+third-party@example.com"
+      ou         = "Security"
+    }
+    # Workloads/NonProd OU — non-production workload accounts
     dev = {
       account_id = "111111111111"
       email      = "aws+dev@example.com"
@@ -34,13 +59,14 @@ locals {
       email      = "aws+staging@example.com"
       ou         = "NonProd"
     }
+    # Workloads/Prod OU — production workload accounts
     prod = {
       account_id = "333333333333"
       email      = "aws+prod@example.com"
       ou         = "Prod"
     }
     dr = {
-      account_id = "666666666666"
+      account_id = "444444444444"
       email      = "aws+dr@example.com"
       ou         = "Prod"
     }


### PR DESCRIPTION
## Reconcile `member_accounts` with per-account configs

Two data defects surfaced by the Control Tower + AFT design epic (#293) — both must be correct before any account enrollment (immutable IDs).

1. **`dr` account-ID conflict (fix):** the org `member_accounts` map said `666666666666`, but `terragrunt/dr/account.hcl` says `444444444444`. The stray `666666666666` appears exactly **once** in the whole repo → it was the typo. Corrected to `444444444444`.
2. **Four accounts missing from the map (add):** `shared` (Infrastructure), `security` / `log-archive` / `third-party` (Security) existed as per-account `terragrunt/<name>/account.hcl` configs but were absent from `member_accounts`, which `docs/ou-structure.md` defines as the canonical account→OU placement mechanism. The org module creates accounts **only** via `for_each = var.member_accounts`, so these were unmanaged. Added with IDs/emails/OUs mirroring each account's own `account.hcl`.

`sandbox` (real on-demand account `007027391583`) is intentionally left out — it is not org-vended.

Validated: `terragrunt hcl fmt` clean (parses + formatted). Downstream consumers (`organization`, `sso`, `budgets`, `transit-gateway`) take the whole map via `for_each`, so additions are non-breaking.

Part of #293 · Advances #168