### PR TITLE
docs(adr): reconcile ADR-0017..0027 status with shipped implementations (epic #252)

### DIFF
--- a/docs/adrs/0017-resource-side-perimeter-and-declarative-org-controls.md
+++ b/docs/adrs/0017-resource-side-perimeter-and-declarative-org-controls.md
@@ -1,10 +1,8 @@
 # ADR-0017: Resource-side data perimeter and declarative org controls (RCPs, EC2 Declarative Policies, full-IAM SCPs)
 
-- Status: **Accepted** — research-backed + doc-verified; ratified, not yet
-  implemented.
+- Status: **Accepted** — **partially implemented** (epic #252); research-backed + doc-verified.
 - Ratified: 2026-06-07 by platform owner.
-- platform-design status: **pending** — no RCPs, EC2 Declarative Policies, or
-  full-IAM-language SCP refactor are wired into this repo yet.
+- platform-design status: **partial** — RCP + Access Analyzer gate merged (#256/#274); AFT = ADR-0035; EC2 Declarative Policies pending (#315).
 - Date: 2026-06-06
 - Authors: platform-team, security
 - Related issues: epic #252

--- a/docs/adrs/0018-eks-pod-identity-as-default-workload-identity.md
+++ b/docs/adrs/0018-eks-pod-identity-as-default-workload-identity.md
@@ -1,10 +1,8 @@
 # ADR-0018: EKS Pod Identity as the default workload identity (IRSA becomes legacy)
 
-- Status: **Accepted** — research-backed + doc-verified; ratified, not yet
-  implemented.
+- Status: **Accepted** — **Implemented** (epic #252); research-backed + doc-verified.
 - Ratified: 2026-06-07 by platform owner.
-- platform-design status: **pending** — workloads still bind identity via IRSA
-  annotations; no `PodIdentityAssociation` resources are wired in.
+- platform-design status: **implemented** — Pod Identity + ESO 2.6 across workloads (#254/#267/#269).
 - Date: 2026-06-06
 - Authors: platform-team, security
 - Related issues: epic #252

--- a/docs/adrs/0019-harvest-cilium-ebpf-capabilities.md
+++ b/docs/adrs/0019-harvest-cilium-ebpf-capabilities.md
@@ -1,10 +1,8 @@
 # ADR-0019: Harvest unused Cilium / eBPF capabilities (OBI tracing, Hubble UI, Tetragon, ClusterMesh)
 
-- Status: **Accepted** — research-backed + doc-verified; ratified, not yet
-  implemented.
+- Status: **Accepted** — **partially implemented** (epic #252); research-backed + doc-verified.
 - Ratified: 2026-06-07 by platform owner.
-- platform-design status: **pending** — Cilium 1.19 is deployed but none of the
-  capabilities below are turned on in this repo.
+- platform-design status: **partial** — OBI/Beyla, Tetragon (enforce), Hubble UI + ClusterMesh (ADR-0043, #311) merged; netkit pilot pending (#314).
 - Date: 2026-06-06
 - Authors: platform-team, security
 - Related issues: epic #252

--- a/docs/adrs/0020-kyverno-and-vap-policy-engine.md
+++ b/docs/adrs/0020-kyverno-and-vap-policy-engine.md
@@ -1,10 +1,8 @@
 # ADR-0020: Kyverno + ValidatingAdmissionPolicy as the policy-engine layer
 
-- Status: **Accepted** — research-backed + doc-verified; ratified, not yet
-  implemented.
+- Status: **Accepted** — **Implemented** (epic #252); research-backed + doc-verified.
 - Ratified: 2026-06-07 by platform owner.
-- platform-design status: **pending** — Kyverno is scaffolded but disabled; no
-  ValidatingAdmissionPolicy resources are authored.
+- platform-design status: **implemented** — Kyverno + VAP in enforce (#266/#270).
 - Date: 2026-06-06
 - Authors: platform-team, security
 - Related issues: epic #252

--- a/docs/adrs/0021-kargo-gitops-promotion-layer.md
+++ b/docs/adrs/0021-kargo-gitops-promotion-layer.md
@@ -1,10 +1,8 @@
 # ADR-0021: Kargo as the GitOps environment-promotion layer
 
-- Status: **Accepted** — research-backed + doc-verified; ratified, not yet
-  implemented.
+- Status: **Accepted** — **Implemented** (epic #252); research-backed + doc-verified.
 - Ratified: 2026-06-07 by platform owner.
-- platform-design status: **pending** — Kargo is scaffolded (Warehouse → Stage →
-  Freight graph) but not activated; the bootstrap App pins the old chart.
+- platform-design status: **implemented** — Kargo 1.9 + Prometheus/Tempo SLO gates (#258).
 - Date: 2026-06-06
 - Authors: platform-team
 - Related issues: epic #252

--- a/docs/adrs/0022-ci-supply-chain-runtime-hardening.md
+++ b/docs/adrs/0022-ci-supply-chain-runtime-hardening.md
@@ -1,10 +1,8 @@
 # ADR-0022: CI supply-chain runtime hardening — Actions SAST + runner egress monitoring
 
-- Status: **Accepted** — research-backed + doc-verified; ratified, partly spiked,
-  not yet fully implemented.
+- Status: **Accepted** — **partially implemented** (epic #252); research-backed + doc-verified.
 - Ratified: 2026-06-07 by platform owner.
-- platform-design status: **pending** — no Actions-workflow linting or runner
-  runtime monitoring is wired in; spike PR #251 prototypes part of it.
+- platform-design status: **partial** — zizmor SARIF gate merged; Harden-Runner/attestations/immutable-releases/cosign-2.4 pending (#313).
 - Implemented by: spike PR #251 (partial — prototypes the zizmor / Harden-Runner
   wiring).
 - Date: 2026-06-06

--- a/docs/adrs/0023-vpc-lattice-resource-connectivity.md
+++ b/docs/adrs/0023-vpc-lattice-resource-connectivity.md
@@ -1,10 +1,8 @@
 # ADR-0023: VPC Lattice resource connectivity for cross-account/cross-VPC TCP resource access
 
-- Status: **Accepted** — research-backed + doc-verified; ratified, not yet
-  implemented.
+- Status: **Accepted** — **Implemented** (epic #252); research-backed + doc-verified.
 - Ratified: 2026-06-07 by platform owner.
-- platform-design status: **pending** — no VPC Lattice Resource Gateway, Resource
-  Configuration, or service-network resource sharing is wired into this repo.
+- platform-design status: **implemented** — VPC Lattice resource gateway + RAM + IAM auth (#265).
 - Date: 2026-06-07
 - Authors: platform-team, security
 - Related issues: epic #252

--- a/docs/adrs/0024-argocd-operational-hardening.md
+++ b/docs/adrs/0024-argocd-operational-hardening.md
@@ -1,10 +1,8 @@
 # ADR-0024: ArgoCD operational hardening (PreDelete hooks, shallow clone, server-side diff/apply, progressive ApplicationSet rollout)
 
-- Status: **Accepted** — research-backed + doc-verified; ratified, not yet
-  implemented.
+- Status: **Accepted** — **Implemented** (epic #252); research-backed + doc-verified.
 - Ratified: 2026-06-07 by platform owner.
-- platform-design status: **pending** — none of the four ArgoCD capabilities below
-  are enabled in this repo's ArgoCD config.
+- platform-design status: **implemented** — shallow clone + server-side diff/apply + RollingSync + PreDelete (#259).
 - Date: 2026-06-07
 - Authors: platform-team
 - Related issues: epic #252

--- a/docs/adrs/0025-envoy-gateway-secondary-l7.md
+++ b/docs/adrs/0025-envoy-gateway-secondary-l7.md
@@ -1,10 +1,8 @@
 # ADR-0025: Envoy Gateway as a secondary L7 GatewayClass alongside Cilium
 
-- Status: **Accepted** — research-backed + doc-verified; ratified, not yet
-  implemented.
+- Status: **Accepted** — **Implemented** (epic #252); research-backed + doc-verified.
 - Ratified: 2026-06-07 by platform owner.
-- platform-design status: **pending** — only the Cilium Gateway API GatewayClass
-  (ADR-0009) is present; no Envoy Gateway GatewayClass is deployed.
+- platform-design status: **implemented** — Envoy Gateway secondary GatewayClass (#260).
 - Date: 2026-06-07
 - Authors: platform-team
 - Related issues: epic #252

--- a/docs/adrs/0026-observability-target-architecture.md
+++ b/docs/adrs/0026-observability-target-architecture.md
@@ -1,10 +1,8 @@
 # ADR-0026: Observability target architecture (LGTM-aligned: Prometheus 3 + Thanos, Loki, Tempo, Alloy)
 
-- Status: **Accepted** — research-backed + doc-verified; ratified, not yet
-  implemented.
+- Status: **Accepted** — **Implemented** (epic #252); research-backed + doc-verified.
 - Ratified: 2026-06-07 by platform owner.
-- platform-design status: **pending** — the target stack below is not fully wired
-  in (Tempo is deployed-but-unfed per ADR-0019; the rest is partial/absent).
+- platform-design status: **implemented** — Prometheus 3.x + Thanos + Loki/Alloy + Tempo/OBI + Pyrra (#261/#275).
 - Date: 2026-06-07
 - Authors: platform-team
 - Related issues: epic #252

--- a/docs/adrs/0027-kubernetes-cost-opencost-cur.md
+++ b/docs/adrs/0027-kubernetes-cost-opencost-cur.md
@@ -1,10 +1,8 @@
 # ADR-0027: Kubernetes cost allocation via OpenCost + AWS CUR/Athena cloud-integration
 
-- Status: **Accepted** — research-backed + doc-verified; ratified, not yet
-  implemented.
+- Status: **Accepted** — **Implemented** (epic #252); research-backed + doc-verified.
 - Ratified: 2026-06-07 by platform owner.
-- platform-design status: **pending** — no OpenCost install or CUR/Athena
-  cloud-integration is wired into this repo.
+- platform-design status: **implemented** — OpenCost + CUR/Athena cost export (#257).
 - Date: 2026-06-07
 - Authors: platform-team, finops
 - Related issues: epic #252

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -16,9 +16,10 @@ Proposed to **Accepted — rolling out** once PR #241 implemented them in-repo
 ADRs 0017–0027 are **research-backed + doc-verified 2026-06-07 (Context7 + official
 AWS/vendor docs)** — formalized from the 2026 platform modernization deep-dives
 (grounded in `infra@572b54d` / `argocd@c364c6c`). They are all **Accepted** —
-**ratified 2026-06-07 by the platform owner** — but remain **pending** in
-platform-design (decided, not yet implemented). They are tracked by ROADMAP Phase 8
-under epic #252. ADRs 0017–0022 were corrected per the 2026-06-07 doc-verification
+**ratified 2026-06-07 by the platform owner** — and are now largely **implemented**
+in platform-design (epic #252), except 0017 / 0019 / 0022 which remain **partial**
+(see the platform-design status column + the remaining-work follow-ups #313/#314/#315).
+They are tracked by ROADMAP Phase 8 under epic #252. ADRs 0017–0022 were corrected per the 2026-06-07 doc-verification
 pass before ratification (e.g. AFT account vending in 0017, the six Pod Identity
 session tags + ESO upgrade prereq in 0018, netkit unblocked on kernel 6.12 in 0019,
 admission-time cosign verification in 0020, OTel SLO-gating in 0021, the supply-chain
@@ -61,17 +62,17 @@ decision.
 | [0014](0014-argo-rollouts-canary-progressive-delivery.md) | Argo Rollouts canary with Gateway API traffic-routing and analysis | Accepted | synced (#238) | ported · adopted |
 | [0015](0015-reusable-ci-pipelines.md) | Reusable CI/CD pipelines for the platform organisation | Accepted — rolling out | synced (#241) | ported · implemented by #241 |
 | [0016](0016-tier1-supply-chain-hardening.md) | Tier 1 CI/CD hardening — dep scan, secrets, SAST, signing, manifest validation, smoke | Accepted | synced (#241, #248) | ported · implemented by #241, #248 |
-| [0017](0017-resource-side-perimeter-and-declarative-org-controls.md) | Resource-side data perimeter and declarative org controls (AFT vending, RCPs, EC2 Declarative Policies, full-IAM SCPs) | Accepted | pending | research-backed + doc-verified |
-| [0018](0018-eks-pod-identity-as-default-workload-identity.md) | EKS Pod Identity as the default workload identity (IRSA becomes legacy) | Accepted | pending | research-backed + doc-verified |
-| [0019](0019-harvest-cilium-ebpf-capabilities.md) | Harvest unused Cilium / eBPF capabilities (OBI tracing, Hubble UI, Tetragon, ClusterMesh, netkit pilot) | Accepted | pending | research-backed + doc-verified |
-| [0020](0020-kyverno-and-vap-policy-engine.md) | Kyverno + ValidatingAdmissionPolicy as the policy-engine layer (admission-time cosign) | Accepted | pending | research-backed + doc-verified |
-| [0021](0021-kargo-gitops-promotion-layer.md) | Kargo as the GitOps environment-promotion layer (OTel SLO-gating) | Accepted | pending | research-backed + doc-verified |
-| [0022](0022-ci-supply-chain-runtime-hardening.md) | CI supply-chain runtime hardening — Actions SAST + runner egress monitoring | Accepted | pending | research-backed + doc-verified |
-| [0023](0023-vpc-lattice-resource-connectivity.md) | VPC Lattice resource connectivity (cross-account/cross-VPC TCP resource access) | Accepted | pending | research-backed + doc-verified |
-| [0024](0024-argocd-operational-hardening.md) | ArgoCD operational hardening (PreDelete hooks, shallow clone, server-side diff/apply, progressive ApplicationSet rollout) | Accepted | pending | research-backed + doc-verified |
-| [0025](0025-envoy-gateway-secondary-l7.md) | Envoy Gateway as a secondary L7 GatewayClass alongside Cilium | Accepted | pending | research-backed + doc-verified |
-| [0026](0026-observability-target-architecture.md) | Observability target architecture (LGTM: Prometheus 3 + Thanos, Loki, Tempo, Alloy) | Accepted | pending | research-backed + doc-verified |
-| [0027](0027-kubernetes-cost-opencost-cur.md) | Kubernetes cost allocation via OpenCost + AWS CUR/Athena | Accepted | pending | research-backed + doc-verified |
+| [0017](0017-resource-side-perimeter-and-declarative-org-controls.md) | Resource-side data perimeter and declarative org controls (AFT vending, RCPs, EC2 Declarative Policies, full-IAM SCPs) | Accepted | partial | research-backed + doc-verified |
+| [0018](0018-eks-pod-identity-as-default-workload-identity.md) | EKS Pod Identity as the default workload identity (IRSA becomes legacy) | Accepted | implemented | research-backed + doc-verified |
+| [0019](0019-harvest-cilium-ebpf-capabilities.md) | Harvest unused Cilium / eBPF capabilities (OBI tracing, Hubble UI, Tetragon, ClusterMesh, netkit pilot) | Accepted | partial | research-backed + doc-verified |
+| [0020](0020-kyverno-and-vap-policy-engine.md) | Kyverno + ValidatingAdmissionPolicy as the policy-engine layer (admission-time cosign) | Accepted | implemented | research-backed + doc-verified |
+| [0021](0021-kargo-gitops-promotion-layer.md) | Kargo as the GitOps environment-promotion layer (OTel SLO-gating) | Accepted | implemented | research-backed + doc-verified |
+| [0022](0022-ci-supply-chain-runtime-hardening.md) | CI supply-chain runtime hardening — Actions SAST + runner egress monitoring | Accepted | partial | research-backed + doc-verified |
+| [0023](0023-vpc-lattice-resource-connectivity.md) | VPC Lattice resource connectivity (cross-account/cross-VPC TCP resource access) | Accepted | implemented | research-backed + doc-verified |
+| [0024](0024-argocd-operational-hardening.md) | ArgoCD operational hardening (PreDelete hooks, shallow clone, server-side diff/apply, progressive ApplicationSet rollout) | Accepted | implemented | research-backed + doc-verified |
+| [0025](0025-envoy-gateway-secondary-l7.md) | Envoy Gateway as a secondary L7 GatewayClass alongside Cilium | Accepted | implemented | research-backed + doc-verified |
+| [0026](0026-observability-target-architecture.md) | Observability target architecture (LGTM: Prometheus 3 + Thanos, Loki, Tempo, Alloy) | Accepted | implemented | research-backed + doc-verified |
+| [0027](0027-kubernetes-cost-opencost-cur.md) | Kubernetes cost allocation via OpenCost + AWS CUR/Athena | Accepted | implemented | research-backed + doc-verified |
 | [0028](0028-unified-platform-tagging-and-labeling-taxonomy.md) | Unified Platform Tagging and Labeling Taxonomy | Accepted | pending | native |
 | [0029](0029-ecr-pull-through-cache.md) | ECR Pull-Through Cache for public upstream registries | Accepted | synced (module) | proposal — doc-verified 2026-06-08 |
 | [0030](0030-bottlerocket-node-os.md) | Bottlerocket as the EKS node operating system | Accepted | synced (module) / pending (manifests) | proposal — doc-verified 2026-06-08 |


### PR DESCRIPTION
Part of the review of epic #252. The 2026-06-07/08 waves (and ADR-0043 ClusterMesh, #311) shipped implementation slices for all 11 accepted ADRs, but the ADR status lines + index still said "ratified, not yet implemented". This reconciles the docs.

## Changes (docs-only)
- **Status + platform-design status** lines flipped per ADR:
  - **Implemented:** 0018, 0020, 0021, 0023, 0024, 0025, 0026, 0027 (with PR refs)
  - **Partial:** 0017 (EC2 Declarative Policies pending → #315), 0019 (netkit pilot pending → #314; ClusterMesh now done via ADR-0043/#311), 0022 (Harden-Runner/attestations/immutable/cosign-2.4 pending → #313)
- `docs/adrs/README.md` index status column + the 0017–0027 intro paragraph updated to match.

## Companion actions (already done)
- Epic #252 checkboxes ticked + review comment posted.
- Follow-up issues filed: #313, #314, #315.

## Test plan
- [x] Docs-only; markdown only. No module/manifest changes.
- [ ] CI (markdown/yaml lint) green.