### PR TITLE
feat(gcp-ml): WS-D self-serve observability (ADR-0039)

### DIFF
--- a/apps/infra/grafana-self-serve/Chart.yaml
+++ b/apps/infra/grafana-self-serve/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: grafana-self-serve
+description: >
+  Per-team Grafana folder, starter dashboard, and alert-rules-as-code template.
+  Teams instantiate this chart via a template PR to get a scoped Grafana folder
+  and a PrometheusRule in their workload namespace without platform tickets.
+  See docs/self-serve-observability.md for the onboarding runbook.
+  ADR-0039.
+type: application
+version: 0.1.0
+appVersion: "1.0"
+keywords:
+  - grafana
+  - dashboards
+  - observability
+  - self-serve
+  - alerts
+home: https://github.com/your-org/platform-design
+maintainers:
+  - name: Platform Team
+    email: platform@example.com
+annotations:
+  platform.system: observability
+  adr: "0039"

--- a/apps/infra/grafana-self-serve/example-teams/team-checkout/argocd-application.yaml
+++ b/apps/infra/grafana-self-serve/example-teams/team-checkout/argocd-application.yaml
@@ -1,0 +1,52 @@
+---
+# ArgoCD Application: team-checkout self-serve observability
+# Onboarded via ADR-0039 template PR.
+# Deploys into the checkout namespace (must pre-exist).
+# Wave 30 — after all observability components (wave 10-20).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: grafana-self-serve-team-checkout
+  namespace: argocd
+  labels:
+    platform.system: "observability"
+    platform.component: "self-serve"
+    platform.env: "production"
+    platform.owner: "team-checkout"
+    platform.managed-by: "argocd"
+    app.kubernetes.io/name: "grafana-self-serve-team-checkout"
+    app.kubernetes.io/component: "self-serve"
+    app.kubernetes.io/managed-by: "argocd"
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/your-org/platform-design.git
+    targetRevision: main
+    path: apps/infra/grafana-self-serve
+    helm:
+      valueFiles:
+        - values.yaml
+        - example-teams/team-checkout/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: checkout
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=false
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m

--- a/apps/infra/grafana-self-serve/example-teams/team-checkout/values.yaml
+++ b/apps/infra/grafana-self-serve/example-teams/team-checkout/values.yaml
@@ -1,0 +1,26 @@
+# Example: team-checkout (non-ML team)
+# Template PR example for the Checkout engineering team.
+# See docs/self-serve-observability.md for the full onboarding guide.
+# ADR-0039.
+
+team:
+  name: "Checkout"
+  slug: "team-checkout"
+  namespace: "checkout"
+  system: "checkout"
+  owner: "team-checkout"
+  env: "production"
+  grafanaServiceAccount: "grafana-sa-team-checkout"
+  ciServiceAccount: "checkout-ci"
+
+ml:
+  enabled: false
+
+# Override default alert thresholds for the Checkout service
+# (slightly tighter error rate tolerance than the default 5%).
+alerts:
+  errorRateThreshold: "0.03"
+  cpuSaturationThreshold: "0.80"
+  memorySaturationThreshold: "0.80"
+  availabilityFor: "5m"
+  saturationFor: "15m"

--- a/apps/infra/grafana-self-serve/example-teams/team-ml-platform/argocd-application.yaml
+++ b/apps/infra/grafana-self-serve/example-teams/team-ml-platform/argocd-application.yaml
@@ -1,0 +1,52 @@
+---
+# ArgoCD Application: team-ml-platform self-serve observability
+# Onboarded via ADR-0039 template PR.
+# Deploys into the ml-monitoring namespace (must pre-exist, created by ADR-0038).
+# Wave 30 — after all observability + ml-monitoring components (wave 10-20).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: grafana-self-serve-team-ml-platform
+  namespace: argocd
+  labels:
+    platform.system: "observability"
+    platform.component: "self-serve"
+    platform.env: "production"
+    platform.owner: "team-ml-platform"
+    platform.managed-by: "argocd"
+    app.kubernetes.io/name: "grafana-self-serve-team-ml-platform"
+    app.kubernetes.io/component: "self-serve"
+    app.kubernetes.io/managed-by: "argocd"
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/your-org/platform-design.git
+    targetRevision: main
+    path: apps/infra/grafana-self-serve
+    helm:
+      valueFiles:
+        - values.yaml
+        - example-teams/team-ml-platform/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ml-monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=false
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m

--- a/apps/infra/grafana-self-serve/example-teams/team-ml-platform/values.yaml
+++ b/apps/infra/grafana-self-serve/example-teams/team-ml-platform/values.yaml
@@ -1,0 +1,33 @@
+# Example: team-ml-platform (ML team with ml.enabled: true)
+# Template PR example for the ML Platform team.
+# Includes ML drift + accuracy panels (ADR-0038 metrics) and ML alert groups.
+# See docs/self-serve-observability.md for the full onboarding guide.
+# ADR-0039.
+
+team:
+  name: "ML Platform"
+  slug: "team-ml-platform"
+  namespace: "ml-monitoring"
+  system: "ml-monitoring"
+  owner: "team-ml-platform"
+  env: "production"
+  grafanaServiceAccount: "grafana-sa-team-ml-platform"
+  ciServiceAccount: "ml-platform-ci"
+
+ml:
+  enabled: true
+  # Scope ML panels to a specific model. Remove or leave empty to show all models.
+  modelName: "domain-adapter-hft"
+  # Scope ML panels to a specific tenant. Remove or leave empty to show all tenants.
+  tenant: "tenant-acme"
+
+# ML-team specific alert thresholds.
+alerts:
+  errorRateThreshold: "0.05"
+  cpuSaturationThreshold: "0.80"
+  memorySaturationThreshold: "0.80"
+  availabilityFor: "5m"
+  saturationFor: "15m"
+  mlDriftThreshold: "0.2"
+  mlAccuracyThreshold: "0.85"
+  mlAlertFor: "10m"

--- a/apps/infra/grafana-self-serve/templates/_helpers.tpl
+++ b/apps/infra/grafana-self-serve/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+grafana-self-serve helpers
+ADR-0039: Self-Serve Observability
+*/}}
+
+{{/*
+Validate required team fields. Called at the top of every template.
+helm lint will surface the error if any required field is empty.
+*/}}
+{{- define "grafana-self-serve.validate" -}}
+{{- $_ := required "team.name is required" .Values.team.name -}}
+{{- $_ := required "team.slug is required" .Values.team.slug -}}
+{{- $_ := required "team.namespace is required" .Values.team.namespace -}}
+{{- $_ := required "team.system is required" .Values.team.system -}}
+{{- $_ := required "team.owner is required" .Values.team.owner -}}
+{{- $_ := required "team.env is required" .Values.team.env -}}
+{{- end -}}
+
+{{/*
+Common ADR-0028 labels applied to every resource.
+platform.system is always "observability" for the self-serve scaffolding itself.
+*/}}
+{{- define "grafana-self-serve.labels" -}}
+platform.system: "observability"
+platform.component: {{ .component | quote }}
+platform.env: {{ .root.Values.team.env | quote }}
+platform.owner: {{ .root.Values.team.slug | quote }}
+platform.managed-by: "argocd"
+app.kubernetes.io/name: "grafana-self-serve"
+app.kubernetes.io/instance: {{ .root.Values.team.slug | quote }}
+app.kubernetes.io/component: {{ .component | quote }}
+app.kubernetes.io/managed-by: "Helm"
+{{- end -}}
+
+{{/*
+Grafana dashboard ConfigMap labels — enables the Grafana sidecar to discover
+and load the dashboard automatically.
+*/}}
+{{- define "grafana-self-serve.dashboardLabels" -}}
+grafana_dashboard: "1"
+platform.system: "observability"
+platform.component: "dashboard"
+platform.env: {{ .Values.team.env | quote }}
+platform.owner: {{ .Values.team.slug | quote }}
+platform.managed-by: "argocd"
+{{- end -}}
+
+{{/*
+Uppercase team slug used as alert name prefix (prevents alertname collisions
+across teams when aggregating in Alertmanager).
+Example: team-checkout -> TEAM_CHECKOUT
+*/}}
+{{- define "grafana-self-serve.alertPrefix" -}}
+{{- .Values.team.slug | upper | replace "-" "_" -}}
+{{- end -}}
+
+{{/*
+Grafana folder UID — stable and deterministic from the team slug.
+Grafana requires folder UIDs to be max 40 chars.
+*/}}
+{{- define "grafana-self-serve.folderUid" -}}
+{{- printf "team-%s" .Values.team.slug | trunc 40 -}}
+{{- end -}}

--- a/apps/infra/grafana-self-serve/templates/configmap-dashboard.yaml
+++ b/apps/infra/grafana-self-serve/templates/configmap-dashboard.yaml
@@ -1,0 +1,427 @@
+---
+# Grafana self-serve: per-team folder + starter dashboard ConfigMap
+# The Grafana sidecar detects ConfigMaps with label grafana_dashboard: "1"
+# and loads them into the Grafana instance automatically.
+#
+# This template produces TWO ConfigMaps:
+#   1. <team-slug>-grafana-folder    — provisions the Grafana folder
+#   2. <team-slug>-grafana-dashboard — the starter dashboard (folder-scoped)
+#
+# ADR-0039: Self-Serve Observability
+# ADR-0028: platform.system = observability (mandatory on every resource)
+{{- include "grafana-self-serve.validate" . }}
+{{- $alertPrefix := include "grafana-self-serve.alertPrefix" . }}
+{{- $folderUid := include "grafana-self-serve.folderUid" . }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.team.slug }}-grafana-folder
+  namespace: {{ .Values.grafanaNamespace }}
+  labels:
+    {{- include "grafana-self-serve.dashboardLabels" . | nindent 4 }}
+  annotations:
+    grafana_folder: {{ printf "team-%s" .Values.team.slug | quote }}
+data:
+  {{ printf "%s-folder.json" .Values.team.slug }}: |
+    {
+      "__inputs": [
+        {
+          "name": "{{ printf "team-%s" .Values.team.slug }}",
+          "type": "folder",
+          "uid": "{{ $folderUid }}",
+          "title": "{{ .Values.team.name }}",
+          "description": "Dashboards for {{ .Values.team.name }} ({{ .Values.team.slug }}). ADR-0039 self-serve."
+        }
+      ],
+      "__requires": [],
+      "annotations": {"list": []},
+      "panels": [],
+      "schemaVersion": 38,
+      "title": "{{ .Values.team.name }}",
+      "uid": "{{ $folderUid }}-root",
+      "version": 1
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.team.slug }}-grafana-dashboard
+  namespace: {{ .Values.grafanaNamespace }}
+  labels:
+    {{- include "grafana-self-serve.dashboardLabels" . | nindent 4 }}
+  annotations:
+    grafana_folder: {{ printf "team-%s" .Values.team.slug | quote }}
+data:
+  {{ printf "%s-starter.json" .Values.team.slug }}: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "datasource": "{{ .Values.datasource.name }}",
+            "enable": true,
+            "expr": "changes(kube_deployment_status_observed_generation{namespace=\"{{ .Values.team.namespace }}\"}[5m]) > 0",
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Deployments",
+            "tagKeys": "deployment,namespace"
+          }
+        ]
+      },
+      "description": "Starter dashboard for {{ .Values.team.name }}. Namespace: {{ .Values.team.namespace }}. platform:system={{ .Values.team.system }}. ADR-0039.",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+          "id": 100,
+          "title": "Service Health (RED Metrics)",
+          "type": "row"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "drawStyle": "line", "fillOpacity": 10,
+                "lineWidth": 2, "showPoints": "never", "spanNulls": false
+              },
+              "unit": "reqps"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 1},
+          "id": 1,
+          "options": {
+            "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "expr": "sum by (service) (rate(http_server_requests_total{namespace=\"{{ .Values.team.namespace }}\",platform_system=\"{{ .Values.team.system }}\"}[5m]))",
+              "legendFormat": "{{ "{{service}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Request Rate (RPS)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "drawStyle": "line", "fillOpacity": 10,
+                "lineWidth": 2, "showPoints": "never"
+              },
+              "max": 100, "min": 0, "unit": "percent"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 1},
+          "id": 2,
+          "options": {
+            "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "expr": "(sum(rate(http_server_requests_total{namespace=\"{{ .Values.team.namespace }}\",status=~\"5..\"}[5m])) / sum(rate(http_server_requests_total{namespace=\"{{ .Values.team.namespace }}\"}[5m]))) * 100",
+              "legendFormat": "5xx Error Rate",
+              "refId": "A"
+            },
+            {
+              "expr": "(sum(rate(http_server_requests_total{namespace=\"{{ .Values.team.namespace }}\",status=~\"4..\"}[5m])) / sum(rate(http_server_requests_total{namespace=\"{{ .Values.team.namespace }}\"}[5m]))) * 100",
+              "legendFormat": "4xx Error Rate",
+              "refId": "B"
+            }
+          ],
+          "title": "Error Rate (%)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "drawStyle": "line", "fillOpacity": 10,
+                "lineWidth": 2, "showPoints": "never"
+              },
+              "unit": "s"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 9},
+          "id": 3,
+          "options": {
+            "legend": {"calcs": ["mean", "p95", "p99"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le, service) (rate(http_server_request_duration_seconds_bucket{namespace=\"{{ .Values.team.namespace }}\"}[5m])))",
+              "legendFormat": "P50 {{ "{{service}}" }}",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le, service) (rate(http_server_request_duration_seconds_bucket{namespace=\"{{ .Values.team.namespace }}\"}[5m])))",
+              "legendFormat": "P95 {{ "{{service}}" }}",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le, service) (rate(http_server_request_duration_seconds_bucket{namespace=\"{{ .Values.team.namespace }}\"}[5m])))",
+              "legendFormat": "P99 {{ "{{service}}" }}",
+              "refId": "C"
+            }
+          ],
+          "title": "Request Duration (P50 / P95 / P99)",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 17},
+          "id": 101,
+          "title": "Resource Saturation",
+          "type": "row"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "drawStyle": "line", "fillOpacity": 10,
+                "lineWidth": 2, "showPoints": "never"
+              },
+              "max": 100, "min": 0, "unit": "percent"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 18},
+          "id": 4,
+          "options": {
+            "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "expr": "(sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"{{ .Values.team.namespace }}\",container!=\"\"}[5m])) / sum by (pod) (kube_pod_container_resource_requests{namespace=\"{{ .Values.team.namespace }}\",resource=\"cpu\"})) * 100",
+              "legendFormat": "CPU {{ "{{pod}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "CPU Saturation (% of request)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "drawStyle": "line", "fillOpacity": 10,
+                "lineWidth": 2, "showPoints": "never"
+              },
+              "max": 100, "min": 0, "unit": "percent"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 18},
+          "id": 5,
+          "options": {
+            "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "expr": "(sum by (pod) (container_memory_working_set_bytes{namespace=\"{{ .Values.team.namespace }}\",container!=\"\"}) / sum by (pod) (kube_pod_container_resource_requests{namespace=\"{{ .Values.team.namespace }}\",resource=\"memory\"})) * 100",
+              "legendFormat": "Mem {{ "{{pod}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory Saturation (% of request)",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 26},
+          "id": 102,
+          "title": "Active Alerts",
+          "type": "row"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "custom": {"align": "auto", "cellOptions": {"type": "color-text"}, "inspect": false},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "yellow", "value": 1},
+                  {"color": "red", "value": 5}
+                ]
+              }
+            }
+          },
+          "gridPos": {"h": 6, "w": 24, "x": 0, "y": 27},
+          "id": 6,
+          "options": {"cellHeight": "sm", "showHeader": true},
+          "targets": [
+            {
+              "expr": "ALERTS{namespace=\"{{ .Values.team.namespace }}\",alertstate=\"firing\"}",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Firing Alerts — {{ .Values.team.name }}",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {"Time": true, "__name__": true},
+                "renameByName": {
+                  "alertname": "Alert",
+                  "severity": "Severity",
+                  "namespace": "Namespace",
+                  "alertstate": "State"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+        {{- if .Values.ml.enabled }},
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 33},
+          "id": 200,
+          "title": "ML Observability (ADR-0038 drift + accuracy metrics)",
+          "type": "row"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "yellow", "value": 0.2},
+                  {"color": "red", "value": 0.4}
+                ]
+              },
+              "unit": "short"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 34},
+          "id": 201,
+          "options": {
+            "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "expr": "ml_monitoring_dataset_drift_score{namespace=\"{{ .Values.team.namespace }}\"{{ if .Values.ml.modelName }},model_name=\"{{ .Values.ml.modelName }}\"{{ end }}{{ if .Values.ml.tenant }},tenant=\"{{ .Values.ml.tenant }}\"{{ end }}}",
+              "legendFormat": "drift {{ "{{model_name}}" }}/{{ "{{tenant}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "ML Dataset Drift Score",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"
+              },
+              "max": 1, "min": 0, "unit": "percentunit"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 34},
+          "id": 202,
+          "options": {
+            "legend": {"calcs": ["lastNotNull", "min"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "expr": "ml_monitoring_model_accuracy{namespace=\"{{ .Values.team.namespace }}\"{{ if .Values.ml.modelName }},model_name=\"{{ .Values.ml.modelName }}\"{{ end }}{{ if .Values.ml.tenant }},tenant=\"{{ .Values.ml.tenant }}\"{{ end }}}",
+              "legendFormat": "accuracy {{ "{{model_name}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Model Accuracy",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 1, "showPoints": "never"
+              },
+              "unit": "short"
+            }
+          },
+          "gridPos": {"h": 6, "w": 12, "x": 0, "y": 42},
+          "id": 203,
+          "options": {
+            "legend": {"calcs": ["sum"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "expr": "increase(ml_monitoring_retrain_triggers_total{namespace=\"{{ .Values.team.namespace }}\"{{ if .Values.ml.tenant }},tenant=\"{{ .Values.ml.tenant }}\"{{ end }}}[1h])",
+              "legendFormat": "{{ "{{trigger}}" }}/{{ "{{outcome}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Retrain Triggers (per hour)",
+          "type": "timeseries"
+        }
+        {{- end }}
+      ],
+      "refresh": "{{ .Values.defaultRefresh }}",
+      "schemaVersion": 38,
+      "style": "dark",
+      "tags": ["self-serve", "{{ .Values.team.slug }}", "{{ .Values.team.system }}"
+        {{- if .Values.ml.enabled }}, "ml"{{- end }}],
+      "templating": {
+        "list": [
+          {
+            "current": {"selected": false, "text": "{{ .Values.datasource.name }}", "value": "{{ .Values.datasource.name }}"},
+            "hide": 0,
+            "includeAll": false,
+            "label": "Datasource",
+            "multi": false,
+            "name": "DS_PROMETHEUS",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "skipUrlSync": false,
+            "type": "datasource"
+          }
+        ]
+      },
+      "time": {
+        "from": "{{ .Values.defaultTimeRange.from }}",
+        "to": "{{ .Values.defaultTimeRange.to }}"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "{{ .Values.team.name }} — Starter Dashboard",
+      "uid": "{{ printf "ss-%s" .Values.team.slug | trunc 40 }}",
+      "version": 1,
+      "weekStart": ""
+    }

--- a/apps/infra/grafana-self-serve/templates/prometheusrule.yaml
+++ b/apps/infra/grafana-self-serve/templates/prometheusrule.yaml
@@ -1,0 +1,204 @@
+---
+# Grafana self-serve: per-team PrometheusRule (alert-rules-as-code)
+#
+# Deployed into team.namespace (NOT the platform monitoring namespace).
+# Teams extend these starter groups by editing their own values or adding
+# extra PrometheusRule objects — without touching platform objects.
+#
+# Alert naming: all alert names carry the team slug prefix in UPPER_CASE
+# (e.g. TEAM_CHECKOUT_HighErrorRate) to prevent alertname collisions when
+# aggregating across teams in Alertmanager.
+#
+# ADR-0039: Self-Serve Observability
+# ADR-0028: platform.system = observability (mandatory on every resource)
+{{- include "grafana-self-serve.validate" . }}
+{{- $alertPrefix := include "grafana-self-serve.alertPrefix" . }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Values.team.slug }}-alerts
+  namespace: {{ .Values.team.namespace }}
+  labels:
+    {{- include "grafana-self-serve.labels" (dict "root" . "component" "alert-rules") | nindent 4 }}
+    prometheus: kube-prometheus
+spec:
+  groups:
+    # -------------------------------------------------------------------------
+    # Availability: HTTP error rate scoped to team namespace.
+    # -------------------------------------------------------------------------
+    - name: {{ .Values.team.slug }}-availability
+      interval: 30s
+      rules:
+        - alert: {{ $alertPrefix }}_HighErrorRate
+          expr: |
+            (
+              sum(rate(http_server_requests_total{
+                namespace="{{ .Values.team.namespace }}",
+                status=~"5.."
+              }[5m]))
+              /
+              sum(rate(http_server_requests_total{
+                namespace="{{ .Values.team.namespace }}"
+              }[5m]))
+            ) > {{ .Values.alerts.errorRateThreshold }}
+          for: {{ .Values.alerts.availabilityFor }}
+          labels:
+            severity: critical
+            team: {{ .Values.team.slug | quote }}
+            namespace: {{ .Values.team.namespace | quote }}
+            platform_system: {{ .Values.team.system | quote }}
+            platform_owner: {{ .Values.team.slug | quote }}
+          annotations:
+            summary: >-
+              High HTTP 5xx error rate — {{ .Values.team.name }}
+              ({{ .Values.team.namespace }})
+            description: >-
+              5xx error rate is {{ "{{ $value | humanizePercentage }}" }}
+              (threshold: {{ .Values.alerts.errorRateThreshold }}).
+              Check service logs in namespace {{ .Values.team.namespace }}.
+            runbook_url: "https://runbooks.internal.example.com/teams/{{ .Values.team.slug }}/high-error-rate"
+
+        - alert: {{ $alertPrefix }}_ServiceDown
+          expr: |
+            absent(http_server_requests_total{
+              namespace="{{ .Values.team.namespace }}"
+            }[5m]) == 1
+          for: {{ .Values.alerts.availabilityFor }}
+          labels:
+            severity: critical
+            team: {{ .Values.team.slug | quote }}
+            namespace: {{ .Values.team.namespace | quote }}
+            platform_system: {{ .Values.team.system | quote }}
+            platform_owner: {{ .Values.team.slug | quote }}
+          annotations:
+            summary: >-
+              No HTTP traffic detected — {{ .Values.team.name }}
+              ({{ .Values.team.namespace }})
+            description: >-
+              No http_server_requests_total series in namespace
+              {{ .Values.team.namespace }} for 5 minutes. Service may be down.
+            runbook_url: "https://runbooks.internal.example.com/teams/{{ .Values.team.slug }}/service-down"
+
+    # -------------------------------------------------------------------------
+    # Saturation: CPU + memory over-saturation scoped to team namespace.
+    # -------------------------------------------------------------------------
+    - name: {{ .Values.team.slug }}-saturation
+      interval: 30s
+      rules:
+        - alert: {{ $alertPrefix }}_HighCPUSaturation
+          expr: |
+            (
+              sum by (pod) (rate(container_cpu_usage_seconds_total{
+                namespace="{{ .Values.team.namespace }}",
+                container!=""
+              }[5m]))
+              /
+              sum by (pod) (kube_pod_container_resource_requests{
+                namespace="{{ .Values.team.namespace }}",
+                resource="cpu"
+              })
+            ) > {{ .Values.alerts.cpuSaturationThreshold }}
+          for: {{ .Values.alerts.saturationFor }}
+          labels:
+            severity: warning
+            team: {{ .Values.team.slug | quote }}
+            namespace: {{ .Values.team.namespace | quote }}
+            platform_system: {{ .Values.team.system | quote }}
+            platform_owner: {{ .Values.team.slug | quote }}
+          annotations:
+            summary: >-
+              High CPU saturation — {{ .Values.team.name }} pod
+              {{ "{{ $labels.pod }}" }}
+            description: >-
+              CPU saturation is {{ "{{ $value | humanizePercentage }}" }}
+              (threshold: {{ .Values.alerts.cpuSaturationThreshold }}).
+            runbook_url: "https://runbooks.internal.example.com/teams/{{ .Values.team.slug }}/cpu-saturation"
+
+        - alert: {{ $alertPrefix }}_HighMemorySaturation
+          expr: |
+            (
+              sum by (pod) (container_memory_working_set_bytes{
+                namespace="{{ .Values.team.namespace }}",
+                container!=""
+              })
+              /
+              sum by (pod) (kube_pod_container_resource_requests{
+                namespace="{{ .Values.team.namespace }}",
+                resource="memory"
+              })
+            ) > {{ .Values.alerts.memorySaturationThreshold }}
+          for: {{ .Values.alerts.saturationFor }}
+          labels:
+            severity: warning
+            team: {{ .Values.team.slug | quote }}
+            namespace: {{ .Values.team.namespace | quote }}
+            platform_system: {{ .Values.team.system | quote }}
+            platform_owner: {{ .Values.team.slug | quote }}
+          annotations:
+            summary: >-
+              High memory saturation — {{ .Values.team.name }} pod
+              {{ "{{ $labels.pod }}" }}
+            description: >-
+              Memory saturation is {{ "{{ $value | humanizePercentage }}" }}
+              (threshold: {{ .Values.alerts.memorySaturationThreshold }}).
+            runbook_url: "https://runbooks.internal.example.com/teams/{{ .Values.team.slug }}/memory-saturation"
+
+    {{- if .Values.ml.enabled }}
+    # -------------------------------------------------------------------------
+    # ML observability (gated by ml.enabled: true).
+    # Consumes ADR-0038 metrics from the ml-monitoring stack.
+    # -------------------------------------------------------------------------
+    - name: {{ .Values.team.slug }}-ml-observability
+      interval: 60s
+      rules:
+        - alert: {{ $alertPrefix }}_MLDriftDetected
+          expr: |
+            ml_monitoring_dataset_drift_score{
+              namespace="{{ .Values.team.namespace }}"
+              {{- if .Values.ml.modelName }},model_name="{{ .Values.ml.modelName }}"{{- end }}
+              {{- if .Values.ml.tenant }},tenant="{{ .Values.ml.tenant }}"{{- end }}
+            } > {{ .Values.alerts.mlDriftThreshold }}
+          for: {{ .Values.alerts.mlAlertFor }}
+          labels:
+            severity: warning
+            team: {{ .Values.team.slug | quote }}
+            namespace: {{ .Values.team.namespace | quote }}
+            platform_system: "observability"
+            platform_owner: {{ .Values.team.slug | quote }}
+            alert_type: ml-drift
+          annotations:
+            summary: >-
+              ML dataset drift detected — {{ .Values.team.name }}
+              {{- if .Values.ml.modelName }} (model: {{ .Values.ml.modelName }}){{- end }}
+            description: >-
+              Drift score {{ "{{ $value }}" }} exceeds threshold
+              {{ .Values.alerts.mlDriftThreshold }} for model
+              {{ "{{ $labels.model_name }}" }}/tenant {{ "{{ $labels.tenant }}" }}.
+              Consider triggering a retrain via the Airflow DAG (ADR-0038).
+            runbook_url: "https://runbooks.internal.example.com/teams/{{ .Values.team.slug }}/ml-drift"
+
+        - alert: {{ $alertPrefix }}_MLAccuracyDegraded
+          expr: |
+            ml_monitoring_model_accuracy{
+              namespace="{{ .Values.team.namespace }}"
+              {{- if .Values.ml.modelName }},model_name="{{ .Values.ml.modelName }}"{{- end }}
+              {{- if .Values.ml.tenant }},tenant="{{ .Values.ml.tenant }}"{{- end }}
+            } < {{ .Values.alerts.mlAccuracyThreshold }}
+          for: {{ .Values.alerts.mlAlertFor }}
+          labels:
+            severity: critical
+            team: {{ .Values.team.slug | quote }}
+            namespace: {{ .Values.team.namespace | quote }}
+            platform_system: "observability"
+            platform_owner: {{ .Values.team.slug | quote }}
+            alert_type: ml-accuracy
+          annotations:
+            summary: >-
+              Model accuracy degraded — {{ .Values.team.name }}
+              {{- if .Values.ml.modelName }} (model: {{ .Values.ml.modelName }}){{- end }}
+            description: >-
+              Model accuracy {{ "{{ $value | humanizePercentage }}" }} is below
+              threshold {{ .Values.alerts.mlAccuracyThreshold }} for model
+              {{ "{{ $labels.model_name }}" }}/tenant {{ "{{ $labels.tenant }}" }}.
+            runbook_url: "https://runbooks.internal.example.com/teams/{{ .Values.team.slug }}/ml-accuracy"
+    {{- end }}

--- a/apps/infra/grafana-self-serve/templates/rbac.yaml
+++ b/apps/infra/grafana-self-serve/templates/rbac.yaml
@@ -1,0 +1,45 @@
+---
+# Grafana self-serve: namespace-scoped RBAC for team PrometheusRule management
+#
+# Grants the team's CI/CD service account (team.ciServiceAccount) rights to
+# manage PrometheusRule objects in their workload namespace only.
+# No cross-namespace access is granted.
+#
+# Platform PrometheusRules in the monitoring namespace are NOT touched.
+#
+# ADR-0039: Self-Serve Observability
+# ADR-0028: platform.system = observability (mandatory on every resource)
+{{- include "grafana-self-serve.validate" . }}
+{{- if .Values.team.ciServiceAccount }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.team.slug }}-prometheusrule-manager
+  namespace: {{ .Values.team.namespace }}
+  labels:
+    {{- include "grafana-self-serve.labels" (dict "root" . "component" "rbac") | nindent 4 }}
+rules:
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: ["prometheusrules"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: ["prometheusrules/status"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.team.slug }}-prometheusrule-manager
+  namespace: {{ .Values.team.namespace }}
+  labels:
+    {{- include "grafana-self-serve.labels" (dict "root" . "component" "rbac") | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.team.ciServiceAccount | quote }}
+    namespace: {{ .Values.team.namespace | quote }}
+roleRef:
+  kind: Role
+  name: {{ .Values.team.slug }}-prometheusrule-manager
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/apps/infra/grafana-self-serve/values.yaml
+++ b/apps/infra/grafana-self-serve/values.yaml
@@ -1,0 +1,93 @@
+# grafana-self-serve — default values
+# ALL team.* fields are REQUIRED. There are no defaults; helm lint will fail
+# if any required field is missing or empty (enforced via required in templates).
+#
+# Override this file in example-teams/<team-slug>/values.yaml.
+# See docs/self-serve-observability.md for the full onboarding guide.
+#
+# ADR-0039: Self-Serve Observability
+
+team:
+  # Human-readable team name (used in Grafana folder title and dashboard title).
+  # Example: "Checkout"
+  name: ""
+
+  # Machine-safe slug — lowercase, hyphens only.
+  # Used as: Grafana folder name, alert rule prefix, label values.
+  # Example: "team-checkout"
+  slug: ""
+
+  # Kubernetes namespace where this team's workloads run.
+  # This is also where PrometheusRule and RBAC objects are deployed.
+  # Must already exist — CreateNamespace=false on the ArgoCD Application.
+  # Example: "checkout"
+  namespace: ""
+
+  # platform:system value (ADR-0028 taxonomy) for this team's workloads.
+  # Example: "checkout", "ml-monitoring", "auth"
+  system: ""
+
+  # platform:owner value (ADR-0028 taxonomy). Typically matches slug.
+  # Example: "team-checkout"
+  owner: ""
+
+  # Deployment environment. Must be one of: production, staging, dev, sandbox.
+  env: ""
+
+  # (Optional) Grafana service-account name used for Editor access on the folder.
+  # Create this service account in Grafana before deploying.
+  # Leave empty to skip folder permission provisioning.
+  grafanaServiceAccount: ""
+
+  # CI/CD service account name in team.namespace that needs PrometheusRule RBAC.
+  # Example: "checkout-ci"
+  # Leave empty to skip RoleBinding creation.
+  ciServiceAccount: ""
+
+# ML-specific configuration. Set ml.enabled: true for ML teams.
+# When enabled, extra dashboard panels for ADR-0038 drift/accuracy metrics
+# are added, and ML-specific alert groups are included in the PrometheusRule.
+ml:
+  enabled: false
+
+  # model_name label value to scope ML panels. Leave empty to show all models.
+  # Example: "domain-adapter-hft"
+  modelName: ""
+
+  # tenant label value from ADR-0038 metric labels.
+  # Example: "tenant-acme"
+  tenant: ""
+
+# Grafana namespace where the Grafana deployment lives and where ConfigMaps
+# must be created for the sidecar to discover them.
+grafanaNamespace: observability
+
+# Prometheus datasource settings (must match apps/infra/observability/grafana-dashboards/values.yaml).
+datasource:
+  name: "Prometheus"
+  uid: "prometheus"
+
+# Dashboard display defaults.
+defaultRefresh: "30s"
+defaultTimeRange:
+  from: "now-1h"
+  to: "now"
+
+# Alert thresholds — adjust per team in their values.yaml.
+alerts:
+  # HTTP error rate threshold (fraction). 0.05 = 5%.
+  errorRateThreshold: "0.05"
+  # CPU saturation threshold (fraction). 0.80 = 80%.
+  cpuSaturationThreshold: "0.80"
+  # Memory saturation threshold (fraction). 0.80 = 80%.
+  memorySaturationThreshold: "0.80"
+  # Sustained duration before availability alert fires.
+  availabilityFor: "5m"
+  # Sustained duration before saturation alert fires.
+  saturationFor: "15m"
+  # ML: drift score threshold (only used when ml.enabled: true).
+  mlDriftThreshold: "0.2"
+  # ML: model accuracy floor (only used when ml.enabled: true).
+  mlAccuracyThreshold: "0.85"
+  # ML: sustained duration before ML alert fires.
+  mlAlertFor: "10m"

--- a/docs/adrs/0039-self-serve-observability.md
+++ b/docs/adrs/0039-self-serve-observability.md
@@ -1,0 +1,354 @@
+# ADR-0039: Self-Serve Observability — Templated Grafana Folders, Dashboards, and Alert-Rules-as-Code
+
+- Status: **Proposed** — plan/validate-only; implementation apply-gated.
+- platform-design status: **pending** — `apps/infra/grafana-self-serve/` introduced
+  in this PR (templates + two sample teams); no Grafana folder provisioner or team
+  PrometheusRules deployed yet.
+- Date: 2026-06-10
+- Authors: platform-team (devops-engineer)
+- Related issues: WS-D "System & self-serve observability + team enablement" (GCP ML
+  Platform plan §4 WS-D); ADR-0034 (Backstage — deferred); ADR-0026 (observability
+  target architecture); ADR-0028 (mandatory platform taxonomy).
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+The platform has a mature **system observability layer**: Prometheus 3.x / Thanos,
+Grafana, Loki, Tempo, Pyroscope, OTel Collector, Alertmanager → PagerDuty — all
+in `apps/infra/observability/`. The existing `grafana-dashboards` Helm chart
+(`apps/infra/observability/grafana-dashboards/`) ships **platform-owned** dashboards
+(cluster-overview, node-health, karpenter, golden-signals, SLO, ML drift) as
+ConfigMaps labelled `grafana_dashboard: "1"`, which the Grafana sidecar picks up
+automatically.
+
+What is entirely absent is a **per-team layer**: individual teams (ML platform,
+checkout, data, SRE, etc.) have no way to:
+
+1. Get a scoped Grafana folder visible only to their team.
+2. Add their own service/workload dashboards without filing a platform ticket.
+3. Define custom alert rules in a Prometheus namespace they own without touching
+   the platform's `PrometheusRule` objects.
+
+The consequence is every new team either duplicates platform dashboards, files
+tickets, or goes dark on alerting — all of which create toil and observability
+gaps. The WS-C ML observability work (ADR-0038) noted this gap in §D5
+("per-team dashboard access control") as a follow-up.
+
+### Why not Backstage?
+
+[ADR-0034](0034-backstage-idp.md) put Backstage on hold pending three conditions:
+
+1. A **dedicated Backstage owner** (engineer or team) assigned to operate the
+   Node.js app, plugins, and catalog hygiene.
+2. The **platform backlog matures** so the Golden Path Scaffolder can reference a
+   stable, fully-implemented set of ADRs (currently many are `pending` in
+   platform-design).
+3. **≥3 teams actively onboarded** via golden-path templates from WS-F.
+
+None of those three conditions are currently met. Deploying Backstage now —
+without a dedicated owner — would produce an abandoned portal within months.
+The GCP ML Platform implementation plan (§7 decision #5) explicitly recommends:
+"ship lightweight self-serve in WS-D first; revisit Backstage when all three
+conditions are met."
+
+**Backstage remains deferred.** This ADR delivers the lightweight self-serve
+layer that bridges the gap until Backstage's revisit criteria are satisfied.
+
+## Decision
+
+**Ship a lightweight, GitOps-delivered self-serve observability layer** based
+entirely on the platform's existing patterns (ConfigMap sidecar, ArgoCD,
+PrometheusRule CRD). No new operators are introduced.
+
+The mechanism has four components:
+
+### D1 — Per-team Grafana folder via ConfigMap provisioning
+
+A ConfigMap labelled `grafana_dashboard: "1"` carries Grafana's folder
+provisioning JSON. The Grafana sidecar picks it up and creates a folder named
+`team-<slug>` in the Grafana org. Folder-level RBAC restricts Viewer access
+to the team's Grafana service account or user group — other teams cannot browse
+the folder.
+
+### D2 — Starter dashboard ConfigMap (parameterised)
+
+A second ConfigMap, also labelled `grafana_dashboard: "1"` with a
+`grafana_folder` annotation pointing to `team-<slug>`, contains a starter
+Grafana dashboard JSON. The dashboard is parameterised by `team.slug`,
+`team.namespace`, and `team.system` (ADR-0028 `platform.system`) via Helm
+values and covers:
+
+| Panel row | Non-ML team | ML team (`ml.enabled: true`) |
+|---|---|---|
+| RED metrics — rate / errors / duration | yes | yes |
+| Pod CPU + memory saturation | yes | yes |
+| Active alert table (namespace-scoped) | yes | yes |
+| ML drift score + model accuracy | no | yes (ADR-0038 metrics) |
+| ML retrain trigger count | no | yes |
+
+### D3 — Alert-rules-as-code (PrometheusRule per team)
+
+A `PrometheusRule` in the team's workload namespace defines two starter alert
+groups:
+
+- `<team-slug>-availability` — fires when HTTP error rate exceeds 5% for 5 min.
+- `<team-slug>-saturation` — fires when CPU or memory saturation exceeds 80% for
+  15 min.
+
+Alert names are prefixed with the team slug in UPPER_CASE to prevent
+`alertname` collisions across teams (e.g. `CHECKOUT_HighErrorRate`).
+
+Teams extend these rules by editing their own `PrometheusRule` in their namespace
+without touching platform objects in the `monitoring` namespace.
+
+### D4 — RBAC: Kubernetes + Grafana folder isolation
+
+**Kubernetes layer:**
+
+- A namespace-scoped `Role` grants the team `get/list/watch/create/update/
+  delete` on `prometheusrules.monitoring.coreos.com` in their workload namespace
+  only.
+- A `RoleBinding` binds it to the team's CI service account (or developer
+  group).
+- The existing Kyverno `require-platform-labels` policy (ADR-0020) validates
+  that `platform.owner` on resources in a namespace matches the namespace's own
+  `platform.owner` label, preventing namespace escape via label forgery.
+
+**Grafana layer:**
+
+- Grafana's folder provisioning sets `permissions` on the team folder:
+  `role: Viewer` for `team-<slug>` org users; `role: Editor` for the team's
+  dedicated service account.
+- Platform dashboards in the `Platform` folder remain read-only for all teams.
+
+### D5 — Self-onboarding via template PR
+
+A team wanting observability creates a PR adding two files under
+`apps/infra/grafana-self-serve/example-teams/<team-slug>/`:
+
+```
+apps/infra/grafana-self-serve/example-teams/<team-slug>/
+├── values.yaml            # team: {name, slug, namespace, system, owner}; ml: {enabled}
+└── argocd-application.yaml
+```
+
+The platform reviewer confirms:
+- `team.system` is a valid ADR-0028 system slug.
+- `team.namespace` is an existing namespace.
+- `team.owner` resolves to a real team slug.
+
+On merge, ArgoCD deploys the chart into the team's namespace, producing:
+- 1 × Grafana folder ConfigMap (sidecar-picked-up).
+- 1 × Grafana dashboard ConfigMap (folder-scoped, sidecar-picked-up).
+- 1 × PrometheusRule (availability + saturation starter rules; + ML groups
+  when `ml.enabled: true`).
+- 1 × Role + RoleBinding (scoped to team namespace).
+
+### Backstage revisit conditions (cite from ADR-0034)
+
+Backstage is explicitly kept deferred until **all three** of the following
+conditions from ADR-0034 are satisfied:
+
+1. **(a) GCP ML platform Phase-3 stable** — WS-A (GKE ML infra), WS-B (ML
+   CI/CD + MLflow), and WS-C (ML observability) fully implemented and operating
+   in production. "Phase-3 stable" means all three workstreams have passed
+   their acceptance criteria and are apply-gated into production.
+2. **(b) Dedicated IDP owner assigned** — a named engineer or team formally
+   assigned to operate the Backstage Node.js app, manage plugin upgrades, and
+   maintain catalog hygiene. No deployment until this is formal.
+3. **(c) ≥3 teams actively onboarded** via golden-path templates from WS-F,
+   validating that the scaffolder template covers real use-cases before
+   committing to the Backstage operational surface.
+
+When all three conditions are met, the template PR pattern established here maps
+1:1 onto a Backstage scaffolder template — no rework required, only UX uplift.
+
+### ADR-0028 label compliance
+
+Every resource generated by the chart carries the five mandatory keys:
+
+| Key (K8s label) | Value |
+|---|---|
+| `platform.system` | `observability` |
+| `platform.component` | `dashboard` / `alert-rules` / `rbac` |
+| `platform.env` | `{{ .Values.team.env }}` (required, no default) |
+| `platform.owner` | `{{ .Values.team.slug }}` |
+| `platform.managed-by` | `argocd` |
+
+## Alternatives considered
+
+### Alternative A: Grafana-Operator `GrafanaFolder` + `GrafanaDashboard` CRDs
+
+Deploy the grafana-operator and use type-safe CRDs for folder and dashboard
+management.
+
+*Not chosen now because:* grafana-operator is not in the current stack. Adding
+it solely for self-serve would introduce a new operator with its own upgrade
+cycle when the existing ConfigMap sidecar pattern is already wired and working.
+**Revisit if the platform adopts grafana-operator for other reasons.**
+
+### Alternative B: Grafana HTTP API push (CI-driven)
+
+A CI job calls `POST /api/folders` and `POST /api/dashboards/db` on PR merge.
+
+*Rejected because:* it requires Grafana admin credentials in CI, breaks the
+GitOps pull-model (ArgoCD cannot reconcile API-side state), and creates drift
+between Git and Grafana. The ConfigMap sidecar is declarative and
+ArgoCD-reconciled.
+
+### Alternative C: Backstage golden-path scaffolder
+
+Use Backstage's scaffolder to generate the template PR automatically.
+
+*Rejected for now because:* Backstage is explicitly on hold (ADR-0034). Even
+when live, the scaffolder output would be identical to the files this ADR
+defines — the scaffolder is a UX layer, not the implementation. When Backstage
+is eventually undeferred, the existing template PR becomes the scaffolder
+template with zero rework.
+
+### Alternative D: Status quo — file platform tickets
+
+Teams continue requesting dashboards and alert rules via platform tickets.
+
+*Rejected because:* this is the problem statement. Centrally-maintained
+dashboards do not scale; platform ticket latency blocks team visibility.
+
+### Alternative E: Per-team Grafana Organization
+
+Create a separate Grafana Org per team.
+
+*Rejected because:* Grafana multi-org is a legacy feature with significant
+overhead (no cross-org dashboards, no shared platform datasource aliases,
+separate session management). Grafana's recommended model since v8 is
+folder-level RBAC within a single org.
+
+## Consequences
+
+### Positive
+
+- **Zero new operators or infrastructure.** Reuses ConfigMap sidecar, ArgoCD,
+  and PrometheusRule CRD — nothing new to operate.
+- **Team autonomy without blast radius.** A broken alert expression in
+  `team-checkout` cannot affect `monitoring`-namespace SLO rules or ML drift
+  alerts.
+- **ML + non-ML unified.** One template, `ml.enabled` flag gates ML panels.
+- **Backstage-ready by construction.** Template PR pattern maps 1:1 onto a
+  Backstage scaffolder template when ADR-0034 conditions are met.
+- **ADR-0028 compliant by construction.** Missing required label values cause
+  `helm lint` to fail.
+
+### Negative
+
+- **Grafana folder RBAC requires manual Grafana user/service-account setup.**
+  Team Grafana users or service accounts must be pre-created in the Grafana
+  org before folder permissions take effect. Documented in the runbook as a
+  one-time step.
+- **Dashboard JSON is Helm-templated.** Go template `{{ }}` syntax in JSON
+  strings requires careful escaping. This is the same tradeoff already present
+  in `configmap-dashboards.yaml`.
+- **Second dashboard requires a PR.** Teams can edit their PrometheusRule
+  freely, but adding a second dashboard still requires a PR. Intentional —
+  keeps Git as the source of truth.
+
+### Risks
+
+- **Namespace escape via label forgery.** A team could label a PrometheusRule
+  with `platform.system: monitoring` to attempt influence over scrape targets.
+  *Mitigated by* the Kyverno `require-platform-labels` policy (ADR-0020),
+  which validates `platform.owner` on resources matches the namespace label.
+- **Grafana sidecar reloads on every ConfigMap change.** High-frequency merges
+  trigger reloads. *Mitigated by* ArgoCD wave `"30"` (after all observability
+  components at wave 10–20) and Grafana's idempotent sidecar behaviour.
+- **Alert name collisions.** Two teams define `HighCPU` in different namespaces;
+  both fire with the same `alertname`. *Mitigated by* prefixing all alert names
+  with `{{ .Values.team.slug | upper }}_`.
+- **Grafana folder permission provisioning not reconciled by ArgoCD.** Grafana
+  folder permissions set via provisioning JSON are applied at sidecar reload but
+  are not subsequently reconciled if changed in the Grafana UI. *Mitigated by*
+  documentation in the runbook: "do not edit folder permissions in the Grafana
+  UI — edit `values.yaml` and raise a PR."
+
+## Implementation notes
+
+This ADR introduces no new operators or cloud resources. The PR adds:
+
+- `apps/infra/grafana-self-serve/` — Helm chart (`apiVersion: v2`,
+  type `application`, wave `"30"`):
+  - `Chart.yaml`, `values.yaml` (required fields, no defaults)
+  - `templates/configmap-dashboard.yaml` — Grafana folder + starter dashboard
+  - `templates/prometheusrule.yaml` — team PrometheusRule (availability +
+    saturation; + ML groups behind `ml.enabled`)
+  - `templates/rbac.yaml` — Role + RoleBinding
+- `apps/infra/grafana-self-serve/example-teams/team-checkout/` — non-ML example
+- `apps/infra/grafana-self-serve/example-teams/team-ml-platform/` — ML example
+- `docs/self-serve-observability.md` — onboarding runbook
+- This ADR + `docs/adrs/README.md` update (0039 row)
+
+**Validation:** `helm lint` + `helm template` on the chart; `yamllint` on all
+new YAML (`.yamllint.yml` config, max 200 lines warning); `kubeconform` on
+rendered PrometheusRule and RBAC manifests.
+
+**ArgoCD Application shape per team:**
+
+```yaml
+source:
+  path: apps/infra/grafana-self-serve
+  helm:
+    valueFiles:
+    - values.yaml
+    - example-teams/<team-slug>/values.yaml
+destination:
+  namespace: <team.namespace>
+syncPolicy:
+  automated:
+    prune: true
+    selfHeal: true
+  syncOptions:
+  - CreateNamespace=false
+```
+
+**Rollback:** deleting a team's ArgoCD Application removes their dashboard
+ConfigMap, PrometheusRule, and RBAC from the cluster. No side effects on
+platform dashboards or other teams.
+
+**Effort:** S — chart skeleton + two example teams + runbook. No new infra.
+
+## Revisit trigger
+
+- **When all three ADR-0034 revisit conditions are met**, promote the template
+  PR pattern to a Backstage scaffolder template and link from ADR-0034 Phase 1
+  scope.
+- **If the platform adopts grafana-operator**, migrate ConfigMap-based folder
+  provisioning to `GrafanaFolder`/`GrafanaDashboard` CRDs and update this ADR.
+- **If >10 teams onboard**, evaluate an ApplicationSet generator over the
+  `example-teams/` directory instead of per-team ArgoCD Applications.
+
+## References
+
+- Grafana dashboard provisioning (ConfigMap sidecar):
+  <https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards>
+- Grafana folder RBAC:
+  <https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/>
+- PrometheusRule CRD (prometheus-operator):
+  <https://prometheus-operator.dev/docs/user-guides/alerting/>
+- ADR-0034 (Backstage deferred — revisit criteria):
+  [0034-backstage-idp.md](0034-backstage-idp.md)
+- ADR-0028 (unified platform taxonomy — mandatory):
+  [0028-unified-platform-tagging-and-labeling-taxonomy.md](0028-unified-platform-tagging-and-labeling-taxonomy.md)
+- ADR-0026 (observability target architecture):
+  [0026-observability-target-architecture.md](0026-observability-target-architecture.md)
+- ADR-0038 (ML observability + drift metrics — feeds ML panel row):
+  [0038-ml-observability-drift.md](0038-ml-observability-drift.md)
+- ADR-0020 (Kyverno policy engine — label validation):
+  [0020-kyverno-and-vap-policy-engine.md](0020-kyverno-and-vap-policy-engine.md)
+- In-repo: `apps/infra/observability/grafana-dashboards/` (ConfigMap sidecar
+  pattern reference); `apps/infra/observability/prometheus-stack/templates/
+  prometheusrules/slo-rules.yaml` (PrometheusRule pattern reference)
+- GCP ML Platform implementation plan §4 WS-D:
+  `docs/gcp-ml-platform/IMPLEMENTATION_PLAN.md`
+
+---
+*Planning-only ADR — proposed, not yet implemented in platform-design.
+WS-D "System & self-serve observability + team enablement"; implementation
+apply-gated. Doc-verified 2026-06-10.*

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -82,6 +82,7 @@ decision.
 | [0036](0036-gke-ml-infra-parity-multiregion.md) | GKE ML-infra parity + multi-region GKE + GCP cost guardrail (GPU Operator, DCGM, Volcano, billing-budget) | Accepted | pending | WS-A of GCP ML platform plan; design 2026-06-10 |
 | [0037](0037-ml-cicd-pipeline-mlflow.md) | ML CI/CD pipeline — Airflow orchestrator + MLflow registry + GCS artifact store | Proposed | pending | WS-B of GCP ML platform plan; design 2026-06-10 |
 | [0038](0038-ml-observability-drift.md) | ML observability — drift detection, accuracy monitoring, and retrain trigger (Evidently + whylogs, Prometheus-native) | Proposed | pending | WS-C of GCP ML platform plan; design 2026-06-10 |
+| [0039](0039-self-serve-observability.md) | Self-serve observability — templated Grafana folders, starter dashboards, and alert-rules-as-code (Backstage deferred, ADR-0034) | Proposed | pending | WS-D of GCP ML platform plan; design 2026-06-10 |
 
 
 

--- a/docs/self-serve-observability.md
+++ b/docs/self-serve-observability.md
@@ -1,0 +1,281 @@
+# Self-Serve Observability — Onboarding Runbook
+
+> **ADR reference:** [ADR-0039](adrs/0039-self-serve-observability.md)
+> **Scope:** WS-D of the GCP ML Platform plan.
+> **Backstage:** explicitly deferred — see ADR-0034 and the revisit conditions
+> in ADR-0039 §D5.
+
+This runbook explains how a team gets a scoped Grafana folder, a starter
+dashboard, and a PrometheusRule in their workload namespace via a template PR.
+No platform ticket required.
+
+---
+
+## What you get
+
+After your PR merges, ArgoCD deploys four resources:
+
+| Resource | Kind | Namespace |
+|---|---|---|
+| `<team-slug>-grafana-folder` | ConfigMap | `observability` (Grafana sidecar picks it up) |
+| `<team-slug>-grafana-dashboard` | ConfigMap | `observability` (folder-scoped starter dashboard) |
+| `<team-slug>-alerts` | PrometheusRule | Your workload namespace |
+| `<team-slug>-prometheusrule-manager` | Role + RoleBinding | Your workload namespace |
+
+The Grafana folder appears at **Dashboards > team-`<your-slug>`**. Only Grafana
+users assigned to your team's folder can browse it. The PrometheusRule fires
+through the existing Alertmanager path.
+
+---
+
+## Prerequisites
+
+Before raising a PR:
+
+1. **Namespace exists.** `CreateNamespace=false` — your workload namespace must
+   already exist. If it does not, bootstrap it in a separate PR with ADR-0028
+   labels on the Namespace object.
+
+2. **`platform:system` value registered.** `team.system` must be a valid ADR-0028
+   system slug already in use by your workloads. If it is new, define it in a
+   separate PR first.
+
+3. **(ML teams only) ADR-0038 ml-monitoring stack deployed.** ML panel rows
+   query `ml_monitoring_*` metrics from `apps/infra/ml-monitoring/`. If that
+   stack is not yet deployed, set `ml.enabled: false` initially and flip to
+   `true` once it is.
+
+4. **(Optional) Grafana service account pre-created.** If you want folder-level
+   Editor access for a team service account, create it in the Grafana UI first,
+   then set `team.grafanaServiceAccount` to its name in `values.yaml`. Leave
+   the field empty to skip.
+
+---
+
+## Step-by-step: raise a template PR
+
+### 1. Copy the example directory
+
+```bash
+cp -r apps/infra/grafana-self-serve/example-teams/team-checkout \
+       apps/infra/grafana-self-serve/example-teams/<your-team-slug>
+```
+
+### 2. Edit `values.yaml`
+
+Fill in every required field in
+`apps/infra/grafana-self-serve/example-teams/<your-team-slug>/values.yaml`:
+
+```yaml
+team:
+  name: "Your Team Name"
+  slug: "team-your-slug"          # lowercase, hyphens only
+  namespace: "your-namespace"     # must already exist
+  system: "your-system"           # ADR-0028 platform:system value
+  owner: "team-your-slug"
+  env: "production"               # production | staging | dev | sandbox
+  grafanaServiceAccount: ""       # optional — leave empty to skip
+  ciServiceAccount: "your-ci-sa"  # optional — leave empty to skip RBAC
+```
+
+ML teams additionally set:
+
+```yaml
+ml:
+  enabled: true
+  modelName: "your-model-name"   # optional filter
+  tenant: "your-tenant"          # optional filter
+```
+
+### 3. Edit `argocd-application.yaml`
+
+Replace all `team-checkout` references with your slug:
+
+```yaml
+metadata:
+  name: grafana-self-serve-<your-team-slug>
+  labels:
+    platform.owner: "<your-team-slug>"
+spec:
+  source:
+    helm:
+      valueFiles:
+        - values.yaml
+        - example-teams/<your-team-slug>/values.yaml
+  destination:
+    namespace: <your-namespace>
+```
+
+### 4. Validate locally (required before PR)
+
+```bash
+# Lint — checks template syntax + required value presence
+helm lint apps/infra/grafana-self-serve \
+  -f apps/infra/grafana-self-serve/example-teams/<your-team-slug>/values.yaml
+
+# Template — render for visual inspection
+helm template grafana-self-serve apps/infra/grafana-self-serve \
+  -f apps/infra/grafana-self-serve/example-teams/<your-team-slug>/values.yaml \
+  --namespace <your-namespace>
+
+# yamllint — style check (max 200 chars/line per .yamllint.yml)
+yamllint -c .yamllint.yml \
+  apps/infra/grafana-self-serve/example-teams/<your-team-slug>/
+
+# kubeconform — schema validation
+helm template grafana-self-serve apps/infra/grafana-self-serve \
+  -f apps/infra/grafana-self-serve/example-teams/<your-team-slug>/values.yaml \
+  --namespace <your-namespace> \
+  | kubeconform -strict -ignore-missing-schemas -
+```
+
+A clean run outputs:
+```
+==> Linting apps/infra/grafana-self-serve
+1 chart(s) linted, 0 chart(s) failed
+```
+
+Fix all errors before raising the PR. CI runs the same checks.
+
+### 5. Raise the PR
+
+Suggested title: `feat: add self-serve observability for <your-team-slug>`
+
+Include:
+- Team slug and workload namespace.
+- Confirmation the namespace pre-exists.
+- `ml.enabled` status and, if true, which ADR-0038 deployment it targets.
+- Paste the `helm lint` output (or "CI green").
+
+### 6. Platform review checklist
+
+The reviewer confirms:
+
+- [ ] `team.system` is a valid ADR-0028 system slug.
+- [ ] `team.namespace` exists in the cluster.
+- [ ] `team.owner` matches a real team slug.
+- [ ] `team.env` is one of `production`, `staging`, `dev`, `sandbox`.
+- [ ] `helm lint` passes with the team's `values.yaml`.
+- [ ] No resources target the `monitoring` namespace.
+- [ ] (ML) `ml.enabled: true` only if `ml-monitoring` is deployed and metrics
+  are flowing.
+
+### 7. After merge
+
+ArgoCD syncs at wave 30. Within ~60 seconds:
+
+- Grafana sidecar reloads — dashboard appears at **Dashboards > team-`<slug>`**.
+- PrometheusRule loads — verify:
+  `kubectl get prometheusrule -n <your-namespace>`
+- RBAC Role + RoleBinding created (if `ciServiceAccount` was set).
+
+---
+
+## What the team owns vs what the platform owns
+
+| Resource | Owner | How to change |
+|---|---|---|
+| `<team-slug>-grafana-folder` ConfigMap | Platform (via template) | Edit `values.yaml`, raise PR |
+| `<team-slug>-grafana-dashboard` ConfigMap | Platform (via template) | Edit `values.yaml`, raise PR |
+| `<team-slug>-alerts` PrometheusRule | **Team** | Edit directly in your namespace (no PR needed for threshold changes); for structural changes raise a PR |
+| Platform dashboards (`cluster-overview` etc.) | Platform only | Do not edit |
+| Platform SLO rules in `monitoring` namespace | Platform only | Do not edit |
+
+### Adding a second dashboard
+
+Raise a PR adding a new ConfigMap in your namespace (or an additional values
+key if the template is extended). The reviewer confirms it carries ADR-0028
+labels and targets your team folder only.
+
+### Modifying alert thresholds
+
+Edit `alerts.*` in your `values.yaml` and raise a PR. Alternatively, if
+`ciServiceAccount` is set, your CI service account can `kubectl patch` the
+`PrometheusRule` directly for urgent threshold changes — bring Git back into
+sync with your next PR.
+
+---
+
+## Grafana folder access
+
+The starter dashboard is in folder `team-<your-slug>`. To grant team members
+access:
+
+1. In Grafana: **Administration > Teams** — create or use a team named
+   `team-<your-slug>` and add members.
+2. **Dashboards > Folders > team-`<your-slug>`** > **Folder settings** >
+   **Permissions** — add the Grafana team with `Viewer` or `Editor`.
+
+If `team.grafanaServiceAccount` was set, folder permissions for that service
+account are provisioned automatically via the folder ConfigMap on sidecar reload.
+
+Do not edit folder permissions in the Grafana UI if they were set via
+provisioning — they will be overwritten on the next sidecar reload. Manage
+them in `values.yaml`.
+
+---
+
+## ML teams: dashboard panel details
+
+When `ml.enabled: true`, the starter dashboard gains a third row:
+
+| Panel | PromQL metric | Source |
+|---|---|---|
+| ML Dataset Drift Score | `ml_monitoring_dataset_drift_score` | ADR-0038 whylogs profiler |
+| Model Accuracy | `ml_monitoring_model_accuracy` | ADR-0038 Evidently drift-exporter |
+| Retrain Triggers (per hour) | `ml_monitoring_retrain_triggers_total` | ADR-0038 retrain-trigger proxy |
+
+All three panels respect `ml.modelName` and `ml.tenant` filters. Leave empty
+to show all models/tenants in your namespace.
+
+The PrometheusRule gains a third group `<team-slug>-ml-observability` with:
+
+- `<PREFIX>_MLDriftDetected` (warning) — fires when drift score exceeds threshold.
+- `<PREFIX>_MLAccuracyDegraded` (critical) — fires when accuracy drops below
+  threshold.
+
+These fire through team-labelled Alertmanager routing alongside — not instead
+of — the platform-level ML alerts in `apps/infra/ml-monitoring/` (ADR-0038).
+
+---
+
+## Troubleshooting
+
+### Dashboard not appearing in Grafana
+
+1. `kubectl get configmap -n observability | grep <team-slug>`
+2. Check Grafana sidecar logs:
+   `kubectl logs -n observability deployment/grafana -c grafana-sc-dashboard`
+3. Confirm label: `kubectl get configmap -n observability <team-slug>-grafana-dashboard -o yaml | grep grafana_dashboard`
+
+### PrometheusRule not loading
+
+1. `kubectl get prometheusrule -n <your-namespace>`
+2. Check prometheus-operator:
+   `kubectl logs -n monitoring deployment/prometheus-operator | grep <team-slug>`
+3. Confirm label: `kubectl get prometheusrule -n <your-namespace> <team-slug>-alerts -o yaml | grep "prometheus: kube-prometheus"`
+
+### ArgoCD Application stuck in OutOfSync
+
+Check wave ordering — wave 30 waits for prometheus-stack (wave 10) and
+ml-monitoring (wave 20) to complete. Run `helm template ... | kubeconform` to
+rule out schema errors.
+
+### ML panels show "No data"
+
+1. Confirm `ml.enabled: true` and `apps/infra/ml-monitoring/` is deployed.
+2. Explore in Grafana: `ml_monitoring_dataset_drift_score{namespace="<ns>"}`.
+3. Verify `ml.modelName` and `ml.tenant` match actual metric label values
+   (case-sensitive).
+
+---
+
+## Reference
+
+- [ADR-0039](adrs/0039-self-serve-observability.md) — decision
+- [ADR-0034](adrs/0034-backstage-idp.md) — Backstage deferred (revisit criteria)
+- [ADR-0028](adrs/0028-unified-platform-tagging-and-labeling-taxonomy.md) — mandatory platform taxonomy
+- [ADR-0038](adrs/0038-ml-observability-drift.md) — ML observability (source of ML panel metrics)
+- [ADR-0026](adrs/0026-observability-target-architecture.md) — observability target architecture
+- Chart source: `apps/infra/grafana-self-serve/`
+- Example teams: `apps/infra/grafana-self-serve/example-teams/`


### PR DESCRIPTION
## WS-D — Self-serve observability + team enablement (Phase 3)

Implements **WS-D** of the GCP ML Platform plan. **Plan/validate-only**.

### ADR-0039
Lightweight **templated Grafana self-serve** (ConfigMap-sidecar pattern, same mechanism as `grafana-dashboards` — zero new operators). **Backstage stays DEFERRED** per ADR-0034 + its 3 revisit conditions (GCP ML Phase-3 stable, dedicated IDP owner, ≥3 teams onboarded); the template-PR pattern maps 1:1 onto a future Backstage scaffolder.

### Delivered
- `apps/infra/grafana-self-serve/` — per-team Grafana folder + starter dashboard + alert-rules-as-code (PrometheusRule) + RBAC, parameterized by team/`platform:system`. ML + non-ML unified via `ml.enabled`; per-team alert-name prefix prevents cross-team collisions; team rules isolated to the team namespace.
- 2 example teams (`team-checkout`, `team-ml-platform`).
- `docs/self-serve-observability.md` — team onboarding runbook (what the team owns vs the platform owns).

### Validation
`helm lint` 0 failures (both teams); `kubeconform -strict` PASS; `yamllint` 0 errors; dashboard JSON valid. `platform:system=observability` (ADR-0028).

> Draft, apply-gated. Independent of WS-A/B/C. Pairs with WS-F golden paths.

Part of the GCP ML Platform plan · ADR-0039