### PR TITLE
feat(gcp-ml): WS-A GKE GPU parity + multi-region + cost guardrail (ADR-0036)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ override.tf.json
 
 # Terragrunt
 .terragrunt-cache/
+**/.terragrunt-stack/
 
 # Helm dependency downloads
 **/charts/*.tgz

--- a/catalog/stacks/gcp-gpu-analysis/terragrunt.stack.hcl
+++ b/catalog/stacks/gcp-gpu-analysis/terragrunt.stack.hcl
@@ -1,34 +1,144 @@
 # ---------------------------------------------------------------------------------------------------------------------
-# GCP GPU Video Analysis Stack Template
+# GCP GPU Video Analysis Stack Template (WS-A — ml-infra)
 # ---------------------------------------------------------------------------------------------------------------------
-# Composable stack that deploys GCP GPU video analysis GKE infrastructure:
+# Composable, multi-region stack that deploys the GCP GPU ML analysis platform.
+#
+# Per region:
 #   gcp-gpu-vpc → gcp-gpu-gke → gcp-gpu-nodepools
+#                            ↘ gke-gpu-operator      (NVIDIA GPU Operator)
+#                            ↘ gke-gpu-dcgm          (DCGM metrics → VictoriaMetrics)
+#                            ↘ gke-gpu-scheduling    (Volcano batch scheduler, ADR-0036)
 #
-# GCP is significantly simpler than AWS (3 units vs 7):
-#   - GKE Dataplane V2 = Cilium built-in (no separate cilium unit)
-#   - GKE native node pools = no Karpenter (no karpenter-iam/controller/nodepools)
-#   - Zone affinity = built into node pool config (no placement-group unit)
+# Region-independent (deployed once):
+#   gcp-billing-budget        (80/100/120% budget → Pub/Sub → Alertmanager)
 #
-# Optimized for real-time video analysis: GPU instances (L4/T4), single-zone
-# pinning for GPU locality, mixed on-demand/spot capacity.
+# Multi-region: region names are parameterised via locals. Each per-region unit is
+# placed under <region>/<unit> and receives a `values.region`. The stack ships two
+# regions (primary + secondary); add a third region by copying the per-region unit
+# block group and pointing it at local.tertiary_region. terragrunt v0.99.5 does not
+# support for_each on unit blocks, so regions are expressed as explicit blocks.
 #
 # Usage (from live tree):
-#   cd terragrunt/gcp-staging/europe-west9/gpu-analysis
-#   terragrunt stack plan
-#   terragrunt stack apply
+#   cd terragrunt/gcp-staging/gpu-analysis
+#   terragrunt stack generate
+#   terragrunt stack run plan
 # ---------------------------------------------------------------------------------------------------------------------
 
-unit "gcp-gpu-vpc" {
+locals {
+  # Regions the GPU analysis platform spans (≥2). Adjust to taste.
+  primary_region   = "europe-west9"
+  secondary_region = "us-central1"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Region-independent: a single billing budget covering the GPU project(s).
+# ---------------------------------------------------------------------------------------------------------------------
+
+unit "gcp-billing-budget" {
+  source = "${get_repo_root()}/catalog/units/gcp-billing-budget"
+  path   = "gcp-billing-budget"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Primary region — full GPU analysis stack.
+# ---------------------------------------------------------------------------------------------------------------------
+
+unit "gcp-gpu-vpc-primary" {
   source = "${get_repo_root()}/catalog/units/gcp-gpu-vpc"
-  path   = "gcp-gpu-vpc"
+  path   = "${local.primary_region}/gcp-gpu-vpc"
+  values = {
+    region = local.primary_region
+  }
 }
 
-unit "gcp-gpu-gke" {
+unit "gcp-gpu-gke-primary" {
   source = "${get_repo_root()}/catalog/units/gcp-gpu-gke"
-  path   = "gcp-gpu-gke"
+  path   = "${local.primary_region}/gcp-gpu-gke"
+  values = {
+    region = local.primary_region
+  }
 }
 
-unit "gcp-gpu-nodepools" {
+unit "gcp-gpu-nodepools-primary" {
   source = "${get_repo_root()}/catalog/units/gcp-gpu-nodepools"
-  path   = "gcp-gpu-nodepools"
+  path   = "${local.primary_region}/gcp-gpu-nodepools"
+  values = {
+    region = local.primary_region
+  }
+}
+
+unit "gke-gpu-operator-primary" {
+  source = "${get_repo_root()}/catalog/units/gke-gpu-operator"
+  path   = "${local.primary_region}/gke-gpu-operator"
+  values = {
+    region = local.primary_region
+  }
+}
+
+unit "gke-gpu-dcgm-primary" {
+  source = "${get_repo_root()}/catalog/units/gke-gpu-dcgm"
+  path   = "${local.primary_region}/gke-gpu-dcgm"
+  values = {
+    region = local.primary_region
+  }
+}
+
+unit "gke-gpu-scheduling-primary" {
+  source = "${get_repo_root()}/catalog/units/gke-gpu-scheduling"
+  path   = "${local.primary_region}/gke-gpu-scheduling"
+  values = {
+    region = local.primary_region
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Secondary region — full GPU analysis stack.
+# ---------------------------------------------------------------------------------------------------------------------
+
+unit "gcp-gpu-vpc-secondary" {
+  source = "${get_repo_root()}/catalog/units/gcp-gpu-vpc"
+  path   = "${local.secondary_region}/gcp-gpu-vpc"
+  values = {
+    region = local.secondary_region
+  }
+}
+
+unit "gcp-gpu-gke-secondary" {
+  source = "${get_repo_root()}/catalog/units/gcp-gpu-gke"
+  path   = "${local.secondary_region}/gcp-gpu-gke"
+  values = {
+    region = local.secondary_region
+  }
+}
+
+unit "gcp-gpu-nodepools-secondary" {
+  source = "${get_repo_root()}/catalog/units/gcp-gpu-nodepools"
+  path   = "${local.secondary_region}/gcp-gpu-nodepools"
+  values = {
+    region = local.secondary_region
+  }
+}
+
+unit "gke-gpu-operator-secondary" {
+  source = "${get_repo_root()}/catalog/units/gke-gpu-operator"
+  path   = "${local.secondary_region}/gke-gpu-operator"
+  values = {
+    region = local.secondary_region
+  }
+}
+
+unit "gke-gpu-dcgm-secondary" {
+  source = "${get_repo_root()}/catalog/units/gke-gpu-dcgm"
+  path   = "${local.secondary_region}/gke-gpu-dcgm"
+  values = {
+    region = local.secondary_region
+  }
+}
+
+unit "gke-gpu-scheduling-secondary" {
+  source = "${get_repo_root()}/catalog/units/gke-gpu-scheduling"
+  path   = "${local.secondary_region}/gke-gpu-scheduling"
+  values = {
+    region = local.secondary_region
+  }
 }

--- a/catalog/units/gcp-billing-budget/terragrunt.hcl
+++ b/catalog/units/gcp-billing-budget/terragrunt.hcl
@@ -1,0 +1,46 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GCP Billing Budget — Catalog Unit (WS-A — ml-infra)
+# ---------------------------------------------------------------------------------------------------------------------
+# Creates a billing budget scoped to the GPU project(s) with 80% / 100% / 120%
+# threshold alerts delivered to a Pub/Sub topic that the Alertmanager webhook bridge
+# subscribes to.
+#
+# No cluster dependency — this is a pure GCP billing/control-plane resource.
+# Requires project.hcl with: project_id, environment, billing_account_id,
+#                            gpu_analysis_config (optional monthly_amount override).
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/gcp-billing-budget"
+}
+
+locals {
+  project_vars = read_terragrunt_config(find_in_parent_folders("project.hcl"))
+
+  gcp_project_id      = local.project_vars.locals.project_id
+  environment         = local.project_vars.locals.environment
+  billing_account_id  = local.project_vars.locals.billing_account_id
+  gpu_analysis_config = try(local.project_vars.locals.gpu_analysis_config, {})
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE INPUTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  billing_account_id = local.billing_account_id
+  topic_project_id   = local.gcp_project_id
+  gpu_project_ids    = [local.gcp_project_id]
+
+  budget_display_name   = "ml-infra-gpu-${local.environment}"
+  monthly_amount        = try(local.gpu_analysis_config.monthly_budget_amount, 10000)
+  threshold_percentages = [0.8, 1.0, 1.2]
+
+  pubsub_topic_name = "ml-infra-budget-alerts-${local.environment}"
+
+  # ADR-0028 GCP-plane labels (underscore keys; system = ml-infra for WS-A).
+  labels = {
+    platform_env   = local.environment
+    platform_owner = "team-data"
+  }
+}

--- a/catalog/units/gke-gpu-dcgm/terragrunt.hcl
+++ b/catalog/units/gke-gpu-dcgm/terragrunt.hcl
@@ -1,0 +1,77 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GKE GPU DCGM Exporter — Catalog Unit (WS-A — ml-infra)
+# ---------------------------------------------------------------------------------------------------------------------
+# Installs the NVIDIA DCGM exporter DaemonSet on the GPU analysis GKE cluster, exposing
+# GPU metrics on :9400 with a ServiceMonitor so VictoriaMetrics scrapes them.
+#
+# Dependencies: gcp-gpu-gke
+# Requires project.hcl with: project_id, environment, gpu_analysis_config
+# Requires region.hcl with: gcp_region
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/gke-gpu-dcgm"
+}
+
+locals {
+  project_vars = read_terragrunt_config(find_in_parent_folders("project.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  gcp_project_id      = local.project_vars.locals.project_id
+  environment         = local.project_vars.locals.environment
+  gcp_region          = local.region_vars.locals.gcp_region
+  gpu_analysis_config = try(local.project_vars.locals.gpu_analysis_config, {})
+}
+
+dependency "gke" {
+  config_path = "../gcp-gpu-gke"
+
+  mock_outputs = {
+    name           = "mock-cluster"
+    endpoint       = "10.0.0.1"
+    ca_certificate = "bW9jay1jZXJ0LWRhdGE="
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+generate "gke_providers" {
+  path      = "gke_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    data "google_client_config" "this" {}
+
+    provider "helm" {
+      kubernetes {
+        host                   = "https://${dependency.gke.outputs.endpoint}"
+        token                  = data.google_client_config.this.access_token
+        cluster_ca_certificate = base64decode("${dependency.gke.outputs.ca_certificate}")
+      }
+    }
+
+    provider "kubernetes" {
+      host                   = "https://${dependency.gke.outputs.endpoint}"
+      token                  = data.google_client_config.this.access_token
+      cluster_ca_certificate = base64decode("${dependency.gke.outputs.ca_certificate}")
+    }
+  PROVIDERS
+}
+
+inputs = {
+  enabled       = try(local.gpu_analysis_config.dcgm_enabled, true)
+  chart_version = try(local.gpu_analysis_config.dcgm_chart_version, "3.6.1")
+
+  gpu_node_selector = {
+    "cloud.google.com/gke-accelerator" = try(local.gpu_analysis_config.gpu_accelerator_type, "nvidia-l4")
+  }
+
+  # VictoriaMetrics is the metrics backend; its operator selects on this release label.
+  service_monitor_release_label = "victoria-metrics"
+  scrape_interval               = "15s"
+
+  platform_labels = {
+    "platform.env"   = local.environment
+    "platform.owner" = "team-data"
+  }
+}

--- a/catalog/units/gke-gpu-operator/terragrunt.hcl
+++ b/catalog/units/gke-gpu-operator/terragrunt.hcl
@@ -1,0 +1,86 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GKE GPU Operator — Catalog Unit (WS-A — ml-infra)
+# ---------------------------------------------------------------------------------------------------------------------
+# Installs the NVIDIA GPU Operator on the GPU analysis GKE cluster via Helm. On GKE
+# the COS image + GKE-managed driver provide driver/toolkit, so the operator runs the
+# device plugin + GFD/NFD/CDI only.
+#
+# Dependencies: gcp-gpu-gke
+# Requires project.hcl with: project_id, environment, gpu_analysis_config
+# Requires region.hcl with: gcp_region
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/gke-gpu-operator"
+}
+
+locals {
+  project_vars = read_terragrunt_config(find_in_parent_folders("project.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  gcp_project_id      = local.project_vars.locals.project_id
+  environment         = local.project_vars.locals.environment
+  gcp_region          = local.region_vars.locals.gcp_region
+  gpu_analysis_config = try(local.project_vars.locals.gpu_analysis_config, {})
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPENDENCY: GCP GPU GKE Cluster
+# ---------------------------------------------------------------------------------------------------------------------
+
+dependency "gke" {
+  config_path = "../gcp-gpu-gke"
+
+  mock_outputs = {
+    name           = "mock-cluster"
+    endpoint       = "10.0.0.1"
+    ca_certificate = "bW9jay1jZXJ0LWRhdGE="
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# PROVIDERS: GKE-authenticated helm + kubernetes via google_client_config token.
+# ---------------------------------------------------------------------------------------------------------------------
+
+generate "gke_providers" {
+  path      = "gke_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    data "google_client_config" "this" {}
+
+    provider "helm" {
+      kubernetes {
+        host                   = "https://${dependency.gke.outputs.endpoint}"
+        token                  = data.google_client_config.this.access_token
+        cluster_ca_certificate = base64decode("${dependency.gke.outputs.ca_certificate}")
+      }
+    }
+
+    provider "kubernetes" {
+      host                   = "https://${dependency.gke.outputs.endpoint}"
+      token                  = data.google_client_config.this.access_token
+      cluster_ca_certificate = base64decode("${dependency.gke.outputs.ca_certificate}")
+    }
+  PROVIDERS
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE INPUTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  enabled       = try(local.gpu_analysis_config.gpu_operator_enabled, true)
+  chart_version = try(local.gpu_analysis_config.gpu_operator_chart_version, "v24.9.2")
+
+  gpu_node_selector = {
+    "cloud.google.com/gke-accelerator" = try(local.gpu_analysis_config.gpu_accelerator_type, "nvidia-l4")
+  }
+
+  platform_labels = {
+    "platform.env"   = local.environment
+    "platform.owner" = "team-data"
+  }
+}

--- a/catalog/units/gke-gpu-scheduling/terragrunt.hcl
+++ b/catalog/units/gke-gpu-scheduling/terragrunt.hcl
@@ -1,0 +1,69 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GKE GPU Batch Scheduling — Catalog Unit (WS-A — ml-infra)
+# ---------------------------------------------------------------------------------------------------------------------
+# Installs the batch scheduler (Volcano by default per ADR-0036, Kueue selectable) on
+# the GPU analysis GKE cluster.
+#
+# Dependencies: gcp-gpu-gke
+# Requires project.hcl with: project_id, environment, gpu_analysis_config
+# Requires region.hcl with: gcp_region
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/gke-gpu-scheduling"
+}
+
+locals {
+  project_vars = read_terragrunt_config(find_in_parent_folders("project.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  gcp_project_id      = local.project_vars.locals.project_id
+  environment         = local.project_vars.locals.environment
+  gcp_region          = local.region_vars.locals.gcp_region
+  gpu_analysis_config = try(local.project_vars.locals.gpu_analysis_config, {})
+}
+
+dependency "gke" {
+  config_path = "../gcp-gpu-gke"
+
+  mock_outputs = {
+    name           = "mock-cluster"
+    endpoint       = "10.0.0.1"
+    ca_certificate = "bW9jay1jZXJ0LWRhdGE="
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+generate "gke_providers" {
+  path      = "gke_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    data "google_client_config" "this" {}
+
+    provider "helm" {
+      kubernetes {
+        host                   = "https://${dependency.gke.outputs.endpoint}"
+        token                  = data.google_client_config.this.access_token
+        cluster_ca_certificate = base64decode("${dependency.gke.outputs.ca_certificate}")
+      }
+    }
+
+    provider "kubernetes" {
+      host                   = "https://${dependency.gke.outputs.endpoint}"
+      token                  = data.google_client_config.this.access_token
+      cluster_ca_certificate = base64decode("${dependency.gke.outputs.ca_certificate}")
+    }
+  PROVIDERS
+}
+
+inputs = {
+  enabled   = try(local.gpu_analysis_config.scheduler_enabled, true)
+  scheduler = try(local.gpu_analysis_config.scheduler, "volcano")
+
+  platform_labels = {
+    "platform.env"   = local.environment
+    "platform.owner" = "team-data"
+  }
+}

--- a/docs/adrs/0036-gke-ml-infra-parity-multiregion.md
+++ b/docs/adrs/0036-gke-ml-infra-parity-multiregion.md
@@ -1,0 +1,442 @@
+# ADR-0036: GKE ML-infrastructure parity (GPU Operator, DCGM, DRA, batch scheduling) + multi-region GKE & GCP cost guardrail
+
+- Status: **Proposed** — plan/validate-only; implementation apply-gated.
+- platform-design status: **pending** — `gcp-gke-gpu-nodepools` and `gcp-gpu-vpc`
+  exist on GCP, but none of the GKE day-2 ML modules (`gke-gpu-operator`,
+  `gke-gpu-dcgm`, `gke-gpu-scheduling`) nor `gcp-billing-budget` exist yet, and
+  there is no second GCP region.
+- Date: 2026-06-10
+- Authors: platform-team (solution-architect), infra
+- Related issues: WS-A "GKE ML infrastructure parity & elasticity" (GCP ML
+  Platform plan); risk-register R1 (multi-region GPU cost), R4 (GPU quota /
+  capacity per region).
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+GPU compute on GCP already exists in this repo as the **`gcp-gke-gpu-nodepools`**
+module: `google_container_node_pool` instances created `for_each` over a config
+map, each pinned to a **single zone for GPU locality**, with **spot** support,
+**scale-to-zero** autoscaling (`min_node_count = 0`), NVIDIA accelerators, taints,
+and **Workload Identity** (`workload_metadata_config { mode = "GKE_METADATA" }`).
+That node-pool primitive — spot / scale-to-zero / per-zone locality / Workload
+Identity — is **settled and is NOT re-opened by this ADR.**
+
+What does **not** yet exist on GKE is the **day-2 ML stack** that the EKS estate
+already runs, and which gives a GPU cluster its operational surface:
+
+- a **GPU driver/operator** layer,
+- **DCGM** GPU telemetry + health auto-remediation,
+- **DRA** (Dynamic Resource Allocation) device classes for typed GPU requests,
+- a **batch scheduler** with gang scheduling and fair-share queues for ML
+  training, plus **HPA/KEDA**-driven elasticity for serving.
+
+The EKS side is the parity reference and is already in-repo:
+
+| Concern | EKS module (in-repo, reference) | GKE gap (this ADR) |
+|---|---|---|
+| GPU operator + driver | `terraform/modules/gpu-operator` (NVIDIA GPU Operator v26.3, DRA driver, GFD/NFD/CDI/toolkit) | `gke-gpu-operator` |
+| GPU telemetry + health | `terraform/modules/gpu-inference-dcgm` (DCGM Exporter v4.5, XID/ECC/temp VMRules, auto-taint CronJob) | `gke-gpu-dcgm` |
+| DRA device classes | `terraform/modules/gpu-inference-dra` (`DeviceClass`/`ResourceClaimTemplate` for H100/A100) | folded into `gke-gpu-scheduling` |
+| Batch scheduling | `terraform/modules/gpu-inference-volcano` (**Volcano** v1.8, gang + `dra`/`binpack`/`topology` plugins, training/inference/batch queues) | `gke-gpu-scheduling` |
+| Serving elasticity | `terraform/modules/keda` (KEDA 2.16) + `hpa-defaults` | reuse on GKE |
+| Cost guardrail | `terraform/modules/budgets` (`aws_budgets_budget`, 80/90/100% → SNS) | **`gcp-billing-budget`** |
+
+Two further forces shape the decision:
+
+1. **GKE mode is locked to Standard.** GKE **Autopilot does not support
+   node-level tooling** (NVIDIA GPU Operator, custom DaemonSets, the
+   device-plugin/driver disable flags). Every decision below assumes **Standard
+   node pools**; Autopilot is explicitly out of scope.
+2. **The plan requires multi-region.** Today GCP has a single region. WS-A asks
+   for **regional GKE in ≥2 GCP regions** with **cross-region serving failover**,
+   which forces a topology decision and lands squarely on risk-register **R1
+   (multi-region GPU cost)** and **R4 (per-region GPU quota/capacity)**.
+
+[ADR-0028](0028-unified-platform-tagging-and-labeling-taxonomy.md) (the unified
+`platform:system` / `platform.system` taxonomy) is mandatory on every resource
+introduced here — AWS-tag form on the Terraform plane, K8s-label form on the
+workload plane — so the GCP fleet is observable/cost-attributable on the same
+`$system` Grafana variable as the AWS fleet.
+
+## Decision
+
+Achieve **GKE ML-infrastructure parity with EKS** and add **multi-region GKE**,
+via four net-new modules plus a topology decision. All five sub-decisions are
+**plan/validate-only**; nothing here applies without passing the apply gate.
+
+### D1 — GPU driver: NVIDIA GPU Operator (not the GKE-managed driver) on GKE Standard
+
+Install the **NVIDIA GPU Operator** as the GKE GPU software layer (new
+`gke-gpu-operator` module), mirroring the EKS `gpu-operator` module: GPU Feature
+Discovery, Node Feature Discovery, container toolkit, CDI, and the **NVIDIA DRA
+driver** — with the in-cluster **DCGM disabled in the operator** because DCGM is
+owned by the dedicated `gke-gpu-dcgm` module (same split as EKS, where
+`gpu-operator` sets `dcgmExporter.enabled = false`).
+
+Chosen over GKE's fully-managed GPU driver because:
+
+- **It is the only path that unlocks DRA on GKE.** GKE DRA for GPUs **requires**
+  `gpu-driver-version=disabled` **and** the `gke-no-default-nvidia-gpu-device-plugin=true`
+  node label **and** `nvidia.com/gpu.present=true` — i.e. the GKE-managed driver
+  and managed device-plugin DaemonSet must be turned **off** and a driver
+  DaemonSet (GPU Operator) must take over. The Operator and DRA share **exactly
+  the same node prerequisites**, so they compose; the managed driver is mutually
+  exclusive with both.
+- **Parity / single mental model.** SREs already operate the NVIDIA GPU Operator
+  (GFD/NFD/CDI/DRA) on EKS; running the same Helm release on GKE means one set
+  of runbooks, dashboards, and ResourceSlice semantics across both clouds.
+- It is the **NVIDIA- and Google-supported** way to manage the GPU stack on GKE
+  Standard (COS or Ubuntu node images); Autopilot — where the Operator is
+  unsupported — is already excluded by the GKE-Standard lock.
+
+**Hard consequence for `gcp-gke-gpu-nodepools` (call-out, not a redesign):** the
+existing module hard-codes the GKE-managed driver via
+`guest_accelerator { gpu_driver_installation_config { gpu_driver_version =
+"LATEST" } }`. That is **incompatible** with the GPU Operator + DRA. The
+Operator-managed pools must be created with the driver **disabled** and carry the
+`gke-no-default-nvidia-gpu-device-plugin=true` + `nvidia.com/gpu.present=true`
+labels. The minimal node-config inputs to express that are specified in the
+`gke-gpu-operator` interface contract in Implementation notes; the node-pool
+module gains a thin, additive "operator-managed driver" switch (no change to its
+spot/scale-to-zero/locality/Workload-Identity behaviour). This coupling is the
+single highest-risk integration point of WS-A and is tracked as such.
+
+### D2 — Batch scheduling: Volcano (not Kueue)
+
+Deploy **Volcano** as the GKE batch scheduler (new `gke-gpu-scheduling` module),
+identical in shape to the EKS `gpu-inference-volcano` module: a **secondary
+scheduler** (`schedulerName: volcano`, opt-in) with the **gang**, **DRA**,
+**binpack** (GPU-weighted), **topology**, and **proportion** plugins, and
+`training` / `inference` / `batch` fair-share **Queues**. The same module also
+ships the **DRA `DeviceClass` / `ResourceClaimTemplate`** objects (folding in the
+EKS `gpu-inference-dra` role) so typed GPU requests (e.g. H100 vs A100, full
+NVLink island) are available to Volcano-scheduled jobs.
+
+Chosen over **GKE Kueue** because:
+
+- **Native gang scheduling.** Distributed ML training needs all-or-nothing pod
+  admission so a multi-GPU job never deadlocks holding a partial set. **Volcano
+  provides gang scheduling natively; Kueue does not** — Kueue is job-level
+  queue/quota admission that then defers pod placement to the default scheduler,
+  and only approximates gang behaviour through framework integrations (e.g.
+  RayJob). The EKS workloads (NCCL training mesh, `PodGroup`-based distributed
+  training) are built on Volcano gang semantics today.
+- **Parity.** EKS already runs Volcano with this exact plugin/queue layout;
+  reusing it on GKE preserves one scheduler binary, one queue taxonomy, one set
+  of `PodGroup` manifests, and one operating model across clouds. Introducing a
+  second, differently-shaped scheduler (Kueue) on GKE only would split the ML
+  scheduling story.
+- **GPU-aware bin-packing + DRA** are first-class in Volcano (the EKS config
+  already weights `binpack.resources.nvidia.com/gpu`), which maximises GPU
+  packing — directly relevant to the R1 cost risk.
+
+Kueue's strengths (lightweight, no new scheduler binary, strong hierarchical
+quota) are real; the industry pattern of **Kueue-for-quota over Volcano-for-gang**
+is recorded as the **revisit trigger** below, not adopted now, to keep WS-A at
+strict parity with the proven EKS stack.
+
+### D3 — DCGM telemetry + GPU health (new `gke-gpu-dcgm`)
+
+Port the EKS `gpu-inference-dcgm` module to GKE: **DCGM Exporter** DaemonSet on
+GPU nodes (custom metrics CSV — utilisation, framebuffer, temperature, power,
+**XID**, **NVLink**, **ECC**), a **ServiceMonitor** into the metrics stack, the
+XID/temperature/ECC/NVLink **alert rules**, and the **GPU-health auto-taint
+CronJob** that taints nodes on XID/ECC bursts (`gpu-health=unhealthy:NoSchedule`)
+and un-taints on recovery. GKE deltas: node selector/toleration keys follow GKE's
+GPU labels (`nvidia.com/gpu.present=true` from D1) and the alert sink is the
+GCP-side Alertmanager that also receives D4 budget alerts.
+
+### D4 — GCP cost guardrail: `gcp-billing-budget` (`google_billing_budget`)
+
+Add a **`gcp-billing-budget`** module wrapping **`google_billing_budget`**, the
+GCP analogue of the EKS `budgets` module. It sets a monthly amount with
+**`threshold_rules` at 0.8 / 1.0 / 1.2** (the API uses a 0.0–1.0
+`threshold_percent`, so 80/100/120%), scoped by `budget_filter` to the GCP
+project(s)/services that carry the GKE GPU spend, and routes **`all_updates_rule`
+→ Pub/Sub topic + Cloud Monitoring notification channels → Alertmanager →
+PagerDuty** (matching the plan's "80/100/120% → PagerDuty via Alertmanager"). It
+sets `disable_default_iam_recipients = true` so paging is the *only* channel (no
+implicit billing-admin email). A **120% / FORECASTED** rule gives early warning
+ahead of the hard monthly number — the primary code-level guard for risk **R1**.
+
+### D5 — Multi-region topology: independent regional GKE in ≥2 regions, DNS/health serving failover
+
+- **Regional, independent GKE clusters in ≥2 GCP regions** (active/active for
+  serving, with primary/secondary roles per service), each a **self-contained
+  copy of the D1–D3 stack** (GPU Operator + DRA + Volcano + DCGM) deployed by a
+  **per-region Terragrunt stack** — the same pattern the AWS side already uses
+  (`terragrunt/{prod,staging,dr}/<region>/platform/terragrunt.stack.hcl`). No
+  stretched/multi-cluster control plane and no cross-region GPU pooling in this
+  phase.
+- **Cross-region serving failover reuses the existing health-checked failover
+  mechanism**, not a new one: the in-repo **`failover-controller`** (Go,
+  health-store-backed DNS failover) + **KEDA/HPA** per cluster for in-region
+  elasticity. A region is taken out of rotation on health-signal loss and serving
+  shifts to the healthy region; **batch/training does NOT fail over** (jobs are
+  region-pinned and re-queued, not migrated) — gang-scheduled GPU jobs are not
+  safely relocatable mid-flight.
+- **Capacity is deliberately asymmetric** to bound cost (R1): the secondary
+  region runs **scale-to-zero GPU pools** (already supported by
+  `gcp-gke-gpu-nodepools`, `min_node_count = 0`) and **spot-first**, sized for
+  failover serving headroom rather than a full hot mirror of training capacity.
+
+### D6 — Reaffirm: GKE Standard + ADR-0028 labels (locked)
+
+- **GKE Standard only.** All GPU node pools and the D1–D3 DaemonSets/operators
+  run on **Standard** node pools. **Autopilot is out of scope** for the GPU plane
+  for the duration of WS-A (it blocks the Operator, custom DaemonSets, and the
+  driver/device-plugin disable flags D1 depends on).
+- **[ADR-0028](0028-unified-platform-tagging-and-labeling-taxonomy.md) is
+  mandatory** on every resource here: the five `platform:*` keys as GCP labels on
+  Terraform-managed resources (`gke-gpu-*` modules accept and apply a `labels`
+  map, exactly as `gcp-gke-gpu-nodepools` already does) and the five
+  `platform.*` keys as K8s labels on the operator/DCGM/Volcano workloads, so the
+  GCP GPU fleet joins the existing single-pane `$system` dashboards and FinOps
+  roll-ups.
+
+A reviewer can check conformance by confirming: (a) GPU pools are created with
+the GKE driver **disabled** + the `gke-no-default-nvidia-gpu-device-plugin=true`
+label (D1); (b) `gke-gpu-operator`, `gke-gpu-dcgm`, `gke-gpu-scheduling`, and
+`gcp-billing-budget` modules exist with the contracts in Implementation notes;
+(c) a second GCP region has its own `platform` Terragrunt stack with the full
+GPU stack; (d) every GCP resource carries the five ADR-0028 labels.
+
+## Alternatives considered
+
+### A1 — GKE-managed GPU driver instead of the GPU Operator
+Keep the existing `gpu_driver_installation_config { gpu_driver_version =
+"LATEST" }` managed-driver path and skip the Operator.
+*Rejected because:* it is **mutually exclusive with DRA on GKE** (DRA mandates
+`gpu-driver-version=disabled` + the managed device-plugin disabled), so it would
+forfeit a required WS-A capability; and it diverges from the EKS operating model,
+giving SREs two different GPU-stack mental models across clouds. The managed
+driver remains the right default for *non-DRA, non-Operator* GPU pools, so D1
+makes the Operator path an additive switch rather than ripping the managed path
+out of `gcp-gke-gpu-nodepools`.
+
+### A2 — Kueue instead of Volcano for batch scheduling
+Adopt GKE-friendly **Kueue** for queueing/quota.
+*Rejected because:* **no native gang scheduling**, which the distributed-training
+workloads require, and it would split scheduling models across clouds (EKS runs
+Volcano). Kept on the table as a future **complement** (Kueue quota *over* Volcano
+gang) — see revisit trigger.
+
+### A3 — Autopilot GPU clusters
+Use GKE Autopilot to cut node-management toil.
+*Rejected because:* Autopilot **does not support** the NVIDIA GPU Operator,
+custom DaemonSets, or the driver/device-plugin disable flags that D1/D3 require —
+it is structurally incompatible with this stack. (The GKE-Standard lock in the
+WS-A scope already encodes this; A3 is recorded for completeness.)
+
+### A4 — Single-region GKE + multi-region only on EKS
+Leave GCP single-region and rely on the AWS estate for geographic redundancy.
+*Rejected because:* WS-A explicitly requires **regional GKE in ≥2 GCP regions**
+with cross-region serving failover; a single GCP region cannot satisfy a GCP
+regional outage or GCP-local data-residency/failover requirements.
+
+### A5 — Stretched / multi-cluster GPU pool (ClusterMesh-style) across regions
+One logical GPU pool spanning regions with cross-region scheduling.
+*Rejected because:* cross-region GPU scheduling pays inter-region latency/egress
+on the hot path, deepens the blast radius (a scheduler/control-plane fault spans
+regions), and offers little benefit for serving (DNS/health failover suffices) —
+while gang-scheduled training is not safely relocatable across regions anyway.
+Independent regional clusters (D5) keep blast radius per-region and cost bounded.
+
+### A6 — GCP-side cost control via Cloud Monitoring/quotas only (no billing budget)
+Rely on monitoring alerts and hard GPU quotas instead of a billing budget.
+*Rejected as the sole guard because:* quotas cap *capacity*, not *spend*, and
+monitoring alerts don't model forecasted month-end cost. `google_billing_budget`
+with a FORECASTED 120% rule is the direct spend guardrail for R1. Per-region GPU
+**quota** management (R4) is complementary and still required — it is an
+operational prerequisite of D5, not a substitute for D4.
+
+## Consequences
+
+### Positive
+- **Cross-cloud parity:** one GPU operating model (Operator + DRA + Volcano +
+  DCGM) and one cost-guardrail pattern across EKS and GKE — shared runbooks,
+  dashboards, queue taxonomy, and ADR-0028 `$system` observability.
+- **Required capabilities unlocked:** DRA typed-GPU requests and gang-scheduled
+  distributed training become available on GKE (impossible under the managed
+  driver / Kueue-only paths).
+- **Geographic resilience:** serving survives a single GCP regional outage via
+  the existing health-checked DNS failover; no new failover machinery.
+- **Spend is observable and paged:** 80/100/120% budget thresholds page on-call
+  before month-end via the existing Alertmanager→PagerDuty path.
+
+### Negative
+- **New surface to operate per region:** GPU Operator, DCGM stack, Volcano, and
+  DRA device classes must be deployed and upgraded in **every** GKE region — N×
+  the day-2 footprint versus single-region.
+- **The `gcp-gke-gpu-nodepools` driver coupling (D1)** is a real, sharp
+  integration: Operator-managed pools must disable the managed driver/device
+  plugin; getting that wrong yields nodes with **no working GPU driver** or a
+  **double-driver** conflict. This is the module-build risk to watch.
+- **Version-skew surface widens:** GPU Operator ↔ DRA driver ↔ GKE version ↔
+  Volcano ↔ DCGM must be co-validated per region (DRA on GKE needs
+  `1.32.1-gke.1489001+`; Volcano's DRA support is on its current line, well ahead
+  of the EKS-pinned v1.8.2).
+
+### Risks
+- **R1 — multi-region GPU cost (highest).** A second region multiplies the most
+  expensive resource in the estate. *Mitigations:* secondary region is
+  **scale-to-zero + spot-first**, sized for failover-serving headroom, **not** a
+  hot training mirror; Volcano GPU-weighted bin-packing maximises utilisation;
+  `gcp-billing-budget` 80/100/120% (incl. FORECASTED) pages early; ADR-0028 labels
+  give per-`system` GPU cost attribution across both regions.
+- **R4 — per-region GPU quota / capacity.** GPU SKUs (and spot availability)
+  differ per GCP region; a region can lack quota or stock for the required
+  accelerator, breaking failover assumptions. *Mitigations:* treat per-region GPU
+  **quota** as an explicit prerequisite of bringing up region N (request/track
+  before enabling its pools); validate accelerator availability per region;
+  prefer accelerator types with multi-region availability; the scale-to-zero
+  secondary lowers steady-state quota pressure but failover still needs *burst*
+  quota — that burst headroom must be reserved, not assumed.
+- **GPU-stack version skew** (see Negative) — *Mitigation:* pin
+  Operator/DRA/Volcano/DCGM chart versions per region and validate against the
+  region's GKE version in CI plan before any apply.
+- **Failover correctness for stateful serving** — DNS failover shifts traffic but
+  not in-region session/state. *Mitigation:* serving must be stateless or
+  externalise state; **batch/training is explicitly excluded from failover**
+  (region-pinned, re-queued).
+
+## Implementation notes
+
+This ADR is **planning-only**: the PR that introduces it creates **no** GCP
+resources, **no** `gke-gpu-*` / `gcp-billing-budget` modules, and **no** second
+region. Implementation is **apply-gated** and lands as separate, plan/validate-only
+PRs per the GCP ML Platform plan.
+
+**Conventions to match (verified against the repo):** `google ~> 6.0`, Terraform
+`~> 1.11` (per `gcp-gke-gpu-nodepools/versions.tf`); every module takes a
+`labels` (map) input carrying the five ADR-0028 keys and merges it the way
+`gcp-gke-gpu-nodepools` already does; Helm-release shape, namespace, and
+toleration/nodeSelector conventions mirror the EKS `gpu-operator` /
+`gpu-inference-dcgm` / `gpu-inference-volcano` / `keda` modules so the two clouds
+stay diff-able.
+
+### Module interface contracts (for the parallel module build)
+
+These are the **input/output contracts** the Terraform Engineer should build to.
+Inputs list the load-bearing ones (each module also takes `labels` (map(string))
+for ADR-0028 and provider/version pins per the conventions above).
+
+**`gke-gpu-operator`** — NVIDIA GPU Operator on GKE Standard (driver + GFD/NFD/CDI
++ DRA driver). Mirrors EKS `gpu-operator`.
+- Inputs: `project_id`, `cluster_id`/`cluster_name`, `chart_version` (NVIDIA GPU
+  Operator), `dra_driver_version`, `driver_enabled = true` (GKE installs the
+  driver via the Operator DaemonSet — opposite of the EKS Bottlerocket default
+  where the AMI pre-bakes it), `dcgm_exporter_enabled = false` (DCGM owned by
+  `gke-gpu-dcgm`), `gpu_node_selector` (default `{ "nvidia.com/gpu.present" =
+  "true" }`), `operator_cpu_limit` / `operator_memory_limit`, `namespace`
+  (default `gpu-operator`).
+- Outputs: `gpu_operator_namespace`, `gpu_operator_version`, `dra_enabled`.
+- **Node-pool coupling (D1):** Operator-managed pools in `gcp-gke-gpu-nodepools`
+  must be created with the managed driver **disabled** and these node labels:
+  `gke-no-default-nvidia-gpu-device-plugin = "true"` and `nvidia.com/gpu.present
+  = "true"`. Expose this as an additive `operator_managed_driver` (bool, default
+  `false`) on `gcp-gke-gpu-nodepools` that (a) omits/clears
+  `gpu_driver_installation_config` (driver disabled) and (b) injects those two
+  labels — **without** touching spot/scale-to-zero/locality/Workload-Identity.
+
+**`gke-gpu-dcgm`** — DCGM Exporter + GPU-health auto-taint + alert rules. Mirrors
+EKS `gpu-inference-dcgm`.
+- Inputs: `dcgm_exporter_version`, `namespace` (default `gpu-monitoring`),
+  `enable_auto_taint` (bool, default `true`), `xid_error_threshold`,
+  `temperature_threshold`, `scrape_interval`, `gpu_node_selector` (GKE:
+  `{ "nvidia.com/gpu.present" = "true" }`), `alert_namespace`, `use_vm_rule`
+  (PrometheusRule vs VMRule, match the GCP-region metrics stack), `kubectl_image`,
+  `taint_cron_schedule`.
+- Outputs: `dcgm_namespace`, `service_monitor_name`, `auto_taint_enabled`,
+  `alert_rule_name`.
+
+**`gke-gpu-scheduling`** — Volcano batch scheduler + queues + DRA device classes.
+Combines EKS `gpu-inference-volcano` + `gpu-inference-dra`.
+- Inputs: `chart_version` (Volcano — current line with DRA, ahead of EKS v1.8.2),
+  `scheduler_replicas`, `controller_replicas`, `training_queue_weight` /
+  `inference_queue_weight` / `batch_queue_weight`, `enable_dra` (bool, default
+  `true` → enables the Volcano `dra` plugin), `device_classes` (map: GPU SKU →
+  CEL `productName` selector, e.g. H100/A100 — GCP accelerator product names),
+  `resource_claim_templates` (single-GPU / full-node-island / prioritized).
+- Outputs: `volcano_namespace`, `volcano_version`, `queue_names` (list),
+  `device_class_names` (list).
+
+**`gcp-billing-budget`** — `google_billing_budget` cost guardrail. GCP analogue of
+EKS `budgets`.
+- Inputs: `billing_account` (ID), `display_name`, `monthly_budget_amount`
+  (units; currency from the billing account), `budget_filter` =
+  `{ projects = [...], services = optional([...]) }` (scope to the GKE/GPU
+  project(s)), `threshold_percents` (default `[0.8, 1.0, 1.2]` — API is 0.0–1.0),
+  `forecasted_threshold_percent` (default `1.2`, `spend_basis = FORECASTED_SPEND`),
+  `pubsub_topic` (`projects/{id}/topics/{topic}` → Alertmanager bridge),
+  `monitoring_notification_channels` (list, ≤5 — Cloud Monitoring → PagerDuty),
+  `disable_default_iam_recipients` (default `true`).
+- Outputs: `budget_id`/`budget_name`, `pubsub_topic`, `threshold_percents`.
+
+**Multi-region wiring (D5):** add a GCP `platform` Terragrunt stack per region
+(`terragrunt/<env>/<gcp-region>/platform/terragrunt.stack.hcl`) composing the GPU
+node pools + the three `gke-gpu-*` units, exactly as the AWS regions compose
+`eks`/`cilium`/`keda`/`hpa-defaults`. `gcp-billing-budget` is **org/project-scoped
+once** (not per region) and filters by project. Pin every chart/module ref
+(`?ref=vX.Y.Z`, no `main`); dev may take the latest pin, prod the proven one.
+
+- Effort: **M–L** (four modules + per-region day-2 stack + node-pool driver
+  coupling + a second region).
+- Rollback: each module/region is independently revertible; the existing
+  single-region GPU plane and the EKS estate remain authoritative throughout.
+
+## Revisit trigger
+
+Re-open this decision if any of the following hold:
+- **Kueue gains production-grade native gang scheduling** (or the
+  Kueue-over-Volcano quota pattern is adopted estate-wide) — re-evaluate D2,
+  potentially running **Kueue for quota over Volcano for gang**.
+- **GKE-managed GPU drivers gain DRA compatibility** (managed driver +
+  DRA + device plugin coexist) — re-evaluate D1; the Operator coupling on
+  `gcp-gke-gpu-nodepools` could be dropped.
+- **GKE Autopilot adds GPU Operator / custom-DaemonSet / DRA support** —
+  re-evaluate the Standard lock (D6/A3).
+- **The R1 cost envelope is breached** despite scale-to-zero + spot + budgets —
+  revisit the multi-region topology (D5): fewer GPU SKUs in the secondary, or a
+  cold-standby (infra-as-code, zero running GPU) failover model.
+- **A third region or a data-residency mandate** changes the topology — revisit
+  D5 (and whether per-region independent clusters still suffice vs. a managed
+  multi-cluster fleet).
+
+## References
+
+- NVIDIA GPU Operator on GKE (Standard; not Autopilot; disable managed driver +
+  device plugin): <https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/google-gke.html>,
+  <https://docs.cloud.google.com/kubernetes-engine/docs/how-to/gpu-operator>
+- GKE GPUs in Standard node pools / driver install options
+  (`gpu-driver-version`): <https://docs.cloud.google.com/kubernetes-engine/docs/how-to/gpus>,
+  <https://docs.cloud.google.com/kubernetes-engine/docs/concepts/gpus>
+- GKE Dynamic Resource Allocation (DRA) for GPUs — GA; requires
+  `1.32.1-gke.1489001+`, `gpu-driver-version=disabled`,
+  `gke-no-default-nvidia-gpu-device-plugin=true`, `nvidia.com/gpu.present=true`:
+  <https://cloud.google.com/kubernetes-engine/docs/how-to/set-up-dra>
+- DCGM Exporter: <https://github.com/NVIDIA/dcgm-exporter>; NVIDIA XID errors:
+  <https://docs.nvidia.com/deploy/xid-errors/index.html>
+- Volcano (gang scheduling, DRA, v1.12+): <https://volcano.sh/en/>,
+  <https://github.com/volcano-sh/volcano/releases>
+- Kueue vs Volcano (gang scheduling gap; Kueue-over-Volcano pattern):
+  <https://www.infracloud.io/blogs/batch-scheduling-on-kubernetes/>
+- `google_billing_budget` (threshold_rules, all_updates_rule/pubsub,
+  monitoring_notification_channels, disable_default_iam_recipients):
+  <https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/billing_budget>
+- KEDA: <https://keda.sh/>
+- In-repo references: `terraform/modules/gpu-operator`,
+  `terraform/modules/gpu-inference-dcgm`, `terraform/modules/gpu-inference-volcano`,
+  `terraform/modules/gpu-inference-dra`, `terraform/modules/keda`,
+  `terraform/modules/budgets`, `terraform/modules/gcp-gke-gpu-nodepools`,
+  `failover-controller/`.
+- Related ADRs: [ADR-0028](0028-unified-platform-tagging-and-labeling-taxonomy.md)
+  (tagging/labeling taxonomy — mandatory here).
+
+---
+*Doc-verified 2026-06-10 against official Google Cloud GKE, NVIDIA GPU Operator,
+Volcano, and HashiCorp `google_billing_budget` documentation. Planning-only ADR —
+proposed, not yet implemented in platform-design. WS-A "GKE ML infrastructure
+parity & elasticity"; implementation apply-gated.*

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -79,6 +79,7 @@ decision.
 | [0032](0032-db-migrations-gitops.md) | DB migrations via ArgoCD PreSync Jobs | Accepted | synced (helm) | proposal — doc-verified 2026-06-08 |
 | [0034](0034-backstage-idp.md) | Backstage as the Internal Developer Platform | Proposed — Deferred (on hold) | pending | proposal — doc-verified 2026-06-08 |
 | [0035](0035-control-tower-and-aft.md) | AWS Control Tower landing zone + Account Factory for Terraform (AFT) vending | Accepted | pending | epic #293 — supersedes ADR-0017 item-0; design 2026-06-09 |
+| [0036](0036-gke-ml-infra-parity-multiregion.md) | GKE ML-infra parity + multi-region GKE + GCP cost guardrail (GPU Operator, DCGM, Volcano, billing-budget) | Accepted | pending | WS-A of GCP ML platform plan; design 2026-06-10 |
 
 
 

--- a/terraform/modules/gcp-billing-budget/README.md
+++ b/terraform/modules/gcp-billing-budget/README.md
@@ -1,0 +1,90 @@
+# gcp-billing-budget
+
+Creates a GCP **billing budget** scoped to one or more GPU projects, with threshold
+alerts at **80% / 100% / 120%** of a configurable monthly amount, delivered to a
+**Pub/Sub topic** that an Alertmanager webhook bridge subscribes to.
+
+Part of **WS-A** of the GCP ML Platform. System: `ml-infra`.
+
+## What it creates
+
+| Resource | Purpose |
+|----------|---------|
+| `google_billing_budget.this` | Budget on the billing account, filtered to GPU project(s), with forecasted-spend threshold rules. |
+| `google_pubsub_topic.budget_alerts` (optional) | Notification topic for budget events. Created by default; set `create_pubsub_topic = false` to reuse an existing topic. |
+| `google_pubsub_topic_iam_member.budget_publisher` (optional) | Grants the Cloud Billing budgets service agent `roles/pubsub.publisher` on the topic. Created only when this module owns the topic. |
+
+## Alertmanager integration
+
+GCP budget alerts are published to the Pub/Sub topic exposed as the `pubsub_topic_id`
+output. A push subscription (or a Cloud Function / pubsub→webhook bridge) forwards
+those messages to the Alertmanager webhook receiver. This module owns the topic and
+its labels; the subscription/bridge is provisioned by the observability workstream.
+
+**Publisher permission (required):** the Google-managed budgets service agent
+`cloud-billing-budgets@system.gserviceaccount.com` must hold `roles/pubsub.publisher`
+on the topic or notifications never fire. When this module creates the topic
+(`create_pubsub_topic = true`) it also creates that binding. When reusing an external
+topic, the caller must grant the binding themselves.
+
+## ADR-0028 labeling
+
+`google_billing_budget` has **no `labels` argument**, so the unified platform
+taxonomy is applied where it can be:
+
+- **Pub/Sub topic** carries the GCP-plane labels: `platform_system = ml-infra`,
+  `platform_component = cost-control`, `platform_managed_by = terragrunt`, plus any
+  caller overrides (e.g. `platform_env`, `platform_owner`).
+- **Budget display name** echoes `[platform_system=ml-infra]` for billing-console
+  grouping.
+
+> GCP label **keys** use underscores (`platform_system`) rather than the colon form
+> (`platform:system`) used for AWS tags, because GCP labels disallow `:`. This is the
+> documented GCP-plane spelling of the ADR-0028 keys.
+
+## Usage
+
+```hcl
+module "gpu_budget" {
+  source = "../../terraform/modules/gcp-billing-budget"
+
+  billing_account_id = "0X0X0X-0X0X0X-0X0X0X"
+  topic_project_id   = "ml-infra-gpu-prod"
+  monthly_amount     = 50000
+  gpu_project_ids    = ["ml-infra-gpu-prod", "ml-infra-gpu-prod-eu"]
+
+  labels = {
+    platform_env   = "production"
+    platform_owner = "team-data"
+  }
+}
+```
+
+## Inputs (key)
+
+| Name | Description | Default |
+|------|-------------|---------|
+| `billing_account_id` | Billing account that owns the budget. | (required) |
+| `monthly_amount` | Monthly budget amount in `currency_code`. | (required) |
+| `gpu_project_ids` | GPU projects to scope the filter to (empty = whole account). | `[]` |
+| `threshold_percentages` | Alert fractions of the monthly amount. | `[0.8, 1.0, 1.2]` |
+| `create_pubsub_topic` | Create the notification topic + publisher binding in this module. | `true` |
+| `topic_project_id` | Project that hosts the notification topic. | (required) |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `budget_id` | Full budget resource ID. |
+| `pubsub_topic_id` | Topic the budget notifies; subscribe Alertmanager here. |
+| `threshold_percentages` | Configured threshold fractions. |
+
+## Testing
+
+```bash
+terraform init -backend=false
+terraform test
+```
+
+Tests use `mock_provider "google"` — no real GCP credentials, billing account, or
+`terraform plan` against live infrastructure are required.

--- a/terraform/modules/gcp-billing-budget/gcp-billing-budget.tftest.hcl
+++ b/terraform/modules/gcp-billing-budget/gcp-billing-budget.tftest.hcl
@@ -1,0 +1,141 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests for the gcp-billing-budget module.
+# Uses a mocked google provider so no real GCP credentials or billing account are
+# required — these are plan-time assertions over the module's logic.
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "google" {}
+
+variables {
+  billing_account_id = "0X0X0X-0X0X0X-0X0X0X"
+  topic_project_id   = "test-ml-infra-gpu"
+  monthly_amount     = 10000
+  gpu_project_ids    = ["test-ml-infra-gpu", "test-ml-infra-gpu-eu"]
+
+  labels = {
+    platform_env   = "staging"
+    platform_owner = "team-data"
+  }
+}
+
+run "creates_default_three_thresholds" {
+  command = plan
+
+  assert {
+    condition     = length(google_billing_budget.this.threshold_rules) == 3
+    error_message = "Expected 3 threshold rules by default (0.8 / 1.0 / 1.2)."
+  }
+}
+
+run "thresholds_match_80_100_120" {
+  command = plan
+
+  assert {
+    condition = alltrue([
+      for r in google_billing_budget.this.threshold_rules : contains([0.8, 1.0, 1.2], r.threshold_percent)
+    ])
+    error_message = "Threshold percentages must default to 0.8, 1.0 and 1.2."
+  }
+}
+
+run "budget_scoped_to_gpu_projects" {
+  command = plan
+
+  assert {
+    condition     = length(google_billing_budget.this.budget_filter[0].projects) == 2
+    error_message = "Budget filter should be scoped to the two supplied GPU projects."
+  }
+
+  assert {
+    condition     = contains(google_billing_budget.this.budget_filter[0].projects, "projects/test-ml-infra-gpu")
+    error_message = "Budget filter must prefix project IDs with projects/."
+  }
+}
+
+run "specified_amount_is_monthly_value" {
+  command = plan
+
+  assert {
+    condition     = google_billing_budget.this.amount[0].specified_amount[0].units == "10000"
+    error_message = "Specified amount units must equal the monthly_amount as a string."
+  }
+}
+
+run "display_name_carries_platform_system" {
+  command = plan
+
+  assert {
+    condition     = strcontains(google_billing_budget.this.display_name, "platform_system=ml-infra")
+    error_message = "Budget display name must echo the ADR-0028 platform_system = ml-infra taxonomy."
+  }
+}
+
+run "creates_pubsub_topic_with_platform_labels" {
+  command = plan
+
+  assert {
+    condition     = length(google_pubsub_topic.budget_alerts) == 1
+    error_message = "Pub/Sub topic should be created by default."
+  }
+
+  assert {
+    condition     = google_pubsub_topic.budget_alerts[0].labels["platform_system"] == "ml-infra"
+    error_message = "Pub/Sub topic must carry the ADR-0028 platform_system = ml-infra label."
+  }
+}
+
+run "grants_billing_sa_publisher_on_topic" {
+  command = plan
+
+  assert {
+    condition     = length(google_pubsub_topic_iam_member.budget_publisher) == 1
+    error_message = "A Pub/Sub publisher binding should be created for the budget topic by default."
+  }
+
+  assert {
+    condition     = google_pubsub_topic_iam_member.budget_publisher[0].role == "roles/pubsub.publisher"
+    error_message = "The budget service agent must be granted roles/pubsub.publisher."
+  }
+
+  assert {
+    condition     = google_pubsub_topic_iam_member.budget_publisher[0].member == "serviceAccount:cloud-billing-budgets@system.gserviceaccount.com"
+    error_message = "Publisher binding must target the Cloud Billing budgets service agent."
+  }
+}
+
+run "custom_thresholds_respected" {
+  command = plan
+
+  variables {
+    threshold_percentages = [0.5, 0.9]
+  }
+
+  assert {
+    condition     = length(google_billing_budget.this.threshold_rules) == 2
+    error_message = "Custom threshold list should override the default three rules."
+  }
+}
+
+run "reuses_existing_topic_when_create_disabled" {
+  command = plan
+
+  variables {
+    create_pubsub_topic = false
+    pubsub_topic_id     = "projects/test-ml-infra-gpu/topics/existing-budget-topic"
+  }
+
+  assert {
+    condition     = length(google_pubsub_topic.budget_alerts) == 0
+    error_message = "No Pub/Sub topic should be created when create_pubsub_topic = false."
+  }
+
+  assert {
+    condition     = length(google_pubsub_topic_iam_member.budget_publisher) == 0
+    error_message = "No publisher binding should be created when reusing an external topic."
+  }
+
+  assert {
+    condition     = google_billing_budget.this.all_updates_rule[0].pubsub_topic == "projects/test-ml-infra-gpu/topics/existing-budget-topic"
+    error_message = "Budget should notify the externally supplied topic when reuse is requested."
+  }
+}

--- a/terraform/modules/gcp-billing-budget/main.tf
+++ b/terraform/modules/gcp-billing-budget/main.tf
@@ -1,0 +1,101 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GCP Billing Budget Module (WS-A — ml-infra)
+# ---------------------------------------------------------------------------------------------------------------------
+# Creates a google_billing_budget on a billing account, scoped to one or more GPU
+# projects, with threshold alerts at 80% / 100% / 120% of a specified monthly
+# amount (configurable). Notifications are delivered to a Pub/Sub topic that an
+# Alertmanager webhook bridge subscribes to (the topic is created here by default).
+#
+# ADR-0028 note: google_billing_budget does NOT support a `labels` argument, so the
+# unified platform taxonomy labels (platform_system = ml-infra, etc.) are applied to
+# the Pub/Sub notification topic — the only labelable resource in this module — and
+# the taxonomy is echoed into the budget display name for billing-console grouping.
+# GCP label keys use underscores (platform_system), not colons, because GCP labels
+# disallow ':' — this is the GCP-plane spelling of the ADR-0028 keys.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  # Full Pub/Sub topic ID the budget notifies. Either the one we create, or a
+  # pre-existing topic supplied by the caller.
+  notification_topic_id = var.create_pubsub_topic ? google_pubsub_topic.budget_alerts[0].id : var.pubsub_topic_id
+
+  # Google-managed Cloud Billing budgets service agent. It must be a Pub/Sub
+  # publisher on the budget topic or notifications never fire.
+  billing_budgets_sa = "serviceAccount:cloud-billing-budgets@system.gserviceaccount.com"
+
+  # ADR-0028 baseline labels for the ml-infra system, merged with caller overrides.
+  platform_labels = merge(
+    {
+      platform_system     = "ml-infra"
+      platform_component  = "cost-control"
+      platform_managed_by = "terragrunt"
+    },
+    var.labels,
+  )
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Pub/Sub topic — budget notifications land here; Alertmanager webhook bridge subscribes.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "google_pubsub_topic" "budget_alerts" {
+  count = var.create_pubsub_topic ? 1 : 0
+
+  project = var.topic_project_id
+  name    = var.pubsub_topic_name
+
+  labels = local.platform_labels
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# IAM — grant the Cloud Billing budgets service agent publish rights on the topic.
+# Without this binding the budget cannot publish notifications and the cost guardrail
+# is inert. Only created when this module owns the topic (create_pubsub_topic = true);
+# when reusing an external topic the caller must already grant this.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "google_pubsub_topic_iam_member" "budget_publisher" {
+  count = var.create_pubsub_topic ? 1 : 0
+
+  project = var.topic_project_id
+  topic   = google_pubsub_topic.budget_alerts[0].name
+  role    = "roles/pubsub.publisher"
+  member  = local.billing_budgets_sa
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Billing budget — scoped to GPU project(s), with 0.8 / 1.0 / 1.2 threshold rules.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "google_billing_budget" "this" {
+  billing_account = var.billing_account_id
+  display_name    = "${var.budget_display_name} [platform_system=ml-infra]"
+
+  budget_filter {
+    projects               = [for p in var.gpu_project_ids : "projects/${p}"]
+    credit_types_treatment = var.credit_types_treatment
+  }
+
+  amount {
+    specified_amount {
+      currency_code = var.currency_code
+      units         = tostring(var.monthly_amount)
+    }
+  }
+
+  # One threshold rule per configured percentage (default 0.8 / 1.0 / 1.2),
+  # evaluated against the forecasted spend so alerts fire ahead of overspend.
+  dynamic "threshold_rules" {
+    for_each = var.threshold_percentages
+    content {
+      threshold_percent = threshold_rules.value
+      spend_basis       = "FORECASTED_SPEND"
+    }
+  }
+
+  all_updates_rule {
+    pubsub_topic                   = local.notification_topic_id
+    schema_version                 = "1.0"
+    disable_default_iam_recipients = var.disable_default_iam_recipients
+  }
+}

--- a/terraform/modules/gcp-billing-budget/outputs.tf
+++ b/terraform/modules/gcp-billing-budget/outputs.tf
@@ -1,0 +1,19 @@
+output "budget_id" {
+  description = "Full resource ID of the billing budget (billingAccounts/.../budgets/...)."
+  value       = google_billing_budget.this.id
+}
+
+output "budget_name" {
+  description = "Server-assigned budget name."
+  value       = google_billing_budget.this.name
+}
+
+output "pubsub_topic_id" {
+  description = "Full Pub/Sub topic ID the budget notifies. Subscribe the Alertmanager webhook bridge to this topic."
+  value       = local.notification_topic_id
+}
+
+output "threshold_percentages" {
+  description = "Threshold fractions configured on the budget (e.g. [0.8, 1.0, 1.2])."
+  value       = var.threshold_percentages
+}

--- a/terraform/modules/gcp-billing-budget/variables.tf
+++ b/terraform/modules/gcp-billing-budget/variables.tf
@@ -1,0 +1,103 @@
+variable "billing_account_id" {
+  description = "GCP billing account ID that owns the budget (format: XXXXXX-XXXXXX-XXXXXX)."
+  type        = string
+}
+
+variable "budget_display_name" {
+  description = "Human-readable name for the budget shown in the GCP billing console."
+  type        = string
+  default     = "ml-infra-gpu-monthly-budget"
+}
+
+variable "monthly_amount" {
+  description = "Specified monthly budget amount in units of currency_code (e.g. 10000 = 10,000 USD/month)."
+  type        = number
+
+  validation {
+    condition     = var.monthly_amount > 0
+    error_message = "monthly_amount must be greater than zero."
+  }
+}
+
+variable "currency_code" {
+  description = "ISO 4217 currency code for the budget amount. Must match the billing account currency."
+  type        = string
+  default     = "USD"
+}
+
+variable "gpu_project_ids" {
+  description = "List of GPU project IDs to scope the budget filter to. Empty list = budget covers the whole billing account."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
+variable "threshold_percentages" {
+  description = "Spend fractions (of monthly_amount) at which to fire budget alerts. Defaults to 80%, 100%, 120%."
+  type        = list(number)
+  default     = [0.8, 1.0, 1.2]
+  nullable    = false
+
+  validation {
+    condition     = length(var.threshold_percentages) > 0
+    error_message = "At least one threshold percentage must be provided."
+  }
+
+  validation {
+    condition     = alltrue([for t in var.threshold_percentages : t > 0])
+    error_message = "All threshold percentages must be greater than zero (expressed as fractions, e.g. 0.8 for 80%)."
+  }
+}
+
+variable "create_pubsub_topic" {
+  description = "Whether this module should create the Pub/Sub topic used for budget notifications. Set false to reuse an existing topic."
+  type        = bool
+  default     = true
+}
+
+variable "pubsub_topic_name" {
+  description = "Short name of the Pub/Sub topic for budget notifications (used when create_pubsub_topic = true)."
+  type        = string
+  default     = "ml-infra-budget-alerts"
+}
+
+variable "pubsub_topic_id" {
+  description = "Full Pub/Sub topic ID (projects/PROJECT/topics/NAME) to notify. Required when create_pubsub_topic = false; otherwise ignored."
+  type        = string
+  default     = null
+}
+
+variable "topic_project_id" {
+  description = "Project in which to create the Pub/Sub notification topic when create_pubsub_topic = true."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.topic_project_id != null
+    error_message = "topic_project_id must be set so the notification topic and budget have a home project."
+  }
+}
+
+variable "credit_types_treatment" {
+  description = "How credits are handled in the budget actual spend. One of INCLUDE_ALL_CREDITS, EXCLUDE_ALL_CREDITS."
+  type        = string
+  default     = "INCLUDE_ALL_CREDITS"
+
+  validation {
+    condition     = contains(["INCLUDE_ALL_CREDITS", "EXCLUDE_ALL_CREDITS"], var.credit_types_treatment)
+    error_message = "credit_types_treatment must be INCLUDE_ALL_CREDITS or EXCLUDE_ALL_CREDITS."
+  }
+}
+
+variable "disable_default_iam_recipients" {
+  description = "When true, only the Pub/Sub topic is notified (no emails to billing admins/users)."
+  type        = bool
+  default     = false
+}
+
+variable "labels" {
+  description = "ADR-0028 platform labels applied to created resources (GCP label keys use underscores, e.g. platform_system = ml-infra)."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}

--- a/terraform/modules/gcp-billing-budget/versions.tf
+++ b/terraform/modules/gcp-billing-budget/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/modules/gcp-gke-gpu-nodepools/gcp-gke-gpu-nodepools.tftest.hcl
+++ b/terraform/modules/gcp-gke-gpu-nodepools/gcp-gke-gpu-nodepools.tftest.hcl
@@ -2,20 +2,111 @@ mock_provider "google" {}
 
 variables {
   project_id   = "test-gcp-project"
+  cluster_id   = "projects/test-gcp-project/locations/us-central1-a/clusters/test"
   cluster_name = "test-gke-cluster"
-  location     = "us-central1"
-  tags = {
-    Environment = "test"
-    Team        = "gpu"
-    ManagedBy   = "terraform"
-  }
+  zone         = "us-central1-a"
+
+  node_pool_configs = {}
 }
 
 run "module_initializes" {
   command = plan
 
+  # A real reference (the parser rejects a bare `true`). The module plans cleanly
+  # with an empty node-pool map and the new switch at its default.
   assert {
-    condition     = true
-    error_message = "Module should initialize without errors"
+    condition     = var.operator_managed_driver == false
+    error_message = "Module should initialize with operator_managed_driver defaulting to false."
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# operator_managed_driver — additive switch. Default false must preserve current
+# behavior; true hands the driver stack to the NVIDIA GPU Operator (ADR-0036).
+# ---------------------------------------------------------------------------------------------------------------------
+
+run "default_false_keeps_gke_managed_driver" {
+  command = plan
+
+  variables {
+    node_pool_configs = {
+      l4 = {
+        machine_type      = "g2-standard-8"
+        accelerator_type  = "nvidia-l4"
+        accelerator_count = 1
+        min_node_count    = 0
+        max_node_count    = 3
+      }
+    }
+  }
+
+  # Default must be false (zero-diff path).
+  assert {
+    condition     = var.operator_managed_driver == false
+    error_message = "operator_managed_driver must default to false."
+  }
+
+  # GKE-managed driver block present at LATEST when operator_managed_driver = false.
+  assert {
+    condition     = google_container_node_pool.this["l4"].node_config[0].guest_accelerator[0].gpu_driver_installation_config[0].gpu_driver_version == "LATEST"
+    error_message = "Default path must keep the GKE-managed gpu_driver_installation_config at LATEST."
+  }
+
+  # No operator-driver labels are injected on the default path (zero diff).
+  assert {
+    condition     = !contains(keys(google_container_node_pool.this["l4"].node_config[0].labels), "gke-no-default-nvidia-gpu-device-plugin")
+    error_message = "Default path must NOT add the gke-no-default-nvidia-gpu-device-plugin label."
+  }
+
+  assert {
+    condition     = !contains(keys(google_container_node_pool.this["l4"].node_config[0].labels), "nvidia.com/gpu.present")
+    error_message = "Default path must NOT add the nvidia.com/gpu.present label."
+  }
+
+  # Baseline labels remain exactly as before.
+  assert {
+    condition     = google_container_node_pool.this["l4"].node_config[0].labels["managed-by"] == "terraform"
+    error_message = "Default path must keep the managed-by = terraform label."
+  }
+}
+
+run "operator_managed_driver_true_omits_driver_and_adds_labels" {
+  command = plan
+
+  variables {
+    operator_managed_driver = true
+
+    node_pool_configs = {
+      l4 = {
+        machine_type      = "g2-standard-8"
+        accelerator_type  = "nvidia-l4"
+        accelerator_count = 1
+        min_node_count    = 0
+        max_node_count    = 3
+      }
+    }
+  }
+
+  # GKE-managed driver block is omitted when the operator owns the driver.
+  assert {
+    condition     = length(google_container_node_pool.this["l4"].node_config[0].guest_accelerator[0].gpu_driver_installation_config) == 0
+    error_message = "operator_managed_driver = true must omit the gpu_driver_installation_config block."
+  }
+
+  # Operator-driver labels are injected.
+  assert {
+    condition     = google_container_node_pool.this["l4"].node_config[0].labels["gke-no-default-nvidia-gpu-device-plugin"] == "true"
+    error_message = "operator_managed_driver = true must add gke-no-default-nvidia-gpu-device-plugin = true."
+  }
+
+  assert {
+    condition     = google_container_node_pool.this["l4"].node_config[0].labels["nvidia.com/gpu.present"] == "true"
+    error_message = "operator_managed_driver = true must add nvidia.com/gpu.present = true."
+  }
+
+  # Baseline labels are still present alongside the operator labels.
+  assert {
+    condition     = google_container_node_pool.this["l4"].node_config[0].labels["managed-by"] == "terraform"
+    error_message = "Operator path must still carry the baseline managed-by = terraform label."
   }
 }

--- a/terraform/modules/gcp-gke-gpu-nodepools/main.tf
+++ b/terraform/modules/gcp-gke-gpu-nodepools/main.tf
@@ -7,7 +7,22 @@
 #
 # Each node pool is pinned to a single zone for GPU locality and uses autoscaling
 # to optimize cost while meeting capacity requirements.
+#
+# When var.operator_managed_driver = true the module hands GPU driver/device-plugin
+# ownership to the NVIDIA GPU Operator (ADR-0036): the gpu_driver_installation_config
+# block is omitted (no GKE-managed driver) and the nodes are labeled to disable the
+# default GKE NVIDIA device plugin. Default false preserves the GKE-managed driver
+# (gpu_driver_version = "LATEST") byte-for-byte.
 # ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  # Extra node labels applied ONLY when the NVIDIA GPU Operator owns the driver stack.
+  # Empty map when operator_managed_driver = false → zero diff vs. the GKE-managed path.
+  operator_driver_labels = var.operator_managed_driver ? {
+    "gke-no-default-nvidia-gpu-device-plugin" = "true"
+    "nvidia.com/gpu.present"                  = "true"
+  } : {}
+}
 
 resource "google_container_node_pool" "this" {
   for_each = var.node_pool_configs
@@ -43,8 +58,13 @@ resource "google_container_node_pool" "this" {
         type  = each.value.accelerator_type
         count = each.value.accelerator_count
 
-        gpu_driver_installation_config {
-          gpu_driver_version = "LATEST"
+        # GKE-managed driver. Omitted when the NVIDIA GPU Operator owns the driver
+        # (operator_managed_driver = true). Default false keeps the LATEST driver.
+        dynamic "gpu_driver_installation_config" {
+          for_each = var.operator_managed_driver ? [] : [1]
+          content {
+            gpu_driver_version = "LATEST"
+          }
         }
       }
     }
@@ -59,7 +79,8 @@ resource "google_container_node_pool" "this" {
       }
     }
 
-    # Labels — merge per-pool labels with common labels
+    # Labels — merge per-pool labels with common labels. operator_driver_labels is
+    # empty unless operator_managed_driver = true, so the default path is unchanged.
     labels = merge(
       var.labels,
       each.value.labels,
@@ -67,7 +88,8 @@ resource "google_container_node_pool" "this" {
         "managed-by"   = "terraform"
         "cluster-role" = "gpu-analysis"
         "node-pool"    = each.key
-      }
+      },
+      local.operator_driver_labels,
     )
 
     oauth_scopes = [

--- a/terraform/modules/gcp-gke-gpu-nodepools/variables.tf
+++ b/terraform/modules/gcp-gke-gpu-nodepools/variables.tf
@@ -44,3 +44,10 @@ variable "labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "operator_managed_driver" {
+  description = "When true, hand GPU driver + device-plugin ownership to the NVIDIA GPU Operator (ADR-0036): omit the GKE-managed gpu_driver_installation_config block and add node labels disabling the default GKE NVIDIA device plugin. Default false preserves the GKE-managed driver (gpu_driver_version = LATEST) byte-for-byte."
+  type        = bool
+  default     = false
+  nullable    = false
+}

--- a/terraform/modules/gke-gpu-dcgm/README.md
+++ b/terraform/modules/gke-gpu-dcgm/README.md
@@ -1,0 +1,76 @@
+# gke-gpu-dcgm
+
+Deploys the **NVIDIA DCGM exporter** as a DaemonSet on **GKE** GPU nodes via
+`helm_release`, exposing GPU metrics (utilisation, memory, temperature, power,
+XID/ECC errors) on `:9400` for **Prometheus / VictoriaMetrics** scrape. Part of
+**WS-A** of the GCP ML Platform. System: `ml-infra`.
+
+## What it creates
+
+| Resource | Purpose |
+|----------|---------|
+| `kubernetes_namespace.dcgm` | Namespace for the exporter, labeled per ADR-0028. |
+| `helm_release.dcgm_exporter` | DCGM exporter DaemonSet + (optionally) a ServiceMonitor. |
+
+Both are gated by `var.enabled`.
+
+## Metrics scrape
+
+The chart renders a Prometheus-Operator **ServiceMonitor** when
+`create_service_monitor = true` (default). The ServiceMonitor carries a `release`
+label (`service_monitor_release_label`, default `victoria-metrics`) so the
+Prometheus/VictoriaMetrics operator selects it. Set `create_service_monitor = false`
+for backends that scrape via plain pod annotations.
+
+The module deliberately avoids `kubernetes_manifest` (which requires a live cluster
+at plan time) by rendering the ServiceMonitor through the chart's own
+`serviceMonitor.enabled` value — this keeps the module fully `terraform validate`-
+and `terraform test`-able with mocked providers.
+
+## ADR-0028 labeling
+
+Kubernetes-plane labels use **dotted** keys. The namespace and exporter pods carry:
+`platform.system = ml-infra`, `platform.component = observability`,
+`platform.managed-by = terragrunt`, merged with any `platform_labels` overrides.
+
+## Usage
+
+```hcl
+module "dcgm" {
+  source = "../../terraform/modules/gke-gpu-dcgm"
+
+  enabled       = true
+  chart_version = "3.6.1"
+
+  gpu_node_selector = { "cloud.google.com/gke-accelerator" = "nvidia-l4" }
+
+  service_monitor_release_label = "victoria-metrics"
+
+  platform_labels = {
+    "platform.env"   = "production"
+    "platform.owner" = "team-data"
+  }
+}
+```
+
+## Testing
+
+```bash
+terraform init -backend=false
+terraform test
+```
+
+Tests mock the `helm` and `kubernetes` providers — no cluster or credentials needed.
+
+## Network isolation (follow-up)
+
+This module creates the `gpu-monitoring` namespace but does **not** ship a NetworkPolicy. The
+EKS gpu-inference stack pairs every GPU namespace with a default-deny baseline plus
+scoped allow rules (see `network-policies/gpu-inference/00-default-deny.yaml`). The
+GKE side needs the same: a **default-deny CiliumNetworkPolicy** for `gpu-monitoring` plus
+scoped-allow policies (DNS/kube-api, metrics scrape, and the specific peers this
+component talks to).
+
+This is **required** for parity and is **deferred to the GitOps / network-policies
+layer** (Dataplane V2 / Cilium), not implemented in this Terraform module. Tracking
+item for the network-policies workstream.

--- a/terraform/modules/gke-gpu-dcgm/gke-gpu-dcgm.tftest.hcl
+++ b/terraform/modules/gke-gpu-dcgm/gke-gpu-dcgm.tftest.hcl
@@ -1,0 +1,87 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests for the gke-gpu-dcgm module.
+# helm and kubernetes providers are mocked — no cluster or credentials required.
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "helm" {}
+mock_provider "kubernetes" {}
+
+variables {
+  platform_labels = {
+    "platform.env"   = "staging"
+    "platform.owner" = "team-data"
+  }
+}
+
+run "default_chart_version_pinned" {
+  command = plan
+
+  assert {
+    condition     = length(var.chart_version) > 0
+    error_message = "Chart version must have a pinned default."
+  }
+}
+
+run "deploys_exporter_when_enabled" {
+  command = plan
+
+  assert {
+    condition     = length(helm_release.dcgm_exporter) == 1
+    error_message = "DCGM exporter Helm release should be created when enabled = true."
+  }
+
+  assert {
+    condition     = length(kubernetes_namespace.dcgm) == 1
+    error_message = "Namespace should be created when enabled = true."
+  }
+}
+
+run "namespace_carries_adr0028_labels" {
+  command = plan
+
+  assert {
+    condition     = kubernetes_namespace.dcgm[0].metadata[0].labels["platform.system"] == "ml-infra"
+    error_message = "Namespace must carry platform.system = ml-infra per ADR-0028."
+  }
+
+  assert {
+    condition     = kubernetes_namespace.dcgm[0].metadata[0].labels["platform.component"] == "observability"
+    error_message = "DCGM namespace should be labeled with platform.component = observability."
+  }
+}
+
+run "release_uses_pinned_version" {
+  command = plan
+
+  assert {
+    condition     = helm_release.dcgm_exporter[0].version == var.chart_version
+    error_message = "Helm release must use the pinned chart_version."
+  }
+}
+
+run "metrics_port_default_9400" {
+  command = plan
+
+  assert {
+    condition     = var.exporter_port == 9400
+    error_message = "DCGM exporter should default to the standard 9400 metrics port."
+  }
+}
+
+run "disabled_creates_nothing" {
+  command = plan
+
+  variables {
+    enabled = false
+  }
+
+  assert {
+    condition     = length(helm_release.dcgm_exporter) == 0
+    error_message = "No Helm release should be created when enabled = false."
+  }
+
+  assert {
+    condition     = length(kubernetes_namespace.dcgm) == 0
+    error_message = "No namespace should be created when enabled = false."
+  }
+}

--- a/terraform/modules/gke-gpu-dcgm/main.tf
+++ b/terraform/modules/gke-gpu-dcgm/main.tf
@@ -1,0 +1,89 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GKE GPU DCGM Exporter Module (WS-A — ml-infra)
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys the NVIDIA DCGM exporter as a DaemonSet on GKE GPU nodes via helm_release,
+# exposing GPU metrics (utilisation, memory, temperature, power, XID/ECC errors) on
+# :9400 for Prometheus / VictoriaMetrics scrape.
+#
+# The dcgm-exporter chart renders an optional Prometheus-Operator ServiceMonitor
+# directly (serviceMonitor.enabled) so the metrics backend selects the target with a
+# `release` label — this keeps the module free of kubernetes_manifest, which would
+# require a live cluster at plan time and break mocked validation.
+#
+# ADR-0028: namespace and exporter workloads carry the Kubernetes-plane platform
+# labels (dotted keys, platform.system = ml-infra).
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  # ADR-0028 Kubernetes-plane baseline labels for the ml-infra system.
+  platform_labels = merge(
+    {
+      "platform.system"     = "ml-infra"
+      "platform.component"  = "observability"
+      "platform.managed-by" = "terragrunt"
+    },
+    var.platform_labels,
+  )
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Namespace — labeled per ADR-0028; also flagged for monitoring discovery.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_namespace" "dcgm" {
+  count = var.enabled ? 1 : 0
+
+  metadata {
+    name = var.namespace
+    labels = merge(local.platform_labels, {
+      "monitoring" = "true"
+    })
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DCGM exporter Helm release (DaemonSet) + optional ServiceMonitor.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "helm_release" "dcgm_exporter" {
+  count = var.enabled ? 1 : 0
+
+  name       = "dcgm-exporter"
+  repository = var.chart_repository
+  chart      = "dcgm-exporter"
+  version    = var.chart_version
+  namespace  = kubernetes_namespace.dcgm[0].metadata[0].name
+  timeout    = var.helm_timeout
+
+  values = [
+    yamlencode({
+      # DaemonSet metrics port.
+      service = {
+        type = "ClusterIP"
+        port = var.exporter_port
+      }
+
+      # Run only on GPU nodes; tolerate the GPU taint.
+      nodeSelector = var.gpu_node_selector
+      tolerations = [
+        {
+          key      = "nvidia.com/gpu"
+          operator = "Exists"
+          effect   = "NoSchedule"
+        }
+      ]
+
+      # ADR-0028 labels on the exporter pods.
+      podLabels = local.platform_labels
+
+      # Prometheus / VictoriaMetrics scrape via ServiceMonitor.
+      serviceMonitor = {
+        enabled  = var.create_service_monitor
+        interval = var.scrape_interval
+        additionalLabels = merge(local.platform_labels, {
+          "release" = var.service_monitor_release_label
+        })
+      }
+    })
+  ]
+}

--- a/terraform/modules/gke-gpu-dcgm/outputs.tf
+++ b/terraform/modules/gke-gpu-dcgm/outputs.tf
@@ -1,0 +1,29 @@
+output "enabled" {
+  description = "Whether the DCGM exporter was deployed by this module."
+  value       = var.enabled
+}
+
+output "namespace" {
+  description = "Namespace the DCGM exporter is installed into (null when disabled)."
+  value       = var.enabled ? kubernetes_namespace.dcgm[0].metadata[0].name : null
+}
+
+output "release_name" {
+  description = "Helm release name of the DCGM exporter (null when disabled)."
+  value       = var.enabled ? helm_release.dcgm_exporter[0].name : null
+}
+
+output "metrics_port" {
+  description = "Port on which DCGM metrics are exposed for scrape."
+  value       = var.exporter_port
+}
+
+output "service_monitor_enabled" {
+  description = "Whether a Prometheus-Operator ServiceMonitor was requested for scrape."
+  value       = var.create_service_monitor
+}
+
+output "platform_labels" {
+  description = "Effective ADR-0028 Kubernetes-plane labels applied to DCGM resources."
+  value       = local.platform_labels
+}

--- a/terraform/modules/gke-gpu-dcgm/variables.tf
+++ b/terraform/modules/gke-gpu-dcgm/variables.tf
@@ -1,0 +1,67 @@
+variable "enabled" {
+  description = "Master toggle. When false the module creates nothing."
+  type        = bool
+  default     = true
+}
+
+variable "namespace" {
+  description = "Namespace into which the DCGM exporter DaemonSet is installed."
+  type        = string
+  default     = "gpu-monitoring"
+}
+
+variable "chart_version" {
+  description = "Pinned dcgm-exporter Helm chart version."
+  type        = string
+  default     = "3.6.1"
+}
+
+variable "chart_repository" {
+  description = "Helm repository hosting the dcgm-exporter chart."
+  type        = string
+  default     = "https://nvidia.github.io/dcgm-exporter/helm-charts"
+}
+
+variable "exporter_port" {
+  description = "Container/service port the DCGM exporter listens on for metrics scraping."
+  type        = number
+  default     = 9400
+}
+
+variable "scrape_interval" {
+  description = "Scrape interval hint embedded in the ServiceMonitor/scrape annotations."
+  type        = string
+  default     = "15s"
+}
+
+variable "create_service_monitor" {
+  description = "Create a Prometheus-Operator ServiceMonitor (true) for Prometheus/VictoriaMetrics scrape. When the metrics backend uses plain pod annotations, set false."
+  type        = bool
+  default     = true
+}
+
+variable "service_monitor_release_label" {
+  description = "Value of the `release` label the ServiceMonitor carries so the Prometheus/VictoriaMetrics operator selects it."
+  type        = string
+  default     = "victoria-metrics"
+}
+
+variable "gpu_node_selector" {
+  description = "Node selector restricting the DaemonSet to GPU nodes. Defaults to the GKE accelerator label key (any value)."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}
+
+variable "helm_timeout" {
+  description = "Helm release timeout in seconds."
+  type        = number
+  default     = 300
+}
+
+variable "platform_labels" {
+  description = "ADR-0028 Kubernetes-plane labels (dotted keys, e.g. platform.system = ml-infra) applied to the namespace and exporter workloads."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}

--- a/terraform/modules/gke-gpu-dcgm/versions.tf
+++ b/terraform/modules/gke-gpu-dcgm/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.25"
+    }
+  }
+}

--- a/terraform/modules/gke-gpu-operator/README.md
+++ b/terraform/modules/gke-gpu-operator/README.md
@@ -1,0 +1,78 @@
+# gke-gpu-operator
+
+Deploys the **NVIDIA GPU Operator** on a **GKE Standard** cluster via `helm_release`,
+toggleable and version-pinned. Part of **WS-A** of the GCP ML Platform. System:
+`ml-infra`.
+
+## What it creates
+
+| Resource | Purpose |
+|----------|---------|
+| `kubernetes_namespace.gpu_operator` | Namespace for the operator, labeled per ADR-0028. |
+| `helm_release.gpu_operator` | The NVIDIA GPU Operator chart (pinned version). |
+
+Both are gated by `var.enabled`. Set `enabled = false` for clusters that rely solely
+on the **GKE-managed GPU driver DaemonSet** instead of the operator.
+
+## GKE defaults
+
+On GKE Standard with COS, the container toolkit ships in the node image and the
+kernel driver is provided by the GKE-managed driver DaemonSet, so:
+
+- `driver_enabled = false`
+- `toolkit_enabled = false`
+- `dcgm_exporter_enabled = false` (DCGM is owned by `gke-gpu-dcgm`)
+
+The operator then provides the device plugin, GPU Feature Discovery (GFD), Node
+Feature Discovery (NFD) and CDI. Flip the driver/toolkit toggles for clusters where
+the operator should own the full stack.
+
+## ADR-0028 labeling
+
+Kubernetes-plane labels use **dotted** keys. The namespace and operator workloads
+carry: `platform.system = ml-infra`, `platform.component = compute`,
+`platform.managed-by = terragrunt`, merged with any `platform_labels` overrides
+(e.g. `platform.env`, `platform.owner`).
+
+## Usage
+
+```hcl
+module "gpu_operator" {
+  source = "../../terraform/modules/gke-gpu-operator"
+
+  enabled       = true
+  chart_version = "v24.9.2"
+
+  gpu_node_selector = { "cloud.google.com/gke-accelerator" = "nvidia-l4" }
+
+  platform_labels = {
+    "platform.env"   = "production"
+    "platform.owner" = "team-data"
+  }
+}
+```
+
+Requires `helm` and `kubernetes` providers configured against the target GKE cluster
+(wired by the catalog unit via a generated provider override).
+
+## Testing
+
+```bash
+terraform init -backend=false
+terraform test
+```
+
+Tests mock the `helm` and `kubernetes` providers — no cluster or credentials needed.
+
+## Network isolation (follow-up)
+
+This module creates the `gpu-operator` namespace but does **not** ship a NetworkPolicy. The
+EKS gpu-inference stack pairs every GPU namespace with a default-deny baseline plus
+scoped allow rules (see `network-policies/gpu-inference/00-default-deny.yaml`). The
+GKE side needs the same: a **default-deny CiliumNetworkPolicy** for `gpu-operator` plus
+scoped-allow policies (DNS/kube-api, metrics scrape, and the specific peers this
+component talks to).
+
+This is **required** for parity and is **deferred to the GitOps / network-policies
+layer** (Dataplane V2 / Cilium), not implemented in this Terraform module. Tracking
+item for the network-policies workstream.

--- a/terraform/modules/gke-gpu-operator/gke-gpu-operator.tftest.hcl
+++ b/terraform/modules/gke-gpu-operator/gke-gpu-operator.tftest.hcl
@@ -1,0 +1,79 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests for the gke-gpu-operator module.
+# helm and kubernetes providers are mocked so no real cluster or credentials are
+# needed; assertions run at plan time over the module's wiring and toggles.
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "helm" {}
+mock_provider "kubernetes" {}
+
+variables {
+  platform_labels = {
+    "platform.env"   = "staging"
+    "platform.owner" = "team-data"
+  }
+}
+
+run "default_chart_version_pinned" {
+  command = plan
+
+  assert {
+    condition     = length(var.chart_version) > 0
+    error_message = "Chart version must have a pinned default."
+  }
+}
+
+run "deploys_operator_when_enabled" {
+  command = plan
+
+  assert {
+    condition     = length(helm_release.gpu_operator) == 1
+    error_message = "GPU operator Helm release should be created when enabled = true."
+  }
+
+  assert {
+    condition     = length(kubernetes_namespace.gpu_operator) == 1
+    error_message = "Namespace should be created when enabled = true."
+  }
+}
+
+run "namespace_carries_adr0028_labels" {
+  command = plan
+
+  assert {
+    condition     = kubernetes_namespace.gpu_operator[0].metadata[0].labels["platform.system"] == "ml-infra"
+    error_message = "Namespace must carry platform.system = ml-infra per ADR-0028."
+  }
+
+  assert {
+    condition     = kubernetes_namespace.gpu_operator[0].metadata[0].labels["platform.env"] == "staging"
+    error_message = "Caller-supplied platform.env label must be merged onto the namespace."
+  }
+}
+
+run "release_uses_pinned_version" {
+  command = plan
+
+  assert {
+    condition     = helm_release.gpu_operator[0].version == var.chart_version
+    error_message = "Helm release must use the pinned chart_version."
+  }
+}
+
+run "disabled_creates_nothing" {
+  command = plan
+
+  variables {
+    enabled = false
+  }
+
+  assert {
+    condition     = length(helm_release.gpu_operator) == 0
+    error_message = "No Helm release should be created when enabled = false."
+  }
+
+  assert {
+    condition     = length(kubernetes_namespace.gpu_operator) == 0
+    error_message = "No namespace should be created when enabled = false."
+  }
+}

--- a/terraform/modules/gke-gpu-operator/main.tf
+++ b/terraform/modules/gke-gpu-operator/main.tf
@@ -1,0 +1,104 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GKE GPU Operator Module (WS-A — ml-infra)
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys the NVIDIA GPU Operator on a GKE Standard cluster via helm_release.
+#
+# On GKE the COS node image already ships the container toolkit and (with the
+# GKE-managed driver DaemonSet) the kernel driver, so driver_enabled / toolkit_enabled
+# default to false — the operator here primarily provides device-plugin, GPU Feature
+# Discovery and Node Feature Discovery. Flip the toggles for clusters that need the
+# operator to own the full driver stack.
+#
+# The whole module is gated by var.enabled so a cluster can instead rely purely on
+# the GKE-managed GPU driver DaemonSet (no operator) by setting enabled = false.
+#
+# ADR-0028: namespace and operator workloads carry the Kubernetes-plane platform
+# labels (dotted keys, platform.system = ml-infra). K8s label keys use dots, unlike
+# the GCP-plane underscore spelling used by GCP resource labels.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  # ADR-0028 Kubernetes-plane baseline labels for the ml-infra system.
+  platform_labels = merge(
+    {
+      "platform.system"     = "ml-infra"
+      "platform.component"  = "compute"
+      "platform.managed-by" = "terragrunt"
+    },
+    var.platform_labels,
+  )
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Namespace — carries the ADR-0028 labels so all operator workloads inherit the system boundary.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_namespace" "gpu_operator" {
+  count = var.enabled ? 1 : 0
+
+  metadata {
+    name   = var.namespace
+    labels = local.platform_labels
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# NVIDIA GPU Operator Helm release.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "helm_release" "gpu_operator" {
+  count = var.enabled ? 1 : 0
+
+  name       = "gpu-operator"
+  repository = var.chart_repository
+  chart      = "gpu-operator"
+  version    = var.chart_version
+  namespace  = kubernetes_namespace.gpu_operator[0].metadata[0].name
+  timeout    = var.helm_timeout
+
+  values = [
+    yamlencode({
+      # GKE-managed driver/toolkit by default — operator just runs plugin + discovery.
+      driver = {
+        enabled = var.driver_enabled
+      }
+      toolkit = {
+        enabled = var.toolkit_enabled
+      }
+      devicePlugin = {
+        enabled = true
+      }
+      gfd = {
+        enabled = true
+      }
+      nfd = {
+        enabled = true
+      }
+      cdi = {
+        enabled = true
+      }
+      # DCGM is owned by the dedicated gke-gpu-dcgm module.
+      dcgmExporter = {
+        enabled = var.dcgm_exporter_enabled
+      }
+      operator = {
+        nodeSelector = var.gpu_node_selector
+        tolerations = [
+          {
+            key      = "nvidia.com/gpu"
+            operator = "Exists"
+            effect   = "NoSchedule"
+          }
+        ]
+        resources = {
+          limits = {
+            cpu    = var.operator_cpu_limit
+            memory = var.operator_memory_limit
+          }
+        }
+        # ADR-0028 labels propagated onto operator-managed pods.
+        labels = local.platform_labels
+      }
+    })
+  ]
+}

--- a/terraform/modules/gke-gpu-operator/outputs.tf
+++ b/terraform/modules/gke-gpu-operator/outputs.tf
@@ -1,0 +1,24 @@
+output "enabled" {
+  description = "Whether the GPU operator was deployed by this module."
+  value       = var.enabled
+}
+
+output "namespace" {
+  description = "Namespace the GPU operator is installed into (null when disabled)."
+  value       = var.enabled ? kubernetes_namespace.gpu_operator[0].metadata[0].name : null
+}
+
+output "release_name" {
+  description = "Helm release name of the GPU operator (null when disabled)."
+  value       = var.enabled ? helm_release.gpu_operator[0].name : null
+}
+
+output "chart_version" {
+  description = "Pinned chart version that was deployed."
+  value       = var.chart_version
+}
+
+output "platform_labels" {
+  description = "Effective ADR-0028 Kubernetes-plane labels applied to operator resources."
+  value       = local.platform_labels
+}

--- a/terraform/modules/gke-gpu-operator/variables.tf
+++ b/terraform/modules/gke-gpu-operator/variables.tf
@@ -1,0 +1,73 @@
+variable "enabled" {
+  description = "Master toggle. When false the module creates nothing (useful for clusters that rely on the GKE-managed GPU driver instead)."
+  type        = bool
+  default     = true
+}
+
+variable "namespace" {
+  description = "Namespace into which the NVIDIA GPU Operator is installed."
+  type        = string
+  default     = "gpu-operator"
+}
+
+variable "chart_version" {
+  description = "Pinned NVIDIA GPU Operator Helm chart version. Pin explicitly per environment for reproducible installs."
+  type        = string
+  default     = "v24.9.2"
+}
+
+variable "chart_repository" {
+  description = "Helm repository hosting the gpu-operator chart."
+  type        = string
+  default     = "https://helm.ngc.nvidia.com/nvidia"
+}
+
+variable "driver_enabled" {
+  description = "Install the NVIDIA driver via the operator. Set false on GKE when using GKE-managed GPU drivers (default for GKE Standard with COS)."
+  type        = bool
+  default     = false
+}
+
+variable "toolkit_enabled" {
+  description = "Install the NVIDIA container toolkit via the operator. Set false on GKE (COS ships the toolkit)."
+  type        = bool
+  default     = false
+}
+
+variable "dcgm_exporter_enabled" {
+  description = "Enable the operator's bundled DCGM exporter. Keep false — DCGM is deployed by the dedicated gke-gpu-dcgm module."
+  type        = bool
+  default     = false
+}
+
+variable "gpu_node_selector" {
+  description = "Node selector identifying GPU nodes the operator components should run on. Defaults to the GKE accelerator label."
+  type        = map(string)
+  default     = { "cloud.google.com/gke-accelerator" = "nvidia-l4" }
+  nullable    = false
+}
+
+variable "operator_cpu_limit" {
+  description = "CPU limit for the operator controller pod."
+  type        = string
+  default     = "500m"
+}
+
+variable "operator_memory_limit" {
+  description = "Memory limit for the operator controller pod."
+  type        = string
+  default     = "512Mi"
+}
+
+variable "helm_timeout" {
+  description = "Helm release timeout in seconds."
+  type        = number
+  default     = 600
+}
+
+variable "platform_labels" {
+  description = "ADR-0028 Kubernetes-plane labels (dotted keys, e.g. platform.system = ml-infra) applied to the namespace and propagated to operator workloads."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}

--- a/terraform/modules/gke-gpu-operator/versions.tf
+++ b/terraform/modules/gke-gpu-operator/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.25"
+    }
+  }
+}

--- a/terraform/modules/gke-gpu-scheduling/README.md
+++ b/terraform/modules/gke-gpu-scheduling/README.md
@@ -1,0 +1,74 @@
+# gke-gpu-scheduling
+
+Deploys a **batch / queueing scheduler** on a **GKE** cluster for GPU analysis
+workloads. Defaults to **Volcano** (native gang scheduling); **Kueue** is selectable
+as an alternative. Part of **WS-A** of the GCP ML Platform. System: `ml-infra`.
+
+## Scheduler choice
+
+**ADR-0036** selected **Volcano** as the WS-A batch scheduler — native gang
+scheduling for distributed training, plus parity with the existing EKS
+`gpu-inference-volcano` stack — so `scheduler` defaults to `volcano`. Set
+`scheduler = "kueue"` to deploy Kueue (job-level queueing, quota and fair-sharing)
+instead. Exactly one scheduler is installed; `enabled = false` falls back to the
+default kube-scheduler.
+
+## What it creates
+
+| Resource | When |
+|----------|------|
+| `kubernetes_namespace.scheduling` | `enabled = true` |
+| `helm_release.volcano` | `enabled && scheduler == "volcano"` (default) |
+| `helm_release.kueue` | `enabled && scheduler == "kueue"` |
+
+## Queue custom resources
+
+`Queue` (Volcano) and `ClusterQueue` / `ResourceFlavor` / `LocalQueue` (Kueue) CRs
+are **not** created here — they require `kubernetes_manifest`, which needs a live
+cluster at plan time and would break mocked validation. They are applied by the
+GitOps/ArgoCD layer after the CRDs exist. This module owns the controller install
+plus namespace labeling.
+
+## ADR-0028 labeling
+
+Kubernetes-plane labels use **dotted** keys. The namespace and scheduler pods carry:
+`platform.system = ml-infra`, `platform.component = scheduler`,
+`platform.managed-by = terragrunt`, merged with any `platform_labels` overrides.
+
+## Usage
+
+```hcl
+module "gpu_scheduling" {
+  source = "../../terraform/modules/gke-gpu-scheduling"
+
+  enabled   = true
+  scheduler = "volcano"
+
+  platform_labels = {
+    "platform.env"   = "production"
+    "platform.owner" = "team-data"
+  }
+}
+```
+
+## Testing
+
+```bash
+terraform init -backend=false
+terraform test
+```
+
+Tests mock the `helm` and `kubernetes` providers — no cluster or credentials needed.
+
+## Network isolation (follow-up)
+
+This module creates the `gpu-batch-scheduling` namespace but does **not** ship a NetworkPolicy. The
+EKS gpu-inference stack pairs every GPU namespace with a default-deny baseline plus
+scoped allow rules (see `network-policies/gpu-inference/00-default-deny.yaml`). The
+GKE side needs the same: a **default-deny CiliumNetworkPolicy** for `gpu-batch-scheduling` plus
+scoped-allow policies (DNS/kube-api, metrics scrape, and the specific peers this
+component talks to).
+
+This is **required** for parity and is **deferred to the GitOps / network-policies
+layer** (Dataplane V2 / Cilium), not implemented in this Terraform module. Tracking
+item for the network-policies workstream.

--- a/terraform/modules/gke-gpu-scheduling/gke-gpu-scheduling.tftest.hcl
+++ b/terraform/modules/gke-gpu-scheduling/gke-gpu-scheduling.tftest.hcl
@@ -1,0 +1,91 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests for the gke-gpu-scheduling module.
+# helm and kubernetes providers are mocked — no cluster or credentials required.
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "helm" {}
+mock_provider "kubernetes" {}
+
+variables {
+  platform_labels = {
+    "platform.env"   = "staging"
+    "platform.owner" = "team-data"
+  }
+}
+
+run "defaults_to_volcano" {
+  command = plan
+
+  assert {
+    condition     = length(helm_release.volcano) == 1
+    error_message = "Volcano should be the default scheduler for WS-A (ADR-0036)."
+  }
+
+  assert {
+    condition     = length(helm_release.kueue) == 0
+    error_message = "Kueue should not be deployed when scheduler defaults to volcano."
+  }
+}
+
+run "namespace_carries_adr0028_labels" {
+  command = plan
+
+  assert {
+    condition     = kubernetes_namespace.scheduling[0].metadata[0].labels["platform.system"] == "ml-infra"
+    error_message = "Namespace must carry platform.system = ml-infra per ADR-0028."
+  }
+
+  assert {
+    condition     = kubernetes_namespace.scheduling[0].metadata[0].labels["platform.component"] == "scheduler"
+    error_message = "Scheduling namespace should be labeled platform.component = scheduler."
+  }
+}
+
+run "volcano_uses_pinned_version" {
+  command = plan
+
+  assert {
+    condition     = helm_release.volcano[0].version == var.volcano_chart_version
+    error_message = "Volcano release must use the pinned volcano_chart_version."
+  }
+}
+
+run "kueue_selectable" {
+  command = plan
+
+  variables {
+    scheduler = "kueue"
+  }
+
+  assert {
+    condition     = length(helm_release.kueue) == 1
+    error_message = "Kueue should be deployed when scheduler = kueue."
+  }
+
+  assert {
+    condition     = length(helm_release.volcano) == 0
+    error_message = "Volcano should not be deployed when scheduler = kueue."
+  }
+}
+
+run "exactly_one_scheduler_deployed" {
+  command = plan
+
+  assert {
+    condition     = (length(helm_release.kueue) + length(helm_release.volcano)) == 1
+    error_message = "Exactly one scheduler must be deployed when enabled."
+  }
+}
+
+run "disabled_creates_nothing" {
+  command = plan
+
+  variables {
+    enabled = false
+  }
+
+  assert {
+    condition     = (length(helm_release.kueue) + length(helm_release.volcano) + length(kubernetes_namespace.scheduling)) == 0
+    error_message = "Nothing should be created when enabled = false."
+  }
+}

--- a/terraform/modules/gke-gpu-scheduling/main.tf
+++ b/terraform/modules/gke-gpu-scheduling/main.tf
@@ -1,0 +1,106 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GKE GPU Batch Scheduling Module (WS-A — ml-infra)
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys a batch/queueing scheduler on a GKE cluster for GPU analysis workloads.
+#
+# Default is Volcano (native gang scheduling for distributed training, secondary
+# scheduler — selected by ADR-0036 for WS-A and matching the EKS gpu-inference-volcano
+# stack). Kueue (job-level queueing, quota and fair-sharing) is selectable via
+# var.scheduler = "kueue". Exactly one is deployed, and the whole module is gated by
+# var.enabled so a cluster can fall back to the default kube-scheduler.
+#
+# Queue/ClusterQueue/ResourceFlavor custom resources are intentionally NOT created
+# here: those CRs require a live cluster (kubernetes_manifest) at plan time, which
+# would break mocked validation. They are applied by the GitOps/ArgoCD layer once the
+# CRDs exist. This module owns the controller install + namespace labeling only.
+#
+# ADR-0028: namespace and scheduler workloads carry the Kubernetes-plane platform
+# labels (dotted keys, platform.system = ml-infra).
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  deploy_kueue   = var.enabled && var.scheduler == "kueue"
+  deploy_volcano = var.enabled && var.scheduler == "volcano"
+
+  # ADR-0028 Kubernetes-plane baseline labels for the ml-infra system.
+  platform_labels = merge(
+    {
+      "platform.system"     = "ml-infra"
+      "platform.component"  = "scheduler"
+      "platform.managed-by" = "terragrunt"
+    },
+    var.platform_labels,
+  )
+
+  gpu_tolerations = var.manage_gpu_taints ? [
+    {
+      key      = "nvidia.com/gpu"
+      operator = "Exists"
+      effect   = "NoSchedule"
+    }
+  ] : []
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Namespace — labeled per ADR-0028.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_namespace" "scheduling" {
+  count = var.enabled ? 1 : 0
+
+  metadata {
+    name   = var.namespace
+    labels = local.platform_labels
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Kueue — alternative GKE batch queueing scheduler.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "helm_release" "kueue" {
+  count = local.deploy_kueue ? 1 : 0
+
+  name       = "kueue"
+  repository = var.kueue_chart_repository
+  chart      = "kueue"
+  version    = var.kueue_chart_version
+  namespace  = kubernetes_namespace.scheduling[0].metadata[0].name
+  timeout    = var.helm_timeout
+
+  values = [
+    yamlencode({
+      controllerManager = {
+        manager = {
+          podLabels   = local.platform_labels
+          tolerations = local.gpu_tolerations
+        }
+      }
+    })
+  ]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Volcano — default gang-scheduling batch scheduler (ADR-0036 selection for WS-A).
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "helm_release" "volcano" {
+  count = local.deploy_volcano ? 1 : 0
+
+  name       = "volcano"
+  repository = var.volcano_chart_repository
+  chart      = "volcano"
+  version    = var.volcano_chart_version
+  namespace  = kubernetes_namespace.scheduling[0].metadata[0].name
+  timeout    = var.helm_timeout
+
+  values = [
+    yamlencode({
+      custom = {
+        scheduler_podLabels   = local.platform_labels
+        controller_podLabels  = local.platform_labels
+        scheduler_tolerations = local.gpu_tolerations
+      }
+    })
+  ]
+}

--- a/terraform/modules/gke-gpu-scheduling/outputs.tf
+++ b/terraform/modules/gke-gpu-scheduling/outputs.tf
@@ -1,0 +1,26 @@
+output "enabled" {
+  description = "Whether a batch scheduler was deployed by this module."
+  value       = var.enabled
+}
+
+output "scheduler" {
+  description = "Which batch scheduler was deployed (kueue or volcano); null when disabled."
+  value       = var.enabled ? var.scheduler : null
+}
+
+output "namespace" {
+  description = "Namespace the scheduler is installed into (null when disabled)."
+  value       = var.enabled ? kubernetes_namespace.scheduling[0].metadata[0].name : null
+}
+
+output "release_name" {
+  description = "Helm release name of the deployed scheduler (null when disabled)."
+  value = var.enabled ? (
+    local.deploy_kueue ? helm_release.kueue[0].name : helm_release.volcano[0].name
+  ) : null
+}
+
+output "platform_labels" {
+  description = "Effective ADR-0028 Kubernetes-plane labels applied to scheduler resources."
+  value       = local.platform_labels
+}

--- a/terraform/modules/gke-gpu-scheduling/variables.tf
+++ b/terraform/modules/gke-gpu-scheduling/variables.tf
@@ -1,0 +1,65 @@
+variable "enabled" {
+  description = "Master toggle. When false the module creates nothing (cluster uses the default kube-scheduler)."
+  type        = bool
+  default     = true
+}
+
+variable "scheduler" {
+  description = "Batch scheduler to deploy. ADR-0036 selected Volcano for WS-A (native gang scheduling for distributed training + parity with the EKS gpu-inference-volcano stack), so volcano is the default; kueue remains selectable."
+  type        = string
+  default     = "volcano"
+
+  validation {
+    condition     = contains(["kueue", "volcano"], var.scheduler)
+    error_message = "scheduler must be one of: kueue, volcano."
+  }
+}
+
+variable "namespace" {
+  description = "Namespace into which the batch scheduler is installed."
+  type        = string
+  default     = "gpu-batch-scheduling"
+}
+
+variable "kueue_chart_version" {
+  description = "Pinned Kueue Helm chart version."
+  type        = string
+  default     = "0.9.1"
+}
+
+variable "kueue_chart_repository" {
+  description = "Helm OCI/HTTP repository hosting the Kueue chart."
+  type        = string
+  default     = "oci://registry.k8s.io/kueue/charts"
+}
+
+variable "volcano_chart_version" {
+  description = "Pinned Volcano Helm chart version (used when scheduler = volcano)."
+  type        = string
+  default     = "1.10.0"
+}
+
+variable "volcano_chart_repository" {
+  description = "Helm repository hosting the Volcano chart."
+  type        = string
+  default     = "https://volcano-sh.github.io/helm-charts"
+}
+
+variable "manage_gpu_taints" {
+  description = "Whether the scheduler should tolerate the nvidia.com/gpu taint for its controller components."
+  type        = bool
+  default     = true
+}
+
+variable "helm_timeout" {
+  description = "Helm release timeout in seconds."
+  type        = number
+  default     = 300
+}
+
+variable "platform_labels" {
+  description = "ADR-0028 Kubernetes-plane labels (dotted keys, e.g. platform.system = ml-infra) applied to the namespace and scheduler workloads."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}

--- a/terraform/modules/gke-gpu-scheduling/versions.tf
+++ b/terraform/modules/gke-gpu-scheduling/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.25"
+    }
+  }
+}


### PR DESCRIPTION
## WS-A — GKE GPU parity + multi-region + cost guardrail (Phase 1 of the GCP ML Platform plan)

Implements **WS-A** of `docs/gcp-ml-platform/IMPLEMENTATION_PLAN.md`. **Plan/validate-only** — no `terraform apply`, no helm install; apply is gated behind explicit human go.

### ADR
- **ADR-0036** — NVIDIA GPU Operator (unlocks DRA on GKE), **Volcano** batch scheduling (native gang scheduling + parity with EKS `gpu-inference-volcano`), DCGM telemetry, **multi-region** regional GKE (≥2 regions + serving failover via the in-repo failover-controller), GCP billing budget; GKE **Standard** reaffirmed; ADR-0028 taxonomy mandatory.

### New Terraform modules (each with `*.tftest.hcl`)
- `gcp-billing-budget` — `google_billing_budget` @ 80/100/120% + FORECASTED → Pub/Sub → Alertmanager/PagerDuty (incl. **Pub/Sub publisher IAM** for the billing service agent).
- `gke-gpu-operator` — NVIDIA GPU Operator via `helm_release` (pinned).
- `gke-gpu-dcgm` — DCGM exporter → Prometheus/VictoriaMetrics.
- `gke-gpu-scheduling` — Volcano (default) / Kueue (selectable) batch scheduler.
- + 4 catalog units; `gcp-gpu-analysis` stack extended to multi-region (`europe-west9` + `us-central1`).

### One additive edit to an existing module
- `gcp-gke-gpu-nodepools` gains `operator_managed_driver` (bool, **default `false` = byte-for-byte zero diff**). When `true`, it omits the GKE-managed driver and adds the operator labels so the GPU Operator + DRA can own the driver.

### Security review (folded in, no CRITICAL)
- **HIGH-1** Pub/Sub publisher IAM added (else budget alerts silently never fire). **HIGH-2** Volcano aligned across module/unit/stack/ADR. **HIGH-3** network-isolation documented as a tracked follow-up (CiliumNetworkPolicy for the 3 GKE namespaces, deferred to the GitOps/network-policies layer). **MEDIUM** `.gitignore` guards `**/.terragrunt-stack/`. **LOW** helm/kubernetes provider pins tightened.

### Validation
**29/29 module tests pass**, `fmt`/`validate` clean, 0 warnings. Providers mocked (`google`/`helm`/`kubernetes`) at `command = plan` — no real GCP creds, no live plan/apply.

### Known follow-ups (not blockers for this design PR)
- NetworkPolicy for the new GKE namespaces (HIGH-3, doc-only here).
- Confirm pinned chart/provider versions against registries before any real apply.
- Depends on the plan PR #296 (still open).

> Draft, pending human review. Apply remains gated. WS-B/WS-C build on this.

Part of the GCP ML Platform plan · ADR-0036