### PR TITLE
feat(gcp-ml): WS-E SOC2 posture + GCP policy parity + on-call (ADR-0040)

### DIFF
--- a/catalog/units/gcp-org-policy/terragrunt.hcl
+++ b/catalog/units/gcp-org-policy/terragrunt.hcl
@@ -1,0 +1,74 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GCP Organization Policy — Catalog Unit (WS-E — security / compliance)
+# ---------------------------------------------------------------------------------------------------------------------
+# Binds the GCP org-policy constraint bundle (public-IP deny, CMEK enforcement,
+# SA-key-creation deny, OS Login, Cloud SQL public-IP deny, GCS uniform/public-access,
+# resource-location residency) to a resource-manager node — giving the GCP estate
+# guardrail parity with the AWS scps + iam-baseline controls.
+#
+# No cluster dependency — this is a pure GCP resource-manager control-plane resource.
+# Apply is GATED: an org-policy change is org-wide; never auto-apply (ADR-0040).
+#
+# Requires project.hcl with: org_policy_parent (organizations/ID | folders/ID |
+#   projects/ID). If org_policy_parent is unset it falls back to scoping the policies
+#   to the unit's own project_id (projects/<project_id>), the safe least-blast-radius
+#   default for a non-prod sandbox.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/gcp-org-policy"
+}
+
+locals {
+  project_vars = read_terragrunt_config(find_in_parent_folders("project.hcl"))
+
+  environment = local.project_vars.locals.environment
+
+  # Prefer an explicit org/folder parent when project.hcl provides one; otherwise
+  # scope to this project only (least blast radius). org-policy binds to a
+  # resource-manager node, not a billing account.
+  org_policy_parent = try(
+    local.project_vars.locals.org_policy_parent,
+    "projects/${local.project_vars.locals.project_id}",
+  )
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE INPUTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  parent = local.org_policy_parent
+
+  # Deny-by-default posture. All constraints on; tune per-environment below.
+  restrict_vm_external_ip          = true
+  disable_sa_key_creation          = true
+  disable_sa_key_upload            = true
+  require_os_login                 = true
+  restrict_public_ip_cloudsql      = true
+  uniform_bucket_level_access      = true
+  enforce_public_access_prevention = true
+
+  # CMEK mandatory for the services the ML platform actually uses (GCS artifact store,
+  # Cloud SQL MLflow backend, Compute/GKE GPU nodes, BigQuery feature data).
+  enforce_cmek = [
+    "bigquery.googleapis.com",
+    "compute.googleapis.com",
+    "storage.googleapis.com",
+    "sqladmin.googleapis.com",
+  ]
+
+  # Data-residency: pin to US + EU location groups (mirrors AWS scps restrict_regions).
+  # Tighten per data-classification before prod.
+  allowed_resource_locations = [
+    "in:us-locations",
+    "in:eu-locations",
+  ]
+
+  # ADR-0028 GCP-plane labels (underscore keys; system = security for WS-E).
+  # Recorded for provenance — org-policy resources are not labelable.
+  labels = {
+    platform_env   = local.environment
+    platform_owner = "team-sec"
+  }
+}

--- a/docs/adrs/0040-soc-posture-and-oncall.md
+++ b/docs/adrs/0040-soc-posture-and-oncall.md
@@ -1,0 +1,311 @@
+# ADR-0040: SOC2 posture (GCP policy parity, cross-cloud WIF, control-to-evidence mapping) + ML on-call
+
+- Status: **Proposed** — plan/validate-only; implementation apply-gated.
+- platform-design status: **pending** — the GCP org-policy module
+  (`gcp-org-policy`) and the compliance/runbook docs are introduced by this ADR; no
+  org-policy is applied and no GCP↔AWS Workload Identity Federation is provisioned
+  until the apply gate is cleared.
+- Date: 2026-06-10
+- Authors: platform-team (security-expert), compliance, SRE
+- Related issues: WS-E "Security posture & SOC compliance + on-call" (GCP ML Platform
+  plan); plan readiness row 6 ("SOC compliance + on-call", partial); ADR-0028
+  (taxonomy), ADR-0038 (drift→PagerDuty route), ADR-0037 (MLflow/Cloud SQL/GCS),
+  ADR-0036 (multi-region GKE), ADR-0018 (Pod Identity / IRSA).
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+The platform already runs a strong security control set, but it is **AWS- and
+K8s-plane heavy** and has **never been mapped to an audit framework**. The plan's
+readiness assessment (row 6) records the gap precisely: on-call exists (PagerDuty +
+Alertmanager + runbooks), the controls exist (Kyverno + VAP, Tetragon, Gatekeeper,
+GuardDuty, `iam-baseline`, SCPs, `secret-rotation`, cosign/syft signing), but there
+is **no SOC2 control-mapping / evidence-collection / posture report**, and **GCP-side
+policy parity is thin**.
+
+Four forces shape this ADR:
+
+1. **GCP lacks a deny-list guardrail plane.** On AWS, SCPs (`terraform/modules/scps`)
+   plus `iam-baseline` give an organization-wide deny layer: deny public S3, require
+   EBS encryption, restrict regions, no root usage. On GCP there is **no equivalent
+   org-policy layer in-repo** — a GCP project today could expose public IPs, create
+   public buckets, mint long-lived service-account keys, or create unencrypted
+   resources, with nothing stopping it.
+
+2. **Cross-cloud identity is still key-based.** Per-pod GKE Workload Identity is
+   **already done** in `gcp-gke-gpu-nodepools`
+   (`workload_metadata_config { mode = "GKE_METADATA" }`) and is **not re-opened
+   here.** What is missing is **cross-cloud federation**: a GCP workload that needs an
+   AWS resource (or vice-versa — e.g. the GCP ML platform reading an S3 dataset, or an
+   AWS job writing to the GCS artifact store from ADR-0037) has no keyless path and
+   would fall back to a static access key. That is exactly the static credential the
+   AWS `iam-baseline` posture forbids.
+
+3. **No auditor-facing control map exists.** A SOC2 (or ISO/customer-security) review
+   asks "which control satisfies CC6.1, and where is the evidence?" Today the answer
+   lives in the heads of the platform team. There is no artifact tying TSC criteria to
+   the modules/apps/actions that satisfy them, and no statement of what is still a gap.
+
+4. **On-call has no ML track and no tested rotation.** ADR-0038 explicitly deferred a
+   **dedicated ML PagerDuty service** to "the follow-up recommended by WS-E," and
+   there are **no ML-incident runbooks** (drift, training-pipeline, serving). The
+   rotation is informal.
+
+[ADR-0028](0028-unified-platform-tagging-and-labeling-taxonomy.md) (the unified
+`platform:system` / `platform.system` taxonomy) is mandatory on everything introduced
+here; `system = security` for the org-policy/posture plane and `compliance` is used as
+the documentation domain. GCP label keys use the underscore spelling
+(`platform_system`) because GCP labels disallow `:`.
+
+## Decision
+
+Make SOC2-style compliance **demonstrable** and complete the **on-call posture on
+GCP**, via four sub-decisions. All are **plan/validate-only**; nothing applies without
+the apply gate, and org-policy / WIF changes additionally require explicit
+blast-radius review (they are organization-wide and identity-critical).
+
+### D1 — GCP policy parity via org-policy constraints (`gcp-org-policy` module)
+
+Introduce `terraform/modules/gcp-org-policy` (+ catalog unit + `*.tftest.hcl`),
+binding a bundle of **GCP Organization Policy constraints** to a resource-manager node
+(org / folder / project) using the **modern `google_org_policy_policy` resource**
+(provider `google ~> 6`, the v2 Org Policy API — **not** the deprecated
+`google_organization_policy`). The bundle maps onto the AWS deny-list controls:
+
+| AWS control (in-repo) | GCP parity (this module) | SOC2 |
+|---|---|---|
+| `scps` deny_s3_public + `iam-baseline` S3 PAB | `storage.publicAccessPrevention` | CC6.6 |
+| `iam-baseline` EBS-encryption-by-default | `gcp.restrictNonCmekServices` (CMEK mandatory) | CC6.1 |
+| `scps` restrict_regions | `gcp.resourceLocations` (data residency) | C1.1 |
+| `iam-baseline` MFA / no static creds | `iam.disableServiceAccountKeyCreation` + `…Upload` | CC6.1/CC6.3 |
+| (no AWS analog — GCP hardening) | `compute.vmExternalIpAccess` (deny public IPs), `compute.requireOsLogin`, `sql.restrictPublicIp`, `storage.uniformBucketLevelAccess` | CC6.1/CC6.6 |
+
+The module is **deny-by-default** (every constraint on), with per-constraint toggles
+for staged rollout and an allow-list for `vmExternalIpAccess` (e.g. a NAT/egress
+instance). Boolean constraints set `spec.rules[].enforce = "TRUE"`; list constraints
+(`restrictNonCmekServices`, `resourceLocations`, `vmExternalIpAccess`) use
+`values { denied_values | allowed_values }` / `deny_all`.
+
+Chosen as the **GCP deny-list plane** because org-policy is the *only* GCP control that
+is **preventive and hierarchy-inherited** the way SCPs are on AWS — it blocks the
+violating API call regardless of IAM grants, giving true parity with the SCP posture
+rather than detect-after-the-fact.
+
+### D2 — Cross-cloud Workload Identity Federation (GCP WIF ↔ AWS IAM), keyless
+
+Adopt **Workload Identity Federation** for cross-cloud access in **both directions**,
+eliminating static cross-cloud credentials:
+
+- **AWS → GCP:** a `google_iam_workload_identity_pool` + AWS provider
+  (`google_iam_workload_identity_pool_provider` with an `aws { account_id }` block).
+  An AWS role's STS identity is exchanged for short-lived GCP credentials via
+  `roles/iam.workloadIdentityUser`, with **attribute mapping** pinning
+  `google.subject = assertion.arn` and `attribute.aws_role`. Google is a **built-in
+  OIDC provider in AWS**, so no `aws_iam_openid_connect_provider` is needed.
+- **GCP → AWS:** the GCP workload's Google identity is presented to an **AWS IAM role
+  whose trust policy federates `accounts.google.com`** (web-identity), again keyless.
+
+This composes with — and depends on — **D1's `iam.disableServiceAccountKeyCreation`**:
+once SA keys are denied org-wide, WIF is the *only* cross-cloud path, which is the
+intended forcing function. The actual pool/provider Terraform is a **follow-up module**
+(`gcp-wif` or folded into `iam-baseline`'s GCP analog) and is **not built in this WS**;
+this ADR ratifies the **decision and the keyless contract**, and D1 ships the
+constraint that makes it mandatory.
+
+### D3 — SOC2 control-to-evidence mapping + repo-anchored evidence collection
+
+Publish [`docs/compliance/soc2-control-matrix.md`](../compliance/soc2-control-matrix.md):
+a matrix from the **SOC2 Trust Services Criteria (CC1–CC9, plus A/C/PI where in
+scope)** to the **existing in-repo controls** that satisfy each criterion (Kyverno,
+Gatekeeper, Tetragon, `iam-baseline`, `scps`, `secret-rotation`, GuardDuty/SecurityHub,
+CloudTrail/Config, cosign/syft supply chain), with each row's **plane**, **evidence
+signal**, and **status** (`evidenced` / `partial` / `gap` / `inherited`), and an
+explicit **still-gap** list.
+
+**Evidence-collection approach: pull-based and repo-anchored.** No separate GRC tool is
+introduced. An auditor request resolves to (1) the ADR documenting the decision, (2)
+the module/app/action implementing it, (3) the `*.tftest.hcl` or CI run proving
+behavior, and (4) the runtime signal (Config evaluation, GuardDuty finding, admission
+deny, **org-policy deny**, fired alert) — all attributable on the ADR-0028 `$system`
+axis. The repo + observability stack **is** the evidence store.
+
+### D4 — On-call rotation formalization + ML-incident runbooks
+
+Publish [`docs/runbooks/ml-incident-runbook.md`](../runbooks/ml-incident-runbook.md)
+(model drift/accuracy, training-pipeline failure, serving outage — each with a triage
+decision tree, mitigation, and recovery) and
+[`docs/runbooks/oncall-rotation-escalation.md`](../runbooks/oncall-rotation-escalation.md)
+(two rotations — `platform-oncall` + `ml-platform-oncall` — L1→L3 escalation with
+per-severity timers, and a quarterly **tabletop**).
+
+These **tie into the existing PagerDuty/Alertmanager wiring**, not a new one: the ML
+runbook routes off the ADR-0038 `ml-drift-pagerduty` / `ml-retrain-webhook` receivers
+and the existing `alertmanager-pagerduty-secret` (ESO-sourced, ADR-0008). The
+`ml-platform-oncall` PagerDuty **service** is the formalization of the dedicated ML
+routing key ADR-0038 D3 deferred to WS-E; until provisioned, ML alerts fall back to the
+shared platform receiver.
+
+### D5 — ADR-0028 label compliance (org-policy plane)
+
+`google_org_policy_policy` is **not a labelable resource** (it is an org-policy
+binding, not a billable resource), exactly as `google_billing_budget` is not in
+`gcp-billing-budget`. The `gcp-org-policy` module therefore carries the ADR-0028
+taxonomy on a `labels` input (GCP underscore keys), defaults
+`platform_system = security` / `platform_component = org-policy` /
+`platform_managed_by = terragrunt`, and exposes it on the `platform_labels` output for
+**provenance** — a reviewer greps for it and the `*.tftest.hcl` asserts it. It is not
+applied to a GCP resource because none in this module accepts labels. K8s/doc artifacts
+use the dotted form (`platform.system`).
+
+## Alternatives considered
+
+### Alternative A: GKE Policy Controller / Gatekeeper constraint bundle on GKE instead of org-policy
+
+The plan offered org-policy **or** a GKE Gatekeeper constraint bundle under
+`apps/infra/policy-controller/`. Rejected as the *primary* deliverable because
+Gatekeeper only governs **Kubernetes admission** — it cannot stop a public IP on a
+Compute VM, a public GCS bucket, a long-lived SA key, or a non-CMEK Cloud SQL
+instance, all of which are **GCP-resource-level** concerns and exactly the SCP-parity
+gap. Org-policy is the correct preventive plane for those. The GKE Gatekeeper bundle
+remains the right tool for *workload* admission and is **parity-designed** here (it
+mirrors the existing EKS `apps/infra/gatekeeper` constraints) but its in-cluster
+delivery to GKE is a tracked **follow-up**, recorded as a `gap` in the matrix (CC5.2).
+
+### Alternative B: deprecated `google_organization_policy` (v1 API)
+
+Rejected. The v1 resource is superseded by `google_org_policy_policy` (v2 Org Policy
+API), which supports the richer `spec.rules` model (conditions, `deny_all`,
+merged inheritance) and is the provider's forward path. Using the deprecated resource
+would incur a near-term migration.
+
+### Alternative C: static cross-cloud access keys (or per-workload secrets via ESO)
+
+Rejected for cross-cloud auth. Even ESO-managed static keys are long-lived secrets that
+must be rotated and can leak; they contradict the `iam-baseline` no-static-creds
+posture. WIF is keyless and short-lived. ESO remains correct for *third-party* secrets
+(Slack/PagerDuty tokens), not for cloud-to-cloud identity.
+
+### Alternative D: adopt a dedicated GRC/compliance SaaS for evidence
+
+Rejected (YAGNI for this stage). A GRC tool adds a second source of truth that drifts
+from the repo. The repo-anchored, pull-based evidence model (D3) keeps evidence next to
+the control and versioned with it. A GRC tool can later *index* this matrix without
+owning it.
+
+### Alternative E: status quo (no GCP guardrails, no control map)
+
+Rejected — it is the exact readiness gap (plan row 6) this WS exists to close, and it
+leaves the GCP estate able to create public/unencrypted/key-based resources with no
+preventive control and no audit story.
+
+## Consequences
+
+### Positive
+
+- **GCP gains a real preventive deny-list plane** at parity with AWS SCPs +
+  `iam-baseline` — public IPs, public buckets, public Cloud SQL, non-CMEK resources,
+  and long-lived SA keys are all blocked at the API.
+- **Cross-cloud identity becomes keyless** (decision ratified; D1 makes it mandatory),
+  removing the last static-credential path between clouds.
+- **The platform is auditable**: a single matrix answers SOC2 TSC questions with repo
+  evidence and an honest gap list.
+- **On-call covers ML** with tested runbooks and a formal escalation policy, closing
+  ADR-0038's deferred ML-PagerDuty follow-up.
+
+### Negative
+
+- **Org-policy is high-blast-radius.** A wrong constraint can block legitimate
+  provisioning org-wide (e.g. CMEK on a service with no key, or `resourceLocations`
+  too tight). Mitigated by per-constraint toggles, an allow-list for external IPs, the
+  apply gate, and staged rollout (project → folder → org).
+- **WIF setup is non-trivial** (attribute mapping, trust policies both directions) and
+  is deferred to a follow-up module — this ADR ships the decision + the forcing
+  constraint, not the pool.
+- **The matrix must be maintained.** It is only useful if kept current as controls
+  change; it is wired into the ADR/PR process (a new control adds a matrix row).
+
+### Risks
+
+- **R1 — org-policy lockout.** Applying `disableServiceAccountKeyCreation` before WIF
+  exists could strand a workload that still needs a key. *Mitigation:* sequence WIF
+  (D2) before/with that constraint in prod; non-prod can enforce immediately since the
+  ML platform uses Workload Identity already.
+- **R2 — false sense of compliance.** A matrix is not an audit. *Mitigation:* statuses
+  are honest (`partial`/`gap` are first-class), and the still-gap list is explicit
+  (GCP SCC/Config, GCP audit-log export, GKE admission delivery, data-disposal proof).
+- **R3 — drift between matrix and reality.** *Mitigation:* evidence is repo-anchored
+  (D3) so the matrix points at code that CI already validates; a stale row points at a
+  removed module and is caught in review.
+- **R4 — CMEK/locations breaking ADR-0037 GCS/Cloud SQL.** *Mitigation:* the catalog
+  unit's `enforce_cmek` already lists `storage`/`sqladmin`, so those services are
+  provisioned CMEK-first by design; `resourceLocations` defaults to US+EU groups that
+  cover the planned regions (ADR-0036).
+
+## Implementation notes
+
+### Files created by this ADR
+
+- `terraform/modules/gcp-org-policy/` — `versions.tf`, `variables.tf`, `main.tf`,
+  `outputs.tf`, `gcp-org-policy.tftest.hcl` (mocked-provider plan tests).
+- `catalog/units/gcp-org-policy/terragrunt.hcl` — per-project/folder/org consumption;
+  falls back to `projects/<project_id>` (least blast radius) when no
+  `org_policy_parent` is set in `project.hcl`.
+- `docs/compliance/soc2-control-matrix.md` — the control-to-evidence matrix (D3).
+- `docs/runbooks/ml-incident-runbook.md` + `docs/runbooks/oncall-rotation-escalation.md`
+  (D4).
+- `docs/adrs/0040-soc-posture-and-oncall.md` (this file) + the README index row.
+
+### Validation performed (plan/validate-only)
+
+- `terraform fmt`, `terraform init -backend=false`, `terraform validate`,
+  `terraform test` (mocked `google` provider) on `gcp-org-policy` — **11/11 tests
+  pass**.
+- `terragrunt hcl fmt --check` on the catalog unit — clean.
+- `yamllint` on any YAML; markdown link sanity on the docs.
+- **No `terraform apply`, no org-policy applied, no WIF pool created.**
+
+### Out of band / follow-ups (tracked as matrix gaps)
+
+- `gcp-wif` pool/provider module (D2 implementation).
+- GKE Gatekeeper constraint-bundle delivery to GKE clusters (CC5.2 gap).
+- GCP Security Command Center / Config-equivalent continuous evaluation (CC4.1 gap).
+- GCP Cloud Audit Logs export + log-based metrics (audit-logging gap).
+- `ml-platform-oncall` PagerDuty service provisioning (expected first-tabletop action
+  item).
+
+### Rollback
+
+Org-policy and the docs are additive. To roll back, set the relevant module toggles to
+`false` (removes the policy bindings) or detach the catalog unit; no data is destroyed.
+WIF is not yet applied, so there is nothing to roll back there.
+
+## Revisit trigger
+
+Revisit this ADR when: (a) the `gcp-wif` module is built (fold the pool/provider
+contract back in), (b) GCP SCC / Config parity lands (flip CC4.1 from `gap`), (c) the
+GKE Gatekeeper bundle is delivered (flip CC5.2), or (d) a real SOC2 audit scopes
+additional TSC categories (A/C/PI) requiring new matrix rows.
+
+## References
+
+- [SOC2 control matrix](../compliance/soc2-control-matrix.md) (D3)
+- [ML incident runbook](../runbooks/ml-incident-runbook.md) +
+  [on-call rotation & escalation](../runbooks/oncall-rotation-escalation.md) (D4)
+- [ADR-0028](0028-unified-platform-tagging-and-labeling-taxonomy.md) — taxonomy
+- [ADR-0038](0038-ml-observability-drift.md) — drift→Alertmanager→PagerDuty (ML
+  PagerDuty follow-up deferred to WS-E)
+- [ADR-0037](0037-ml-cicd-pipeline-mlflow.md) — MLflow / Cloud SQL / GCS (CMEK +
+  public-IP constraints protect these)
+- [ADR-0036](0036-gke-ml-infra-parity-multiregion.md) — multi-region GKE (locations
+  guardrail) + DCGM/serving failover referenced by the ML runbook
+- [ADR-0018](0018-eks-pod-identity-as-default-workload-identity.md) — Pod Identity /
+  IRSA (AWS-side keyless identity; WIF is the cross-cloud analog)
+- GCP Org Policy v2 — `google_org_policy_policy` (hashicorp/google ~> 6);
+  constraints: `compute.vmExternalIpAccess`, `iam.disableServiceAccountKeyCreation`,
+  `gcp.restrictNonCmekServices`, `gcp.resourceLocations`,
+  `storage.publicAccessPrevention`, `sql.restrictPublicIp`,
+  `storage.uniformBucketLevelAccess`, `compute.requireOsLogin`.
+- GCP Workload Identity Federation with AWS — `google_iam_workload_identity_pool` +
+  `…_provider` `aws { account_id }`; Google as a built-in OIDC provider in AWS IAM.
+- SOC2 Trust Services Criteria (2017, revised) — Common Criteria CC1–CC9.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -82,6 +82,7 @@ decision.
 | [0036](0036-gke-ml-infra-parity-multiregion.md) | GKE ML-infra parity + multi-region GKE + GCP cost guardrail (GPU Operator, DCGM, Volcano, billing-budget) | Accepted | pending | WS-A of GCP ML platform plan; design 2026-06-10 |
 | [0037](0037-ml-cicd-pipeline-mlflow.md) | ML CI/CD pipeline — Airflow orchestrator + MLflow registry + GCS artifact store | Proposed | pending | WS-B of GCP ML platform plan; design 2026-06-10 |
 | [0038](0038-ml-observability-drift.md) | ML observability — drift detection, accuracy monitoring, and retrain trigger (Evidently + whylogs, Prometheus-native) | Proposed | pending | WS-C of GCP ML platform plan; design 2026-06-10 |
+| [0040](0040-soc-posture-and-oncall.md) | SOC2 posture — GCP org-policy parity + cross-cloud WIF (GCP↔AWS) + control-to-evidence matrix + ML on-call/runbooks | Proposed | pending | WS-E of GCP ML platform plan; design 2026-06-10 |
 
 
 

--- a/docs/compliance/soc2-control-matrix.md
+++ b/docs/compliance/soc2-control-matrix.md
@@ -1,0 +1,173 @@
+# SOC2 Control-to-Evidence Matrix
+
+> **Status:** Design-target (WS-E of the GCP ML Platform plan). This matrix maps the
+> SOC2 **Trust Services Criteria (TSC, 2017 revised — Common Criteria CC-series)** to
+> the **controls that already exist in this repository** plus the **GCP-side controls
+> WS-E adds** ([ADR-0040](../adrs/0040-soc-posture-and-oncall.md)). It is the
+> single artifact an auditor (or the platform owner) uses to answer "which control
+> satisfies this criterion, and where is the evidence?"
+>
+> "Evidence" here means a repo artifact (Terraform module / ArgoCD app / GitHub Action
+> / runbook) and the runtime signal it produces (a deny event, a Config rule
+> evaluation, a CloudTrail log, a signed image attestation, a fired alert). Nothing in
+> this matrix is applied without the apply gate (ADR-0040, plan §); the matrix
+> describes the **intended control surface** and flags what is **still a gap**.
+
+## How to read this
+
+- **Plane** — `AWS` (Terragrunt/Terraform control plane), `K8s` (ArgoCD/Helm workload
+  plane), `GCP` (the new GCP estate), or `CI` (GitHub Actions supply chain).
+- **Status** — `evidenced` (control exists in-repo and produces auditable signal),
+  `partial` (control exists but coverage is incomplete), `gap` (no control yet;
+  WS-E or a follow-up closes it), `inherited` (cloud-provider shared responsibility).
+- Every control carries the [ADR-0028](../adrs/0028-unified-platform-tagging-and-labeling-taxonomy.md)
+  `platform:system` / `platform.system` taxonomy so evidence is attributable to a
+  logical system on the same Grafana `$system` variable across AWS + GCP.
+
+---
+
+## CC1 — Control Environment (governance, accountability)
+
+| Criterion | Control (repo artifact) | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC1.1 Integrity & ethics; defined org structure | OU split — Prod / Non-Prod / Deployments / Suspended / Sandbox ([ADR-0001](../adrs/0001-ou-split.md)); `terraform/modules/organization` | AWS | Org/OU tree in Organizations; per-OU SCP attachment | evidenced |
+| CC1.2 Board/owner oversight | ADR ratification trail (`docs/adrs/README.md` records owner ratification dates) | — | ADR status + ratification footer per ADR | evidenced |
+| CC1.3 Authority & responsibility | ADR-0028 `platform:owner` taxonomy on every resource (team-sec / team-data / team-ml-platform) | AWS+K8s+GCP | `owner` tag/label per resource; Backstage ownership (ADR-0034, deferred) | partial |
+| CC1.4 Competence / on-call readiness | On-call rotation + tabletop ([docs/runbooks/oncall-rotation-escalation.md](../runbooks/oncall-rotation-escalation.md)) | — | Tabletop exercise record; PagerDuty schedule | evidenced (WS-E) |
+
+## CC2 — Communication & Information
+
+| Criterion | Control (repo artifact) | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC2.1 Quality information for control | Unified observability stack (`apps/infra/observability/prometheus-stack`, VictoriaMetrics, OTel) | K8s | Metrics/logs/traces with ADR-0028 labels | evidenced |
+| CC2.2 Internal comms of responsibilities | Runbooks (`docs/sre-runbook.md`, `docs/runbooks/*`, `docs/multi-region/runbooks/*`) + incident Slack templates | — | Runbook docs; #incidents channel templates | evidenced |
+| CC2.3 External comms | Incident comms templates in on-call doc (status-page / stakeholder updates) | — | Comms templates in [oncall doc](../runbooks/oncall-rotation-escalation.md) | partial |
+
+## CC3 — Risk Assessment
+
+| Criterion | Control (repo artifact) | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC3.1 Objectives for risk ID | Risk register referenced by the GCP ML plan (R1–R5) and per-ADR Risks sections | — | ADR "Risks" sections; plan risk register | evidenced |
+| CC3.2 Risk identification & analysis | Drift/accuracy monitoring ([ADR-0038](../adrs/0038-ml-observability-drift.md)); GuardDuty findings (`terraform/modules/guardduty-org`) | GCP-ML+AWS | Evidently/whylogs metrics; GuardDuty findings feed | partial |
+| CC3.3 Fraud risk | GuardDuty threat detection (`guardduty-org`, `securityhub-org`) | AWS | GuardDuty/SecurityHub findings | evidenced |
+| CC3.4 Change-impact on risk | ADR process; `terraform plan` in PR + `*.tftest.hcl` gating | AWS+CI | PR plan output; passing module tests | evidenced |
+
+## CC4 — Monitoring Activities
+
+| Criterion | Control (repo artifact) | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC4.1 Ongoing/separate evaluations | AWS Config + Security Hub (`aws-config`, `config-org`, `security-hub`, `securityhub-org`) | AWS | Config rule evaluations; SecurityHub CIS/FSBP score | evidenced |
+| CC4.1 (GCP parity) | Gap → **WS-E follow-up**: GCP Security Command Center / Config equivalent | GCP | (not yet) | gap |
+| CC4.2 Deficiency communication | Findings → Alertmanager → PagerDuty; SecurityHub → SNS | AWS+K8s | Fired alerts; PagerDuty incidents | evidenced |
+
+## CC5 — Control Activities
+
+| Criterion | Control (repo artifact) | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC5.1 Control selection to mitigate risk | SCPs (`terraform/modules/scps`) + org-policy (`terraform/modules/gcp-org-policy`, WS-E) as the deny-list control layer | AWS+GCP | SCP/org-policy deny events | evidenced (GCP new) |
+| CC5.2 Technology general controls | Admission policy: Kyverno (`apps/infra/kyverno`) + Gatekeeper (`apps/infra/gatekeeper`) + GKE Gatekeeper constraint-bundle parity (ADR-0040) | K8s | Admission deny audit events | evidenced (GKE parity designed) |
+| CC5.3 Policy deployment via procedures | GitOps — ArgoCD app-of-apps; policies delivered as code | K8s | ArgoCD sync status; Git history | evidenced |
+
+## CC6 — Logical & Physical Access Controls *(the core security family)*
+
+| Criterion | Control (repo artifact) | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC6.1 Identity & least-privilege access | `iam-baseline` (password policy, MFA, Access Analyzer); IRSA/Pod Identity (ADR-0018); GKE Workload Identity (`gcp-gke-gpu-nodepools`); **org-policy `iam.disableServiceAccountKeyCreation` + cross-cloud WIF (WS-E)** | AWS+K8s+GCP | Access Analyzer findings; no static SA keys; WIF token-exchange logs | evidenced (GCP new) |
+| CC6.2 Registration/authorization of users | SSO permission sets (`docs/runbooks/sso-permission-sets.md`); break-glass IAM (ADR-0011) | AWS | Permission-set assignments; break-glass audit | evidenced |
+| CC6.3 Role-based access / segregation | RBAC + namespace isolation; `platform:owner` segregation; org-policy SA-key deny (WS-E) | K8s+GCP | RBAC bindings; org-policy deny | evidenced |
+| CC6.4 Physical access | Cloud-provider responsibility (AWS/GCP shared responsibility — out of platform scope) | — | Provider SOC2/ISO report (inherited) | inherited |
+| CC6.5 Data disposal | Velero backup lifecycle (`apps/infra/velero`); KMS key destruction protection (`terraform/modules/kms`) | AWS+K8s | Backup/retention policy; KMS schedule | partial |
+| CC6.6 Boundary protection (network) | Cilium NetworkPolicies + default-deny (`kyverno generate-default-deny-netpol`); TGW segmentation (ADR-0013); **org-policy `compute.vmExternalIpAccess` / `sql.restrictPublicIp` / `storage.publicAccessPrevention` (WS-E)** | K8s+AWS+GCP | NetworkPolicy enforcement; org-policy deny of public IPs | evidenced (GCP new) |
+| CC6.7 Transmission encryption / restriction | mTLS (Cilium, `docs/runbooks/cilium-mtls.md`); TLS ingress (Gateway API, ADR-0009) | K8s | mTLS handshake; TLS cert chain | evidenced |
+| CC6.8 Malicious-software prevention | Image signing/verification: cosign (`.github/actions/cosign-sign`) + Kyverno `verify-images` + Gatekeeper `block-latest-tag`; Trivy scan (`.github/actions/trivy-scan`); Tetragon runtime (`apps/infra/tetragon`) | CI+K8s | cosign attestations; admission verify deny; Trivy report; eBPF events | evidenced |
+
+## CC7 — System Operations (detection, incident response)
+
+| Criterion | Control (repo artifact) | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC7.1 Vulnerability detection | Trivy (`.github/actions/trivy-scan`), CodeQL SAST (`sast-codeql`), dep scans (`node-dep-scan`, `python-dep-scan`), SBOM (`syft-sbom`) | CI | Scan reports; SBOM artifacts | evidenced |
+| CC7.2 Anomaly/security-event monitoring | GuardDuty (`guardduty-org`) + Tetragon runtime (`apps/infra/tetragon`) + Security Hub | AWS+K8s | GuardDuty findings; Tetragon eBPF events | evidenced |
+| CC7.3 Security-incident evaluation | Incident runbooks ([ml-incident-runbook](../runbooks/ml-incident-runbook.md), `docs/sre-runbook.md`); PagerDuty severity routing | — | Incident records; PagerDuty timeline | evidenced (WS-E adds ML) |
+| CC7.4 Incident response | On-call rotation + escalation L1→L3 ([oncall doc](../runbooks/oncall-rotation-escalation.md)) | — | PagerDuty escalation; postmortems | evidenced (WS-E) |
+| CC7.5 Recovery from incidents | DR runbooks (`docs/runbooks/DISASTER_RECOVERY.md`, `velero-restore.md`, multi-region failover) | — | Restore tests; failover drills | evidenced |
+
+## CC8 — Change Management
+
+| Criterion | Control (repo artifact) | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC8.1 Authorized, tested, approved changes | PR workflow + `terraform plan` + `*.tftest.hcl` + CI gates (ADR-0015/0016); ArgoCD GitOps; ML CI/CD (ADR-0037) | AWS+K8s+CI | PR approvals; passing tests; plan diff; ArgoCD sync | evidenced |
+
+## CC9 — Risk Mitigation
+
+| Criterion | Control (repo artifact) | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC9.1 Risk-mitigation (business disruption) | Multi-region GKE + serving failover (ADR-0036); billing budgets (`gcp-billing-budget`, `budgets`) | GCP+AWS | Failover drills; budget threshold alerts | evidenced |
+| CC9.2 Vendor/third-party management | SBOM + signed-image supply chain (`syft-sbom`, `cosign-sign`); pinned chart/provider versions | CI+K8s | SBOM; signature attestations; pin diffs | evidenced |
+
+---
+
+## Audit-logging cross-cut (spans CC4 / CC6 / CC7)
+
+| Concern | Control (repo artifact) | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| Org-wide audit trail | CloudTrail (`terraform/modules/cloudtrail`, `cloudtrail-org`) | AWS | Immutable multi-region trail, log-file validation | evidenced |
+| Config/state recording | AWS Config (`aws-config`, `config-org`) | AWS | Config snapshots + rule evaluations | evidenced |
+| Secret lifecycle / rotation | `terraform/modules/secret-rotation` + `secrets`; ESO ([ADR-0008]) | AWS+K8s | Rotation Lambda runs; ESO sync events | evidenced |
+| Encryption key management | `terraform/modules/kms` (CMK rotation, destroy protection) | AWS | KMS rotation status | evidenced |
+| GCP audit logging | Gap → **WS-E follow-up**: Cloud Audit Logs export + log-based metrics | GCP | (not yet) | gap |
+
+---
+
+## Availability (A-series), Confidentiality (C-series), Processing Integrity (PI-series)
+
+These TSC categories are *additional* to the Common Criteria and apply only if the
+SOC2 report scope includes them. Where the platform already has coverage:
+
+| Criterion | Control | Plane | Status |
+|---|---|---|---|
+| A1.1 Capacity management | KEDA/HPA elasticity + GPU budgets (ADR-0036); cost (`opencost`, `gcp-billing-budget`) | K8s+GCP | evidenced |
+| A1.2 Backup & recovery | Velero + DR runbooks; multi-region | K8s+AWS | evidenced |
+| A1.3 Recovery testing | Failover drills + tabletop (WS-E on-call doc) | — | partial |
+| C1.1 Confidential-data identification | ADR-0028 `platform:system` + data-residency org-policy (`gcp.resourceLocations`, WS-E) | GCP | evidenced (GCP new) |
+| C1.2 Confidential-data disposal | KMS destruction protection; Velero retention | AWS+K8s | partial |
+| PI1.x Processing integrity (ML correctness) | Drift/accuracy monitoring + retrain trigger (ADR-0038); ML CI/CD model registry (ADR-0037) | GCP-ML | evidenced |
+
+---
+
+## Coverage summary — what WS-E changes
+
+**Before WS-E** the platform had strong AWS-plane and K8s-plane controls but the
+**GCP estate lacked a deny-list guardrail layer**, **cross-cloud identity was
+key-based**, and there was **no auditor-facing control map** or **ML-incident on-call
+posture**. WS-E closes:
+
+| SOC2 area | GCP/posture gap WS-E closes | New artifact |
+|---|---|---|
+| CC5.1 / CC6.6 | No GCP org-policy deny layer (public IPs, public buckets, Cloud SQL public IP) | `terraform/modules/gcp-org-policy` |
+| CC6.1 | GCP CMEK + SA-key-creation not enforced; cross-cloud creds were static | org-policy `restrictNonCmekServices` + `disableServiceAccountKeyCreation`; **GCP↔AWS WIF** (ADR-0040) |
+| C1.1 | No data-residency control on GCP | org-policy `gcp.resourceLocations` |
+| CC1.4 / CC7.3 / CC7.4 | No ML-incident runbooks; on-call rotation informal | [ml-incident-runbook](../runbooks/ml-incident-runbook.md) + [oncall-rotation-escalation](../runbooks/oncall-rotation-escalation.md) |
+| (all) | No auditor-facing control-to-evidence map | **this matrix** |
+
+### Still-gap (tracked, not closed by WS-E)
+
+- **CC4.1 (GCP)** — no GCP Security Command Center / Config-equivalent continuous
+  evaluation yet (AWS has Config + Security Hub; GCP side is a follow-up).
+- **Audit-logging (GCP)** — Cloud Audit Logs export + log-based metrics are a
+  follow-up; AWS CloudTrail/Config parity is not yet on GCP.
+- **CC5.2 (GKE admission)** — Kyverno/Gatekeeper run on EKS today; the GKE Gatekeeper
+  constraint bundle is parity-designed in ADR-0040 but its in-cluster delivery to GKE
+  is a follow-up (this WS ships the **org-policy** plane on GCP).
+- **CC6.5 / C1.2 (data disposal)** — KMS + Velero retention exist but a documented,
+  tested confidential-data-disposal procedure is partial.
+- **CC1.3 (ownership)** — `platform:owner` taxonomy is present but the Backstage
+  ownership catalog (ADR-0034) is deferred, so ownership evidence is tag-based not
+  catalog-based.
+
+> **Evidence-collection approach (ADR-0040, D3):** evidence is *pull-based and
+> repo-anchored*. An auditor request resolves to: (1) the ADR documenting the
+> decision, (2) the Terraform module / ArgoCD app / GitHub Action implementing it,
+> (3) the `*.tftest.hcl` or CI run proving it behaves, and (4) the runtime signal
+> (Config evaluation, GuardDuty finding, admission deny, org-policy deny, fired
+> alert). No separate GRC tool is introduced; the repo + observability stack *is*
+> the evidence store, queried on the ADR-0028 `$system` axis.

--- a/docs/runbooks/ml-incident-runbook.md
+++ b/docs/runbooks/ml-incident-runbook.md
@@ -1,0 +1,201 @@
+# Runbook: ML-Platform Incident Response
+
+> **Scope:** ML-specific incidents on the GKE ML platform — model drift / accuracy
+> regression, training-pipeline failure, and serving outage. This runbook **extends**
+> the general [SRE runbook](../sre-runbook.md) and
+> [on-call rotation & escalation](oncall-rotation-escalation.md); follow those for
+> generic triage, PagerDuty acknowledgement, and comms templates. Here we cover the
+> ML-domain decision trees only.
+>
+> **System / owner (ADR-0028):** `platform.system = ml-monitoring` /
+> `ml-platform`; `platform.owner = team-ml-platform`. All alerts referenced below
+> carry `platform_system` so they route on the same Grafana `$system` axis.
+>
+> **Wiring:** drift/accuracy alerts fire via the ADR-0038 Alertmanager route
+> (`apps/infra/ml-monitoring/templates/prometheusrules/ml-drift-alerts.yaml`) to the
+> `ml-drift-pagerduty` receiver and, on `severity=critical`, to the
+> `ml-retrain-webhook`. The dedicated **ML PagerDuty service** is the WS-E
+> formalization called out as a follow-up in ADR-0038 D3.
+
+## Severity definitions (ML)
+
+| Severity | Definition | PagerDuty | ACK SLA |
+|---|---|---|---|
+| **SEV1** | Serving down or returning errors for a production model; user-facing impact | Page ML on-call immediately | 5 min |
+| **SEV2** | Accuracy/drift breach on a production model, or training pipeline blocking a scheduled retrain/release | Page ML on-call | 15 min |
+| **SEV3** | Drift warning trend, non-blocking pipeline failure, staging-only issue | Notify Slack `#ml-incidents` | 1 h |
+
+---
+
+## Scenario 1 — Model drift / accuracy regression
+
+**Symptoms / alerts:** `MLDriftDetected`, `MLAccuracyBelowThreshold`,
+`MLPredictionDistributionShift` (Evidently / whylogs exporters, ADR-0038). PagerDuty
+incident on the `ml-drift-pagerduty` service.
+
+### Triage
+
+1. **Acknowledge** in PagerDuty (stops escalation timer).
+2. **Identify the model + tenant + domain** from alert labels:
+   ```promql
+   # Which model/tenant is drifting and by how much?
+   ml_drift_score{platform_system="ml-monitoring"} > on(model_name) group_left
+     ml_drift_threshold{platform_system="ml-monitoring"}
+   ```
+3. **Classify the drift** (Grafana ML-observability dashboard):
+   - **Data drift** (input distribution shifted) vs **concept drift** (input→label
+     relationship shifted) vs **accuracy-only** (ground-truth labels regressed).
+   - Check whether drift correlates with a recent **upstream data change** (new
+     source, schema change) or a **model deploy** (`mlflow` model-version bump).
+
+### Decision tree
+
+| Finding | Action |
+|---|---|
+| Drift is **data-quality** (bad/late upstream batch) | Do **not** retrain on poisoned data. Quarantine the batch, fix upstream, re-run feature pipeline. Suppress the retrain webhook (see "Stop a retrain storm" below). |
+| Drift is **genuine concept drift**, model still serving safely | Allow the **automated retrain trigger** (ADR-0038 D4) to proceed; monitor the retrain job. Confirm the new candidate beats the incumbent in the MLflow eval gate before promotion. |
+| **Accuracy below SLA** and user-impacting | Treat as **SEV1/2**: roll back to the last-good MLflow model version (Scenario 3 rollback), THEN retrain offline. |
+| Drift is a **false positive** (threshold too tight) | Tune the threshold in the PrometheusRule; record in postmortem. Do not silence permanently without owner sign-off. |
+
+### Stop a retrain storm
+
+The `ml-retrain-webhook` has `repeat_interval: 6h` (ADR-0038 D3) to bound retrain
+frequency. To pause retraining during an incident:
+```bash
+# Silence the critical route that fires the retrain webhook (NOT the pager route).
+amtool silence add platform_system=ml-monitoring severity=critical \
+  --duration=4h --comment="INC-XXXX: drift from bad upstream batch, retrain paused" \
+  --author="$ONCALL"
+```
+> A retrain on poisoned data is worse than no retrain. Always confirm data integrity
+> before letting the model relearn.
+
+### Recovery / exit
+
+- New model version passes the MLflow eval gate and drift score returns under
+  threshold for 2 consecutive evaluation windows.
+- Document root cause (data vs concept vs threshold) in the postmortem.
+
+---
+
+## Scenario 2 — Training-pipeline failure
+
+**Symptoms / alerts:** Airflow DAG failure (ADR-0037 orchestrator), `MLRetrainJobFailed`,
+MLflow run marked `FAILED`, or the retrain webhook returning non-2xx.
+
+### Triage
+
+1. **Acknowledge**; classify SEV (blocking a scheduled release = SEV2, else SEV3).
+2. **Locate the failed task** in Airflow:
+   ```bash
+   kubectl -n ml-platform logs -l platform.system=ml-platform,platform.component=airflow-worker --tail=200
+   # Or via the Airflow UI: DAGs → ml_retrain → failed task → logs
+   ```
+3. **Bucket the failure:**
+
+| Failure class | Signal | First action |
+|---|---|---|
+| **Data/feature** | Feature pipeline empty/schema mismatch | Validate upstream source + feature store; do not auto-retry blindly |
+| **Resource** | GPU `Pending` / OOMKilled / quota | Check Volcano queue + GPU capacity (ADR-0036); check `gcp-billing-budget` did not throttle; bump request or wait for spot capacity |
+| **Artifact store** | GCS write denied / Cloud SQL unreachable | Check org-policy did not block (CMEK / public-IP); check MLflow backend Cloud SQL health (ADR-0037) |
+| **Code/dependency** | Import/version error | Likely a bad model-code change; revert the offending commit, re-trigger |
+| **Transient** | Network blip, preemption | Re-trigger the DAG run; if it passes, log as transient |
+
+### Resource-exhaustion sub-procedure (most common)
+
+```bash
+# GPU schedulability (Volcano gang scheduling, ADR-0036)
+kubectl get pods -n ml-platform -o wide | grep -E "Pending|OOMKilled"
+kubectl describe podgroup -n ml-platform | grep -A3 "Unschedulable"
+
+# Is the GPU node pool scaled to zero / out of spot capacity?
+kubectl get nodes -l cloud.google.com/gke-accelerator --show-labels
+```
+- If spot capacity is unavailable, fall back to on-demand for the retrain (cost
+  trade-off; note it in the incident — ties to `gcp-billing-budget` alerts).
+
+### Recovery / exit
+
+- DAG run succeeds end-to-end; MLflow run `FINISHED`; model registered.
+- If the failure blocked a release, confirm the downstream serving deploy is
+  unblocked. Record the failure class in the postmortem.
+
+---
+
+## Scenario 3 — Serving outage (SEV1)
+
+**Symptoms / alerts:** `MLServingDown`, `MLServingHighErrorRate`,
+`MLServingHighLatency`, 5xx from the inference gateway, or a model endpoint failing
+health checks.
+
+### Triage (first 5 minutes)
+
+1. **Acknowledge** (5-min SLA). Open an incident channel (`#ml-incidents`) using the
+   template in the [on-call doc](oncall-rotation-escalation.md).
+2. **Confirm blast radius:**
+   ```bash
+   # Serving pods healthy?
+   kubectl get pods -n ml-serving -l platform.system=ml-platform -o wide
+   # Error rate + latency by model — Grafana: ML Serving SLO dashboard
+   ```
+   ```promql
+   sum(rate(ml_serving_requests_total{platform_system="ml-platform",code=~"5.."}[5m]))
+     / sum(rate(ml_serving_requests_total{platform_system="ml-platform"}[5m]))
+   ```
+3. **Is it one model or cluster-wide?** One model → likely a bad model version.
+   Cluster-wide → likely infra (node pool, GPU driver, gateway, region).
+
+### Decision tree
+
+| Finding | Action |
+|---|---|
+| **Single model**, error rate spiked after a deploy | **Roll back** to last-good MLflow model version (below). Fastest path to recovery. |
+| **GPU/driver** issue (DCGM XID errors, node NotReady) | Cordon/drain the bad node; DCGM auto-taint (ADR-0036) should evict; verify GPU operator health |
+| **Region-wide** outage | Initiate **cross-region serving failover** (ADR-0036 D5; see DNS/health failover runbooks under `docs/multi-region/runbooks/`) |
+| **Gateway/ingress** | Check Gateway API / Envoy (ADR-0009); not ML-specific — hand to platform on-call |
+| **Capacity** (HPA maxed, queue backing up) | Scale serving replicas / GPU pool; check KEDA triggers (ADR-0036) |
+
+### Roll back a model version (fastest SEV1 mitigation)
+
+```bash
+# Identify current vs last-good version in the MLflow registry (ADR-0037)
+# Promote the previous version back to the serving alias, then restart serving.
+mlflow models ...                                   # set serving alias to prior version
+kubectl -n ml-serving rollout restart deployment/<model-serving-deploy>
+kubectl -n ml-serving rollout status  deployment/<model-serving-deploy>
+```
+> Roll back **first**, root-cause **second**. A SEV1 serving outage is mitigated by
+> reverting to a known-good model version, not by debugging the new one live.
+
+### Cross-region failover (region-wide outage)
+
+Follow `docs/multi-region/runbooks/failover-manual.md` (manual) /
+`failover-auto.md` (health-check driven). ML serving runs as independent regional
+deployments (ADR-0036 D5) — failover is DNS/health-based, no shared GPU pool.
+
+### Recovery / exit
+
+- Error rate < SLO and latency normal for 15 min; SLO budget burn arrested.
+- If rolled back: schedule offline investigation of the bad model version before
+  any re-promotion (links to Scenario 1 if drift-related).
+
+---
+
+## Postmortem (all SEV1/SEV2)
+
+Use the blameless postmortem template in the [SRE runbook](../sre-runbook.md).
+ML-specific fields to capture:
+
+- Model name / version / tenant / domain.
+- Drift vs pipeline vs serving classification.
+- Whether the automated retrain trigger helped or hurt (feeds ADR-0038 threshold
+  tuning).
+- Evidence pointers for the SOC2 matrix (CC7.3/CC7.4): incident timeline, PagerDuty
+  record, the alert that fired, the remediation commit/PR.
+
+## Tabletop (acceptance for WS-E)
+
+The on-call rotation is validated by a **tabletop exercise** (see the
+[on-call doc](oncall-rotation-escalation.md)) that walks one scenario from each
+class above (drift → pipeline → serving) without touching production. Record the
+exercise date + participants as CC1.4 / A1.3 evidence.

--- a/docs/runbooks/oncall-rotation-escalation.md
+++ b/docs/runbooks/oncall-rotation-escalation.md
@@ -1,0 +1,130 @@
+# On-Call Rotation & Escalation
+
+> **Scope (WS-E):** formalizes the on-call **rotation**, **escalation policy**, and
+> **tabletop validation** for the platform, with an **ML on-call** track for the GKE
+> ML platform. It builds on the escalation paths already documented in the
+> [SRE runbook](../sre-runbook.md#on-call-procedures); this doc is the
+> authoritative rotation/escalation reference and is the CC1.4 / CC7.4 evidence
+> anchor in the [SOC2 control matrix](../compliance/soc2-control-matrix.md).
+>
+> **Owner (ADR-0028):** `platform.owner = team-sec` (security/compliance posture);
+> the ML track is co-owned with `team-ml-platform`.
+
+## Rotations
+
+The platform runs **two PagerDuty rotations** plus the pre-existing observability
+services (`observability-platform`, `application-monitoring` — see SRE runbook).
+
+| Rotation | PagerDuty service | Covers | Primary owner |
+|---|---|---|---|
+| **Platform on-call** | `platform-oncall` | Infra: clusters, networking, IAM/org-policy, GCP + AWS control plane, gateways, DR/failover | team-sec + SRE |
+| **ML on-call** | `ml-platform-oncall` | ML drift/accuracy, training pipelines (Airflow/MLflow), model serving — see [ML incident runbook](ml-incident-runbook.md) | team-ml-platform |
+
+> The `ml-platform-oncall` service is the **WS-E formalization** of the dedicated ML
+> PagerDuty routing key that ADR-0038 D3 flagged as a follow-up. Until it is
+> provisioned, ML drift alerts fall back to the existing `alertmanager-pagerduty-secret`
+> receiver shared with the platform rotation.
+
+### Rotation mechanics
+
+- **Cadence:** weekly, handed over at a fixed weekday/time; each rotation has a
+  **primary** and a **secondary** (backup) responder.
+- **Schedule source of truth:** PagerDuty (not this doc). This doc defines the
+  *policy*; PagerDuty holds the *who and when*.
+- **Handover:** outgoing primary posts an open-incidents + watch-items summary to
+  `#oncall-handover` at the start of each rotation.
+- **Coverage:** 24×7 for SEV1; business-hours-best-effort for SEV3.
+
+## Escalation policy
+
+Aligned with the SRE-runbook L1→L3 model, with explicit timers per severity.
+
+| Level | Who | Engages when |
+|---|---|---|
+| **L1** | On-call primary (platform or ML) | Page fires; ACK within the severity SLA |
+| **L2** | On-call secondary + domain expert (Senior SRE / Senior ML Eng + Platform Team) | L1 has not ACKed within SLA, **or** L1 requests help, **or** unresolved after 30 min |
+| **L3** | Engineering leadership / incident commander | User-impacting > 1 h, **or** cross-team coordination, **or** any SEV1 declared a major incident |
+
+### Per-severity timers
+
+| Severity | ACK SLA | Auto-escalate L1→L2 | Declare major incident (L3) |
+|---|---|---|---|
+| **SEV1** | 5 min | 10 min no-ACK | At declaration (serving down / data loss) |
+| **SEV2** | 15 min | 30 min no-ACK | > 1 h unresolved + user impact |
+| **SEV3** | 1 h (Slack) | next business day | n/a |
+
+PagerDuty enforces the no-ACK auto-escalation; this table is the policy PagerDuty is
+configured against. Severity definitions for ML incidents are in the
+[ML incident runbook](ml-incident-runbook.md#severity-definitions-ml); infra
+severities follow the SRE runbook.
+
+## Alerting → paging wiring
+
+```
+Prometheus rule  ──▶  Alertmanager route (platform_system label)  ──▶  PagerDuty service
+  (ADR-0038)            (apps/infra/ml-monitoring/...routes)            (platform / ml)
+                                   │
+                                   ├─ severity=critical  ──▶ page (5-min SLA)
+                                   ├─ severity=warning   ──▶ Slack #incidents (1-h)
+                                   └─ platform_system=ml-monitoring + critical
+                                                          ──▶ ml-retrain-webhook (bounded 6h)
+```
+
+- Routing-key + receiver secrets are sourced via **ESO** (ADR-0008), mirroring the
+  existing `alertmanager-slack-secret` / `alertmanager-pagerduty-secret` pattern — no
+  static tokens (CC6.1 evidence; consistent with the org-policy SA-key-creation deny).
+
+## Incident communication templates
+
+Reuse the SRE-runbook Slack templates. ML incidents additionally tag the model /
+tenant / domain:
+
+```
+🚨 ML INCIDENT [SEVn]: <brief description>
+━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Service: ml-platform-oncall
+Model:   <name>@<version>  Tenant: <tenant>  Domain: <domain>
+Alert:   <alertname>  (platform_system=ml-monitoring|ml-platform)
+Impact:  <serving error rate / accuracy delta / pipeline blocked>
+Status:  Investigating
+Assigned: @ml-oncall
+```
+
+Status updates every 30 min (SEV1/SEV2) until resolved; final update links the
+postmortem.
+
+## Tabletop exercise (WS-E acceptance)
+
+The plan's acceptance criterion is that the rotation + ML runbooks are **tested in a
+tabletop**. Run a **quarterly** tabletop covering one scenario from each ML class:
+
+1. **Drift** — "model X accuracy dropped 8% after an upstream schema change."
+2. **Pipeline** — "nightly retrain DAG fails on GPU `Pending` for 2 h."
+3. **Serving** — "model Y serving returns 30% 5xx after a version bump."
+
+For each: walk the [ML incident runbook](ml-incident-runbook.md) decision tree, name
+the responder at each escalation level, identify the mitigation (silence / rollback /
+failover), and the evidence the incident would produce.
+
+**Record (CC1.4 / CC7.4 / A1.3 evidence):**
+
+| Field | Value |
+|---|---|
+| Date | _<YYYY-MM-DD>_ |
+| Facilitator | _<name>_ |
+| Participants | _<platform + ML on-call, leadership observer>_ |
+| Scenarios exercised | drift / pipeline / serving |
+| Gaps found | _<e.g. ml-platform-oncall service not yet provisioned>_ |
+| Action items | _<owner + due>_ |
+
+> The first tabletop is expected to surface the `ml-platform-oncall` PagerDuty
+> service provisioning as an action item — that is the intended outcome (it confirms
+> the fallback path works and the dedicated service is the next step).
+
+## References
+
+- [SRE runbook — On-Call Procedures](../sre-runbook.md#on-call-procedures)
+- [ML incident runbook](ml-incident-runbook.md)
+- [SOC2 control matrix](../compliance/soc2-control-matrix.md) (CC1.4, CC7.3, CC7.4, A1.3)
+- [ADR-0038](../adrs/0038-ml-observability-drift.md) — drift→Alertmanager→PagerDuty route
+- [ADR-0040](../adrs/0040-soc-posture-and-oncall.md) — SOC posture & on-call decision

--- a/terraform/modules/gcp-org-policy/gcp-org-policy.tftest.hcl
+++ b/terraform/modules/gcp-org-policy/gcp-org-policy.tftest.hcl
@@ -1,0 +1,185 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests for the gcp-org-policy module (WS-E — security / compliance).
+# Uses a mocked google provider so no real GCP org / credentials are required — these
+# are plan-time assertions over the module's logic. No org-policy is ever applied.
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "google" {}
+
+variables {
+  parent = "organizations/123456789012"
+
+  labels = {
+    platform_env   = "production"
+    platform_owner = "team-sec"
+  }
+}
+
+run "all_defaults_enforce_eight_constraints" {
+  command = plan
+
+  # Defaults: vmExternalIp, disableSAKeyCreation, disableSAKeyUpload, requireOsLogin,
+  # sql.restrictPublicIp, uniformBucketLevelAccess, publicAccessPrevention, CMEK = 8.
+  # gcp.resourceLocations is OFF by default (allowed_resource_locations is empty).
+  assert {
+    condition     = output.enforced_constraint_count == 8
+    error_message = "With all defaults on and no locations set, the module should enforce eight constraints."
+  }
+}
+
+run "vm_external_ip_denies_all_when_no_allowlist" {
+  command = plan
+
+  assert {
+    condition     = google_org_policy_policy.vm_external_ip[0].spec[0].rules[0].deny_all == "TRUE"
+    error_message = "With an empty allow-list, compute.vmExternalIpAccess must deny_all."
+  }
+
+  assert {
+    condition     = google_org_policy_policy.vm_external_ip[0].name == "organizations/123456789012/policies/compute.vmExternalIpAccess"
+    error_message = "Policy name must be parent/policies/<constraint>."
+  }
+}
+
+run "sa_key_creation_enforced_true" {
+  command = plan
+
+  assert {
+    condition     = google_org_policy_policy.disable_sa_key_creation[0].spec[0].rules[0].enforce == "TRUE"
+    error_message = "iam.disableServiceAccountKeyCreation must be enforced TRUE."
+  }
+}
+
+run "cmek_denies_listed_services" {
+  command = plan
+
+  assert {
+    condition     = length(google_org_policy_policy.restrict_non_cmek_services) == 1
+    error_message = "CMEK enforcement should be active when enforce_cmek is non-empty (default has four services)."
+  }
+
+  assert {
+    condition     = contains(google_org_policy_policy.restrict_non_cmek_services[0].spec[0].rules[0].values[0].denied_values, "storage.googleapis.com")
+    error_message = "CMEK constraint must deny non-CMEK storage by default."
+  }
+}
+
+run "public_access_prevention_enforced_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(google_org_policy_policy.public_access_prevention) == 1
+    error_message = "storage.publicAccessPrevention must be enforced by default (S3-PAB parity)."
+  }
+}
+
+run "constraint_list_contains_expected_names" {
+  command = plan
+
+  assert {
+    condition     = contains(output.enforced_constraints, "iam.disableServiceAccountKeyCreation")
+    error_message = "enforced_constraints output must list the SA-key-creation constraint."
+  }
+
+  assert {
+    condition     = contains(output.enforced_constraints, "gcp.restrictNonCmekServices")
+    error_message = "enforced_constraints output must list the CMEK constraint."
+  }
+}
+
+run "platform_labels_carry_security_system" {
+  command = plan
+
+  assert {
+    condition     = output.platform_labels["platform_system"] == "security"
+    error_message = "ADR-0028 platform_system must default to security for this module."
+  }
+
+  assert {
+    condition     = output.platform_labels["platform_owner"] == "team-sec"
+    error_message = "Caller label override (platform_owner = team-sec) must be merged in."
+  }
+}
+
+# -------------------------------------------------------------------------------------------------------------------
+# Toggle-off path — a staged rollout can carve a constraint out.
+# -------------------------------------------------------------------------------------------------------------------
+
+run "disabling_a_constraint_removes_it" {
+  command = plan
+
+  variables {
+    disable_sa_key_upload            = false
+    enforce_public_access_prevention = false
+  }
+
+  assert {
+    condition     = length(google_org_policy_policy.disable_sa_key_upload) == 0
+    error_message = "Setting disable_sa_key_upload = false must remove that policy."
+  }
+
+  assert {
+    condition     = length(google_org_policy_policy.public_access_prevention) == 0
+    error_message = "Setting enforce_public_access_prevention = false must remove that policy."
+  }
+}
+
+# -------------------------------------------------------------------------------------------------------------------
+# allow-list path — external IP permitted for named instances instead of deny_all.
+# -------------------------------------------------------------------------------------------------------------------
+
+run "vm_external_ip_allowlist_permits_named" {
+  command = plan
+
+  variables {
+    vm_external_ip_allowed_projects = ["projects/edge-ingress/zones/us-central1-a/instances/nat-gw-0"]
+  }
+
+  assert {
+    condition     = google_org_policy_policy.vm_external_ip[0].spec[0].rules[0].deny_all == null
+    error_message = "With an allow-list, deny_all must be null (allow-list takes over)."
+  }
+
+  assert {
+    condition     = contains(google_org_policy_policy.vm_external_ip[0].spec[0].rules[0].values[0].allowed_values, "projects/edge-ingress/zones/us-central1-a/instances/nat-gw-0")
+    error_message = "Allow-listed instance must appear in allowed_values."
+  }
+}
+
+# -------------------------------------------------------------------------------------------------------------------
+# resource-location guardrail — only active when locations supplied.
+# -------------------------------------------------------------------------------------------------------------------
+
+run "resource_locations_active_when_supplied" {
+  command = plan
+
+  variables {
+    allowed_resource_locations = ["in:us-locations", "in:eu-locations"]
+  }
+
+  assert {
+    condition     = length(google_org_policy_policy.resource_locations) == 1
+    error_message = "gcp.resourceLocations must be enforced when allowed_resource_locations is non-empty."
+  }
+
+  assert {
+    condition     = contains(google_org_policy_policy.resource_locations[0].spec[0].rules[0].values[0].allowed_values, "in:eu-locations")
+    error_message = "resourceLocations must carry the supplied allowed location groups."
+  }
+}
+
+# -------------------------------------------------------------------------------------------------------------------
+# parent validation — reject a malformed parent.
+# -------------------------------------------------------------------------------------------------------------------
+
+run "rejects_malformed_parent" {
+  command = plan
+
+  variables {
+    parent = "not-a-valid-parent"
+  }
+
+  expect_failures = [
+    var.parent,
+  ]
+}

--- a/terraform/modules/gcp-org-policy/main.tf
+++ b/terraform/modules/gcp-org-policy/main.tf
@@ -1,0 +1,186 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# GCP Organization Policy Module (WS-E — security / compliance)
+# ---------------------------------------------------------------------------------------------------------------------
+# Binds a set of GCP org-policy constraints to a resource-manager node (org / folder
+# / project) to give the GCP estate guardrail parity with the AWS SCP + iam-baseline
+# controls already in this repo:
+#
+#   AWS control (in-repo)                         GCP parity (this module)
+#   ------------------------------------------    -------------------------------------------------
+#   scps deny_s3_public + iam-baseline S3 PAB     storage.publicAccessPrevention
+#   iam-baseline EBS-encryption-by-default        gcp.restrictNonCmekServices (CMEK)
+#   scps restrict_regions                         gcp.resourceLocations
+#   iam-baseline MFA / no static creds            iam.disableServiceAccountKeyCreation/Upload
+#   (no AWS analog — GCP-specific hardening)      compute.vmExternalIpAccess, compute.requireOsLogin,
+#                                                 sql.restrictPublicIp, storage.uniformBucketLevelAccess
+#
+# Uses the modern `google_org_policy_policy` resource (provider google ~> 6, the
+# v2 Org Policy API), NOT the deprecated `google_organization_policy` (v1). Boolean
+# constraints set `spec.rules[].enforce = "TRUE"`; list constraints set
+# `deny_all` / `values { allowed_values | denied_values }`.
+#
+# ADR-0028 note: org-policy bindings are not labelable GCP resources, so the
+# platform taxonomy is carried on var.labels for provenance (see variables.tf) and
+# echoed into the local below; it is not applied to a billable resource here. This
+# mirrors how gcp-billing-budget handles google_billing_budget's lack of labels.
+#
+# plan/validate-only — apply is gated behind explicit human approval + blast-radius
+# review (an org-policy change is org-wide and must never auto-apply).
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  # ADR-0028 baseline taxonomy for this system, merged with caller overrides.
+  # Recorded for provenance; see variables.tf for why it is not applied to a resource.
+  platform_labels = merge(
+    {
+      platform_system     = "security"
+      platform_component  = "org-policy"
+      platform_managed_by = "terragrunt"
+    },
+    var.labels,
+  )
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# compute.vmExternalIpAccess — LIST constraint (allow-list of instances permitted an
+# external IP). Empty allow-list => deny_all (no external IPs); non-empty => permit
+# only those values.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "google_org_policy_policy" "vm_external_ip" {
+  count = var.restrict_vm_external_ip ? 1 : 0
+
+  name   = "${var.parent}/policies/compute.vmExternalIpAccess"
+  parent = var.parent
+
+  spec {
+    rules {
+      deny_all = length(var.vm_external_ip_allowed_projects) == 0 ? "TRUE" : null
+
+      dynamic "values" {
+        for_each = length(var.vm_external_ip_allowed_projects) > 0 ? [1] : []
+        content {
+          allowed_values = var.vm_external_ip_allowed_projects
+        }
+      }
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Boolean constraints — enforce = TRUE.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "google_org_policy_policy" "disable_sa_key_creation" {
+  count = var.disable_sa_key_creation ? 1 : 0
+
+  name   = "${var.parent}/policies/iam.disableServiceAccountKeyCreation"
+  parent = var.parent
+
+  spec {
+    rules {
+      enforce = "TRUE"
+    }
+  }
+}
+
+resource "google_org_policy_policy" "disable_sa_key_upload" {
+  count = var.disable_sa_key_upload ? 1 : 0
+
+  name   = "${var.parent}/policies/iam.disableServiceAccountKeyUpload"
+  parent = var.parent
+
+  spec {
+    rules {
+      enforce = "TRUE"
+    }
+  }
+}
+
+resource "google_org_policy_policy" "require_os_login" {
+  count = var.require_os_login ? 1 : 0
+
+  name   = "${var.parent}/policies/compute.requireOsLogin"
+  parent = var.parent
+
+  spec {
+    rules {
+      enforce = "TRUE"
+    }
+  }
+}
+
+resource "google_org_policy_policy" "restrict_public_ip_cloudsql" {
+  count = var.restrict_public_ip_cloudsql ? 1 : 0
+
+  name   = "${var.parent}/policies/sql.restrictPublicIp"
+  parent = var.parent
+
+  spec {
+    rules {
+      enforce = "TRUE"
+    }
+  }
+}
+
+resource "google_org_policy_policy" "uniform_bucket_level_access" {
+  count = var.uniform_bucket_level_access ? 1 : 0
+
+  name   = "${var.parent}/policies/storage.uniformBucketLevelAccess"
+  parent = var.parent
+
+  spec {
+    rules {
+      enforce = "TRUE"
+    }
+  }
+}
+
+resource "google_org_policy_policy" "public_access_prevention" {
+  count = var.enforce_public_access_prevention ? 1 : 0
+
+  name   = "${var.parent}/policies/storage.publicAccessPrevention"
+  parent = var.parent
+
+  spec {
+    rules {
+      enforce = "TRUE"
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# List constraints — CMEK and resource-location guardrails.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "google_org_policy_policy" "restrict_non_cmek_services" {
+  count = length(var.enforce_cmek) > 0 ? 1 : 0
+
+  name   = "${var.parent}/policies/gcp.restrictNonCmekServices"
+  parent = var.parent
+
+  spec {
+    rules {
+      values {
+        # Services listed here are DENIED the ability to create non-CMEK resources,
+        # i.e. CMEK becomes mandatory for them.
+        denied_values = var.enforce_cmek
+      }
+    }
+  }
+}
+
+resource "google_org_policy_policy" "resource_locations" {
+  count = length(var.allowed_resource_locations) > 0 ? 1 : 0
+
+  name   = "${var.parent}/policies/gcp.resourceLocations"
+  parent = var.parent
+
+  spec {
+    rules {
+      values {
+        allowed_values = var.allowed_resource_locations
+      }
+    }
+  }
+}

--- a/terraform/modules/gcp-org-policy/outputs.tf
+++ b/terraform/modules/gcp-org-policy/outputs.tf
@@ -1,0 +1,43 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Outputs for the gcp-org-policy module (WS-E — security / compliance).
+# ---------------------------------------------------------------------------------------------------------------------
+
+output "parent" {
+  description = "The resource-manager node the policies are bound to."
+  value       = var.parent
+}
+
+output "enforced_constraints" {
+  description = "GCP org-policy constraint names actually enforced by this module instance (count-gated resources only appear when enabled)."
+  value = compact([
+    length(google_org_policy_policy.vm_external_ip) > 0 ? "compute.vmExternalIpAccess" : "",
+    length(google_org_policy_policy.disable_sa_key_creation) > 0 ? "iam.disableServiceAccountKeyCreation" : "",
+    length(google_org_policy_policy.disable_sa_key_upload) > 0 ? "iam.disableServiceAccountKeyUpload" : "",
+    length(google_org_policy_policy.require_os_login) > 0 ? "compute.requireOsLogin" : "",
+    length(google_org_policy_policy.restrict_public_ip_cloudsql) > 0 ? "sql.restrictPublicIp" : "",
+    length(google_org_policy_policy.uniform_bucket_level_access) > 0 ? "storage.uniformBucketLevelAccess" : "",
+    length(google_org_policy_policy.public_access_prevention) > 0 ? "storage.publicAccessPrevention" : "",
+    length(google_org_policy_policy.restrict_non_cmek_services) > 0 ? "gcp.restrictNonCmekServices" : "",
+    length(google_org_policy_policy.resource_locations) > 0 ? "gcp.resourceLocations" : "",
+  ])
+}
+
+output "enforced_constraint_count" {
+  description = "Number of org-policy constraints enforced by this module instance."
+  value = (
+    length(google_org_policy_policy.vm_external_ip) +
+    length(google_org_policy_policy.disable_sa_key_creation) +
+    length(google_org_policy_policy.disable_sa_key_upload) +
+    length(google_org_policy_policy.require_os_login) +
+    length(google_org_policy_policy.restrict_public_ip_cloudsql) +
+    length(google_org_policy_policy.uniform_bucket_level_access) +
+    length(google_org_policy_policy.public_access_prevention) +
+    length(google_org_policy_policy.restrict_non_cmek_services) +
+    length(google_org_policy_policy.resource_locations)
+  )
+}
+
+output "platform_labels" {
+  description = "ADR-0028 taxonomy recorded for this module instance (provenance; org-policy resources are not labelable)."
+  value       = local.platform_labels
+}

--- a/terraform/modules/gcp-org-policy/variables.tf
+++ b/terraform/modules/gcp-org-policy/variables.tf
@@ -1,0 +1,115 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Inputs for the gcp-org-policy module (WS-E — security / compliance).
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "parent" {
+  description = <<-EOT
+    The resource-manager node the org policies bind to, in `google_org_policy_policy`
+    parent form: `organizations/{ORG_ID}`, `folders/{FOLDER_ID}`, or
+    `projects/{PROJECT_ID}`. Binding at the organization or a top-level folder gives
+    org-wide guardrails; binding at a project scopes them to a single GCP project.
+  EOT
+  type        = string
+
+  validation {
+    condition     = can(regex("^(organizations|folders|projects)/[^/]+$", var.parent))
+    error_message = "parent must be one of organizations/ID, folders/ID, or projects/ID."
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Boolean constraint toggles — each maps to a CIS / SOC2-relevant GCP org-policy
+# constraint. All default ON (deny-by-default posture); set false to carve a
+# constraint out (e.g. during a staged rollout).
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "restrict_vm_external_ip" {
+  description = "Enforce constraints/compute.vmExternalIpAccess (deny public IPs on Compute/GKE VMs unless explicitly allow-listed). SOC2 CC6.6."
+  type        = bool
+  default     = true
+}
+
+variable "vm_external_ip_allowed_projects" {
+  description = "When restrict_vm_external_ip is true, allow-list values for compute.vmExternalIpAccess (e.g. projects/ID/zones/.../instances/...). Empty = deny all external IPs."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
+variable "disable_sa_key_creation" {
+  description = "Enforce constraints/iam.disableServiceAccountKeyCreation (block long-lived SA keys; forces Workload Identity / WIF). SOC2 CC6.1 / CC6.3."
+  type        = bool
+  default     = true
+}
+
+variable "disable_sa_key_upload" {
+  description = "Enforce constraints/iam.disableServiceAccountKeyUpload (block uploading externally-generated SA keys). Complements disable_sa_key_creation."
+  type        = bool
+  default     = true
+}
+
+variable "require_os_login" {
+  description = "Enforce constraints/compute.requireOsLogin (centralised IAM-managed SSH instead of project SSH keys). SOC2 CC6.1."
+  type        = bool
+  default     = true
+}
+
+variable "restrict_public_ip_cloudsql" {
+  description = "Enforce constraints/sql.restrictPublicIp (Cloud SQL — the MLflow backend store in ADR-0037 — may not have a public IP). SOC2 CC6.6."
+  type        = bool
+  default     = true
+}
+
+variable "uniform_bucket_level_access" {
+  description = "Enforce constraints/storage.uniformBucketLevelAccess (GCS — MLflow artifact store — must use uniform bucket-level IAM, no per-object ACLs). SOC2 CC6.1 / CC6.3."
+  type        = bool
+  default     = true
+}
+
+variable "enforce_public_access_prevention" {
+  description = "Enforce constraints/storage.publicAccessPrevention (no public GCS buckets org-wide). SOC2 CC6.6 — parity with the AWS S3 account public-access block in iam-baseline / scps deny_s3_public."
+  type        = bool
+  default     = true
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CMEK enforcement — list constraint requiring customer-managed encryption keys.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "enforce_cmek" {
+  description = "Services that may only create resources with customer-managed keys, via constraints/gcp.restrictNonCmekServices. SOC2 CC6.1 — encryption at rest. Empty list = disabled."
+  type        = list(string)
+  default = [
+    "bigquery.googleapis.com",
+    "compute.googleapis.com",
+    "storage.googleapis.com",
+    "sqladmin.googleapis.com",
+  ]
+  nullable = false
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Resource location restriction — list constraint pinning resources to allowed regions.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "allowed_resource_locations" {
+  description = "Enforce constraints/gcp.resourceLocations (data-residency guardrail; mirrors the AWS scps restrict_regions control). Values are location group/value forms, e.g. in:eu-locations, in:us-locations. Empty = disabled."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# ADR-0028 labels. NOTE: google_org_policy_policy has NO labels argument (it is an
+# org-policy binding, not a labelable resource), so — exactly like the
+# gcp-billing-budget module documents for google_billing_budget — the ADR-0028
+# taxonomy is asserted via this variable for catalog/test provenance and is the
+# contract a reviewer greps for. Keys use the GCP underscore spelling.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "labels" {
+  description = "ADR-0028 platform taxonomy (GCP underscore keys, e.g. platform_system = security). Recorded for provenance; org-policy resources are not labelable, so these are not applied to a GCP resource here."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}

--- a/terraform/modules/gcp-org-policy/versions.tf
+++ b/terraform/modules/gcp-org-policy/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## WS-E — SOC2 posture + GCP policy parity + ML on-call (Phase 3)

Implements **WS-E** of the GCP ML Platform plan. **Plan/validate-only**.

### ADR-0040
GCP-side **policy parity** (GCP org-policy v2), **cross-cloud WIF federation** (GCP WIF ↔ AWS IAM — note basic per-pod GKE Workload Identity is already done in WS-A; this is federation + org policy), **SOC2 control-mapping + evidence**, and **on-call** rotation + ML-incident runbooks.

### Delivered
- `terraform/modules/gcp-org-policy/` (+ catalog unit, `*.tftest.hcl` **11/11**) — `google_org_policy_policy` constraints: no external IP, disable SA-key create/upload, require OS Login, restrict CloudSQL public IP, uniform bucket access + public-access prevention, require CMEK, resource-location residency.
- `docs/compliance/soc2-control-matrix.md` — SOC2 CC-criteria → existing platform controls (Kyverno/Tetragon/Gatekeeper, iam-baseline, SCPs, secret-rotation, GuardDuty/SecurityHub, CloudTrail/Config) + the GCP gaps this WS closes. **Still-gaps tracked honestly** (SCC/Config, GCP audit-log export, Gatekeeper in-cluster delivery, `gcp-wif` pool module, Backstage ownership).
- `docs/runbooks/ml-incident-runbook.md` + `oncall-rotation-escalation.md` (drift / pipeline-failure / serving-outage, tied to PagerDuty/Alertmanager).

### Validation
`terraform fmt/validate` clean, **11/11 tests** (mock google provider). Cross-doc links resolve. `platform:system` via `var.labels` (org-policy is non-labelable, same pattern as `gcp-billing-budget`).

### Honest scope note
WIF is ratified + its forcing constraint (`disableServiceAccountKeyCreation`) ships now; the `google_iam_workload_identity_pool` provider/pool is a deferred `gcp-wif` follow-up.

> Draft, apply-gated. Independent of WS-A/B/C.

Part of the GCP ML Platform plan · ADR-0040