### PR TITLE
feat(gcp-ml): WS-F golden paths + contracts + RACI (ADR-0041)

### DIFF
--- a/docs/adrs/0041-golden-paths-collaboration.md
+++ b/docs/adrs/0041-golden-paths-collaboration.md
@@ -1,0 +1,265 @@
+# ADR-0041: Golden-path templates, shared contracts, and cross-team collaboration model
+
+- Status: **Proposed** — plan/validate-only; implementation apply-gated.
+- platform-design status: **pending** — `templates/golden-paths/` directory introduced by
+  this ADR; no Backstage scaffolder installed; golden paths delivered as template directories
+  + onboarding docs.
+- Date: 2026-06-10
+- Authors: platform-team (devops-engineer)
+- Related issues: WS-F "Collaboration / golden paths" (GCP ML Platform plan §4 WS-F);
+  plan readiness row 4 ("Collaboration — golden paths + shared contracts + IDP missing");
+  ADR-0034 (Backstage — deferred); ADR-0037 (WS-B ML CI/CD + MLflow); ADR-0038 (WS-C
+  drift/accuracy monitoring); ADR-0039 (WS-D self-serve observability).
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+The GCP ML Platform implementation plan (§2, row 4) identifies a partial gap in the
+**collaboration layer**: Grafana dashboards exist, but golden paths, shared API/data
+contracts, and a cross-team IDP are missing.
+
+Four workstreams (WS-A..E) have now delivered their platform artifacts:
+
+| Workstream | Key artifact | WS-F consumes |
+|-----------|-------------|---------------|
+| WS-B (ADR-0037) | `.github/workflows/ml-pipeline.yml`, `apps/infra/airflow/` (4 DAGs), `apps/infra/mlflow/` | Train→eval→register→deploy pipeline that golden paths must wire new models into |
+| WS-C (ADR-0038) | `apps/infra/ml-monitoring/` (Evidently drift-exporter, whylogs profiler, `retrain-trigger`, PrometheusRule) | Drift/accuracy metrics + retrain webhook that every model service must expose |
+| WS-D (ADR-0039) | `apps/infra/grafana-self-serve/` (per-team Grafana folder + dashboard + alert-rules, ConfigMap-sidecar) | Self-serve observability surface that every new team/service must provision |
+
+Three concrete problems remain unsolved:
+
+1. **No standard starting point for a new model service.** A new model takes weeks to
+   integrate manually because there is no reference that shows how to wire
+   `ml-pipeline.yml` + MLflow registration + Evidently drift-exporter + grafana-self-serve
+   in one place. Each team re-invents the same glue.
+
+2. **No shared API/data contract.** ML engineers define model request/response schemas
+   ad-hoc. Backend and frontend teams discover mismatches at integration time. There is
+   no single authoritative spec that all four personas (data, ML, backend, frontend) sign
+   off on before code is written.
+
+3. **No RACI or handoff protocol.** The production model lifecycle touches four personas
+   with overlapping responsibilities. Without an explicit RACI, gaps (who triggers a
+   retrain? who owns a drift alert?) and overlaps (duplicate dashboards, conflicting
+   alert thresholds) are inevitable.
+
+### Why template directories, not a Backstage scaffolder?
+
+[ADR-0034](0034-backstage-idp.md) deferred Backstage pending three conditions:
+
+1. A dedicated Backstage owner is assigned.
+2. The platform backlog matures (many ADRs still `pending`).
+3. Three or more teams are actively onboarded via golden-path templates from this
+   WS-F iteration.
+
+Condition 3 creates a bootstrapping dependency: the WS-F golden paths must exist and
+prove value before Backstage's revisit criteria can be met. Implementing golden paths
+as Backstage scaffolders now — without a dedicated owner — would leave them abandoned.
+
+The implementation plan (§7 #5) recommends: "ship lightweight self-serve in WS-D first;
+revisit Backstage when all three conditions are met." The same logic applies to WS-F:
+ship template directories first, map them onto Backstage scaffolders later.
+
+**Chosen approach:** every golden path is a directory under `templates/golden-paths/`
+containing templated files with clearly marked `{{UPPER_SNAKE_CASE}}` substitution
+points, a `README.md` onboarding guide, and an `argocd-application.yaml` stub. The
+directory structure is explicitly designed to map 1:1 onto a Backstage Software Template
+when ADR-0034 is revisited.
+
+### ADR-0028 mandate
+
+[ADR-0028](0028-unified-platform-tagging-and-labeling-taxonomy.md) requires
+`platform.system` / `platform.component` / `platform.env` / `platform.owner` /
+`platform.managed-by` labels on every Kubernetes resource and the equivalent tags on
+every cloud resource. All template files in this ADR carry these labels as substitutable
+placeholders. `platform.system` defaults to `ml-pipeline` for model-service and pipeline
+templates (per ADR-0037 §D) and `observability` for dashboard templates (per ADR-0039 §D).
+
+## Decision
+
+### D1 — Template-directory golden paths (three paths)
+
+Deliver three golden paths as `templates/golden-paths/{path-name}/` directories:
+
+| Path | Template directory | Purpose |
+|------|--------------------|---------|
+| **new-model-service** | `templates/golden-paths/new-model-service/` | New model pre-wired to ml-pipeline.yml, MLflow, WS-C drift-exporter, WS-D dashboard |
+| **new-ml-pipeline** | `templates/golden-paths/new-ml-pipeline/` | New Airflow DAG mirroring WS-B DAG shape + MLflow registration + drift metric emission |
+| **new-dashboard** | `templates/golden-paths/new-dashboard/` | New team grafana-self-serve values (re-uses WS-D chart); onboards a new team in one PR |
+
+Each template directory contains:
+
+- `README.md` — human-readable onboarding guide with a numbered checklist, copy-paste
+  commands, and links to the underlying WS-B/C/D artifacts.
+- One or more templated files with `{{UPPER_SNAKE_CASE}}` placeholders (never live
+  values, never secrets).
+- An `argocd-application.yaml` stub pre-filled with the correct chart path, wave
+  annotation, and ADR-0028 labels.
+- An explicit mapping to the corresponding Backstage Software Template fields so
+  migration is mechanical when ADR-0034 is revisited.
+
+### D2 — Shared API/data contracts (`docs/contracts/`)
+
+Publish a canonical contract specification at `docs/contracts/` covering:
+
+- **`model-api-contract.md`** — model request/response schema (OpenAPI-compatible
+  JSON Schema fragments) + feature schema, versioning policy, and a worked example.
+- **`example-domain-adapter-contract.yaml`** — a concrete YAML instance of the contract
+  for the `domain-adapter` model family, suitable for use in CI contract tests.
+
+All four engineering personas (data, ML, backend, frontend) are expected to read and
+sign off on the contract before a new model service is promoted beyond staging.
+The contract file lives in the repo so it is version-controlled and reviewable via PR.
+
+### D3 — RACI and handoff protocol (`docs/golden-paths/RACI-and-handoffs.md`)
+
+Document the production model lifecycle as:
+
+1. A **RACI matrix** mapping five lifecycle activities (feature pipeline, model training,
+   drift monitoring, serving/API, incident response) to four personas (Data Engineering,
+   ML Engineering, Backend/Frontend, Platform/SRE) with explicit R/A/C/I assignments.
+2. A **handoff flow** (Mermaid-compatible text diagram) showing the artifact hand-off
+   sequence from raw data → trained adapter → registered model → deployed service →
+   monitored production, including WS-B/C/D system boundaries.
+3. An **on-call and escalation table** (supplement to ADR-0040 ML-incident runbooks)
+   recording who gets paged first per alert class and what the first-response action is.
+
+### D4 — Backstage migration path
+
+Each template directory README includes a "Backstage future mapping" section recording:
+
+- Backstage Software Template `spec.type` mapping.
+- Which `parameters` blocks map to which `{{PLACEHOLDER}}` values.
+- Which `steps` blocks (fetch template, publish, register catalog entity) are needed.
+
+This makes the migration to a Backstage scaffolder a mechanical transformation rather
+than a redesign.
+
+## Alternatives considered
+
+### A1 — Implement golden paths as Backstage scaffolders immediately
+
+Deploy Backstage (reversing ADR-0034 deferral) and implement WS-F as Software Templates.
+
+*Rejected because:* ADR-0034 deferral conditions are not met (no dedicated owner, many
+ADRs still `pending`). A Backstage deployment without an owner degrades within months.
+ADR-0039 successfully shipped lightweight WS-D self-serve without Backstage, proving
+the template-directory pattern is sufficient.
+
+### A2 — Reuse an existing open-source golden-path framework (Cookiecutter/Copier)
+
+Use a templating engine to generate golden-path scaffolds.
+
+*Partially adopted, rejected as a mandatory dependency:* the `{{PLACEHOLDER}}`
+convention used here is intentionally compatible with both `envsubst`-style substitution
+and Copier/Cookiecutter config. However, adding a Python/Go CLI dependency to the
+developer workflow without a dedicated owner creates a new failure mode. Template
+directories with documented `envsubst` substitution are simpler and sufficient.
+
+### A3 — Inline the contracts into the ADRs
+
+Document model API contracts inside each ADR rather than in `docs/contracts/`.
+
+*Rejected because:* ADRs are decision records, not living specifications. Contracts
+must be updated as the API evolves without creating new ADRs; a versioned file in
+`docs/contracts/` is the correct artifact for a living spec.
+
+### A4 — Status quo (no golden paths, no contracts, no RACI)
+
+Continue with ad-hoc onboarding and per-team schema definitions.
+
+*Rejected because:* this is exactly the gap identified in the implementation plan (§2,
+row 4). Repeated manual integration cost and integration-time mismatches are documented
+failure modes.
+
+## Consequences
+
+### Positive
+
+- A new model team can onboard end-to-end (training pipeline + drift monitoring +
+  dashboard + serving contract) from a single starting point rather than reading five
+  separate ADRs and four separate `values.yaml` files.
+- Shared contracts surface schema mismatches before code is written, not at integration
+  time.
+- RACI eliminates the "who owns drift alerts?" ambiguity.
+- Template directories require no new operators and no new infra; they are checked-in
+  docs with zero runtime footprint.
+- `platform.system = ml-pipeline` (model/pipeline templates) and `platform.system =
+  observability` (dashboard template) are pre-populated in every stub, satisfying the
+  ADR-0028 OPA gate from day one.
+
+### Negative
+
+- Template files require manual `envsubst`/`sed` substitution until Backstage is
+  available. A numbered checklist in each README reduces substitution errors.
+- Three template directories add maintenance surface. Changes to WS-B/C/D artifacts
+  require updating the corresponding template.
+
+### Risks
+
+- **Template drift:** if WS-B/C/D charts evolve and templates are not updated, teams
+  hit integration errors. Mitigation: each template README records the WS-B/C/D chart
+  versions it was verified against; CI yamllint + kubeconform validate template YAML
+  on every PR.
+- **Contract adoption:** teams may bypass the contract review step. Mitigation: the
+  RACI assigns contract sign-off as a blocking pre-condition before staging promotion.
+- **Backstage deferral indefinite:** if ADR-0034 revisit criteria are never met, the
+  template-directory approach becomes permanent. Mitigation: the revisit criteria are
+  tied to observable milestones in the implementation plan (Phase-3 GCP ML stable).
+
+## Implementation notes
+
+### Files created by this ADR
+
+| File | Purpose |
+|------|---------|
+| `docs/adrs/0041-golden-paths-collaboration.md` | This ADR |
+| `templates/golden-paths/new-model-service/README.md` | Onboarding guide |
+| `templates/golden-paths/new-model-service/values-grafana-self-serve.yaml` | WS-D values |
+| `templates/golden-paths/new-model-service/values-ml-monitoring.yaml` | WS-C values |
+| `templates/golden-paths/new-model-service/ml-pipeline-trigger.yaml` | Pipeline dispatch example |
+| `templates/golden-paths/new-model-service/argocd-application.yaml` | ArgoCD stub |
+| `templates/golden-paths/new-ml-pipeline/README.md` | Onboarding guide |
+| `templates/golden-paths/new-ml-pipeline/dag_template.py` | Airflow DAG scaffold |
+| `templates/golden-paths/new-ml-pipeline/argocd-application.yaml` | ArgoCD stub |
+| `templates/golden-paths/new-dashboard/README.md` | Onboarding guide |
+| `templates/golden-paths/new-dashboard/values.yaml` | grafana-self-serve values template |
+| `templates/golden-paths/new-dashboard/argocd-application.yaml` | ArgoCD stub |
+| `docs/contracts/model-api-contract.md` | Model request/response + feature schema spec |
+| `docs/contracts/example-domain-adapter-contract.yaml` | Concrete contract example |
+| `docs/golden-paths/RACI-and-handoffs.md` | RACI matrix + handoff flow |
+
+### Backstage future mapping
+
+When ADR-0034 is revisited, each golden path maps to a Backstage Software Template:
+
+| Template directory | Backstage `spec.type` | Key `parameters` |
+|--------------------|-----------------------|------------------|
+| `new-model-service` | `model-service` | `modelName`, `tenant`, `domain`, `teamSlug`, `namespace` |
+| `new-ml-pipeline` | `ml-pipeline` | `dagName`, `modelName`, `tenant`, `domain` |
+| `new-dashboard` | `team-dashboard` | `teamName`, `teamSlug`, `namespace`, `system` |
+
+### Rollback
+
+Template directories are documentation artefacts with no deployment. If a template
+produces a broken resource, the team's PR fails CI before merge.
+
+## References
+
+- [ADR-0034](0034-backstage-idp.md) — Backstage deferred
+- [ADR-0037](0037-ml-cicd-pipeline-mlflow.md) — WS-B ML CI/CD + MLflow
+- [ADR-0038](0038-ml-observability-drift.md) — WS-C drift/accuracy monitoring
+- [ADR-0039](0039-self-serve-observability.md) — WS-D self-serve observability
+- [ADR-0028](0028-unified-platform-tagging-and-labeling-taxonomy.md) — Platform taxonomy
+- [ADR-0040](0040-soc-posture-and-oncall.md) — WS-E SOC posture + ML on-call runbooks
+- In-repo: `docs/gcp-ml-platform/IMPLEMENTATION_PLAN.md` §4 WS-F and §7 #5
+- In-repo: `apps/infra/grafana-self-serve/values.yaml` (WS-D chart values reference)
+- In-repo: `apps/infra/ml-monitoring/values.yaml` (WS-C chart values reference)
+- In-repo: `.github/workflows/ml-pipeline.yml` (WS-B pipeline reference)
+- In-repo: `apps/infra/airflow/dags/` (WS-B DAG scaffolds)
+- CNCF Backstage Software Templates: <https://backstage.io/docs/features/software-templates/>
+
+---
+*Planning-only ADR — proposed, not yet implemented. WS-F "Collaboration / golden paths";
+implementation apply-gated. Design 2026-06-10.*

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -84,6 +84,7 @@ decision.
 | [0038](0038-ml-observability-drift.md) | ML observability — drift detection, accuracy monitoring, and retrain trigger (Evidently + whylogs, Prometheus-native) | Proposed | pending | WS-C of GCP ML platform plan; design 2026-06-10 |
 | [0039](0039-self-serve-observability.md) | Self-serve observability — templated Grafana folders, starter dashboards, and alert-rules-as-code (Backstage deferred, ADR-0034) | Proposed | pending | WS-D of GCP ML platform plan; design 2026-06-10 |
 | [0040](0040-soc-posture-and-oncall.md) | SOC2 posture — GCP org-policy parity + cross-cloud WIF (GCP↔AWS) + control-to-evidence matrix + ML on-call/runbooks | Proposed | pending | WS-E of GCP ML platform plan; design 2026-06-10 |
+| [0041](0041-golden-paths-collaboration.md) | Golden-path templates, shared contracts, and cross-team collaboration model (Backstage deferred, ADR-0034) | Proposed | pending | WS-F of GCP ML platform plan; design 2026-06-10 |
 
 
 

--- a/docs/contracts/example-domain-adapter-contract.yaml
+++ b/docs/contracts/example-domain-adapter-contract.yaml
@@ -1,0 +1,118 @@
+# example-domain-adapter-contract.yaml
+#
+# Concrete contract instance for the domain-adapter model family.
+# Written against model-api-contract.md v1.0.0.
+#
+# Use this file as a template when writing a contract instance for a new model.
+# Replace the values below with your model's specifics.
+#
+# Contract sign-off is required before staging promotion.
+# See templates/golden-paths/new-model-service/README.md Step 5.
+#
+# ADR references:
+#   ADR-0037 (WS-B): model_name + model_version registration in MLflow
+#   ADR-0038 (WS-C): monitoring labels (model_name, tenant, domain)
+#   ADR-0039 (WS-D): observability SLOs
+#   ADR-0041 (WS-F): this contract template
+
+contract_spec_version: "1.0.0"
+contract_instance_version: "1.0.0"
+date: "2026-06-10"
+
+model:
+  # MLflow registered model name. Must match the registry entry from ml-pipeline.yml.
+  name: "domain-adapter-hft"
+  tenant: "tenant-acme"
+  domain: "hft"
+  description: >
+    LoRA domain adapter for high-frequency trading (HFT) transaction analysis.
+    Trained on the hft Iceberg snapshot; outputs a buy/sell/hold signal with an
+    expected edge in USD. Served via vLLM multi-LoRA on GKE GPU node pool.
+  registry_stage: "Staging"
+
+signoff:
+  data_engineering_lead: ""   # Fill in: "Alice Smith <alice@example.com>"
+  ml_engineering_lead: ""     # Fill in: "Bob Jones <bob@example.com>"
+  backend_lead: ""             # Fill in: "Carol Lee <carol@example.com>"
+  frontend_lead: "N/A"         # No frontend consumer for this model
+  sign_off_date: ""            # Fill in: YYYY-MM-DD
+
+request_schema:
+  required_features:
+    # Common fields (§3.1 of model-api-contract.md)
+    - name: "transaction_id"
+      type: "string"
+      description: "Unique transaction identifier"
+
+    - name: "timestamp_utc"
+      type: "string"
+      format: "YYYY-MM-DDTHH:MM:SSZ"
+      description: "Transaction timestamp in UTC"
+
+    - name: "amount_usd"
+      type: "number"
+      description: "Transaction amount in USD"
+
+    - name: "currency_code"
+      type: "string"
+      description: "ISO 4217 three-letter currency code"
+
+    - name: "merchant_category"
+      type: "string"
+      description: "Merchant category code (MCC)"
+
+    # hft domain-specific features (§3.2)
+    - name: "bid_ask_spread"
+      type: "number"
+      description: "Bid-ask spread at time of transaction"
+
+    - name: "order_book_depth"
+      type: "integer"
+      description: "Number of price levels in order book"
+
+    - name: "venue_id"
+      type: "string"
+      description: "Trading venue identifier"
+
+    - name: "latency_microseconds"
+      type: "integer"
+      description: "Round-trip latency in microseconds"
+
+response_schema:
+  # Domain-specific prediction fields for the hft domain (§4.1)
+  prediction_fields:
+    - name: "signal"
+      type: "string"
+      enum: ["buy", "sell", "hold"]
+      description: "Trading signal"
+
+    - name: "edge_usd"
+      type: "number"
+      description: "Expected edge in USD for this signal"
+
+slo_overrides:
+  # Override the default SLO targets from §5 of model-api-contract.md.
+  p50_latency_ms: 30         # Stricter than default 50ms (HFT latency requirement)
+  p99_latency_ms: 100        # Stricter than default 200ms
+  error_rate_threshold: 0.005
+  model_accuracy_floor: 0.87  # Slightly stricter than default 0.85
+  drift_score_ceiling: 0.15   # Stricter than default 0.2
+
+observability:
+  # These values must match the ADR-0038 metric labels on drift-exporter exactly.
+  metric_labels:
+    model_name: "domain-adapter-hft"
+    tenant: "tenant-acme"
+    domain: "hft"
+  # Fill in after WS-D onboarding:
+  grafana_dashboard_url: ""
+  # Fill in after first training run:
+  mlflow_experiment_url: ""
+
+breaking_changes:
+  - none
+
+notes: >
+  First contract instance for the domain-adapter-hft model.
+  HFT domain requires stricter latency SLOs than the platform defaults.
+  Frontend team is not a consumer for this model; frontend_lead is N/A.

--- a/docs/contracts/model-api-contract.md
+++ b/docs/contracts/model-api-contract.md
@@ -1,0 +1,236 @@
+# Model API Contract
+
+**Version:** 1.0.0
+**Status:** Ratified — enforced as a pre-staging-promotion gate (see
+`docs/golden-paths/RACI-and-handoffs.md` §Handoffs, Handoff H3).
+**Owners:** ML Engineering (spec author), Backend (consumer), Data Engineering
+(feature schema), Platform/SRE (observability alignment).
+
+All four personas must sign off on a new model's contract instance before the model
+is promoted beyond staging. See `docs/contracts/example-domain-adapter-contract.yaml`
+for a worked example and `templates/golden-paths/new-model-service/README.md` Step 5
+for the sign-off checklist.
+
+---
+
+## 1. Versioning policy
+
+- The contract version follows **semver** (`MAJOR.MINOR.PATCH`).
+- A breaking change to request or response schema (removing a field, changing a type,
+  narrowing an enum) increments `MAJOR`.
+- A backward-compatible addition (new optional field, wider enum) increments `MINOR`.
+- Documentation-only corrections increment `PATCH`.
+- Each model's contract instance records the spec version it was written against.
+
+---
+
+## 2. Model request schema
+
+All model-serving endpoints accept `application/json` conforming to:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12",
+  "title": "ModelRequest",
+  "type": "object",
+  "required": ["model_name", "tenant", "domain", "features"],
+  "additionalProperties": false,
+  "properties": {
+    "model_name": {
+      "type": "string",
+      "description": "MLflow registered model name (lower-kebab). Must match ADR-0037 registry entry.",
+      "example": "domain-adapter-hft"
+    },
+    "tenant": {
+      "type": "string",
+      "description": "Tenant identifier (ADR-0038 multi-tenant label). Must match ml_monitoring metric labels.",
+      "example": "tenant-acme"
+    },
+    "domain": {
+      "type": "string",
+      "enum": ["hft", "solana", "insurance", "rtb"],
+      "description": "ML domain. Must match the Airflow DAG param enum."
+    },
+    "features": {
+      "type": "object",
+      "description": "Feature vector. Schema is model-specific; see §3.",
+      "additionalProperties": true
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Optional idempotency key. Used for OTel distributed tracing.",
+      "example": "req-7f3a1b2c"
+    },
+    "model_version": {
+      "type": "string",
+      "description": "Optional MLflow model version. Omit to use the Production alias.",
+      "example": "42"
+    }
+  }
+}
+```
+
+### Request contract rules
+
+1. `model_name` + `tenant` + `domain` must match the values registered in MLflow
+   and the WS-C Evidently drift-exporter label set.
+2. `features` must contain all fields listed in §3 for the given domain.
+3. Backend services must set `request_id` to a value traceable via OTel/Tempo.
+
+---
+
+## 3. Feature schema
+
+Feature schemas are domain-specific. The canonical source of truth for feature
+definitions is the Iceberg schema in `docs/transaction-analytics/03-ml-inference.md`.
+
+### 3.1 Common fields (all domains)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `transaction_id` | string | Unique transaction identifier |
+| `timestamp_utc` | string (ISO 8601) | Transaction timestamp. Format: `YYYY-MM-DDTHH:MM:SSZ` |
+| `amount_usd` | number (float64) | Transaction amount in USD |
+| `currency_code` | string | ISO 4217 three-letter currency code |
+| `merchant_category` | string | MCC code string |
+
+### 3.2 Domain-specific fields
+
+#### hft (High-Frequency Trading)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `bid_ask_spread` | number (float64) | Bid-ask spread at time of transaction |
+| `order_book_depth` | integer | Number of price levels in order book |
+| `venue_id` | string | Trading venue identifier |
+| `latency_microseconds` | integer | Round-trip latency in microseconds |
+
+#### rtb (Real-Time Bidding)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `bid_floor_usd` | number (float64) | Auction floor price |
+| `ad_slot_size` | string | Slot dimensions, e.g., "300x250" |
+| `user_segment` | string | Anonymised user segment ID |
+| `supply_type` | string | One of: `web`, `app`, `ctv` |
+
+#### insurance
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `policy_id` | string | Policy identifier |
+| `claim_type` | string | One of: `auto`, `home`, `health`, `commercial` |
+| `risk_score` | number (float64, 0.0–1.0) | Pre-computed risk score |
+| `days_since_last_claim` | integer | Days since last claim event |
+
+#### solana
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `slot_number` | integer | Solana slot number |
+| `transaction_type` | string | One of: `transfer`, `stake`, `swap`, `program_call` |
+| `program_id` | string | Solana program address |
+| `lamports` | integer | Transaction amount in lamports |
+
+---
+
+## 4. Model response schema
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12",
+  "title": "ModelResponse",
+  "type": "object",
+  "required": ["model_name", "model_version", "tenant", "domain", "prediction", "latency_ms"],
+  "additionalProperties": false,
+  "properties": {
+    "model_name": {
+      "type": "string",
+      "description": "Echo of the requested model_name."
+    },
+    "model_version": {
+      "type": "string",
+      "description": "Resolved MLflow model version that served this prediction."
+    },
+    "tenant": {
+      "type": "string",
+      "description": "Echo of the requested tenant."
+    },
+    "domain": {
+      "type": "string",
+      "description": "Echo of the requested domain."
+    },
+    "prediction": {
+      "type": "object",
+      "description": "Domain-specific prediction output. See §4.1.",
+      "additionalProperties": true
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "description": "Optional model confidence score."
+    },
+    "latency_ms": {
+      "type": "number",
+      "description": "Server-side inference latency in milliseconds."
+    },
+    "mlflow_run_id": {
+      "type": "string",
+      "description": "MLflow run ID of the training run that produced this model version. Enables full reproducibility audit (SOC2 / ADR-0040)."
+    },
+    "request_id": {
+      "type": "string",
+      "description": "Echo of the request_id if provided."
+    }
+  }
+}
+```
+
+### 4.1 Prediction output (domain-specific)
+
+Each domain's `prediction` object must contain at minimum:
+
+| Domain | Required fields |
+|--------|----------------|
+| `hft` | `signal: string` (one of: `buy`, `sell`, `hold`), `edge_usd: number` |
+| `rtb` | `bid_usd: number`, `win_probability: number` |
+| `insurance` | `fraud_probability: number`, `risk_tier: string` |
+| `solana` | `anomaly_score: number`, `anomaly_type: string` |
+
+---
+
+## 5. SLO targets
+
+These are the minimum SLOs a model service must satisfy before production promotion.
+Backend and ML leads jointly own these numbers.
+
+| SLO | Target | Measurement |
+|-----|--------|-------------|
+| p50 latency | < 50ms | OTel Tempo, Prometheus histogram |
+| p99 latency | < 200ms | OTel Tempo, Prometheus histogram |
+| Error rate (5xx) | < 0.5% | Prometheus `http_requests_total` |
+| Model accuracy | > 85% | Evidently drift-exporter (WS-C, ADR-0038) |
+| Drift score | < 0.2 | Evidently/whylogs (WS-C, ADR-0038) |
+| Availability | 99.9% | Alertmanager PrometheusRule (WS-D, ADR-0039) |
+
+---
+
+## 6. Observability alignment
+
+To satisfy the WS-C (ADR-0038) monitoring contract, every model service must:
+
+1. Emit `ml_monitoring_model_accuracy` and `ml_monitoring_dataset_drift_score`
+   Prometheus metrics with labels `{model_name, tenant, domain}`.
+2. Use the OTel Collector for distributed traces — set `request_id` in the
+   `tracestate` header or as the OTel span ID correlation.
+3. Log structured JSON with `model_name`, `tenant`, `domain`, `request_id`,
+   `latency_ms`, and `model_version` on every inference request.
+
+---
+
+## 7. Changelog
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0.0 | 2026-06-10 | platform-team (WS-F ADR-0041) | Initial contract |

--- a/docs/golden-paths/RACI-and-handoffs.md
+++ b/docs/golden-paths/RACI-and-handoffs.md
@@ -1,0 +1,188 @@
+# RACI and Handoffs: Production Model Lifecycle
+
+**Document scope:** the end-to-end lifecycle for a new ML model from raw data to
+monitored production, covering the four engineering personas and the five lifecycle
+activities. This supplements the ADR-0040 ML-incident runbooks with a day-1
+ownership model.
+
+**Related ADRs:** ADR-0037 (WS-B), ADR-0038 (WS-C), ADR-0039 (WS-D),
+ADR-0040 (WS-E on-call), ADR-0041 (WS-F, this document).
+
+---
+
+## 1. Personas
+
+| ID | Persona | Responsibility scope |
+|----|---------|---------------------|
+| DE | **Data Engineering** | Feature pipelines, Iceberg snapshot management, data quality, reference dataset curation |
+| ML | **ML Engineering** | Model training, evaluation, MLflow registry, DAG authorship, adapter packaging |
+| BE | **Backend / Frontend** | API integration, inference client, contract implementation, latency budgets |
+| PL | **Platform / SRE** | Infrastructure, GitOps delivery, observability stack, on-call, incident command |
+
+---
+
+## 2. RACI matrix
+
+**Key:** R = Responsible (does the work) · A = Accountable (owns the outcome) ·
+C = Consulted (input required) · I = Informed (notified)
+
+| Activity | DE | ML | BE | PL |
+|----------|----|----|----|-----|
+| **A1 — Feature pipeline: design schema** | R/A | C | C | I |
+| **A2 — Feature pipeline: implement + deploy Iceberg snapshot** | R/A | C | I | C |
+| **A3 — Feature pipeline: validate reference dataset quality** | R/A | C | I | I |
+| **B1 — Model training: configure Airflow DAG** | C | R/A | I | C |
+| **B2 — Model training: run train→eval pipeline (ml-pipeline.yml)** | I | R/A | I | C |
+| **B3 — Model training: MLflow registration + cosign sign** | I | R/A | I | C |
+| **B4 — Contract spec: author model-api-contract instance** | C | R/A | C | I |
+| **B5 — Contract spec: sign off on instance before staging** | C | A | R (BE) | I |
+| **C1 — Drift monitoring: configure drift-exporter per model (WS-C)** | I | R | I | A |
+| **C2 — Drift monitoring: set alert thresholds in grafana-self-serve** | I | R | I | A |
+| **C3 — Drift alert fires: acknowledge + classify** | I | R | I | A |
+| **C4 — Drift alert fires: trigger retrain or escalate** | I | R/A | I | C |
+| **D1 — Serving/API: implement inference client** | I | C | R/A | I |
+| **D2 — Serving/API: integrate request_id / OTel tracing** | I | I | R/A | C |
+| **D3 — Serving/API: validate SLO targets (p50/p99/error rate)** | I | C | R/A | C |
+| **E1 — On-call: platform/infra alert fires** | I | I | I | R/A |
+| **E2 — On-call: model accuracy / drift alert fires** | I | R/A | I | C |
+| **E3 — On-call: incident declared (P0/P1)** | I | C | C | R/A |
+| **E4 — On-call: post-incident review + runbook update** | C | C | C | R/A |
+
+### Gap resolution rules
+
+- **B5 sign-off blocks staging promotion.** The ml-pipeline.yml `deploy` job
+  environment gate (`environment: staging`) requires the contract sign-off to
+  be documented in the PR description before reviewer approval.
+- **C4 retrain decision.** ML Engineering decides whether to trigger a retrain
+  (`trigger_reason: drift` via the Alertmanager webhook receiver) or escalate to
+  Platform if the Airflow DAG is unavailable.
+- **E2 / E3 escalation.** If a model accuracy alert does not self-resolve within
+  30 minutes, ML Engineering escalates to Platform for incident command per the
+  ADR-0040 `ml-platform-oncall` PagerDuty service.
+
+---
+
+## 3. Handoff flow
+
+The diagram below shows the artifact hand-off sequence. System boundaries match the
+WS-B/C/D components.
+
+```
+Data Engineering              ML Engineering             Backend/Frontend      Platform/SRE
+     |                              |                           |                    |
+─── Feature pipeline ──────────────────────────────────────────────────────────────────────
+     |                              |                           |                    |
+[H1] Freeze Iceberg snapshot ──────>|                           |                    |
+     | (airflow/dags/               |                           |                    |
+     |  train_domain_adapter.py:    |                           |                    |
+     |  freeze_snapshot())          |                           |                    |
+     |                              |                           |                    |
+─── Model training (WS-B) ─────────────────────────────────────────────────────────────────
+     |                              |                           |                    |
+     |                         [H2] train_domain_adapter DAG   |                    |
+     |                              | (triggered by             |                    |
+     |                              |  ml-pipeline.yml or       |                    |
+     |                              |  drift webhook)           |                    |
+     |                         [H3] eval_adapter_debate + quality gate               |
+     |                              | win_rate >= 0.55          |                    |
+     |                         [H4] Register model in MLflow ─────────────────────> |
+     |                              | cosign sign + SBOM        |                    |
+     |                              | (.github/actions/*)       |                    |
+─── Contract sign-off ──────────────────────────────────────────────────────────────────────
+     |                         [H5] Contract instance PR ──────>|                    |
+     |                              | (docs/contracts/)         | sign off           |
+─── Staging promotion ──────────────────────────────────────────────────────────────────────
+     |                         [H6] Kargo: dev (auto) ─────────────────────────────>|
+     |                         [H7] Kargo: staging (reviewer gate) ────────────────>|
+─── Production deployment ──────────────────────────────────────────────────────────────────
+     |                         [H8] Kargo: prod (manual gate) ──────────────────── >|
+─── Drift monitoring (WS-C/D) ──────────────────────────────────────────────────────────────
+     |                              |              WS-C drift-exporter ─────────── >|
+     |                              |              (apps/infra/ml-monitoring/)      |
+     |                              |                     Prometheus + Grafana       |
+     |                              |                     (grafana-self-serve/)      |
+─── Retrain trigger (WS-C -> WS-B) ─────────────────────────────────────────────────────────
+     |                         [H9] Drift alert fires ──────────────────────────── >|
+     |                              | Alertmanager webhook -> Airflow REST           |
+     |                              | POST .../train_domain_adapter/dagRuns          |
+     |                              | conf: {trigger_reason: "drift"}               |
+     |                         [H2 repeats for retrain]         |                    |
+```
+
+### Handoff summary table
+
+| ID | Artifact handed off | From | To | Gate / mechanism |
+|----|--------------------|----|-----|-----------------|
+| H1 | Iceberg snapshot (frozen, versioned) | DE | ML | Airflow `freeze_snapshot()` task; snapshot_id recorded in MLflow run |
+| H2 | Trained LoRA adapter | ML | ML (eval) | Airflow `TriggerDagRunOperator` → `eval_adapter_debate` |
+| H3 | Eval report (win_rate, p95_distance) | ML (eval) | ML (register) | Quality gate: `win_rate >= 0.55`; blocks promotion on failure |
+| H4 | Signed model artifact + SBOM | ML | BE + PL | MLflow registry (Staging) + cosign signature + OCI image |
+| H5 | Contract instance (YAML) | ML | BE | PR to `docs/contracts/`; sign-off from BE required before H6 |
+| H6 | Staged deploy (dev) | ML | PL | Kargo auto-promotion; `post_deployment_smoke` DAG fires 30 min later |
+| H7 | Staged deploy (staging) | ML | PL | Kargo reviewer gate; human reviewer approval required |
+| H8 | Staged deploy (prod) | PL | BE/all | Kargo manual gate; platform on-call confirms readiness |
+| H9 | Drift alert (Alertmanager) | PL (infra) | ML | Alertmanager webhook receiver → Airflow REST API retrain trigger |
+
+---
+
+## 4. On-call and escalation
+
+This table supplements the ADR-0040 ML-incident runbooks. It covers first-response
+for the alert classes emitted by WS-B/C/D.
+
+| Alert | First paged | Ack SLA | First action | Escalate to | Escalate after |
+|-------|------------|---------|--------------|-------------|----------------|
+| `AirflowDagRunFailed` (any DAG) | ML on-call | 15 min | Check Airflow logs → retry DAG run | Platform if infra issue | 30 min |
+| `MLModelDriftHigh` (drift > 0.4) | ML on-call | 15 min | Inspect Evidently report → trigger retrain manually if auto-trigger failed | Platform if Airflow down | 30 min |
+| `MLModelAccuracyLow` (accuracy < 0.75) | ML on-call | 15 min | Check eval metrics in MLflow → consider rollback via ArgoCD | Platform for Kargo rollback | 30 min |
+| `MLflowTrackingDown` | Platform on-call | 5 min | Check MLflow pod health → ArgoCD sync | Escalate to P1 if pipeline blocked | 15 min |
+| `GrafanaFolderMissing` (self-serve) | Platform on-call | 30 min | ArgoCD re-sync grafana-self-serve app | n/a | n/a |
+| Platform infra alert (any) | Platform on-call | 5 min | Per ADR-0040 runbooks | Incident command if P0/P1 | 15 min |
+
+### Escalation path
+
+```
+ML alert fires
+    |
+    v
+ML Engineering on-call  (PagerDuty: ml-platform-oncall)
+    |  > 30 min unresolved OR infra cause confirmed
+    v
+Platform / SRE on-call  (PagerDuty: platform-oncall)
+    |  P0 declared (full outage / data loss risk)
+    v
+Incident Commander (Platform lead or on-call manager)
+    |  > 60 min OR confirmed customer impact
+    v
+Engineering Manager + Comms
+```
+
+---
+
+## 5. ADR-0034 revisit criteria (Backstage)
+
+The three conditions that must be met before Backstage (ADR-0034) is revisited:
+
+1. GCP ML platform reaches Phase-3 stable (WS-A..E all applied and running in prod).
+2. A dedicated Backstage owner (engineer or team) is assigned.
+3. Three or more teams have successfully onboarded via the WS-F golden paths in
+   this document.
+
+Current status: condition 1 pending (WS-A..E are plan/validate-only);
+conditions 2 and 3 not yet met.
+
+---
+
+## 6. References
+
+- `docs/adrs/0037-ml-cicd-pipeline-mlflow.md` (WS-B)
+- `docs/adrs/0038-ml-observability-drift.md` (WS-C)
+- `docs/adrs/0039-self-serve-observability.md` (WS-D)
+- `docs/adrs/0040-soc-posture-and-oncall.md` (WS-E, ML runbooks)
+- `docs/adrs/0041-golden-paths-collaboration.md` (WS-F)
+- `docs/contracts/model-api-contract.md` (contract spec)
+- `docs/self-serve-observability.md` (WS-D onboarding guide)
+- `.github/workflows/ml-pipeline.yml` (WS-B pipeline)
+- `apps/infra/airflow/dags/` (WS-B DAGs)
+- `apps/infra/ml-monitoring/` (WS-C drift-exporter)
+- `apps/infra/grafana-self-serve/` (WS-D self-serve chart)

--- a/templates/golden-paths/new-dashboard/README.md
+++ b/templates/golden-paths/new-dashboard/README.md
@@ -1,0 +1,145 @@
+# Golden Path: New Team Dashboard
+
+This template onboards a new team into the WS-D (ADR-0039) self-serve observability
+layer: one Grafana folder + starter dashboard + PrometheusRule alert groups, delivered
+in a single PR.
+
+Backstage scaffolder mapping: `spec.type: team-dashboard`
+
+Chart: `apps/infra/grafana-self-serve/`
+Chart versions verified against WS-D chart as of 2026-06-10.
+
+---
+
+## When to use this template
+
+Use this golden path when:
+- A team is new to the platform and needs a scoped Grafana folder
+- The team is non-ML (no drift monitoring needed) — if you need ML panels,
+  use the `new-model-service` golden path instead (`templates/golden-paths/new-model-service/`)
+- You want to start from the standard RED + saturation + alerts dashboard
+
+---
+
+## Prerequisites
+
+- [ ] Namespace `{{TEAM_NAMESPACE}}` exists in the cluster
+- [ ] Grafana service account `grafana-sa-{{TEAM_SLUG}}` exists in Grafana
+  (create via Grafana UI or API before ArgoCD sync)
+- [ ] CI service account `{{TEAM_SLUG}}-ci` exists in namespace `{{TEAM_NAMESPACE}}`
+  (for PrometheusRule RBAC; omit `ciServiceAccount` if not needed)
+
+---
+
+## Step 1 — Substitute placeholders
+
+```bash
+export TEAM_NAME="Checkout"           # human-readable
+export TEAM_SLUG="team-checkout"      # lower-kebab
+export TEAM_NAMESPACE="checkout"      # Kubernetes namespace
+export TEAM_SYSTEM="checkout"         # ADR-0028 platform.system
+export TEAM_OWNER="team-checkout"     # ADR-0028 platform.owner
+export PLATFORM_ENV="production"      # production | staging | dev | sandbox
+
+mkdir -p out
+for f in values.yaml argocd-application.yaml; do
+  envsubst < "$f" > "out/${f}"
+done
+
+# Verify no raw {{}} remain
+grep -r '{{' out/ && echo "UNSUBSTITUTED PLACEHOLDERS FOUND" || echo "OK"
+```
+
+---
+
+## Step 2 — Commit the files
+
+Place the substituted files in the PR at:
+```
+apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/values.yaml
+apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/argocd-application.yaml
+```
+
+---
+
+## Step 3 — Validate
+
+```bash
+yamllint -c .yamllint.yml out/values.yaml out/argocd-application.yaml
+
+helm template apps/infra/grafana-self-serve \
+  -f apps/infra/grafana-self-serve/values.yaml \
+  -f out/values.yaml
+```
+
+The render should produce:
+- A ConfigMap with `grafana_dashboard: "1"` label (Grafana folder provisioning)
+- A ConfigMap with `grafana_folder` annotation (starter dashboard)
+- A PrometheusRule with availability and saturation alert groups
+- A Role + RoleBinding for CI service account PrometheusRule management
+
+---
+
+## Step 4 — Open the PR
+
+PR checklist:
+- [ ] All `{{PLACEHOLDER}}` substituted; no raw template strings remain
+- [ ] `yamllint -c .yamllint.yml` passes
+- [ ] `helm template` renders without error
+- [ ] ADR-0028 labels present: `platform.system`, `platform.owner`, `platform.env`,
+      `platform.component`, `platform.managed-by`
+- [ ] Grafana SA `grafana-sa-{{TEAM_SLUG}}` created before the PR is merged
+- [ ] Platform review obtained (see `docs/golden-paths/RACI-and-handoffs.md`)
+
+---
+
+## What you get after merge
+
+- Grafana folder `team-{{TEAM_SLUG}}` visible only to your team service account
+- A starter dashboard with RED panels, resource saturation, and an alerts table
+- PrometheusRule alert groups in namespace `{{TEAM_NAMESPACE}}`
+- RBAC Role + RoleBinding for CI PrometheusRule management
+
+For ML panels, set `ml.enabled: true` and fill in `ml.modelName` + `ml.tenant`
+(see `apps/infra/grafana-self-serve/values.yaml` for all ML options, and
+`templates/golden-paths/new-model-service/` for the full ML onboarding path).
+
+---
+
+## Platform support
+
+- ADR-0039 (WS-D): grafana-self-serve architecture
+- `docs/self-serve-observability.md`: full onboarding guide with troubleshooting
+- ADR-0041 (WS-F): this template
+
+---
+
+## Backstage future mapping
+
+```yaml
+# catalog-info.yaml (future — do not deploy before ADR-0034 revisit)
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: new-dashboard
+spec:
+  type: team-dashboard
+  parameters:
+    - title: Team identity
+      properties:
+        teamName:    # -> {{TEAM_NAME}}
+        teamSlug:    # -> {{TEAM_SLUG}}
+        namespace:   # -> {{TEAM_NAMESPACE}}
+        system:      # -> {{TEAM_SYSTEM}}
+        teamOwner:   # -> {{TEAM_OWNER}}
+        platformEnv: # -> {{PLATFORM_ENV}}
+  steps:
+    - id: fetch-template
+      action: fetch:template
+      input:
+        url: ./templates/golden-paths/new-dashboard
+    - id: publish
+      action: publish:github:pull-request
+    - id: register
+      action: catalog:register
+```

--- a/templates/golden-paths/new-dashboard/argocd-application.yaml
+++ b/templates/golden-paths/new-dashboard/argocd-application.yaml
@@ -1,0 +1,65 @@
+---
+# Golden Path: new-dashboard — ArgoCD Application stub (grafana-self-serve)
+# WS-D (ADR-0039) chart: apps/infra/grafana-self-serve
+#
+# USAGE: substitute all {{PLACEHOLDER}} values, then commit this file at:
+#   apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/argocd-application.yaml
+#
+# Deploys into {{TEAM_NAMESPACE}}. The namespace must pre-exist.
+# Wave 30 — after all observability components (wave 10-20).
+#
+# See README.md for full instructions.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  # Substitute: grafana-self-serve-{{TEAM_SLUG}}
+  name: "grafana-self-serve-{{TEAM_SLUG}}"
+  namespace: argocd
+  labels:
+    # ADR-0028 platform taxonomy (K8s plane)
+    platform.system: "observability"
+    platform.component: "self-serve"
+    # Substitute: {{PLATFORM_ENV}}
+    platform.env: "{{PLATFORM_ENV}}"
+    # Substitute: {{TEAM_OWNER}}
+    platform.owner: "{{TEAM_OWNER}}"
+    platform.managed-by: "argocd"
+    # Substitute: grafana-self-serve-{{TEAM_SLUG}}
+    app.kubernetes.io/name: "grafana-self-serve-{{TEAM_SLUG}}"
+    app.kubernetes.io/component: "self-serve"
+    app.kubernetes.io/managed-by: "argocd"
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/your-org/platform-design.git
+    targetRevision: main
+    path: apps/infra/grafana-self-serve
+    helm:
+      valueFiles:
+        - values.yaml
+        # Substitute: example-teams/{{TEAM_SLUG}}/values.yaml
+        - "example-teams/{{TEAM_SLUG}}/values.yaml"
+  destination:
+    server: https://kubernetes.default.svc
+    # Substitute: {{TEAM_NAMESPACE}}
+    namespace: "{{TEAM_NAMESPACE}}"
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=false
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m

--- a/templates/golden-paths/new-dashboard/values.yaml
+++ b/templates/golden-paths/new-dashboard/values.yaml
@@ -1,0 +1,66 @@
+# Golden Path: new-dashboard — grafana-self-serve values template
+# WS-D (ADR-0039) chart: apps/infra/grafana-self-serve
+#
+# USAGE: substitute all {{PLACEHOLDER}} values before committing.
+# Place the substituted file at:
+#   apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/values.yaml
+#
+# For ML teams that also need drift + accuracy panels, set ml.enabled: true
+# and fill in ml.modelName + ml.tenant, or use the new-model-service template
+# (templates/golden-paths/new-model-service/).
+#
+# See README.md for full instructions.
+
+team:
+  # Human-readable team name shown in the Grafana folder title.
+  # Substitute: {{TEAM_NAME}}
+  name: "{{TEAM_NAME}}"
+
+  # Machine-safe slug — lowercase, hyphens only.
+  # Substitute: {{TEAM_SLUG}}
+  slug: "{{TEAM_SLUG}}"
+
+  # Kubernetes namespace where this team's workloads run.
+  # Must already exist (CreateNamespace=false on the ArgoCD Application).
+  # Substitute: {{TEAM_NAMESPACE}}
+  namespace: "{{TEAM_NAMESPACE}}"
+
+  # platform.system value (ADR-0028 taxonomy).
+  # Substitute: {{TEAM_SYSTEM}}  e.g., "checkout", "auth", "data-pipeline"
+  system: "{{TEAM_SYSTEM}}"
+
+  # platform.owner value (ADR-0028 taxonomy).
+  # Substitute: {{TEAM_OWNER}}
+  owner: "{{TEAM_OWNER}}"
+
+  # Deployment environment.
+  # Substitute: {{PLATFORM_ENV}}
+  env: "{{PLATFORM_ENV}}"
+
+  # Grafana service account for folder Editor access.
+  # Create this SA in Grafana before ArgoCD sync.
+  # Substitute: grafana-sa-{{TEAM_SLUG}}
+  grafanaServiceAccount: "grafana-sa-{{TEAM_SLUG}}"
+
+  # CI/CD service account in team.namespace for PrometheusRule RBAC.
+  # Substitute: {{TEAM_SLUG}}-ci  (leave empty string to skip RoleBinding)
+  ciServiceAccount: "{{TEAM_SLUG}}-ci"
+
+# ML-specific panels — leave disabled for non-ML teams.
+# Set enabled: true and fill in modelName + tenant for ML teams.
+ml:
+  enabled: false
+  modelName: ""
+  tenant: ""
+
+# Alert thresholds — adjust for your team's SLOs.
+alerts:
+  errorRateThreshold: "0.05"
+  cpuSaturationThreshold: "0.80"
+  memorySaturationThreshold: "0.80"
+  availabilityFor: "5m"
+  saturationFor: "15m"
+  # ML thresholds (only used when ml.enabled: true):
+  mlDriftThreshold: "0.2"
+  mlAccuracyThreshold: "0.85"
+  mlAlertFor: "10m"

--- a/templates/golden-paths/new-ml-pipeline/README.md
+++ b/templates/golden-paths/new-ml-pipeline/README.md
@@ -1,0 +1,192 @@
+# Golden Path: New ML Pipeline (Airflow DAG)
+
+This template creates a new Airflow DAG that mirrors the WS-B (ADR-0037) DAG shape.
+It registers artifacts in MLflow and emits drift metrics so they are scrapeable by
+WS-C (ADR-0038) Evidently + whylogs.
+
+Backstage scaffolder mapping: `spec.type: ml-pipeline`
+
+Chart versions verified against:
+- `apps/infra/airflow/dags/` (WS-B) — DAG scaffolds as of 2026-06-10
+- `apps/infra/mlflow/` (WS-B) — MLflow chart as of 2026-06-10
+
+---
+
+## When to use this template
+
+Use this golden path when you need a **net-new Airflow DAG** that is:
+- Not one of the four canonical WS-B DAGs (`train_domain_adapter`, `eval_adapter_debate`,
+  `mine_templates`, `promote_to_edge`)
+- Processing a new data domain or running a periodic batch ML job
+- Registering its own model artifacts in MLflow
+- Expected to emit distribution metrics for WS-C monitoring
+
+If you are adding a new **model** that uses the existing canonical DAGs, use the
+`new-model-service` golden path instead (`templates/golden-paths/new-model-service/`).
+
+---
+
+## Prerequisites
+
+- [ ] Airflow is deployed at `$AIRFLOW_BASE_URL` (WS-B `apps/infra/airflow/`)
+- [ ] MLflow tracking server is reachable at `$MLFLOW_TRACKING_URI` (WS-B `apps/infra/mlflow/`)
+- [ ] WS-C `ml-monitoring` namespace and Pushgateway exist (`apps/infra/ml-monitoring/`)
+- [ ] Your DAG code will live in `apps/infra/airflow/dags/{{DAG_NAME}}.py`
+  (Airflow gitSync picks it up automatically from the repo)
+
+---
+
+## Step 1 — Substitute placeholders
+
+```bash
+export DAG_NAME="my_custom_pipeline"        # snake_case; becomes the Airflow dag_id
+export MODEL_NAME="my-model"                # lower-kebab; MLflow model registry name
+export TENANT="tenant-acme"                 # ADR-0038 multi-tenant label
+export DOMAIN="hft"                         # one of: hft, solana, insurance, rtb
+export TEAM_OWNER="team-ml-platform"        # ADR-0028 platform.owner
+export PLATFORM_ENV="production"            # production | staging | dev | sandbox
+
+# Copy the DAG template
+cp dag_template.py apps/infra/airflow/dags/${DAG_NAME}.py
+
+# Substitute non-Python placeholder YAML
+mkdir -p out
+envsubst < argocd-application.yaml > out/argocd-application.yaml
+
+# Verify no raw {{}} remain in the YAML output
+grep -r '{{' out/ && echo "UNSUBSTITUTED PLACEHOLDERS FOUND" || echo "OK"
+```
+
+In the Python DAG file, replace the `# SUBSTITUTE:` comment blocks manually
+(shell variable substitution in Python source is fragile).
+
+---
+
+## Step 2 — Implement the DAG tasks
+
+Open `apps/infra/airflow/dags/{{DAG_NAME}}.py` and implement the four `# SCAFFOLD`
+task bodies:
+
+| Task | What to implement |
+|------|-------------------|
+| `ingest_data` | Load data from source (Iceberg snapshot, GCS, Pub/Sub, BigQuery, etc.) |
+| `run_batch_job` | Submit work: VolcanoJob for GPU tasks, PythonOperator for CPU tasks |
+| `register_results` | Write metrics + artifacts to MLflow (see MLflow integration below) |
+| `emit_drift_metrics` | Push feature distributions to Prometheus Pushgateway (see below) |
+
+### MLflow integration
+
+The `register_results` task uses:
+- `MLFLOW_TRACKING_URI` env var (injected from ESO ExternalSecret at
+  `apps/infra/mlflow/templates/external-secret.yaml`)
+- Experiment name convention: `{{TENANT}}/{{DOMAIN}}/{{DAG_NAME}}`
+- Model registry name: `{{MODEL_NAME}}`
+
+```python
+import mlflow
+import os
+
+mlflow.set_tracking_uri(os.environ["MLFLOW_TRACKING_URI"])
+mlflow.set_experiment(f"{tenant}/{domain}/{dag_name}")
+
+with mlflow.start_run(run_name=f"{tenant}/{domain}/{dag_name}"):
+    mlflow.log_params({"tenant": tenant, "domain": domain})
+    mlflow.log_metrics({"accuracy": 0.0, "loss": 0.0})  # replace with real metrics
+    # mlflow.pytorch.log_model(model, "model")
+    mlflow.register_model(
+        f"runs:/{mlflow.active_run().info.run_id}/model",
+        model_name,
+    )
+```
+
+### Drift metrics (WS-C integration)
+
+The `emit_drift_metrics` task pushes to the shared Pushgateway:
+
+```python
+from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+
+registry = CollectorRegistry()
+g = Gauge(
+    "ml_monitoring_dataset_drift_score",
+    "Evidently dataset drift score",
+    ["model_name", "tenant", "domain"],
+    registry=registry,
+)
+g.labels(model_name=model_name, tenant=tenant, domain=domain).set(drift_score)
+
+push_to_gateway(
+    "prometheus-pushgateway.ml-monitoring.svc.cluster.local:9091",
+    job=dag_name,
+    registry=registry,
+)
+```
+
+Labels must match ADR-0038 §D1: `model_name`, `tenant`, `domain`.
+
+---
+
+## Step 3 — Validate the DAG locally
+
+```bash
+# Install Airflow in a venv (match the chart-pinned version)
+pip install "apache-airflow==2.9.*" --constraint \
+  "https://raw.githubusercontent.com/apache/airflow/constraints-2.9.3/constraints-3.11.txt"
+
+# Parse the DAG (should complete without errors or import warnings)
+python apps/infra/airflow/dags/{{DAG_NAME}}.py
+airflow dags list-import-errors
+```
+
+---
+
+## Step 4 — Open the PR
+
+PR checklist:
+- [ ] `apps/infra/airflow/dags/{{DAG_NAME}}.py` included
+- [ ] `yamllint -c .yamllint.yml out/argocd-application.yaml` passes
+- [ ] DAG parses without errors (`airflow dags list-import-errors`)
+- [ ] MLflow experiment name follows `{{TENANT}}/{{DOMAIN}}/{{DAG_NAME}}`
+- [ ] Drift metrics pushed to Pushgateway use labels `model_name`, `tenant`, `domain`
+- [ ] ADR-0028 labels in all Kubernetes manifests
+- [ ] Link to MLflow experiment after first DAG run
+
+---
+
+## Platform support
+
+- ADR-0037 (WS-B): Airflow + MLflow architecture
+- ADR-0038 (WS-C): drift metrics + Pushgateway integration
+- ADR-0041 (WS-F): this template
+
+---
+
+## Backstage future mapping
+
+```yaml
+# catalog-info.yaml (future — do not deploy before ADR-0034 revisit)
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: new-ml-pipeline
+spec:
+  type: ml-pipeline
+  parameters:
+    - title: Pipeline identity
+      properties:
+        dagName:     # -> {{DAG_NAME}}
+        modelName:   # -> {{MODEL_NAME}}
+        tenant:      # -> {{TENANT}}
+        domain:      # -> {{DOMAIN}}
+        teamOwner:   # -> {{TEAM_OWNER}}
+        platformEnv: # -> {{PLATFORM_ENV}}
+  steps:
+    - id: fetch-template
+      action: fetch:template
+      input:
+        url: ./templates/golden-paths/new-ml-pipeline
+    - id: publish
+      action: publish:github:pull-request
+    - id: register
+      action: catalog:register
+```

--- a/templates/golden-paths/new-ml-pipeline/argocd-application.yaml
+++ b/templates/golden-paths/new-ml-pipeline/argocd-application.yaml
@@ -1,0 +1,68 @@
+---
+# Golden Path: new-ml-pipeline — ArgoCD Application stub
+# WS-B (ADR-0037): ml-pipeline namespace
+#
+# This stub is only needed if your DAG requires dedicated per-pipeline
+# Kubernetes resources (e.g., a dedicated ExternalSecret or ConfigMap).
+# For DAG-only additions (just a .py file in apps/infra/airflow/dags/),
+# the existing Airflow ArgoCD Application picks up the new DAG via gitSync
+# automatically — no separate Application needed.
+#
+# USAGE: substitute all {{PLACEHOLDER}} values, then commit this file
+# alongside your DAG if you need pipeline-specific K8s resources.
+#
+# Wave 25 — after Airflow (wave 20) + ml-monitoring (wave 20).
+# ADR-0028 platform labels: system=ml-pipeline, component=airflow.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  # Substitute: ml-pipeline-{{DAG_NAME}}
+  name: "ml-pipeline-{{DAG_NAME}}"
+  namespace: argocd
+  labels:
+    # ADR-0028 platform taxonomy (K8s plane)
+    platform.system: "ml-pipeline"
+    platform.component: "airflow"
+    # Substitute: {{PLATFORM_ENV}}
+    platform.env: "{{PLATFORM_ENV}}"
+    # Substitute: {{TEAM_OWNER}}
+    platform.owner: "{{TEAM_OWNER}}"
+    platform.managed-by: "argocd"
+    # Substitute: ml-pipeline-{{DAG_NAME}}
+    app.kubernetes.io/name: "ml-pipeline-{{DAG_NAME}}"
+    app.kubernetes.io/component: "airflow"
+    app.kubernetes.io/managed-by: "argocd"
+  annotations:
+    argocd.argoproj.io/sync-wave: "25"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/your-org/platform-design.git
+    targetRevision: main
+    # If pipeline-specific K8s resources live under a dedicated path, update below.
+    # For DAG-only additions, remove this Application and rely on the Airflow app.
+    path: apps/infra/airflow
+    helm:
+      valueFiles:
+        - values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ml-pipeline
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=false
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m

--- a/templates/golden-paths/new-ml-pipeline/dag_template.py
+++ b/templates/golden-paths/new-ml-pipeline/dag_template.py
@@ -1,0 +1,243 @@
+"""
+{{DAG_NAME}} — Airflow DAG template (WS-F golden path, ADR-0041)
+
+Mirrors the WS-B (ADR-0037) DAG shape:
+  ingest_data -> run_batch_job -> register_results -> emit_drift_metrics
+
+Instructions:
+  1. Rename this file to apps/infra/airflow/dags/{{DAG_NAME}}.py
+  2. Replace all SUBSTITUTE: comment blocks with real values.
+  3. Implement the four # SCAFFOLD task bodies.
+  4. See README.md for the MLflow and Pushgateway integration patterns.
+
+Platform labels (ADR-0028):
+  platform.system    = ml-pipeline
+  platform.component = airflow
+  platform.owner     = {{TEAM_OWNER}}
+  platform.env       = {{PLATFORM_ENV}}
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from airflow.decorators import dag, task
+from airflow.models.param import Param
+
+# ---------------------------------------------------------------------------
+# Executor config — CPU task pods (adjust nodeSelector for your pool)
+# ---------------------------------------------------------------------------
+_CPU_EXECUTOR_CONFIG = {
+    "pod_override": {
+        "spec": {
+            "nodeSelector": {"cloud.google.com/gke-nodepool": "ml-cpu-pool"},
+        }
+    }
+}
+
+# GPU executor config (uncomment if tasks need GPU resources)
+# _GPU_EXECUTOR_CONFIG = {
+#     "pod_override": {
+#         "spec": {
+#             "schedulerName": "volcano",
+#             "nodeSelector": {
+#                 "cloud.google.com/gke-nodepool": "gpu-a100-pool",
+#                 "nvidia.com/gpu.present": "true",
+#             },
+#             "tolerations": [
+#                 {"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSchedule"}
+#             ],
+#         }
+#     }
+# }
+
+
+@dag(
+    # SUBSTITUTE: replace {{DAG_NAME}} with your snake_case DAG identifier.
+    dag_id="{{DAG_NAME}}",
+    # SUBSTITUTE: update the description.
+    description="Custom ML pipeline: {{DAG_NAME}} (WS-F golden path).",
+    # Set a schedule expression or leave None for triggered-only.
+    schedule=None,
+    start_date=datetime(2026, 1, 1),
+    catchup=False,
+    max_active_runs=1,
+    default_args={
+        "retries": 1,
+        "retry_delay": timedelta(minutes=5),
+        # SUBSTITUTE: replace {{TEAM_OWNER}} with your team slug.
+        "owner": "{{TEAM_OWNER}}",
+    },
+    params={
+        # SUBSTITUTE: replace {{TENANT}} default with your tenant identifier.
+        "tenant": Param(default="{{TENANT}}", type="string", description="Tenant identifier"),
+        # SUBSTITUTE: replace {{DOMAIN}} default with your ML domain.
+        "domain": Param(
+            default="{{DOMAIN}}",
+            type="string",
+            enum=["hft", "solana", "insurance", "rtb"],
+            description="ML domain",
+        ),
+        "trigger_reason": Param(
+            default="manual",
+            type="string",
+            enum=["threshold", "drift", "manual"],
+            description="Trigger source",
+        ),
+    },
+    tags=["ml-pipeline", "{{DAG_NAME}}"],
+)
+def dag_factory():
+    """
+    Custom ML pipeline: {{DAG_NAME}}.
+
+    Replace this docstring with a description of what this pipeline does,
+    what data it processes, and what model artifacts it produces.
+    """
+
+    @task(executor_config=_CPU_EXECUTOR_CONFIG)
+    def ingest_data(tenant: str, domain: str, **context) -> dict:
+        """
+        Load and validate the input data.
+        Returns a data metadata dict (paths, row counts, snapshot IDs).
+
+        SCAFFOLD: implement your data loading logic here.
+        Examples:
+          - Freeze an Iceberg snapshot (see train_domain_adapter.py pattern)
+          - Download a GCS file: gs://<bucket>/<tenant>/<domain>/data.parquet
+          - Query BigQuery with a time-bounded window
+        """
+        # SCAFFOLD: replace with real data ingestion
+        run_ts = context["logical_date"].isoformat()
+        return {
+            "snapshot_id": f"scaffold-{tenant}-{domain}-{run_ts}",
+            "row_count": 0,
+            "source_path": f"gs://scaffold-bucket/{tenant}/{domain}/data.parquet",
+        }
+
+    @task(executor_config=_CPU_EXECUTOR_CONFIG)
+    def run_batch_job(data_meta: dict, tenant: str, domain: str, **context) -> dict:
+        """
+        Execute the ML computation (training, scoring, or batch inference).
+        Returns a results dict (metrics, output paths, job IDs).
+
+        SCAFFOLD: implement your computation here.
+        CPU tasks: use PythonOperator or BashOperator patterns.
+        GPU tasks: submit a VolcanoJob (see train_domain_adapter.py for the pattern),
+                   update executor_config to _GPU_EXECUTOR_CONFIG.
+        """
+        # SCAFFOLD: replace with real batch job submission
+        return {
+            "job_id": f"scaffold-{tenant}-{domain}",
+            "status": "SCAFFOLD",
+            "output_path": data_meta["source_path"].replace("data.parquet", "output.parquet"),
+            "accuracy": 0.0,
+            "loss": 0.0,
+        }
+
+    @task(executor_config=_CPU_EXECUTOR_CONFIG)
+    def register_results(
+        data_meta: dict,
+        job_results: dict,
+        tenant: str,
+        domain: str,
+        **context,
+    ) -> dict:
+        """
+        Register metrics and artifacts in MLflow.
+        Returns: {"mlflow_run_id": str, "model_version": str}
+
+        Convention:
+          experiment_name = f"{tenant}/{domain}/{{DAG_NAME}}"
+          model_name      = "{{MODEL_NAME}}"
+
+        SCAFFOLD: replace with real MLflow calls.
+        """
+        # SCAFFOLD: implement MLflow registration
+        # import mlflow, os
+        # mlflow.set_tracking_uri(os.environ["MLFLOW_TRACKING_URI"])
+        # mlflow.set_experiment(f"{tenant}/{domain}/{{DAG_NAME}}")
+        # with mlflow.start_run(run_name=f"{tenant}/{domain}"):
+        #     mlflow.log_params({**data_meta, "tenant": tenant, "domain": domain})
+        #     mlflow.log_metrics({"accuracy": job_results["accuracy"]})
+        #     version = mlflow.register_model(
+        #         f"runs:/{mlflow.active_run().info.run_id}/model",
+        #         "{{MODEL_NAME}}")
+        return {
+            "mlflow_run_id": "scaffold-run-id",
+            "model_version": "0",
+        }
+
+    @task(executor_config=_CPU_EXECUTOR_CONFIG)
+    def emit_drift_metrics(
+        job_results: dict,
+        tenant: str,
+        domain: str,
+        **context,
+    ) -> None:
+        """
+        Push feature distribution + accuracy metrics to the Prometheus Pushgateway
+        so WS-C (ADR-0038) can compute drift and trigger retraining.
+
+        Labels must match ADR-0038 D1: model_name, tenant, domain.
+        Pushgateway: prometheus-pushgateway.ml-monitoring.svc.cluster.local:9091
+
+        SCAFFOLD: replace with real metric values from job_results.
+        """
+        # SCAFFOLD: implement Pushgateway push
+        # from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+        # registry = CollectorRegistry()
+        # accuracy_g = Gauge(
+        #     "ml_monitoring_model_accuracy",
+        #     "Model accuracy score",
+        #     ["model_name", "tenant", "domain"],
+        #     registry=registry,
+        # )
+        # drift_g = Gauge(
+        #     "ml_monitoring_dataset_drift_score",
+        #     "Dataset drift score",
+        #     ["model_name", "tenant", "domain"],
+        #     registry=registry,
+        # )
+        # accuracy_g.labels(
+        #     model_name="{{MODEL_NAME}}", tenant=tenant, domain=domain
+        # ).set(job_results["accuracy"])
+        # drift_g.labels(
+        #     model_name="{{MODEL_NAME}}", tenant=tenant, domain=domain
+        # ).set(0.0)  # replace with real drift score
+        # push_to_gateway(
+        #     "prometheus-pushgateway.ml-monitoring.svc.cluster.local:9091",
+        #     job="{{DAG_NAME}}",
+        #     registry=registry,
+        # )
+        pass
+
+    # -------------------------------------------------------------------------
+    # DAG wiring
+    # -------------------------------------------------------------------------
+    tenant = "{{ params.tenant }}"
+    domain = "{{ params.domain }}"
+
+    data = ingest_data(tenant=tenant, domain=domain)
+    results = run_batch_job(data_meta=data, tenant=tenant, domain=domain)
+    reg = register_results(
+        data_meta=data, job_results=results, tenant=tenant, domain=domain
+    )
+    emit_drift_metrics(job_results=results, tenant=tenant, domain=domain)
+
+    # Uncomment to trigger downstream DAGs on success:
+    # from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+    # trigger_downstream = TriggerDagRunOperator(
+    #     task_id="trigger_downstream",
+    #     trigger_dag_id="some_downstream_dag",
+    #     conf={
+    #         "mlflow_run_id": "{{ task_instance.xcom_pull('register_results')['mlflow_run_id'] }}",
+    #     },
+    # )
+    # reg >> trigger_downstream  # type: ignore[operator]
+
+    _ = reg  # suppress unused variable warning until trigger is wired
+
+
+# SUBSTITUTE: rename the variable to match {{DAG_NAME}}_dag_instance
+dag_instance = dag_factory()

--- a/templates/golden-paths/new-model-service/README.md
+++ b/templates/golden-paths/new-model-service/README.md
@@ -1,0 +1,220 @@
+# Golden Path: New Model Service
+
+This template wires a new ML model into the full platform stack:
+- **WS-B** (ADR-0037): `ml-pipeline.yml` train→eval→register→deploy + MLflow registry
+- **WS-C** (ADR-0038): Evidently drift-exporter + whylogs profiler per-model namespace
+- **WS-D** (ADR-0039): `grafana-self-serve` per-team dashboard + alert rules
+
+Backstage scaffolder mapping: `spec.type: model-service`
+(see "Backstage future mapping" at the bottom of this file).
+
+Chart versions verified against:
+- `apps/infra/ml-monitoring` (WS-C) — chart as of 2026-06-10
+- `apps/infra/grafana-self-serve` (WS-D) — chart as of 2026-06-10
+- `.github/workflows/ml-pipeline.yml` (WS-B) — as of 2026-06-10
+
+---
+
+## Prerequisites
+
+Before you start, confirm:
+
+- [ ] Namespace `{{MODEL_NAMESPACE}}` exists in the cluster
+  (or ask Platform to create it via `kubectl create namespace {{MODEL_NAMESPACE}}`)
+- [ ] GCS bucket `gs://{{GCS_MLFLOW_ARTIFACTS_BUCKET}}` exists
+  (provisioned by WS-B `terraform/modules/ml-artifact-store`)
+- [ ] MLflow tracking server is reachable at `$MLFLOW_TRACKING_URI`
+  (deployed by WS-B `apps/infra/mlflow/`)
+- [ ] Airflow is reachable at `$AIRFLOW_BASE_URL`
+  (deployed by WS-B `apps/infra/airflow/`)
+- [ ] Grafana service account `grafana-sa-{{TEAM_SLUG}}` exists in Grafana
+  (create via Grafana UI or API before ArgoCD sync)
+- [ ] Model training code lives under `models/{{MODEL_NAME}}/` or `adapters/{{MODEL_NAME}}/`
+  (triggers `.github/workflows/ml-pipeline.yml` on push)
+- [ ] You have read `docs/contracts/model-api-contract.md` and your model's request/response
+  schema matches the platform contract
+- [ ] Contract sign-off obtained from Data Eng, Backend, and Frontend leads
+  (see `docs/golden-paths/RACI-and-handoffs.md` — required before staging promotion)
+
+---
+
+## Step 1 — Substitute placeholders
+
+Copy this template directory to a working location and substitute all placeholders.
+Use `envsubst` or `sed`:
+
+```bash
+# Set your values
+export MODEL_NAME="fraud-uk"              # lower-kebab; used in DAG IDs, MLflow model name
+export MODEL_NAMESPACE="fraud-uk"         # Kubernetes namespace for this model
+export TEAM_SLUG="team-ml-fraud"          # lower-kebab; used in Grafana folder + alert prefix
+export TEAM_NAME="ML Fraud"              # human-readable
+export TEAM_OWNER="team-ml-fraud"        # ADR-0028 platform.owner
+export TENANT="tenant-acme"              # ADR-0038 multi-tenant label
+export DOMAIN="hft"                      # one of: hft, solana, insurance, rtb
+export PLATFORM_ENV="production"         # production | staging | dev | sandbox
+export GCS_MLFLOW_ARTIFACTS_BUCKET="mlflow-artifacts-prod-yourproject"
+
+# Substitute in all template files (dry-run first)
+mkdir -p out
+for f in values-grafana-self-serve.yaml values-ml-monitoring.yaml \
+          ml-pipeline-trigger.yaml argocd-application.yaml; do
+  envsubst < "$f" > "out/${f}"
+done
+```
+
+Verify no `{{` remain:
+```bash
+grep -r '{{' out/ && echo "UNSUBSTITUTED PLACEHOLDERS FOUND" || echo "OK"
+```
+
+---
+
+## Step 2 — Wire the training pipeline (WS-B)
+
+The file `ml-pipeline-trigger.yaml` shows the exact `workflow_dispatch` payload to
+trigger `.github/workflows/ml-pipeline.yml` for your model. The pipeline:
+
+1. Calls `POST /api/v1/dags/train_domain_adapter/dagRuns`
+   with `conf.model_id = {{MODEL_NAME}}`, `conf.tenant = {{TENANT}}`,
+   `conf.domain = {{DOMAIN}}`
+2. Polls `eval_adapter_debate` dag run until terminal state
+3. Reads eval metrics from MLflow — gate: `win_rate >= 0.55`
+4. Registers model version in MLflow and transitions to Staging
+5. Generates SBOM (`.github/actions/syft-sbom`) and cosign-signs the artifact
+6. Opens Kargo promotion: dev (auto) → staging (reviewer) → prod (manual gate)
+
+No changes to the workflow file are needed — it is parameterised by `inputs.model`.
+
+Reference: `.github/workflows/ml-pipeline.yml`
+
+---
+
+## Step 3 — Configure drift monitoring (WS-C)
+
+Apply the substituted `values-ml-monitoring.yaml` as a per-model override. Options:
+
+- **Recommended:** add a `modelNamespaces` entry in the main
+  `apps/infra/ml-monitoring/values.yaml` PR.
+- **Alternative:** create a standalone ArgoCD Application that merges
+  `apps/infra/ml-monitoring/values.yaml` with your per-model overrides.
+
+The WS-C chart deploys per namespace:
+- An Evidently `drift-exporter` Deployment (accuracy, PSI, KL divergence, F1)
+- A whylogs profiler Deployment (inline distribution profiling)
+- A ServiceMonitor so Prometheus scrapes `/metrics` on port 8001
+- A PrometheusRule with `{{TEAM_SLUG_UPPER}}_DRIFT_HIGH` and
+  `{{TEAM_SLUG_UPPER}}_ACCURACY_LOW` alert groups (TEAM_SLUG_UPPER = upper-case
+  version of TEAM_SLUG with hyphens replaced by underscores)
+
+The drift alert fires the retrain trigger webhook:
+`POST $AIRFLOW_BASE_URL/api/v1/dags/train_domain_adapter/dagRuns`
+with `conf = {"tenant": "{{TENANT}}", "domain": "{{DOMAIN}}", "trigger_reason": "drift"}`.
+
+Reference: `apps/infra/ml-monitoring/values.yaml`,
+`docs/adrs/0038-ml-observability-drift.md`
+
+---
+
+## Step 4 — Provision team dashboard (WS-D)
+
+Create a PR adding your substituted files:
+
+```
+apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/values.yaml
+apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/argocd-application.yaml
+```
+
+The WS-D chart provisions:
+- A Grafana folder `team-{{TEAM_SLUG}}`
+- A starter dashboard with RED metrics, resource saturation, alerts table, and ML panels
+  (ML panels activate because `ml.enabled: true` — drift score, accuracy, retrain trigger
+  rate, all scoped to `model_name = {{MODEL_NAME}}`, `tenant = {{TENANT}}`)
+- A PrometheusRule with availability + saturation + ML alert groups
+  in namespace `{{MODEL_NAMESPACE}}`
+
+Reference: `apps/infra/grafana-self-serve/values.yaml`,
+`docs/self-serve-observability.md`, `docs/adrs/0039-self-serve-observability.md`
+
+---
+
+## Step 5 — Contract sign-off
+
+Before merging the ArgoCD Application into staging, confirm:
+
+```
+[ ] docs/contracts/model-api-contract.md read by all four personas
+[ ] Request/response schema for {{MODEL_NAME}} matches the contract spec
+[ ] Feature schema for {{MODEL_NAME}} matches the contract spec
+[ ] Signed off by:
+    Data Eng lead _________
+    ML Eng lead _________
+    Backend lead _________
+    Frontend lead _________  (if a UI consumes this model)
+```
+
+See `docs/contracts/example-domain-adapter-contract.yaml` for a worked example.
+
+---
+
+## Step 6 — Open the PR
+
+PR checklist:
+- [ ] All `{{PLACEHOLDER}}` substituted; no raw template strings remain in output files
+- [ ] `yamllint -c .yamllint.yml` passes on all new YAML files
+- [ ] `helm template apps/infra/grafana-self-serve \
+       -f apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/values.yaml`
+       renders without error
+- [ ] ADR-0028 labels present on every K8s resource:
+      `platform.system`, `platform.owner`, `platform.env`,
+      `platform.component`, `platform.managed-by`
+- [ ] Contract sign-off documented in PR description
+- [ ] Link to the MLflow experiment URL once first training run completes
+
+---
+
+## Platform support
+
+Questions? Contact `#platform-eng` on Slack or open an issue referencing:
+- ADR-0037 (WS-B): training pipeline issues
+- ADR-0038 (WS-C): drift monitoring issues
+- ADR-0039 (WS-D): dashboard issues
+- ADR-0041 (WS-F): this template
+
+---
+
+## Backstage future mapping
+
+When ADR-0034 is revisited, this template maps to a Backstage Software Template:
+
+```yaml
+# catalog-info.yaml (future — do not deploy before ADR-0034 revisit)
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: new-model-service
+spec:
+  type: model-service
+  parameters:
+    - title: Model identity
+      properties:
+        modelName:       # -> {{MODEL_NAME}}
+        namespace:       # -> {{MODEL_NAMESPACE}}
+        tenant:          # -> {{TENANT}}
+        domain:          # -> {{DOMAIN}}
+    - title: Team identity
+      properties:
+        teamSlug:        # -> {{TEAM_SLUG}}
+        teamName:        # -> {{TEAM_NAME}}
+        teamOwner:       # -> {{TEAM_OWNER}}
+        platformEnv:     # -> {{PLATFORM_ENV}}
+  steps:
+    - id: fetch-template
+      action: fetch:template
+      input:
+        url: ./templates/golden-paths/new-model-service
+    - id: publish
+      action: publish:github:pull-request
+    - id: register
+      action: catalog:register
+```

--- a/templates/golden-paths/new-model-service/argocd-application.yaml
+++ b/templates/golden-paths/new-model-service/argocd-application.yaml
@@ -1,0 +1,65 @@
+---
+# Golden Path: new-model-service — ArgoCD Application stub (grafana-self-serve)
+# WS-D (ADR-0039) chart: apps/infra/grafana-self-serve
+#
+# USAGE: substitute all {{PLACEHOLDER}} values, then commit this file at:
+#   apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/argocd-application.yaml
+#
+# Deploys into {{MODEL_NAMESPACE}}. The namespace must pre-exist.
+# Wave 30 — after all observability + ml-monitoring components (wave 10-20).
+#
+# See README.md Step 4 for full instructions.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  # Substitute: grafana-self-serve-{{TEAM_SLUG}}
+  name: "grafana-self-serve-{{TEAM_SLUG}}"
+  namespace: argocd
+  labels:
+    # ADR-0028 platform taxonomy (K8s plane)
+    platform.system: "observability"
+    platform.component: "self-serve"
+    # Substitute: {{PLATFORM_ENV}}
+    platform.env: "{{PLATFORM_ENV}}"
+    # Substitute: {{TEAM_OWNER}}
+    platform.owner: "{{TEAM_OWNER}}"
+    platform.managed-by: "argocd"
+    # Substitute: grafana-self-serve-{{TEAM_SLUG}}
+    app.kubernetes.io/name: "grafana-self-serve-{{TEAM_SLUG}}"
+    app.kubernetes.io/component: "self-serve"
+    app.kubernetes.io/managed-by: "argocd"
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/your-org/platform-design.git
+    targetRevision: main
+    path: apps/infra/grafana-self-serve
+    helm:
+      valueFiles:
+        - values.yaml
+        # Substitute: example-teams/{{TEAM_SLUG}}/values.yaml
+        - "example-teams/{{TEAM_SLUG}}/values.yaml"
+  destination:
+    server: https://kubernetes.default.svc
+    # Substitute: {{MODEL_NAMESPACE}}
+    namespace: "{{MODEL_NAMESPACE}}"
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=false
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m

--- a/templates/golden-paths/new-model-service/ml-pipeline-trigger.yaml
+++ b/templates/golden-paths/new-model-service/ml-pipeline-trigger.yaml
@@ -1,0 +1,53 @@
+# Golden Path: new-model-service — ml-pipeline.yml dispatch payload
+# WS-B (ADR-0037): .github/workflows/ml-pipeline.yml
+#
+# This is a REFERENCE file, not a deployed Kubernetes manifest.
+# It documents the GitHub workflow_dispatch payload for your model.
+#
+# USAGE (after substituting {{PLACEHOLDER}} values):
+#
+#   gh workflow run ml-pipeline.yml \
+#     --ref main \
+#     --field model={{MODEL_NAME}} \
+#     --field environment={{PLATFORM_ENV}}
+#
+# Or via GitHub REST API:
+#   curl -X POST \
+#     -H "Authorization: Bearer $GH_TOKEN" \
+#     -H "Accept: application/vnd.github+json" \
+#     https://api.github.com/repos/YOUR_ORG/platform-design/actions/workflows/ml-pipeline.yml/dispatches \
+#     -d '{"ref":"main","inputs":{"model":"{{MODEL_NAME}}","environment":"{{PLATFORM_ENV}}"}}'
+#
+# The ml-pipeline.yml workflow then:
+#   1. POST $AIRFLOW_BASE_URL/api/v1/dags/train_domain_adapter/dagRuns
+#      conf: {model_id: {{MODEL_NAME}}, tenant: {{TENANT}}, domain: {{DOMAIN}}}
+#   2. Poll eval_adapter_debate dag run until terminal state
+#   3. Quality gate: win_rate >= 0.55
+#   4. Register model version in MLflow (-> Staging)
+#   5. SBOM (syft) + cosign sign + attest
+#   6. Kargo promotion: dev (auto) -> staging (reviewer) -> prod (manual)
+#
+# Reference: .github/workflows/ml-pipeline.yml
+
+dispatch:
+  workflow: ml-pipeline.yml
+  ref: main
+  inputs:
+    # Substitute: {{MODEL_NAME}}
+    model: "{{MODEL_NAME}}"
+    # Substitute: {{PLATFORM_ENV}}
+    environment: "{{PLATFORM_ENV}}"
+
+# Airflow DAG configuration injected via dagRuns conf (for reference):
+airflow_dag_conf:
+  model_id: "{{MODEL_NAME}}"
+  tenant: "{{TENANT}}"
+  domain: "{{DOMAIN}}"
+  # First run is always manual; drift trigger uses "drift".
+  trigger_reason: "manual"
+
+# MLflow model registration path (for reference):
+mlflow:
+  model_name: "{{MODEL_NAME}}"
+  # Artifacts stored at: gs://{{GCS_MLFLOW_ARTIFACTS_BUCKET}}/{{MODEL_NAME}}/<git-sha>
+  artifact_bucket: "{{GCS_MLFLOW_ARTIFACTS_BUCKET}}"

--- a/templates/golden-paths/new-model-service/values-grafana-self-serve.yaml
+++ b/templates/golden-paths/new-model-service/values-grafana-self-serve.yaml
@@ -1,0 +1,66 @@
+# Golden Path: new-model-service — grafana-self-serve values
+# WS-D (ADR-0039) chart: apps/infra/grafana-self-serve
+#
+# USAGE: substitute all {{PLACEHOLDER}} values before committing.
+# Place the substituted file at:
+#   apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/values.yaml
+#
+# See README.md Step 4 for full instructions.
+
+team:
+  # Human-readable team name shown in the Grafana folder title.
+  # Substitute: {{TEAM_NAME}}
+  name: "{{TEAM_NAME}}"
+
+  # Machine-safe slug — lowercase, hyphens only.
+  # Substitute: {{TEAM_SLUG}}
+  slug: "{{TEAM_SLUG}}"
+
+  # Kubernetes namespace where this team's workloads run.
+  # Must already exist (CreateNamespace=false on the ArgoCD Application).
+  # Substitute: {{MODEL_NAMESPACE}}
+  namespace: "{{MODEL_NAMESPACE}}"
+
+  # platform.system value (ADR-0028). For a model service: ml-pipeline.
+  system: "ml-pipeline"
+
+  # platform.owner value (ADR-0028).
+  # Substitute: {{TEAM_OWNER}}
+  owner: "{{TEAM_OWNER}}"
+
+  # Deployment environment.
+  # Substitute: {{PLATFORM_ENV}}
+  env: "{{PLATFORM_ENV}}"
+
+  # Grafana service account for folder Editor access.
+  # Create this SA in Grafana before ArgoCD sync.
+  # Substitute: grafana-sa-{{TEAM_SLUG}}
+  grafanaServiceAccount: "grafana-sa-{{TEAM_SLUG}}"
+
+  # CI/CD service account in team.namespace for PrometheusRule RBAC.
+  # Substitute: {{TEAM_SLUG}}-ci
+  ciServiceAccount: "{{TEAM_SLUG}}-ci"
+
+# ML panels enabled — wires ADR-0038 drift + accuracy metrics into the dashboard.
+ml:
+  enabled: true
+
+  # Scope ML panels to this specific model.
+  # Substitute: {{MODEL_NAME}}
+  modelName: "{{MODEL_NAME}}"
+
+  # Scope ML panels to this tenant (ADR-0038 multi-tenant label).
+  # Substitute: {{TENANT}}
+  tenant: "{{TENANT}}"
+
+# Alert thresholds — adjust for your model SLOs.
+alerts:
+  errorRateThreshold: "0.05"
+  cpuSaturationThreshold: "0.80"
+  memorySaturationThreshold: "0.80"
+  availabilityFor: "5m"
+  saturationFor: "15m"
+  # Drift and accuracy floors from docs/contracts/model-api-contract.md.
+  mlDriftThreshold: "0.2"
+  mlAccuracyThreshold: "0.85"
+  mlAlertFor: "10m"

--- a/templates/golden-paths/new-model-service/values-ml-monitoring.yaml
+++ b/templates/golden-paths/new-model-service/values-ml-monitoring.yaml
@@ -1,0 +1,65 @@
+# Golden Path: new-model-service — ml-monitoring per-model override
+# WS-C (ADR-0038) chart: apps/infra/ml-monitoring
+#
+# USAGE: substitute all {{PLACEHOLDER}} values, then add this as a
+# modelNamespaces entry in apps/infra/ml-monitoring/values.yaml
+# (or mount as a second values file in a per-model ArgoCD Application).
+#
+# See README.md Step 3 for full instructions.
+#
+# ADR-0028 platform labels (K8s plane):
+#   platform.system     = ml-monitoring
+#   platform.component  = drift-exporter
+#   platform.env        = {{PLATFORM_ENV}}
+#   platform.owner      = {{TEAM_OWNER}}
+#   platform.managed-by = argocd
+
+# Namespace for this model's drift-monitoring components.
+# Substitute: {{MODEL_NAMESPACE}}
+namespace: "{{MODEL_NAMESPACE}}"
+
+driftExporter:
+  enabled: true
+
+  # Per-model GCS reference dataset path.
+  # Pattern: <bucket>/<modelName>/<tenant>/<domain>/reference.parquet
+  referenceBucketUri: "gs://{{GCS_MLFLOW_ARTIFACTS_BUCKET}}/{{MODEL_NAME}}/{{TENANT}}/{{DOMAIN}}/reference.parquet"
+
+  # Model-specific drift thresholds.
+  # Adjust to match the contract floors in docs/contracts/model-api-contract.md.
+  defaultThresholds:
+    datasetDriftScore:
+      warning: 0.20
+      critical: 0.40
+    featurePsiScore:
+      warning: 0.10
+      critical: 0.25
+    featureKlDivergence:
+      warning: 0.10
+      critical: 0.30
+    modelAccuracy:
+      warning: 0.85
+      critical: 0.75
+    modelF1Score:
+      warning: 0.80
+      critical: 0.65
+
+whylogsProfiler:
+  enabled: true
+
+  # Pushgateway address — typically shared across all model namespaces.
+  pushgatewayAddress: "http://prometheus-pushgateway.ml-monitoring.svc.cluster.local:9091"
+
+  # Labels injected into every whylogs push for multi-tenant PromQL queries.
+  extraLabels:
+    model_name: "{{MODEL_NAME}}"
+    tenant: "{{TENANT}}"
+    domain: "{{DOMAIN}}"
+
+# ADR-0028 platform labels applied to all K8s resources in this release.
+platformLabels:
+  "platform.system": "ml-monitoring"
+  "platform.component": "drift-exporter"
+  "platform.env": "{{PLATFORM_ENV}}"
+  "platform.owner": "{{TEAM_OWNER}}"
+  "platform.managed-by": "argocd"


### PR DESCRIPTION
## WS-F — Golden paths + contracts + RACI (final workstream)

Implements **WS-F**, the last workstream of the GCP ML Platform plan. **Plan/validate-only**. After this, the whole plan (WS-A..F, ADR-0036..0041) is implemented as draft PRs.

### ADR-0041
Template-dir **golden paths** (Backstage-deferred per ADR-0034, designed to map onto a future scaffolder), shared **API/data contracts**, and a **RACI/handoff** model bridging data / ML / backend / frontend.

### Delivered
- `templates/golden-paths/new-model-service/` — scaffold pre-wired to **WS-B** (`ml-pipeline.yml` dispatch + MLflow), **WS-C** (`ml-monitoring` per-model drift-exporter override + retrain trigger), **WS-D** (`grafana-self-serve` dashboard, `ml.enabled`).
- `templates/golden-paths/new-ml-pipeline/` — Airflow DAG template mirroring the WS-B `train_domain_adapter` shape + MLflow register + Pushgateway drift-metric emission (exact WS-C metric/label names).
- `templates/golden-paths/new-dashboard/` — `grafana-self-serve` team-values template (WS-D pattern).
- `docs/contracts/` — ModelRequest/Response JSON Schema + per-domain feature schema + a concrete example (`domain-adapter-hft`).
- `docs/golden-paths/RACI-and-handoffs.md` — 20-activity RACI + H1..H9 handoff flow + escalation.

### Validation
`yamllint` 0 errors (8 YAML); `helm template grafana-self-serve` with both golden-path value files renders cleanly; `kubeconform -strict` PASS (PrometheusRule CRD skipped, same as WS-D); **22 cross-reference paths to WS-B/C/D all resolve**. `platform:system` labels throughout (ADR-0028).

### Caveats
- Backstage scaffolder deferred (ADR-0034); golden paths are template dirs + onboarding READMEs that map 1:1 onto a future scaffolder.
- `dag_template.py` is valid Python; Airflow DAG-parse is a documented local step (`airflow dags list-import-errors`).

> Draft, apply-gated. Completes the GCP ML Platform plan.

Part of the GCP ML Platform plan · ADR-0041