### PR TITLE
feat(gcp-ml): WS-C ML observability — Evidently/whylogs drift (ADR-0038)

### DIFF
--- a/apps/infra/ml-monitoring/Chart.yaml
+++ b/apps/infra/ml-monitoring/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: ml-monitoring
+description: >-
+  ML observability stack: Evidently drift-exporter + whylogs distribution
+  profiler + retrain-trigger webhook proxy. Exports feature drift, data
+  distribution shift, and model accuracy as Prometheus metrics into the
+  existing Grafana/Thanos/Alertmanager stack. ADR-0038.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+
+keywords:
+  - ml-monitoring
+  - drift
+  - evidently
+  - whylogs
+  - prometheus
+  - model-accuracy
+
+maintainers:
+  - name: ML Platform Team
+    email: platform@example.com
+
+annotations:
+  category: ML Observability
+  platform: Kubernetes
+  adr: "0038"

--- a/apps/infra/ml-monitoring/alertmanager-routes-overlay.yaml
+++ b/apps/infra/ml-monitoring/alertmanager-routes-overlay.yaml
@@ -1,0 +1,115 @@
+# Alertmanager Routes Overlay — ADR-0038 D3
+#
+# PURPOSE:
+#   This file documents the Alertmanager route additions required by WS-C
+#   and provides a ready-to-merge patch for the prometheus-stack values.yaml.
+#
+#   DO NOT edit apps/infra/observability/prometheus-stack/values.yaml directly
+#   from this chart — Alertmanager config is owned by the prometheus-stack
+#   ArgoCD Application.  The routes below must be added to
+#   apps/infra/observability/prometheus-stack/values.yaml under
+#   kube-prometheus-stack.alertmanager.alertmanagerSpec.config when WS-C
+#   is promoted to production.
+#
+# MERGE INSTRUCTIONS (platform team action required before WS-C go-live):
+#   1. Add the two routes below into the `routes:` list in prometheus-stack/values.yaml
+#      BEFORE the existing `severity = critical` routes (so they match first
+#      for platform_system=ml-monitoring alerts).
+#   2. Add the two receivers (ml-drift-pagerduty, ml-retrain-webhook) to the
+#      `receivers:` list.
+#   3. Add `alertmanager-retrain-token` to alertmanagerSpec.secrets list
+#      (alongside the existing alertmanager-slack-secret and
+#      alertmanager-pagerduty-secret entries).
+#   4. yamllint and helm lint prometheus-stack before applying.
+#
+# RETRAIN DEDUPLICATION:
+#   repeat_interval: 6h on the retrain webhook route prevents retrain storms.
+#   The ml-retrain-trigger proxy also enforces a 15-minute in-process
+#   deduplication window per (tenant, domain) pair.
+#
+# ============================================================================
+# ADD to kube-prometheus-stack.alertmanager.alertmanagerSpec.config.route.routes
+# (insert BEFORE the existing `severity = critical` catch-all routes)
+# ============================================================================
+
+# routes_patch:
+# -----------------------------------------------------------------------
+#   # ML Monitoring: critical drift/accuracy → PagerDuty
+#   # continue: true so the retrain webhook route also fires
+#   - matchers:
+#     - platform_system = ml-monitoring
+#     - severity = critical
+#     receiver: 'ml-drift-pagerduty'
+#     continue: true
+#     group_wait: 10s
+#     group_by: ['model_name', 'tenant', 'domain', 'alertname']
+#
+#   # ML Monitoring: critical drift/accuracy → retrain-trigger webhook
+#   # repeat_interval: 6h prevents retrain storms between drift recovery cycles
+#   - matchers:
+#     - platform_system = ml-monitoring
+#     - severity = critical
+#     receiver: 'ml-retrain-webhook'
+#     group_wait: 10s
+#     group_by: ['model_name', 'tenant', 'domain', 'alertname']
+#     repeat_interval: 6h
+# -----------------------------------------------------------------------
+
+# ============================================================================
+# ADD to kube-prometheus-stack.alertmanager.alertmanagerSpec.config.receivers
+# ============================================================================
+
+# receivers_patch:
+# -----------------------------------------------------------------------
+#   - name: 'ml-drift-pagerduty'
+#     pagerduty_configs:
+#     - service_key_file: '/etc/alertmanager/secrets/alertmanager-pagerduty-secret/service-key'
+#       description: 'ML drift: {{ .GroupLabels.alertname }} — {{ .GroupLabels.model_name }} ({{ .GroupLabels.tenant }}/{{ .GroupLabels.domain }})'
+#       details:
+#         model_name: '{{ .GroupLabels.model_name }}'
+#         tenant: '{{ .GroupLabels.tenant }}'
+#         domain: '{{ .GroupLabels.domain }}'
+#         severity: '{{ .GroupLabels.severity }}'
+#         platform_system: 'ml-monitoring'
+#       send_resolved: true
+#
+#   - name: 'ml-retrain-webhook'
+#     webhook_configs:
+#     # ml-retrain-trigger proxy URL (in-cluster service DNS)
+#     # The proxy translates to:
+#     #   POST /api/v1/dags/train_domain_adapter/dagRuns
+#     #   body: { conf: { tenant: "...", domain: "...", trigger: "drift" } }
+#     # Falls back to K8s Job if Airflow is unreachable (WS-B not yet deployed).
+#     - url: 'http://ml-retrain-trigger.ml-monitoring.svc.cluster.local:8080/webhook'
+#       send_resolved: false
+#       http_config:
+#         bearer_token_file: '/etc/alertmanager/secrets/alertmanager-retrain-token/token'
+#       max_alerts: 10
+# -----------------------------------------------------------------------
+
+# ============================================================================
+# ADD to kube-prometheus-stack.alertmanager.alertmanagerSpec.secrets
+# ============================================================================
+
+# secrets_patch:
+# -----------------------------------------------------------------------
+#   - alertmanager-retrain-token
+# -----------------------------------------------------------------------
+#
+# CROSS-NAMESPACE NOTE:
+#   The alertmanager-retrain-token ExternalSecret in this chart creates the
+#   Secret in the ml-monitoring namespace. Alertmanager mounts secrets from
+#   its own namespace (observability/monitoring). A second ExternalSecret
+#   targeted to the Alertmanager namespace is required:
+#
+#     apiVersion: external-secrets.io/v1beta1
+#     kind: ExternalSecret
+#     metadata:
+#       name: alertmanager-retrain-token
+#       namespace: observability       # <-- Alertmanager's namespace
+#     spec:
+#       # same remoteRef as ml-monitoring chart ExternalSecret
+#       ...
+#
+#   OR use a ClusterExternalSecret to create in both namespaces.
+#   See ADR-0038 Implementation Notes.

--- a/apps/infra/ml-monitoring/argocd-application.yaml
+++ b/apps/infra/ml-monitoring/argocd-application.yaml
@@ -1,0 +1,67 @@
+---
+# ArgoCD Application — ML Monitoring (WS-C, ADR-0038)
+# Deploy after prometheus-stack (wave 10) so Prometheus CRDs exist.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ml-monitoring
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: ml-monitoring
+    app.kubernetes.io/component: ml-observability
+    platform.system: ml-monitoring
+    platform.component: drift-exporter
+    platform.env: production
+    platform.owner: team-ml-platform
+    platform.managed-by: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"  # After prometheus-stack wave 10
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+
+  source:
+    repoURL: https://github.com/your-org/platform-infrastructure.git
+    targetRevision: main
+    path: apps/infra/ml-monitoring
+
+    helm:
+      valueFiles:
+        - values.yaml
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ml-monitoring
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - RespectIgnoreDifferences=true
+      - ApplyOutOfSyncOnly=true
+
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas
+    - group: "*"
+      kind: "*"
+      managedFieldsManagers:
+        - kube-controller-manager
+
+  revisionHistoryLimit: 3

--- a/apps/infra/ml-monitoring/templates/_helpers.tpl
+++ b/apps/infra/ml-monitoring/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{/*
+ml-monitoring Helm helpers — ADR-0038
+All platform labels are inlined in each template file rather than via a
+shared helper, to avoid Helm whitespace trimming edge-cases with nindent.
+This file is retained for selector and name helpers.
+*/}}
+
+{{/*
+Chart name helper
+*/}}
+{{- define "ml-monitoring.name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Selector labels
+Usage: {{- include "ml-monitoring.selectorLabels" (dict "name" "ml-drift-exporter") | nindent 6 }}
+*/}}
+{{- define "ml-monitoring.selectorLabels" -}}
+app.kubernetes.io/name: {{ .name }}
+{{- end }}

--- a/apps/infra/ml-monitoring/templates/deployment-drift-exporter.yaml
+++ b/apps/infra/ml-monitoring/templates/deployment-drift-exporter.yaml
@@ -1,0 +1,139 @@
+{{- if .Values.driftExporter.enabled }}
+{{- range .Values.modelNamespaces }}
+---
+# Evidently drift-exporter Deployment — one per (tenant, domain)
+# Computes model accuracy, test-suite results, column-level drift.
+# Scrape endpoint: http://<svc>:{{ $.Values.driftExporter.port }}/metrics
+# ADR-0038 D1
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-drift-exporter-{{ .tenant }}-{{ .domain }}
+  namespace: {{ .namespace }}
+  labels:
+    app.kubernetes.io/name: ml-drift-exporter
+    app.kubernetes.io/component: drift-exporter
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    platform.system: "ml-monitoring"
+    platform.component: "drift-exporter"
+    platform.env: {{ index $.Values.platformLabels "platform.env" | quote }}
+    platform.owner: {{ index $.Values.platformLabels "platform.owner" | quote }}
+    platform.managed-by: "argocd"
+    model-name: {{ .modelName | quote }}
+    tenant: {{ .tenant | quote }}
+    domain: {{ .domain | quote }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ml-drift-exporter
+      tenant: {{ .tenant | quote }}
+      domain: {{ .domain | quote }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ml-drift-exporter
+        app.kubernetes.io/component: drift-exporter
+        platform.system: "ml-monitoring"
+        platform.component: "drift-exporter"
+        platform.env: {{ index $.Values.platformLabels "platform.env" | quote }}
+        platform.owner: {{ index $.Values.platformLabels "platform.owner" | quote }}
+        platform.managed-by: "argocd"
+        model-name: {{ .modelName | quote }}
+        tenant: {{ .tenant | quote }}
+        domain: {{ .domain | quote }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ $.Values.driftExporter.port | quote }}
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: {{ $.Values.rbac.serviceAccountName }}
+      securityContext:
+        runAsNonRoot: {{ $.Values.driftExporter.securityContext.runAsNonRoot }}
+        runAsUser: {{ $.Values.driftExporter.securityContext.runAsUser }}
+        seccompProfile:
+          type: {{ $.Values.driftExporter.securityContext.seccompProfile.type }}
+      containers:
+        - name: drift-exporter
+          image: "{{ $.Values.driftExporter.image.repository }}:{{ $.Values.driftExporter.image.tag }}"
+          imagePullPolicy: {{ $.Values.driftExporter.image.pullPolicy }}
+          ports:
+            - name: metrics
+              containerPort: {{ $.Values.driftExporter.port }}
+              protocol: TCP
+          env:
+            - name: MODEL_NAME
+              value: {{ .modelName | quote }}
+            - name: TENANT
+              value: {{ .tenant | quote }}
+            - name: DOMAIN
+              value: {{ .domain | quote }}
+            - name: PLATFORM_SYSTEM
+              value: "ml-monitoring"
+            - name: REFERENCE_BUCKET_URI
+              value: {{ $.Values.driftExporter.referenceBucketUri | quote }}
+            - name: EVALUATION_INTERVAL_SECONDS
+              value: {{ $.Values.driftExporter.evaluationIntervalSeconds | quote }}
+            - name: THRESHOLD_DATASET_DRIFT_WARNING
+              value: {{ $.Values.driftExporter.defaultThresholds.datasetDriftScore.warning | quote }}
+            - name: THRESHOLD_DATASET_DRIFT_CRITICAL
+              value: {{ $.Values.driftExporter.defaultThresholds.datasetDriftScore.critical | quote }}
+            - name: THRESHOLD_ACCURACY_WARNING
+              value: {{ $.Values.driftExporter.defaultThresholds.modelAccuracy.warning | quote }}
+            - name: THRESHOLD_ACCURACY_CRITICAL
+              value: {{ $.Values.driftExporter.defaultThresholds.modelAccuracy.critical | quote }}
+          resources:
+            requests:
+              cpu: {{ $.Values.driftExporter.resources.requests.cpu | quote }}
+              memory: {{ $.Values.driftExporter.resources.requests.memory | quote }}
+            limits:
+              cpu: {{ $.Values.driftExporter.resources.limits.cpu | quote }}
+              memory: {{ $.Values.driftExporter.resources.limits.memory | quote }}
+          securityContext:
+            allowPrivilegeEscalation: {{ $.Values.driftExporter.securityContext.allowPrivilegeEscalation }}
+            readOnlyRootFilesystem: {{ $.Values.driftExporter.securityContext.readOnlyRootFilesystem }}
+            capabilities:
+              drop: {{ $.Values.driftExporter.securityContext.capabilities.drop | toJson }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 10
+      restartPolicy: Always
+---
+# Service for Evidently drift-exporter scrape endpoint
+apiVersion: v1
+kind: Service
+metadata:
+  name: ml-drift-exporter-{{ .tenant }}-{{ .domain }}
+  namespace: {{ .namespace }}
+  labels:
+    app.kubernetes.io/name: ml-drift-exporter
+    app.kubernetes.io/component: drift-exporter
+    platform.system: "ml-monitoring"
+    platform.component: "drift-exporter"
+    platform.env: {{ index $.Values.platformLabels "platform.env" | quote }}
+    platform.owner: {{ index $.Values.platformLabels "platform.owner" | quote }}
+    platform.managed-by: "argocd"
+    tenant: {{ .tenant | quote }}
+    domain: {{ .domain | quote }}
+spec:
+  selector:
+    app.kubernetes.io/name: ml-drift-exporter
+    tenant: {{ .tenant | quote }}
+    domain: {{ .domain | quote }}
+  ports:
+    - name: metrics
+      port: {{ $.Values.driftExporter.port }}
+      targetPort: metrics
+      protocol: TCP
+  type: ClusterIP
+{{- end }}
+{{- end }}

--- a/apps/infra/ml-monitoring/templates/deployment-retrain-trigger.yaml
+++ b/apps/infra/ml-monitoring/templates/deployment-retrain-trigger.yaml
@@ -1,0 +1,125 @@
+{{- if .Values.retrainTrigger.enabled }}
+---
+# Retrain-trigger webhook proxy Deployment
+# Receives Alertmanager webhooks, translates to Airflow REST API calls.
+# Fallback: creates K8s Job in ml-monitoring namespace (ADR-0038 D4).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-retrain-trigger
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: ml-retrain-trigger
+    app.kubernetes.io/component: retrain-trigger
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    platform.system: "ml-monitoring"
+    platform.component: "retrain-trigger"
+    platform.env: {{ index .Values.platformLabels "platform.env" | quote }}
+    platform.owner: {{ index .Values.platformLabels "platform.owner" | quote }}
+    platform.managed-by: "argocd"
+spec:
+  replicas: {{ .Values.retrainTrigger.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ml-retrain-trigger
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ml-retrain-trigger
+        app.kubernetes.io/component: retrain-trigger
+        platform.system: "ml-monitoring"
+        platform.component: "retrain-trigger"
+        platform.env: {{ index .Values.platformLabels "platform.env" | quote }}
+        platform.owner: {{ index .Values.platformLabels "platform.owner" | quote }}
+        platform.managed-by: "argocd"
+    spec:
+      serviceAccountName: {{ .Values.rbac.serviceAccountName }}
+      securityContext:
+        runAsNonRoot: {{ .Values.retrainTrigger.securityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.retrainTrigger.securityContext.runAsUser }}
+        seccompProfile:
+          type: {{ .Values.retrainTrigger.securityContext.seccompProfile.type }}
+      containers:
+        - name: retrain-trigger
+          image: "{{ .Values.retrainTrigger.image.repository }}:{{ .Values.retrainTrigger.image.tag }}"
+          imagePullPolicy: {{ .Values.retrainTrigger.image.pullPolicy }}
+          ports:
+            - name: webhook
+              containerPort: {{ .Values.retrainTrigger.port }}
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          env:
+            - name: AIRFLOW_BASE_URL
+              value: {{ .Values.retrainTrigger.airflow.baseUrl | quote }}
+            - name: AIRFLOW_DAG_ID
+              value: {{ .Values.retrainTrigger.airflow.dagId | quote }}
+            - name: DEDUPLICATION_WINDOW_SECONDS
+              value: {{ .Values.retrainTrigger.deduplicationWindowSeconds | quote }}
+            - name: PLATFORM_SYSTEM
+              value: "ml-monitoring"
+            - name: AIRFLOW_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.retrainTrigger.airflow.credentialsSecretName }}
+                  key: username
+            - name: AIRFLOW_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.retrainTrigger.airflow.credentialsSecretName }}
+                  key: password
+          resources:
+            requests:
+              cpu: {{ .Values.retrainTrigger.resources.requests.cpu | quote }}
+              memory: {{ .Values.retrainTrigger.resources.requests.memory | quote }}
+            limits:
+              cpu: {{ .Values.retrainTrigger.resources.limits.cpu | quote }}
+              memory: {{ .Values.retrainTrigger.resources.limits.memory | quote }}
+          securityContext:
+            allowPrivilegeEscalation: {{ .Values.retrainTrigger.securityContext.allowPrivilegeEscalation }}
+            readOnlyRootFilesystem: {{ .Values.retrainTrigger.securityContext.readOnlyRootFilesystem }}
+            capabilities:
+              drop: {{ .Values.retrainTrigger.securityContext.capabilities.drop | toJson }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: webhook
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: webhook
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      restartPolicy: Always
+---
+# Service for retrain-trigger webhook (receives Alertmanager POST)
+apiVersion: v1
+kind: Service
+metadata:
+  name: ml-retrain-trigger
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: ml-retrain-trigger
+    app.kubernetes.io/component: retrain-trigger
+    platform.system: "ml-monitoring"
+    platform.component: "retrain-trigger"
+    platform.env: {{ index .Values.platformLabels "platform.env" | quote }}
+    platform.owner: {{ index .Values.platformLabels "platform.owner" | quote }}
+    platform.managed-by: "argocd"
+spec:
+  selector:
+    app.kubernetes.io/name: ml-retrain-trigger
+  ports:
+    - name: webhook
+      port: {{ .Values.retrainTrigger.service.port }}
+      targetPort: webhook
+      protocol: TCP
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+      protocol: TCP
+  type: {{ .Values.retrainTrigger.service.type }}
+{{- end }}

--- a/apps/infra/ml-monitoring/templates/externalsecrets.yaml
+++ b/apps/infra/ml-monitoring/templates/externalsecrets.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.externalSecrets.enabled }}
+---
+# ExternalSecret: Airflow API credentials (ADR-0008 ESO pattern)
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: airflow-api-credentials
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: ml-monitoring
+    app.kubernetes.io/component: retrain-trigger
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    platform.system: "ml-monitoring"
+    platform.component: "retrain-trigger"
+    platform.env: {{ index .Values.platformLabels "platform.env" | quote }}
+    platform.owner: {{ index .Values.platformLabels "platform.owner" | quote }}
+    platform.managed-by: "argocd"
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStoreRef.name }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind }}
+  target:
+    name: {{ .Values.externalSecrets.airflowCredentials.secretName }}
+    creationPolicy: Owner
+  data:
+    - secretKey: username
+      remoteRef:
+        key: {{ .Values.externalSecrets.airflowCredentials.remoteRef.key }}
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: {{ .Values.externalSecrets.airflowCredentials.remoteRef.key }}
+        property: password
+---
+# ExternalSecret: Alertmanager retrain webhook bearer token
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: alertmanager-retrain-token
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: ml-monitoring
+    app.kubernetes.io/component: retrain-trigger
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    platform.system: "ml-monitoring"
+    platform.component: "retrain-trigger"
+    platform.env: {{ index .Values.platformLabels "platform.env" | quote }}
+    platform.owner: {{ index .Values.platformLabels "platform.owner" | quote }}
+    platform.managed-by: "argocd"
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStoreRef.name }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind }}
+  target:
+    name: {{ .Values.externalSecrets.alertmanagerRetrainToken.secretName }}
+    creationPolicy: Owner
+  data:
+    - secretKey: token
+      remoteRef:
+        key: {{ .Values.externalSecrets.alertmanagerRetrainToken.remoteRef.key }}
+        property: token
+{{- end }}

--- a/apps/infra/ml-monitoring/templates/namespace.yaml
+++ b/apps/infra/ml-monitoring/templates/namespace.yaml
@@ -1,0 +1,15 @@
+---
+# Namespace for the ml-monitoring shared components (retrain-trigger, etc.)
+# Per-model namespaces (ml-<tenant>-<domain>) are created by ArgoCD
+# CreateNamespace=true when per-model Applications are instantiated.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: ml-monitoring
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    platform.system: "ml-monitoring"
+    platform.env: {{ index .Values.platformLabels "platform.env" | quote }}
+    platform.owner: {{ index .Values.platformLabels "platform.owner" | quote }}
+    platform.managed-by: "argocd"

--- a/apps/infra/ml-monitoring/templates/networkpolicies/network-policies.yaml
+++ b/apps/infra/ml-monitoring/templates/networkpolicies/network-policies.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.networkPolicy.enabled }}
+# NetworkPolicies for ml-monitoring (ADR-0038 D6, closes WS-A security HIGH-3).
+# Portable K8s NetworkPolicy — CNI-enforced regardless of the Cilium policy mode
+# (ADR-0019). Default-deny + scoped allows per the component contract.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ml-monitoring-default-deny
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- range $k, $v := .Values.platformLabels }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+spec:
+  podSelector: {}
+  policyTypes: [Ingress, Egress]
+  egress:
+    # DNS resolution is always allowed (kube-dns / CoreDNS).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ml-drift-exporter
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- range $k, $v := .Values.platformLabels }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: ml-drift-exporter
+  policyTypes: [Ingress, Egress]
+  ingress:
+    # Only the kube-prometheus-stack scraper may reach the metrics port.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.monitoringNamespace | default "monitoring" }}
+      ports:
+        - port: {{ .Values.driftExporter.port | default 8001 }}
+          protocol: TCP
+  egress:
+    # GCS HTTPS for reference-dataset reads (+ DNS handled by default-deny).
+    - ports:
+        - port: 443
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ml-retrain-trigger
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- range $k, $v := .Values.platformLabels }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: ml-retrain-trigger
+  policyTypes: [Ingress, Egress]
+  ingress:
+    # Alertmanager webhook + Prometheus scrape, both from the monitoring namespace.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.monitoringNamespace | default "monitoring" }}
+      ports:
+        - port: {{ .Values.retrainTrigger.port | default 8080 }}
+          protocol: TCP
+  egress:
+    # Reach the Airflow REST API to fire train_domain_adapter (+ DNS via default-deny).
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 8080
+          protocol: TCP
+{{- end }}

--- a/apps/infra/ml-monitoring/templates/prometheusrules/ml-drift-alerts.yaml
+++ b/apps/infra/ml-monitoring/templates/prometheusrules/ml-drift-alerts.yaml
@@ -1,0 +1,221 @@
+{{- if .Values.prometheusRule.enabled }}
+---
+# PrometheusRule: ML drift and accuracy alerts — ADR-0038 D2/D3
+# Critical alerts route to: ml-drift-pagerduty + ml-retrain-webhook
+# Warning alerts route to: slack only
+# Alertmanager route overlay lives in templates/prometheusrules/ml-alertmanager-routes.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: ml-drift-alerts
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: ml-monitoring
+    app.kubernetes.io/component: drift-exporter
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    platform.system: "ml-monitoring"
+    platform.component: "drift-exporter"
+    platform.env: {{ index .Values.platformLabels "platform.env" | quote }}
+    platform.owner: {{ index .Values.platformLabels "platform.owner" | quote }}
+    platform.managed-by: "argocd"
+    {{- range $k, $v := .Values.prometheusRule.additionalLabels }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+spec:
+  groups:
+
+    # =========================================================================
+    # Dataset drift (whylogs PSI/KL + Evidently combined score)
+    # =========================================================================
+    - name: ml-monitoring.dataset-drift
+      interval: 60s
+      rules:
+
+        - alert: MLDatasetDriftWarning
+          expr: |
+            ml_monitoring_dataset_drift_score{platform_system="ml-monitoring"} > {{ .Values.driftExporter.defaultThresholds.datasetDriftScore.warning }}
+          for: 30m
+          labels:
+            severity: warning
+            platform_system: ml-monitoring
+            team: team-ml-platform
+          annotations:
+            summary: "ML dataset drift elevated for {{ "{{" }} $labels.model_name {{ "}}" }} ({{ "{{" }} $labels.tenant {{ "}}" }}/{{ "{{" }} $labels.domain {{ "}}" }})"
+            description: "Dataset drift score {{ "{{" }} $value | humanize {{ "}}" }} > {{ .Values.driftExporter.defaultThresholds.datasetDriftScore.warning }}. Review feature distributions."
+            runbook_url: "https://runbooks.internal.example.com/ml-monitoring/dataset-drift"
+
+        - alert: MLDatasetDriftCritical
+          expr: |
+            ml_monitoring_dataset_drift_score{platform_system="ml-monitoring"} > {{ .Values.driftExporter.defaultThresholds.datasetDriftScore.critical }}
+          for: 15m
+          labels:
+            severity: critical
+            platform_system: ml-monitoring
+            team: team-ml-platform
+          annotations:
+            summary: "CRITICAL ML dataset drift: {{ "{{" }} $labels.model_name {{ "}}" }} ({{ "{{" }} $labels.tenant {{ "}}" }}/{{ "{{" }} $labels.domain {{ "}}" }})"
+            description: "Dataset drift score {{ "{{" }} $value | humanize {{ "}}" }} > {{ .Values.driftExporter.defaultThresholds.datasetDriftScore.critical }}. Retrain trigger will fire."
+            runbook_url: "https://runbooks.internal.example.com/ml-monitoring/dataset-drift-critical"
+
+        - alert: MLFeaturePSIWarning
+          expr: |
+            ml_monitoring_feature_psi_score{platform_system="ml-monitoring"} > {{ .Values.driftExporter.defaultThresholds.featurePsiScore.warning }}
+          for: 30m
+          labels:
+            severity: warning
+            platform_system: ml-monitoring
+            team: team-ml-platform
+          annotations:
+            summary: "ML feature PSI elevated: {{ "{{" }} $labels.feature {{ "}}" }} in {{ "{{" }} $labels.model_name {{ "}}" }}"
+            description: "PSI = {{ "{{" }} $value | humanize {{ "}}" }} (moderate threshold: {{ .Values.driftExporter.defaultThresholds.featurePsiScore.warning }})."
+            runbook_url: "https://runbooks.internal.example.com/ml-monitoring/feature-psi"
+
+        - alert: MLFeaturePSICritical
+          expr: |
+            ml_monitoring_feature_psi_score{platform_system="ml-monitoring"} > {{ .Values.driftExporter.defaultThresholds.featurePsiScore.critical }}
+          for: 15m
+          labels:
+            severity: critical
+            platform_system: ml-monitoring
+            team: team-ml-platform
+          annotations:
+            summary: "CRITICAL ML feature PSI: {{ "{{" }} $labels.feature {{ "}}" }} in {{ "{{" }} $labels.model_name {{ "}}" }}"
+            description: "PSI = {{ "{{" }} $value | humanize {{ "}}" }} (severe threshold: {{ .Values.driftExporter.defaultThresholds.featurePsiScore.critical }})."
+            runbook_url: "https://runbooks.internal.example.com/ml-monitoring/feature-psi-critical"
+
+        - alert: MLDriftDetected
+          expr: |
+            ml_monitoring_drift_detected{platform_system="ml-monitoring"} == 1
+          for: 15m
+          labels:
+            severity: critical
+            platform_system: ml-monitoring
+            team: team-ml-platform
+          annotations:
+            summary: "ML drift detected: {{ "{{" }} $labels.model_name {{ "}}" }} ({{ "{{" }} $labels.tenant {{ "}}" }}/{{ "{{" }} $labels.domain {{ "}}" }})"
+            description: "Evidently drift flag sustained 15+ min. Retrain trigger will fire."
+            runbook_url: "https://runbooks.internal.example.com/ml-monitoring/drift-detected"
+
+    # =========================================================================
+    # Model accuracy/quality (Evidently test suite)
+    # =========================================================================
+    - name: ml-monitoring.model-accuracy
+      interval: 60s
+      rules:
+
+        - alert: MLModelAccuracyWarning
+          expr: |
+            ml_monitoring_model_accuracy{platform_system="ml-monitoring"} < {{ .Values.driftExporter.defaultThresholds.modelAccuracy.warning }}
+          for: 30m
+          labels:
+            severity: warning
+            platform_system: ml-monitoring
+            team: team-ml-platform
+          annotations:
+            summary: "ML model accuracy degraded: {{ "{{" }} $labels.model_name {{ "}}" }}"
+            description: "Accuracy = {{ "{{" }} $value | humanize {{ "}}" }} (warning threshold: {{ .Values.driftExporter.defaultThresholds.modelAccuracy.warning }})."
+            runbook_url: "https://runbooks.internal.example.com/ml-monitoring/model-accuracy"
+
+        - alert: MLModelAccuracyCritical
+          expr: |
+            ml_monitoring_model_accuracy{platform_system="ml-monitoring"} < {{ .Values.driftExporter.defaultThresholds.modelAccuracy.critical }}
+          for: 15m
+          labels:
+            severity: critical
+            platform_system: ml-monitoring
+            team: team-ml-platform
+          annotations:
+            summary: "CRITICAL ML accuracy: {{ "{{" }} $labels.model_name {{ "}}" }} ({{ "{{" }} $labels.tenant {{ "}}" }}/{{ "{{" }} $labels.domain {{ "}}" }})"
+            description: "Accuracy = {{ "{{" }} $value | humanize {{ "}}" }} below {{ .Values.driftExporter.defaultThresholds.modelAccuracy.critical }}. Retrain trigger will fire."
+            runbook_url: "https://runbooks.internal.example.com/ml-monitoring/model-accuracy-critical"
+
+        - alert: MLModelF1Warning
+          expr: |
+            ml_monitoring_model_f1_score{platform_system="ml-monitoring"} < {{ .Values.driftExporter.defaultThresholds.modelF1Score.warning }}
+          for: 30m
+          labels:
+            severity: warning
+            platform_system: ml-monitoring
+            team: team-ml-platform
+          annotations:
+            summary: "ML F1 score degraded: {{ "{{" }} $labels.model_name {{ "}}" }}"
+            description: "F1 = {{ "{{" }} $value | humanize {{ "}}" }} (warning threshold: {{ .Values.driftExporter.defaultThresholds.modelF1Score.warning }})."
+            runbook_url: "https://runbooks.internal.example.com/ml-monitoring/model-f1"
+
+        - alert: MLModelF1Critical
+          expr: |
+            ml_monitoring_model_f1_score{platform_system="ml-monitoring"} < {{ .Values.driftExporter.defaultThresholds.modelF1Score.critical }}
+          for: 15m
+          labels:
+            severity: critical
+            platform_system: ml-monitoring
+            team: team-ml-platform
+          annotations:
+            summary: "CRITICAL ML F1 score: {{ "{{" }} $labels.model_name {{ "}}" }}"
+            description: "F1 = {{ "{{" }} $value | humanize {{ "}}" }} below {{ .Values.driftExporter.defaultThresholds.modelF1Score.critical }}."
+            runbook_url: "https://runbooks.internal.example.com/ml-monitoring/model-f1-critical"
+
+    # =========================================================================
+    # Operational: exporter health + retrain trigger health
+    # =========================================================================
+    - name: ml-monitoring.operational
+      interval: 60s
+      rules:
+
+        - alert: MLDriftExporterDown
+          expr: |
+            up{job=~"ml-drift-exporter-.*", platform_system="ml-monitoring"} == 0
+          for: 5m
+          labels:
+            severity: critical
+            platform_system: ml-monitoring
+            team: team-ml-platform
+          annotations:
+            summary: "ML drift exporter down: {{ "{{" }} $labels.model_name {{ "}}" }}"
+            description: "Evidently drift exporter unreachable 5+ min. Drift monitoring is blind."
+            runbook_url: "https://runbooks.internal.example.com/ml-monitoring/exporter-down"
+
+        - alert: MLRetrainTriggerFailures
+          expr: |
+            rate(ml_monitoring_retrain_triggers_total{outcome!="success",platform_system="ml-monitoring"}[15m]) > 0.1
+          for: 10m
+          labels:
+            severity: warning
+            platform_system: ml-monitoring
+            team: team-ml-platform
+          annotations:
+            summary: "ML retrain trigger failures: {{ "{{" }} $labels.tenant {{ "}}" }}/{{ "{{" }} $labels.domain {{ "}}" }}"
+            description: "Failure rate {{ "{{" }} $value | humanize {{ "}}" }}/s (outcome={{ "{{" }} $labels.outcome {{ "}}" }})."
+            runbook_url: "https://runbooks.internal.example.com/ml-monitoring/retrain-trigger-failures"
+
+    # =========================================================================
+    # Recording rules (pre-aggregated for Grafana dashboard efficiency)
+    # =========================================================================
+    - name: ml-monitoring.recording-rules
+      interval: 60s
+      rules:
+
+        - record: ml_monitoring:dataset_drift_score:max_by_model
+          expr: |
+            max by (model_name, tenant, domain) (
+              ml_monitoring_dataset_drift_score{platform_system="ml-monitoring"}
+            )
+
+        - record: ml_monitoring:model_accuracy:avg_by_domain
+          expr: |
+            avg by (tenant, domain) (
+              ml_monitoring_model_accuracy{platform_system="ml-monitoring"}
+            )
+
+        - record: ml_monitoring:models_in_critical_drift:count
+          expr: |
+            count(
+              ml_monitoring_dataset_drift_score{platform_system="ml-monitoring"}
+                > {{ .Values.driftExporter.defaultThresholds.datasetDriftScore.critical }}
+            ) or vector(0)
+
+        - record: ml_monitoring:retrain_triggers:total_24h
+          expr: |
+            sum(increase(ml_monitoring_retrain_triggers_total{platform_system="ml-monitoring",outcome="success"}[24h]))
+              or vector(0)
+{{- end }}

--- a/apps/infra/ml-monitoring/templates/serviceaccount.yaml
+++ b/apps/infra/ml-monitoring/templates/serviceaccount.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.rbac.create }}
+---
+# ServiceAccount for the retrain-trigger Deployment.
+# Annotated with GKE Workload Identity for GCS reference-data access.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.rbac.serviceAccountName }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: retrain-trigger
+    platform.system: "ml-monitoring"
+    platform.env: {{ index .Values.platformLabels "platform.env" | quote }}
+    platform.owner: {{ index .Values.platformLabels "platform.owner" | quote }}
+    platform.managed-by: "argocd"
+  {{- if .Values.rbac.workloadIdentityAnnotation }}
+  annotations:
+    iam.gke.io/gcp-service-account: {{ .Values.rbac.workloadIdentityAnnotation | quote }}
+  {{- end }}
+automountServiceAccountToken: true
+---
+# Role: allows retrain-trigger to create Jobs in ml-monitoring namespace
+# (Job fallback path — ADR-0038 D4)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ml-retrain-trigger-job-creator
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: retrain-trigger
+    platform.system: "ml-monitoring"
+    platform.env: {{ index .Values.platformLabels "platform.env" | quote }}
+    platform.owner: {{ index .Values.platformLabels "platform.owner" | quote }}
+    platform.managed-by: "argocd"
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ml-retrain-trigger-job-creator
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: retrain-trigger
+    platform.system: "ml-monitoring"
+    platform.env: {{ index .Values.platformLabels "platform.env" | quote }}
+    platform.owner: {{ index .Values.platformLabels "platform.owner" | quote }}
+    platform.managed-by: "argocd"
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.rbac.serviceAccountName }}
+    namespace: {{ .Values.namespace }}
+roleRef:
+  kind: Role
+  name: ml-retrain-trigger-job-creator
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/apps/infra/ml-monitoring/templates/servicemonitors/ml-monitoring-servicemonitor.yaml
+++ b/apps/infra/ml-monitoring/templates/servicemonitors/ml-monitoring-servicemonitor.yaml
@@ -1,0 +1,106 @@
+{{- if .Values.serviceMonitor.enabled }}
+{{- range .Values.modelNamespaces }}
+---
+# ServiceMonitor: Evidently drift-exporter per model namespace
+# Namespace-scoped to prevent cross-tenant metric bleed (ADR-0038 D5).
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: ml-drift-exporter-{{ .tenant }}-{{ .domain }}
+  namespace: {{ .namespace }}
+  labels:
+    app.kubernetes.io/name: ml-drift-exporter
+    app.kubernetes.io/component: drift-exporter
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    platform.system: "ml-monitoring"
+    platform.component: "drift-exporter"
+    platform.env: {{ index $.Values.platformLabels "platform.env" | quote }}
+    platform.owner: {{ index $.Values.platformLabels "platform.owner" | quote }}
+    platform.managed-by: "argocd"
+    tenant: {{ .tenant | quote }}
+    domain: {{ .domain | quote }}
+    {{- range $k, $v := $.Values.serviceMonitor.prometheusSelector }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ml-drift-exporter
+      tenant: {{ .tenant | quote }}
+      domain: {{ .domain | quote }}
+  endpoints:
+    - port: metrics
+      interval: {{ $.Values.serviceMonitor.scrapeInterval }}
+      scrapeTimeout: {{ $.Values.serviceMonitor.scrapeTimeout }}
+      path: /metrics
+      scheme: http
+      relabelings:
+        # Inject platform_system on all scraped series (ADR-0028)
+        - targetLabel: platform_system
+          replacement: ml-monitoring
+        - targetLabel: model_name
+          replacement: {{ .modelName | quote }}
+        - targetLabel: tenant
+          replacement: {{ .tenant | quote }}
+        - targetLabel: domain
+          replacement: {{ .domain | quote }}
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod
+        - sourceLabels: [__meta_kubernetes_service_name]
+          targetLabel: service
+      metricRelabelings:
+        # Keep only ml_monitoring_ prefixed metrics from this endpoint
+        - sourceLabels: [__name__]
+          regex: "ml_monitoring_.*|up"
+          action: keep
+{{- end }}
+{{- if .Values.retrainTrigger.enabled }}
+---
+# ServiceMonitor: retrain-trigger self-metrics (trigger counters)
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: ml-retrain-trigger
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: ml-retrain-trigger
+    app.kubernetes.io/component: retrain-trigger
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    platform.system: "ml-monitoring"
+    platform.component: "retrain-trigger"
+    platform.env: {{ index .Values.platformLabels "platform.env" | quote }}
+    platform.owner: {{ index .Values.platformLabels "platform.owner" | quote }}
+    platform.managed-by: "argocd"
+    {{- range $k, $v := .Values.serviceMonitor.prometheusSelector }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ml-retrain-trigger
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.serviceMonitor.scrapeInterval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      path: /metrics
+      relabelings:
+        - targetLabel: platform_system
+          replacement: ml-monitoring
+        - targetLabel: component
+          replacement: retrain-trigger
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+      metricRelabelings:
+        - sourceLabels: [__name__]
+          regex: "ml_monitoring_retrain.*|up"
+          action: keep
+{{- end }}
+{{- end }}

--- a/apps/infra/ml-monitoring/values.yaml
+++ b/apps/infra/ml-monitoring/values.yaml
@@ -1,0 +1,217 @@
+# ML Monitoring Helm values — ADR-0038
+# platform:system = ml-monitoring (ADR-0028 taxonomy)
+
+# ---------------------------------------------------------------------------
+# ADR-0028 platform labels applied to every K8s resource in this chart
+# ---------------------------------------------------------------------------
+platformLabels:
+  "platform.system": "ml-monitoring"
+  "platform.env": "production"
+  "platform.owner": "team-ml-platform"
+  "platform.managed-by": "argocd"
+
+# ---------------------------------------------------------------------------
+# Global namespace for shared components (retrain-trigger, pushgateway)
+# ---------------------------------------------------------------------------
+namespace: ml-monitoring
+
+# ---------------------------------------------------------------------------
+# Evidently drift-exporter — per-model Deployment
+# Computes model accuracy, test-suite results, column-level drift.
+# Scrape endpoint: http://<svc>:8001/metrics
+# ---------------------------------------------------------------------------
+driftExporter:
+  enabled: true
+  image:
+    repository: evidently-ai/drift-exporter
+    tag: "0.4.35"        # Pin to a released tag; update after testing
+    pullPolicy: IfNotPresent
+
+  port: 8001
+
+  # How often Evidently re-runs the test suite (seconds).
+  evaluationIntervalSeconds: 300
+
+  resources:
+    requests:
+      cpu: "200m"
+      memory: "512Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+
+  # GCS/S3 bucket holding the per-model reference datasets.
+  # Path pattern: <bucket>/<modelName>/<tenant>/<domain>/reference.parquet
+  referenceBucketUri: "gs://your-project-ml-reference-data"
+
+  # Drift thresholds — override per model via modelNamespaces entries.
+  defaultThresholds:
+    datasetDriftScore:
+      warning: 0.20
+      critical: 0.40
+    featurePsiScore:
+      warning: 0.10
+      critical: 0.25
+    featureKlDivergence:
+      warning: 0.10
+      critical: 0.30
+    modelAccuracy:
+      warning: 0.85
+      critical: 0.75
+    modelF1Score:
+      warning: 0.80
+      critical: 0.65
+
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop: ["ALL"]
+
+# ---------------------------------------------------------------------------
+# whylogs distribution profiler — standalone Deployment per model namespace.
+# Pushes metrics to the Prometheus Pushgateway.
+# ---------------------------------------------------------------------------
+whylogsProfiler:
+  enabled: true
+  image:
+    repository: whylabs/whylogs-profiler
+    tag: "1.3.7"
+    pullPolicy: IfNotPresent
+
+  pushgatewayUrl: "http://prometheus-pushgateway.monitoring.svc:9091"
+
+  # Evaluation window for distribution comparison (seconds).
+  windowSeconds: 3600
+
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "300m"
+      memory: "512Mi"
+
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop: ["ALL"]
+
+# ---------------------------------------------------------------------------
+# Retrain-trigger webhook proxy
+# Receives Alertmanager webhook, translates to Airflow REST API call.
+# Fallback: creates K8s Job in ml-monitoring namespace.
+# ---------------------------------------------------------------------------
+retrainTrigger:
+  enabled: true
+  image:
+    repository: gcr.io/your-project/ml-retrain-trigger
+    tag: "0.1.0"
+    pullPolicy: IfNotPresent
+
+  port: 8080
+  replicas: 2
+
+  # De-duplication window — prevents multiple DAG runs for same (tenant,domain)
+  # within this interval after a trigger fires.
+  deduplicationWindowSeconds: 900   # 15 minutes
+
+  airflow:
+    baseUrl: "http://airflow-webserver.airflow.svc:8080"
+    dagId: "train_domain_adapter"
+    credentialsSecretName: "airflow-api-credentials"
+
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "200m"
+      memory: "256Mi"
+
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop: ["ALL"]
+
+  service:
+    type: ClusterIP
+    port: 8080
+
+# ---------------------------------------------------------------------------
+# ExternalSecret configuration (ADR-0008 — ESO)
+# ---------------------------------------------------------------------------
+externalSecrets:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: cluster-secret-store
+    kind: ClusterSecretStore
+  airflowCredentials:
+    secretName: airflow-api-credentials
+    remoteRef:
+      key: ml-monitoring/airflow-api-credentials
+  alertmanagerRetrainToken:
+    secretName: alertmanager-retrain-token
+    remoteRef:
+      key: ml-monitoring/alertmanager-retrain-token
+
+# ---------------------------------------------------------------------------
+# ServiceMonitor configuration (Prometheus scrape)
+# ---------------------------------------------------------------------------
+serviceMonitor:
+  enabled: true
+  prometheusSelector:
+    prometheus: kube-prometheus
+  scrapeInterval: "30s"
+  scrapeTimeout: "10s"
+
+# ---------------------------------------------------------------------------
+# PrometheusRule / alert rules
+# ---------------------------------------------------------------------------
+prometheusRule:
+  enabled: true
+  additionalLabels:
+    prometheus: kube-prometheus
+
+# ---------------------------------------------------------------------------
+# Model namespaces — one entry per (model, tenant, domain).
+# Replace the empty list with actual model configurations before applying.
+# ---------------------------------------------------------------------------
+modelNamespaces: []
+# Example:
+# - namespace: ml-tenant-acme-hft
+#   modelName: domain-adapter-hft
+#   tenant: tenant-acme
+#   domain: hft
+#   thresholds: {}
+
+# ---------------------------------------------------------------------------
+# NetworkPolicy — FOLLOW-UP: enable after ADR-0019 Cilium enforce rollout
+# ---------------------------------------------------------------------------
+networkPolicy:
+  enabled: false
+
+# ---------------------------------------------------------------------------
+# RBAC
+# ---------------------------------------------------------------------------
+rbac:
+  create: true
+  serviceAccountName: ml-retrain-trigger
+  # GKE Workload Identity annotation for GCS reference-data access
+  workloadIdentityAnnotation: ""
+  # e.g. "iam.gke.io/gcp-service-account: ml-drift@your-project.iam.gserviceaccount.com"

--- a/apps/infra/observability/grafana-dashboards/templates/configmap-ml-drift.yaml
+++ b/apps/infra/observability/grafana-dashboards/templates/configmap-ml-drift.yaml
@@ -1,0 +1,386 @@
+---
+# Grafana Dashboard ConfigMap: ML Drift & Accuracy Monitoring — ADR-0038 D2
+# Follows the same convention as configmap-dashboards.yaml.
+# Label grafana_dashboard=1 causes the Grafana sidecar to auto-import.
+# Note: Grafana template expressions like {{ "{{" }}model_name{{ "}}" }} are
+# escaped to prevent Helm from interpreting them.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-ml-drift
+  namespace: {{ .Values.grafanaNamespace }}
+  labels:
+    {{- range $key, $val := .Values.dashboardLabels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    platform.system: "ml-monitoring"
+    platform.component: "grafana-dashboard"
+    platform.managed-by: "argocd"
+data:
+  ml-drift-accuracy.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "ML model drift detection, feature distribution shift, and accuracy degradation. Per-tenant/domain view. ADR-0038.",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [
+        {
+          "asDropdown": true,
+          "icon": "external link",
+          "includeVars": true,
+          "keepTime": true,
+          "tags": ["ml-monitoring"],
+          "title": "ML Monitoring Dashboards",
+          "type": "dashboards"
+        }
+      ],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+          "id": 100,
+          "title": "Overview",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "Number of models currently in critical drift state",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "yellow", "value": 1},
+                  {"color": "red", "value": 3}
+                ]
+              },
+              "unit": "short"
+            }
+          },
+          "gridPos": {"h": 4, "w": 4, "x": 0, "y": 1},
+          "id": 1,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"]}
+          },
+          "pluginVersion": "10.0.0",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "{{ .Values.datasources.prometheus.uid }}"},
+              "expr": "ml_monitoring:models_in_critical_drift:count",
+              "legendFormat": "Models in critical drift",
+              "refId": "A"
+            }
+          ],
+          "title": "Models in Critical Drift",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "Total successful retrain triggers in last 24 hours",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "blue", "value": null}
+                ]
+              },
+              "unit": "short"
+            }
+          },
+          "gridPos": {"h": 4, "w": 4, "x": 4, "y": 1},
+          "id": 2,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"]}
+          },
+          "pluginVersion": "10.0.0",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "{{ .Values.datasources.prometheus.uid }}"},
+              "expr": "ml_monitoring:retrain_triggers:total_24h",
+              "legendFormat": "Retrain triggers (24h)",
+              "refId": "A"
+            }
+          ],
+          "title": "Retrain Triggers (24h)",
+          "type": "stat"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 5},
+          "id": 101,
+          "title": "Dataset Drift",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "Evidently dataset drift score (0 = no drift, 1 = full drift). Warning 0.20, Critical 0.40.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "yellow", "value": 0.2},
+                  {"color": "red", "value": 0.4}
+                ]
+              },
+              "unit": "short",
+              "min": 0,
+              "max": 1
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 6},
+          "id": 10,
+          "options": {
+            "legend": {"displayMode": "list", "placement": "bottom"},
+            "tooltip": {"mode": "multi"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "{{ .Values.datasources.prometheus.uid }}"},
+              "expr": "ml_monitoring_dataset_drift_score{platform_system=\"ml-monitoring\", tenant=~\"$tenant\", domain=~\"$domain\"}",
+              "legendFormat": "{{ "{{" }}model_name{{ "}}" }} drift score",
+              "refId": "A"
+            }
+          ],
+          "title": "Dataset Drift Score",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "PSI (Population Stability Index) per feature. Warning >0.10, Critical >0.25.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"lineWidth": 1},
+              "unit": "short",
+              "min": 0
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 6},
+          "id": 11,
+          "options": {
+            "legend": {"displayMode": "list", "placement": "right"},
+            "tooltip": {"mode": "multi"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "{{ .Values.datasources.prometheus.uid }}"},
+              "expr": "ml_monitoring_feature_psi_score{platform_system=\"ml-monitoring\", tenant=~\"$tenant\", domain=~\"$domain\"}",
+              "legendFormat": "{{ "{{" }}feature{{ "}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Feature PSI by Feature",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 14},
+          "id": 102,
+          "title": "Model Accuracy & Quality",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "Model accuracy from Evidently test suite. Warning <0.85, Critical <0.75.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"lineWidth": 2},
+              "unit": "percentunit",
+              "min": 0,
+              "max": 1
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 15},
+          "id": 20,
+          "options": {
+            "legend": {"displayMode": "list", "placement": "bottom"},
+            "tooltip": {"mode": "multi"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "{{ .Values.datasources.prometheus.uid }}"},
+              "expr": "ml_monitoring_model_accuracy{platform_system=\"ml-monitoring\", tenant=~\"$tenant\", domain=~\"$domain\"}",
+              "legendFormat": "{{ "{{" }}model_name{{ "}}" }} accuracy",
+              "refId": "A"
+            }
+          ],
+          "title": "Model Accuracy",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "Model F1 score. Warning <0.80, Critical <0.65.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"lineWidth": 2},
+              "unit": "percentunit",
+              "min": 0,
+              "max": 1
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 15},
+          "id": 21,
+          "options": {
+            "legend": {"displayMode": "list", "placement": "bottom"},
+            "tooltip": {"mode": "multi"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "{{ .Values.datasources.prometheus.uid }}"},
+              "expr": "ml_monitoring_model_f1_score{platform_system=\"ml-monitoring\", tenant=~\"$tenant\", domain=~\"$domain\"}",
+              "legendFormat": "{{ "{{" }}model_name{{ "}}" }} F1",
+              "refId": "A"
+            }
+          ],
+          "title": "Model F1 Score",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 23},
+          "id": 103,
+          "title": "Retrain Trigger Activity",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "Rate of retrain triggers fired by outcome (success / airflow_error / k8s_fallback / deduped).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"lineWidth": 2},
+              "unit": "short"
+            }
+          },
+          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 24},
+          "id": 30,
+          "options": {
+            "legend": {"displayMode": "list", "placement": "bottom"},
+            "tooltip": {"mode": "multi"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "{{ .Values.datasources.prometheus.uid }}"},
+              "expr": "sum by (outcome, tenant, domain) (rate(ml_monitoring_retrain_triggers_total{platform_system=\"ml-monitoring\", tenant=~\"$tenant\", domain=~\"$domain\"}[5m]))",
+              "legendFormat": "{{ "{{" }}outcome{{ "}}" }} - {{ "{{" }}tenant{{ "}}" }}/{{ "{{" }}domain{{ "}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Retrain Trigger Rate by Outcome",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "1m",
+      "schemaVersion": 36,
+      "style": "dark",
+      "tags": ["ml-monitoring", "drift", "accuracy"],
+      "templating": {
+        "list": [
+          {
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{{ .Values.datasources.prometheus.uid }}"
+            },
+            "definition": "label_values(ml_monitoring_dataset_drift_score{platform_system=\"ml-monitoring\"}, tenant)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Tenant",
+            "multi": true,
+            "name": "tenant",
+            "query": {
+              "query": "label_values(ml_monitoring_dataset_drift_score{platform_system=\"ml-monitoring\"}, tenant)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{{ .Values.datasources.prometheus.uid }}"
+            },
+            "definition": "label_values(ml_monitoring_dataset_drift_score{platform_system=\"ml-monitoring\", tenant=~\"$tenant\"}, domain)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Domain",
+            "multi": true,
+            "name": "domain",
+            "query": {
+              "query": "label_values(ml_monitoring_dataset_drift_score{platform_system=\"ml-monitoring\", tenant=~\"$tenant\"}, domain)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {"from": "now-6h", "to": "now"},
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "ML Drift & Accuracy Monitoring",
+      "uid": "ml-drift-accuracy-v1",
+      "version": 1
+    }

--- a/docs/adrs/0038-ml-observability-drift.md
+++ b/docs/adrs/0038-ml-observability-drift.md
@@ -1,0 +1,485 @@
+# ADR-0038: ML Observability — Drift Detection, Accuracy Monitoring, and Retrain Trigger
+
+- Status: **Proposed** — plan/validate-only; implementation apply-gated.
+- platform-design status: **pending** — no `apps/infra/ml-monitoring` yet deployed,
+  no drift metrics flowing into Prometheus, no retrain webhook wired.
+- Date: 2026-06-10
+- Authors: platform-team (devops-engineer), ml-platform
+- Related issues: WS-C "Model & ML Observability" (GCP ML Platform plan §4 WS-C);
+  risk-register R3 (Evidently multi-tenant isolation), R2 (Airflow stability).
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+The platform has a strong **system observability** layer (Prometheus 3.x / Thanos,
+Grafana, Loki, Tempo, Alertmanager → PagerDuty, OTel Collector — all in
+`apps/infra/observability/`). What is entirely absent is **ML observability**:
+there are no metrics for feature drift, data distribution shift, prediction
+accuracy degradation, or model-serving quality in the Prometheus/Grafana stack.
+
+The `docs/transaction-analytics/04-training-pipeline.md` documents three retrain
+triggers: a label-threshold trigger, a **drift trigger** (KL divergence over a
+rolling window), and a manual trigger. The drift trigger is described at the
+pipeline-design level — there is no deployed monitor, no Prometheus metrics, and
+no automated path from "drift detected" to "retrain fires". The gap is confirmed
+by the implementation plan §2 row #3 ("gap — no Evidently/whylogs deployed").
+
+Two OSS-native candidates exist:
+
+| Tool | Architecture | Prometheus export | Strengths | Weaknesses |
+|------|-------------|-------------------|-----------|------------|
+| **Evidently AI** | Python SDK + optional server, reports + monitors | Native `PrometheusLogger` / `/metrics` HTTP endpoint; every test result is a gauge/counter | Rich test suite (PSI, KL, chi², EMD), model-quality tests (accuracy, precision, recall, F1, MAE, RMSE); presets for classification/regression/ranking; active development | Server adds ops overhead; Python-heavy; large image |
+| **whylogs** | Lightweight Python SDK + WhyLabs SaaS (optional) | `whylogs.core.metrics` → Prometheus pushgateway or `/metrics`; `prom_metrics_handler` in whylogs ≥ 1.3 | Tiny footprint, designed for high-throughput streaming, columnar profile (approximate histograms, frequent items), runs inline in serving pods | Fewer ready-made ML-quality tests vs Evidently; accuracy/classification metrics require extra instrumentation; WhyLabs SaaS needed for full dashboarding unless hand-rolled |
+
+**Decision driver:** the platform owns Grafana, Thanos, and Alertmanager — it
+needs metrics that feed existing PromQL dashboards and alert rules. Both tools
+can export to Prometheus. The key differentiator is **test depth**: the
+transaction-analytics domain runs LLM adapters for HFT/RTB/insurance and needs
+both **feature-distribution drift** (KL, PSI) *and* **model-quality scores**
+(classification accuracy, RMSE, debate-eval pass rate) as Prometheus metrics.
+Evidently provides both in a single cohesive test runner. whylogs provides
+lightweight distribution profiling but requires more bespoke work for
+model-quality tests.
+
+**Multi-tenancy:** the platform serves multiple (tenant, domain) pairs
+(`docs/transaction-analytics/00-domains.md`). Each pair has its own training
+window, reference distribution, and accuracy profile. Namespace-per-model
+isolation (risk R3 from the plan) is the natural fence.
+
+## Decision
+
+**Use both tools with a clear role split**, deployed as a single
+`ml-monitoring` service in `apps/infra/ml-monitoring/`:
+
+| Role | Tool | Why |
+|------|------|-----|
+| **Feature drift + data distribution shift** (KL divergence, PSI, chi-squared, EMD) | **whylogs** (sidecar/inline profiler) | Minimal overhead, runs inside or adjacent to the serving pod, continuous per-batch profiling, Prometheus push or pull endpoint |
+| **Model accuracy / quality tests** (classification accuracy, precision/recall/F1, RMSE, MAE, debate-eval pass rate) | **Evidently** (dedicated `drift-exporter` Deployment) | Rich test battery, computes against a held-out reference dataset, exports a `/metrics` Prometheus endpoint natively |
+| **Prometheus scrape** | Single ServiceMonitor per namespace | Scrapes both the Evidently `/metrics` endpoint and the whylogs Pushgateway |
+| **Alert routing** | Existing Alertmanager + PagerDuty path | Reuse existing `pagerduty-critical` receiver; add ML-specific route and retrain webhook receiver |
+| **Retrain trigger** | Alertmanager webhook receiver → Airflow REST API | Primary: `POST /api/v1/dags/train_domain_adapter/dagRuns`; fallback: K8s Job CRD |
+
+### D1 — Metric export architecture
+
+```
+Serving pod (per-namespace)
+  ├── whylogs inline profiler  ──push──►  Pushgateway :9091
+  │   (feature distributions)             (or pull /metrics)
+  └── Evidently drift-exporter  ──pull──►  ServiceMonitor /metrics :8001
+      (accuracy, test suite)
+                                                │
+                                   Prometheus / Thanos scrape
+                                                │
+                                   Grafana dashboards  +  Alertmanager
+```
+
+**Metric namespace:** all metrics are prefixed `ml_monitoring_` and carry these
+labels on every series to satisfy ADR-0028 and enable multi-tenant isolation:
+
+| Label | Value | Rationale |
+|-------|-------|-----------|
+| `platform_system` | `ml-monitoring` | ADR-0028 mandatory key (K8s dotted form becomes underscore in PromQL) |
+| `model_name` | e.g. `domain-adapter-hft` | Identifies the model |
+| `tenant` | e.g. `tenant-acme` | Tenant isolation (R3) |
+| `domain` | e.g. `hft`, `rtb`, `insurance` | Domain isolation |
+| `namespace` | K8s namespace | Matches namespace-per-model |
+| `environment` | `production`, `staging` | From external label |
+
+**Core metric families exported:**
+
+```
+# whylogs — distribution profiles
+ml_monitoring_feature_psi_score{feature, model_name, tenant, domain}            gauge
+ml_monitoring_feature_kl_divergence{feature, model_name, tenant, domain}        gauge
+ml_monitoring_feature_missing_rate{feature, model_name, tenant, domain}         gauge
+ml_monitoring_feature_zero_rate{feature, model_name, tenant, domain}            gauge
+ml_monitoring_dataset_drift_score{model_name, tenant, domain}                   gauge
+ml_monitoring_drift_detected{model_name, tenant, domain}                        gauge  # 1/0
+ml_monitoring_dataset_rows_total{model_name, tenant, domain}                    counter
+
+# Evidently — model quality / accuracy tests
+ml_monitoring_model_accuracy{model_name, tenant, domain}                        gauge
+ml_monitoring_model_precision{model_name, tenant, domain}                       gauge
+ml_monitoring_model_recall{model_name, tenant, domain}                          gauge
+ml_monitoring_model_f1_score{model_name, tenant, domain}                        gauge
+ml_monitoring_model_rmse{model_name, tenant, domain}                            gauge  # regression
+ml_monitoring_test_suite_result{test_name, status, model_name, tenant, domain}  gauge  # 1=pass 0=fail
+ml_monitoring_column_drift_score{column, stat_test, model_name, tenant, domain} gauge
+ml_monitoring_prediction_drift{model_name, tenant, domain}                      gauge
+ml_monitoring_exporter_errors_total{model_name, tenant, domain}                 counter
+
+# Retrain trigger accounting
+ml_monitoring_retrain_triggers_total{trigger, tenant, domain, outcome}          counter
+```
+
+### D2 — Drift alert thresholds
+
+Thresholds are defaults; per-tenant override via Helm values or a ConfigMap:
+
+| Metric | Warning | Critical | Window | Note |
+|--------|---------|----------|--------|------|
+| `ml_monitoring_dataset_drift_score` | > 0.2 | > 0.4 | 1h | Combined drift score |
+| `ml_monitoring_feature_psi_score` | > 0.1 | > 0.25 | 1h | PSI moderate/severe |
+| `ml_monitoring_feature_kl_divergence` | > 0.1 | > 0.3 | 1h | KL divergence |
+| `ml_monitoring_model_accuracy` | < 0.85 | < 0.75 | 1h rolling | Classification accuracy |
+| `ml_monitoring_model_f1_score` | < 0.80 | < 0.65 | 1h rolling | F1 score |
+| `ml_monitoring_drift_detected` | — | = 1 sustained 15m | — | Binary drift flag |
+
+Critical alerts → PagerDuty + retrain trigger. Warning alerts → Slack only.
+
+### D3 — Drift → Alertmanager → PagerDuty route
+
+New Alertmanager route entries added via the Helm overlay in
+`apps/infra/ml-monitoring/templates/prometheusrules/ml-alertmanager-routes.yaml`:
+
+```yaml
+# Route: ML drift/accuracy alerts → PagerDuty + retrain webhook
+routes:
+- matchers:
+  - platform_system = ml-monitoring
+  receiver: ml-drift-pagerduty
+  continue: true
+  group_by: [model_name, tenant, domain, alertname]
+  group_wait: 5m
+  repeat_interval: 2h
+
+- matchers:
+  - platform_system = ml-monitoring
+  - severity = critical
+  receiver: ml-retrain-webhook
+  group_by: [model_name, tenant, domain]
+  group_wait: 5m
+  repeat_interval: 6h   # Prevent retrain storm
+```
+
+The `ml-drift-pagerduty` receiver uses the existing
+`alertmanager-pagerduty-secret` mount (same Secret already in the
+prometheus-stack `alertmanagerSpec.secrets` list). A dedicated ML PagerDuty
+service/routing key is the follow-up recommended by WS-E (SOC posture), not
+required for WS-C launch.
+
+The `ml-retrain-webhook` receiver:
+
+```yaml
+- name: ml-retrain-webhook
+  webhook_configs:
+  - url: 'http://ml-retrain-trigger.ml-monitoring.svc:8080/webhook'
+    send_resolved: false
+    http_config:
+      bearer_token_file: '/etc/alertmanager/secrets/alertmanager-retrain-token/token'
+    max_alerts: 10
+```
+
+The bearer token is sourced from an ExternalSecret (`alertmanager-retrain-token`)
+mounted via ESO (ADR-0008 pattern), matching the existing `alertmanager-slack-secret`
+and `alertmanager-pagerduty-secret` pattern in the prometheus-stack values.
+
+### D4 — Retrain trigger mechanism
+
+The retrain-trigger is a webhook receiver called `ml-retrain-webhook` whose URL
+is the `ml-retrain-trigger` Deployment in the `ml-monitoring` namespace.
+
+**Primary path — Airflow REST API:**
+
+```
+Alertmanager (critical drift alert)
+  │
+  └──► POST http://ml-retrain-trigger.ml-monitoring.svc:8080/webhook
+             (Alertmanager webhook format)
+                │
+                ▼ translate + de-duplicate (15-min window per tenant/domain)
+             POST http://airflow-webserver.airflow.svc:8080/api/v1/dags/train_domain_adapter/dagRuns
+             Headers: Authorization: Basic <ESO-sourced base64 user:pass>
+             Body: {
+               "conf": {
+                 "tenant":  "<Labels.tenant>",
+                 "domain":  "<Labels.domain>",
+                 "trigger": "drift",
+                 "model":   "<Labels.model_name>",
+                 "alert":   "<Labels.alertname>"
+               }
+             }
+```
+
+The trigger proxy is a lightweight Deployment (`ml-retrain-trigger`) in the
+`ml-monitoring` namespace. It:
+1. Receives the Alertmanager `POST /webhook` payload (JSON array of firing alerts).
+2. De-duplicates by `(tenant, domain)` within a configurable window
+   (default 15 minutes) to prevent a single alert group from firing multiple
+   DAG runs during the `repeat_interval`.
+3. Calls the Airflow REST API `POST /api/v1/dags/train_domain_adapter/dagRuns`.
+4. On Airflow 4xx/5xx → creates a K8s Job fallback (see below).
+5. Records all outcomes as `ml_monitoring_retrain_triggers_total{outcome="success"|"airflow_error"|"fallback_job_created"}`.
+
+**Fallback path — K8s Job CRD:**
+
+When Airflow is unavailable (WS-B not yet deployed, or Airflow returns 5xx), the
+trigger service creates a K8s Job from a template ConfigMap:
+
+```yaml
+# Stored in ConfigMap ml-retrain-job-template in ml-monitoring namespace
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: retrain-domain-adapter-
+  namespace: ml-monitoring
+  labels:
+    platform.system: ml-monitoring
+    platform.component: retrain-trigger
+    platform.env: production
+    platform.owner: team-ml-platform
+    platform.managed-by: argocd
+    trigger: drift-fallback
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: ml-retrain-trigger
+      containers:
+      - name: trigger
+        image: gcr.io/your-project/ml-retrain-trigger:latest
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          curl -s -X POST \
+            -H "Authorization: Basic $(cat /var/run/secrets/airflow/credentials | base64)" \
+            -H "Content-Type: application/json" \
+            -d "{\"conf\":{\"tenant\":\"$TENANT\",\"domain\":\"$DOMAIN\",\"trigger\":\"drift-fallback\"}}" \
+            http://airflow-webserver.airflow.svc:8080/api/v1/dags/train_domain_adapter/dagRuns
+        env:
+        - name: TENANT
+          value: "$(TENANT)"
+        - name: DOMAIN
+          value: "$(DOMAIN)"
+```
+
+The K8s Job path requires the `ml-retrain-trigger` ServiceAccount to have
+`jobs/create` permission in the `ml-monitoring` namespace (the Job runs
+in-namespace and calls Airflow via HTTP). The ClusterRole / RoleBinding are
+templated in `apps/infra/ml-monitoring/templates/`.
+
+**Airflow REST API compatibility note:** Airflow 2.x and 3.x both expose
+`POST /api/v1/dags/{dag_id}/dagRuns` (stable REST API v1, doc-verified 2026-06-10).
+The `conf` dict passes `tenant`, `domain`, and `trigger` key to the
+`train_domain_adapter` DAG as DAG run config, matching the three-trigger design
+in `docs/transaction-analytics/04-training-pipeline.md`. The DAG reads
+`dag_run.conf["tenant"]` and `dag_run.conf["domain"]` for its `(tenant, domain)`
+scoping; the `conf["trigger"] = "drift"` value distinguishes this from the
+threshold and manual triggers in the same DAG.
+
+### D5 — Multi-tenant isolation (risk R3)
+
+Each `(model_name, tenant, domain)` combination is deployed in its own Kubernetes
+namespace (`ml-<tenant>-<domain>`). The Evidently drift-exporter Deployment and
+the whylogs Pushgateway run per namespace. The ServiceMonitor's
+`namespaceSelector` is set to the owning namespace, and the metric label
+`platform_system=ml-monitoring` is injected via relabeling at scrape time.
+
+Cross-tenant false positive alerting is structurally impossible: separate
+Prometheus series, separate alert instances, separate route group keys ensure
+a drift event in `tenant-acme/hft` does not trigger a retrain for
+`tenant-beta/insurance`.
+
+Grafana dashboards use `$model_name`, `$tenant`, `$domain` template variables
+(query-driven from `label_values()`) so each tenant sees only their own series
+without requiring Grafana row-level access control (a follow-up WS-D item).
+
+### D6 — NetworkPolicy (implemented, toggle default-off)
+
+Portable K8s NetworkPolicies are **implemented** in
+`apps/infra/ml-monitoring/templates/networkpolicies/network-policies.yaml`
+(closes WS-A security HIGH-3): default-deny + DNS, scoped ingress to
+`ml-drift-exporter`/`ml-retrain-trigger` from the monitoring namespace, and
+egress to GCS/Airflow. They are CNI-enforced regardless of the Cilium policy
+mode (ADR-0019). `networkPolicy.enabled` defaults to **`false`** so the
+default-deny does not cut off co-components (pushgateway / whylogs profiler)
+before their allow-rules are verified; flip to `true` after that check.
+Critical rules:
+- Ingress to `ml-retrain-trigger` from Alertmanager pods only (namespace selector).
+- Egress from `ml-retrain-trigger` to `airflow-webserver` in `airflow` namespace,
+  and to `kube-apiserver` for Job creation.
+- Egress from Evidently drift-exporter to GCS/S3 reference-dataset bucket
+  (via GKE Workload Identity — no node-level credentials).
+- All ML monitoring pods: deny egress to `10.0.0.0/8` except the above paths.
+
+### D7 — ADR-0028 label compliance
+
+Every resource in `apps/infra/ml-monitoring/` carries the five ADR-0028 keys:
+
+| Key (K8s label) | Value |
+|-----------------|-------|
+| `platform.system` | `ml-monitoring` |
+| `platform.component` | `drift-exporter` (Evidently) / `distribution-profiler` (whylogs) / `retrain-trigger` |
+| `platform.env` | `production` / `staging` (parameterised per ArgoCD environment) |
+| `platform.owner` | `team-ml-platform` |
+| `platform.managed-by` | `argocd` |
+
+Prometheus metric labels follow the `platform_system` (underscore) form as
+required by PromQL (dots are not valid in PromQL label names). The
+`relabelings` stanza in each ServiceMonitor injects `platform_system=ml-monitoring`
+on all scraped series.
+
+A reviewer can confirm compliance by: (a) `grep -r "platform.system" apps/infra/ml-monitoring/templates/` returning a hit in every resource template; (b) `helm lint apps/infra/ml-monitoring/` passing; (c) `kubeconform` reporting no schema violations.
+
+## Alternatives considered
+
+### A1 — Evidently only (no whylogs)
+
+Deploy only Evidently for all monitoring.
+*Rejected because:* Evidently's server-side report computation requires batch
+window alignment and is not optimised for high-throughput streaming feature
+profiling (e.g. 100k+ transactions/minute in the RTB domain). whylogs runs
+inline as a profiler and costs orders of magnitude less compute for distribution
+tracking. Using Evidently for everything forces the per-batch scheduling problem
+onto every model, including those that only need lightweight drift detection.
+
+### A2 — whylogs only (no Evidently)
+
+Deploy only whylogs for all monitoring.
+*Rejected because:* whylogs' Prometheus integration (≥ 1.3 `prom_metrics_handler`)
+is focused on distribution profiles. Computing model accuracy (F1, RMSE) against
+a held-out reference requires either WhyLabs SaaS (external dependency, not
+OSS-only) or significant bespoke instrumentation that duplicates Evidently's
+test-suite batteries. Evidently's `TestSuite` runs arbitrary quality checks with
+a single Python class; replacing that with whylogs-only means writing quality-gate
+logic from scratch.
+
+### A3 — Managed ML observability (Vertex AI Model Monitoring, Arize, Fiddler)
+
+Use a managed SaaS drift/accuracy service instead of OSS.
+*Rejected because:* the WS-C scope decision is explicitly "OSS, Prometheus-native
+— reuses the existing Grafana/Thanos/Alertmanager stack" (implementation plan §7
+decision #3). Managed services introduce external data egress (PII risk for
+financial transactions), recurring SaaS cost, and a second observability pane
+outside Grafana — all contradicting the platform's single-pane-of-glass design
+(ADR-0026, ADR-0028).
+
+### A4 — Custom Prometheus exporter (no Evidently/whylogs)
+
+Write a bespoke drift-exporter that computes KL divergence / PSI directly.
+*Rejected because:* it re-invents a non-trivial numerical library (statistical
+distribution tests, column-level profiling). Both Evidently and whylogs are
+battle-tested OSS libraries with Prometheus integration; building equivalent
+functionality from scratch is a maintenance liability and delays WS-C.
+
+### A5 — Alertmanager webhook directly to Airflow (no proxy)
+
+Send the raw Alertmanager webhook payload directly to the Airflow REST API.
+*Rejected because:* Alertmanager's webhook payload (Prometheus alerting format)
+is not the Airflow `dagRuns` JSON format. A translation layer is required in all
+cases. The proxy also provides de-duplication (prevents retrain storms during
+alert `repeat_interval`), circuit-breaking against Airflow unavailability, and
+the K8s Job fallback — none of which are possible in a direct webhook to Airflow.
+
+## Consequences
+
+### Positive
+- **ML drift and accuracy gap closed:** feature drift (PSI, KL), data distribution
+  shift, model accuracy, and model quality tests all appear as Prometheus metrics
+  in the existing Grafana/Thanos stack — zero new observability infrastructure
+  required.
+- **Automated retrain trigger:** a material drift event in production automatically
+  fires `train_domain_adapter` via Airflow REST, with a K8s Job fallback, reducing
+  mean time to retrain.
+- **Multi-tenant safe (R3 mitigated):** namespace-per-model + `(tenant, domain)`
+  label scoping makes cross-tenant interference structurally impossible.
+- **Reuses existing stack:** no new alert routing infrastructure; the existing
+  Alertmanager → PagerDuty path gains ML-specific matchers and a webhook receiver.
+- **ADR-0028 compliant:** every resource carries the five platform taxonomy keys;
+  the `$system=ml-monitoring` Grafana variable slots into the existing
+  `platform_system` single-pane dashboards.
+
+### Negative
+- **Two tools to operate:** SREs need familiarity with both Evidently's
+  `TestSuite` configuration and whylogs' `DatasetProfileView` schema.
+- **Reference dataset management:** Evidently requires a stable reference dataset
+  per `(model_name, tenant, domain)`. This must be versioned, refreshed after
+  every retrain, and stored in GCS/S3 (fetched by the drift-exporter at startup).
+- **Retrain storm risk:** multiple concurrent tenant alerts can fire multiple DAG
+  runs. The 15-minute de-duplication window and 6-hour `repeat_interval` on the
+  retrain route are the primary guards.
+- **NetworkPolicy follow-up:** ML monitoring pods have broader egress than ideal
+  until the Cilium policy layer (ADR-0019) is enabled in enforce mode.
+
+### Risks
+- **R3 — Multi-tenant drift isolation (Low).** Mitigation: namespace-per-model +
+  per-`(tenant, domain)` metric labels + independent alert instances.
+- **Airflow unavailability during WS-B ramp-up.** Mitigation: K8s Job fallback
+  in the trigger proxy; Job path is independently tested.
+- **Reference data staleness.** Mitigation: `promote_to_edge` DAG writes a
+  reference-updated marker to GCS; drift-exporter watches and reloads. Tracked
+  as a WS-B/WS-C integration acceptance criterion.
+- **High-frequency alert → retrain storm.** Mitigation: `repeat_interval: 6h`
+  on the retrain webhook route + 15-minute per-`(tenant, domain)` de-duplication
+  in the proxy + Airflow serialises overlapping runs for the same `(tenant, domain)`.
+
+## Implementation notes
+
+This ADR is **planning-only.** The PR introduces:
+- `apps/infra/ml-monitoring/` (ArgoCD Application + Helm chart for the
+  drift-exporter and retrain-trigger)
+- `apps/infra/observability/grafana-dashboards/templates/configmap-ml-drift.yaml`
+  (new dashboard ConfigMap, following the `configmap-dashboards.yaml` convention)
+- This ADR + `docs/adrs/README.md` update
+
+No GCP resources are created. The drift-exporter and trigger-proxy are in-cluster
+K8s workloads; GCS access for reference datasets uses GKE Workload Identity
+(already present on `gcp-gke-gpu-nodepools`, reaffirmed ADR-0036 D6).
+
+**Helm chart conventions (matching the repo):**
+- Chart type: `application`; `apiVersion: v2`
+- All resources carry the five ADR-0028 label keys in `metadata.labels`
+- `values.yaml` parameterises image, resources, modelNamespaces
+  (list of `{namespace, modelName, tenant, domain}`), drift thresholds,
+  Airflow endpoint, and secret names
+- ArgoCD Application: wave annotation `"20"` (after prometheus-stack wave 10),
+  `automated: {prune: true, selfHeal: true}`, `syncOptions: [CreateNamespace=true]`
+- `helm lint` and `kubeconform` validation required before merge
+
+**Airflow REST API (doc-verified 2026-06-10):**
+`POST /api/v1/dags/{dag_id}/dagRuns` is stable in Airflow 2.x and 3.x.
+The proxy uses Basic auth from a K8s Secret mounted via ESO (ADR-0008 pattern).
+Credentials reference: `airflow-api-credentials` ExternalSecret in the
+`ml-monitoring` namespace.
+
+- Effort: **M** (chart skeleton + two new Helm templates + Alertmanager route overlay)
+- Rollback: the ArgoCD Application is independently revertible; removing the
+  Alertmanager overlay stops ML-specific routing and the retrain webhook immediately
+  without touching the main prometheus-stack.
+
+## Revisit trigger
+
+- **Evidently or whylogs ship a joint Prometheus-native SDK** covering both
+  distribution profiling and model quality tests — collapse the two-tool split.
+- **A managed drift-monitoring service on GCP** becomes Prometheus-federated
+  without data egress — re-evaluate alternative A3.
+- **Airflow REST API changes incompatibly** (Airflow 4.x deprecates `/api/v1/`)
+  — update the trigger proxy endpoint; K8s Job fallback continues regardless.
+- **More than 50 model namespaces** — evaluate whether per-namespace ServiceMonitors
+  scale or require a federated aggregation approach.
+
+## References
+
+- Evidently AI Prometheus integration: <https://docs.evidentlyai.com/user-guide/monitoring/collector_service>
+- whylogs Prometheus export (`prom_metrics_handler`):
+  <https://whylogs.readthedocs.io/en/latest/integrations/prometheus.html>
+- PSI thresholds (> 0.1 moderate, > 0.25 severe): industry standard
+- Airflow REST API — `POST /api/v1/dags/{dag_id}/dagRuns`:
+  <https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html>
+- Alertmanager webhook receiver: <https://prometheus.io/docs/alerting/latest/configuration/#webhook_config>
+- `train_domain_adapter` DAG: `docs/transaction-analytics/04-training-pipeline.md`
+- ADR-0028 (platform taxonomy — mandatory): [0028-unified-platform-tagging-and-labeling-taxonomy.md](0028-unified-platform-tagging-and-labeling-taxonomy.md)
+- ADR-0026 (observability target architecture): [0026-observability-target-architecture.md](0026-observability-target-architecture.md)
+- ADR-0036 (GKE ML infra, GKE Standard + Workload Identity): [0036-gke-ml-infra-parity-multiregion.md](0036-gke-ml-infra-parity-multiregion.md)
+- ADR-0003 (Cilium CNI): [0003-cilium-over-aws-vpc-cni.md](0003-cilium-over-aws-vpc-cni.md)
+- ADR-0008 (ESO for secrets): [0008-external-secrets-operator.md](0008-external-secrets-operator.md)
+- In-repo: `apps/infra/observability/prometheus-stack/values.yaml` (Alertmanager
+  baseline), `apps/infra/observability/grafana-dashboards/` (dashboard convention),
+  `apps/infra/opencost/` (ArgoCD Application shape)
+
+---
+*Doc-verified 2026-06-10 against Evidently AI, whylogs, and Airflow REST API
+documentation. Planning-only ADR — proposed, not yet implemented in
+platform-design. WS-C "Model & ML Observability"; implementation apply-gated.*

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -80,6 +80,7 @@ decision.
 | [0034](0034-backstage-idp.md) | Backstage as the Internal Developer Platform | Proposed — Deferred (on hold) | pending | proposal — doc-verified 2026-06-08 |
 | [0035](0035-control-tower-and-aft.md) | AWS Control Tower landing zone + Account Factory for Terraform (AFT) vending | Accepted | pending | epic #293 — supersedes ADR-0017 item-0; design 2026-06-09 |
 | [0036](0036-gke-ml-infra-parity-multiregion.md) | GKE ML-infra parity + multi-region GKE + GCP cost guardrail (GPU Operator, DCGM, Volcano, billing-budget) | Accepted | pending | WS-A of GCP ML platform plan; design 2026-06-10 |
+| [0038](0038-ml-observability-drift.md) | ML observability — drift detection, accuracy monitoring, and retrain trigger (Evidently + whylogs, Prometheus-native) | Proposed | pending | WS-C of GCP ML platform plan; design 2026-06-10 |
 
 
 
@@ -95,6 +96,8 @@ decision.
   ADRs land last as 0015–0016.
 - ADR-0033 is intentionally unassigned (reserved gap between the Batch-B ADRs
   and the Backstage proposal).
+- ADR-0037 is intentionally unassigned (reserved gap; WS-B ML CI/CD + MLflow ADR
+  will use that slot).
 
 ## Conventions
 


### PR DESCRIPTION
## WS-C — ML observability: Evidently/whylogs drift (Phase 2)

Implements **WS-C** of the GCP ML Platform plan. **Plan/validate-only** — no apply/helm-install.

### ADR-0038
**Evidently** (feature drift, prediction accuracy) + **whylogs** (data distribution profiling), exporting Prometheus metrics into the **existing** Grafana/Thanos/Alertmanager stack — no new monitoring backend. Drift → Alertmanager → PagerDuty, and drift → retrain trigger.

### Delivered
- `apps/infra/ml-monitoring/` — ArgoCD app; `drift-exporter` + `retrain-trigger` deployments; ServiceMonitor; PrometheusRule (`ml-drift-alerts`); ESO secrets; SA; namespace.
- **Retrain trigger** — Alertmanager webhook receiver → Airflow REST `POST /api/v1/dags/train_domain_adapter/dagRuns` (fires the WS-B DAG); K8s Job CRD fallback.
- **Real K8s NetworkPolicies** (`network-policies.yaml`): default-deny + DNS + scoped ingress from the monitoring namespace + egress to GCS/Airflow — **closes WS-A security HIGH-3**. Toggle `networkPolicy.enabled` defaults **off** so the default-deny doesn't cut off co-components (pushgateway/whylogs) before their allows are verified.
- Grafana drift/accuracy dashboard (per model/tenant).
- Multi-tenant isolation via namespace-per-model + `platform:system` label filtering (risk R3).

### Validation
`helm lint` clean; `helm template` renders cleanly incl. the 3 NetworkPolicies (`--set networkPolicy.enabled=true`). All resources carry `platform:system=ml-monitoring` (ADR-0028).

> Draft, apply-gated. Builds on WS-A (#297). Pairs with WS-B (#298) — drift fires WS-B's retrain DAG.

Part of the GCP ML Platform plan · ADR-0038