### PR TITLE
ci: fix yamllint bracket spacing in validate-agents workflow

### DIFF
--- a/.github/workflows/validate-agents.yml
+++ b/.github/workflows/validate-agents.yml
@@ -2,9 +2,9 @@ name: Validate Copilot Agents
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
   pull_request:
-    branches: [ main, master ]
+    branches: [main, master]
 
 permissions:
   contents: read


### PR DESCRIPTION
Fixes the repo-wide `yamllint` check failing on main with `too many spaces inside brackets` in `.github/workflows/validate-agents.yml` (`branches: [ main, master ]` → `[main, master]`).

This unblocks the open Dependabot PRs (their inherited base showed this failure). No functional change to the workflow triggers.

## Test plan
- [x] `yamllint -c .yamllint.yml` clean on the file
- [ ] CI yamllint green