### PR TITLE
feat(aws-wsC): AWS ML observability / drift

### DIFF
--- a/apps/infra/ml-monitoring/alertmanager-routes-overlay-aws.yaml
+++ b/apps/infra/ml-monitoring/alertmanager-routes-overlay-aws.yaml
@@ -1,0 +1,137 @@
+# Alertmanager Routes Overlay — AWS (ADR-0048 D4, ADR-0038 D3)
+#
+# PURPOSE:
+#   AWS-specific Alertmanager route additions for WS-C ML monitoring.
+#   The underlying route/receiver logic is identical to the GCP overlay
+#   (alertmanager-routes-overlay.yaml, ADR-0038 D3) — inherited verbatim
+#   because the retrain trigger is cluster-agnostic (ADR-0048 D4 scope guard).
+#
+#   This file documents the AWS-specific Alertmanager namespace + secret paths.
+#   On the aws-eks-gpu-* cluster, Alertmanager runs in the 'monitoring' namespace
+#   (kube-prometheus-stack default, consistent with ADR-0026).
+#
+# DO NOT edit apps/infra/observability/prometheus-stack/values.yaml directly
+# from this chart — Alertmanager config is owned by the prometheus-stack
+# ArgoCD Application. Merge these patches into prometheus-stack/values.yaml
+# under kube-prometheus-stack.alertmanager.alertmanagerSpec.config when WS-C
+# is promoted to production on the aws-eks-gpu-* cluster.
+#
+# MERGE INSTRUCTIONS (platform team action required before WS-C go-live on AWS):
+#   1. Add the two routes below into the `routes:` list in prometheus-stack/values.yaml
+#      BEFORE the existing `severity = critical` catch-all routes.
+#   2. Add the two receivers (ml-drift-pagerduty, ml-retrain-webhook) to the
+#      `receivers:` list.
+#   3. Add 'alertmanager-retrain-token' to alertmanagerSpec.secrets.
+#   4. Create the cross-namespace ExternalSecret for alertmanager-retrain-token
+#      in the 'monitoring' namespace (see CROSS-NAMESPACE NOTE below).
+#   5. yamllint and helm lint prometheus-stack before applying.
+#
+# AWS vs GCP diff:
+#   - Alertmanager namespace: 'monitoring' (same on both clouds with this stack)
+#   - Secret backend: AWS Secrets Manager (ADR-0008 ESO) vs GCP Secret Manager
+#   - Secret key: aws-ml-platform/ml-monitoring/alertmanager-retrain-token
+#   - Retrain-trigger in-cluster URL: unchanged (ClusterIP DNS, cloud-agnostic)
+#
+# RETRAIN DEDUPLICATION:
+#   repeat_interval: 6h prevents retrain storms (inherited from ADR-0038 D3).
+#   The ml-retrain-trigger proxy also deduplicates per (tenant, domain) pair
+#   within a 15-minute in-process window (values.yaml deduplicationWindowSeconds).
+#
+# ============================================================================
+# ADD to kube-prometheus-stack.alertmanager.alertmanagerSpec.config.route.routes
+# (insert BEFORE the existing severity=critical catch-all routes)
+# ============================================================================
+
+# routes_patch:
+# -----------------------------------------------------------------------
+#   # ML Monitoring (AWS): critical drift/accuracy → PagerDuty
+#   # continue: true so the retrain webhook route also fires
+#   - matchers:
+#     - platform_system = ml-monitoring
+#     - severity = critical
+#     receiver: 'ml-drift-pagerduty'
+#     continue: true
+#     group_wait: 10s
+#     group_by: ['model_name', 'tenant', 'domain', 'alertname']
+#
+#   # ML Monitoring (AWS): critical drift/accuracy → retrain-trigger webhook
+#   # repeat_interval: 6h prevents retrain storms between drift recovery cycles
+#   - matchers:
+#     - platform_system = ml-monitoring
+#     - severity = critical
+#     receiver: 'ml-retrain-webhook'
+#     group_wait: 10s
+#     group_by: ['model_name', 'tenant', 'domain', 'alertname']
+#     repeat_interval: 6h
+# -----------------------------------------------------------------------
+
+# ============================================================================
+# ADD to kube-prometheus-stack.alertmanager.alertmanagerSpec.config.receivers
+# ============================================================================
+
+# receivers_patch:
+# -----------------------------------------------------------------------
+#   - name: 'ml-drift-pagerduty'
+#     pagerduty_configs:
+#     - service_key_file: '/etc/alertmanager/secrets/alertmanager-pagerduty-secret/service-key'
+#       description: 'ML drift (AWS EKS): {{ .GroupLabels.alertname }} — {{ .GroupLabels.model_name }} ({{ .GroupLabels.tenant }}/{{ .GroupLabels.domain }})'
+#       details:
+#         model_name: '{{ .GroupLabels.model_name }}'
+#         tenant: '{{ .GroupLabels.tenant }}'
+#         domain: '{{ .GroupLabels.domain }}'
+#         severity: '{{ .GroupLabels.severity }}'
+#         platform_system: 'ml-monitoring'
+#         cluster: 'aws-eks-gpu'
+#       send_resolved: true
+#
+#   - name: 'ml-retrain-webhook'
+#     webhook_configs:
+#     # ml-retrain-trigger proxy URL (in-cluster ClusterIP DNS, ADR-0038 D4).
+#     # The proxy translates to:
+#     #   POST /api/v1/dags/train_domain_adapter/dagRuns
+#     #   body: { conf: { tenant: "...", domain: "...", trigger: "drift" } }
+#     # Falls back to K8s Job if Airflow is unreachable (WS-B not yet deployed).
+#     - url: 'http://ml-retrain-trigger.ml-monitoring.svc.cluster.local:8080/webhook'
+#       send_resolved: false
+#       http_config:
+#         bearer_token_file: '/etc/alertmanager/secrets/alertmanager-retrain-token/token'
+#       max_alerts: 10
+# -----------------------------------------------------------------------
+
+# ============================================================================
+# ADD to kube-prometheus-stack.alertmanager.alertmanagerSpec.secrets
+# ============================================================================
+
+# secrets_patch:
+# -----------------------------------------------------------------------
+#   - alertmanager-retrain-token
+# -----------------------------------------------------------------------
+#
+# CROSS-NAMESPACE NOTE (AWS):
+#   The alertmanager-retrain-token ExternalSecret in the ml-monitoring chart
+#   creates the Secret in the 'ml-monitoring' namespace. Alertmanager mounts
+#   secrets from its own namespace ('monitoring' on this stack). A second
+#   ExternalSecret targeting the 'monitoring' namespace is required:
+#
+#     apiVersion: external-secrets.io/v1beta1
+#     kind: ExternalSecret
+#     metadata:
+#       name: alertmanager-retrain-token
+#       namespace: monitoring           # Alertmanager's namespace (AWS stack)
+#     spec:
+#       refreshInterval: "1h"
+#       secretStoreRef:
+#         name: cluster-secret-store
+#         kind: ClusterSecretStore
+#       target:
+#         name: alertmanager-retrain-token
+#         creationPolicy: Owner
+#       data:
+#         - secretKey: token
+#           remoteRef:
+#             # AWS Secrets Manager key (ADR-0008 / ADR-0031 rotation applied)
+#             key: aws-ml-platform/ml-monitoring/alertmanager-retrain-token
+#             property: token
+#
+#   OR use a ClusterExternalSecret to create in both 'ml-monitoring' and
+#   'monitoring' namespaces simultaneously.

--- a/apps/infra/ml-monitoring/argocd-application-aws.yaml
+++ b/apps/infra/ml-monitoring/argocd-application-aws.yaml
@@ -1,0 +1,83 @@
+# ArgoCD Application — ML Monitoring on AWS EKS GPU cluster (WS-C, ADR-0048 D4)
+# Mirrors argocd-application.yaml (GCP/GKE) with AWS-specific value overrides.
+#
+# Cited ADRs:
+#   ADR-0048 D4 — drift monitor deployed on aws-eks-gpu-* cluster, AWS metrics backend
+#   ADR-0038    — Evidently/whylogs architecture (cluster-agnostic, inherited)
+#   ADR-0028    — platform:system = ml-monitoring labels on every resource
+#   ADR-0018    — EKS Pod Identity (no GKE Workload Identity annotation needed)
+#
+# Deploy after prometheus-stack (wave 10) so Prometheus CRDs exist.
+# Deploy after mlflow (wave 15, WS-B) so Airflow REST endpoint is available.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ml-monitoring-aws
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: ml-monitoring-aws
+    app.kubernetes.io/component: ml-observability
+    platform.system: ml-monitoring
+    platform.component: drift-exporter
+    platform.env: production
+    platform.owner: team-ml-platform
+    platform.managed-by: argocd
+  annotations:
+    # wave 20: after prometheus-stack (10) and mlflow-aws (15, WS-B)
+    argocd.argoproj.io/sync-wave: "20"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+
+  source:
+    repoURL: https://github.com/your-org/platform-infrastructure.git
+    targetRevision: main
+    path: apps/infra/ml-monitoring
+
+    helm:
+      # Apply base values first, then AWS-specific overrides.
+      # values-aws.yaml overrides: referenceBucketUri (s3://), ECR images,
+      # empty workloadIdentityAnnotation (EKS Pod Identity, ADR-0018),
+      # AWS Secrets Manager ESO key paths (ADR-0008).
+      valueFiles:
+        - values.yaml
+        - values-aws.yaml
+
+  destination:
+    # Target the greenfield aws-eks-gpu-* cluster (ADR-0044).
+    # Update server URL to the aws-eks-gpu-* API endpoint after WS-A lands.
+    server: https://kubernetes.default.svc
+    namespace: ml-monitoring
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - RespectIgnoreDifferences=true
+      - ApplyOutOfSyncOnly=true
+
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas
+    - group: "*"
+      kind: "*"
+      managedFieldsManagers:
+        - kube-controller-manager
+
+  revisionHistoryLimit: 3

--- a/apps/infra/ml-monitoring/values-aws.yaml
+++ b/apps/infra/ml-monitoring/values-aws.yaml
@@ -1,0 +1,236 @@
+# ML Monitoring Helm values — AWS overrides (ADR-0048 D4, ADR-0038)
+# platform:system = ml-monitoring (ADR-0028 taxonomy)
+#
+# This file overrides values.yaml with AWS-specific settings:
+#   - S3 reference-dataset bucket URI (s3://) instead of GCS (gs://)
+#   - ECR image repositories instead of gcr.io / dockerhub
+#   - EKS Pod Identity annotation absent (ADR-0018; Pod Identity uses no SA annotation)
+#   - AWS Secrets Manager secret paths (ADR-0008 ESO with AWS provider)
+#
+# Cited ADRs:
+#   ADR-0048 D4 — drift monitor on EKS with AWS metrics backend
+#   ADR-0038    — Evidently/whylogs architecture (inherited cluster-agnostic)
+#   ADR-0028    — platform:system = ml-monitoring label taxonomy
+#   ADR-0018    — EKS Pod Identity (replaces GKE Workload Identity)
+#   ADR-0008    — ExternalSecrets Operator (AWS Secrets Manager provider)
+#   ADR-0029    — ECR pull-through cache (upstream image base)
+
+# ---------------------------------------------------------------------------
+# ADR-0028 platform labels — same system value as GCP
+# ---------------------------------------------------------------------------
+platformLabels:
+  "platform.system": "ml-monitoring"
+  "platform.env": "production"
+  "platform.owner": "team-ml-platform"
+  "platform.managed-by": "argocd"
+
+# ---------------------------------------------------------------------------
+# Shared namespace (same as GCP)
+# ---------------------------------------------------------------------------
+namespace: ml-monitoring
+
+# ---------------------------------------------------------------------------
+# Evidently drift-exporter — AWS delta: S3 reference bucket + ECR image
+# ---------------------------------------------------------------------------
+driftExporter:
+  enabled: true
+  image:
+    # ECR pull-through cache (ADR-0029): upstream evidently image cached in ECR.
+    # Replace <account-id> and <region> with environment-specific values set
+    # via ArgoCD ApplicationSet or environment-specific parameter overrides.
+    repository: "<account-id>.dkr.ecr.<region>.amazonaws.com/evidently-ai/drift-exporter"
+    tag: "0.4.35"
+    pullPolicy: IfNotPresent
+
+  port: 8001
+  evaluationIntervalSeconds: 300
+
+  resources:
+    requests:
+      cpu: "200m"
+      memory: "512Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+
+  # AWS delta (ADR-0048 D4): S3 reference-dataset bucket (s3://) replaces GCS (gs://).
+  # Naming mirrors aws-ml-artifact-store (WS-B): mlflow-reference-data-{env}-{account}
+  # Path pattern inside bucket: <modelName>/<tenant>/<domain>/reference.parquet
+  # Access via EKS Pod Identity + ABAC condition (ADR-0018):
+  #   aws:PrincipalTag/platform:system == aws:ResourceTag/platform:system
+  referenceBucketUri: "s3://mlflow-reference-data-production-<account-id>"
+
+  defaultThresholds:
+    datasetDriftScore:
+      warning: 0.20
+      critical: 0.40
+    featurePsiScore:
+      warning: 0.10
+      critical: 0.25
+    featureKlDivergence:
+      warning: 0.10
+      critical: 0.30
+    modelAccuracy:
+      warning: 0.85
+      critical: 0.75
+    modelF1Score:
+      warning: 0.80
+      critical: 0.65
+
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop: ["ALL"]
+
+# ---------------------------------------------------------------------------
+# whylogs distribution profiler — AWS delta: ECR image
+# ---------------------------------------------------------------------------
+whylogsProfiler:
+  enabled: true
+  image:
+    # ECR pull-through cache (ADR-0029): whylabs/whylogs-profiler base image.
+    repository: "<account-id>.dkr.ecr.<region>.amazonaws.com/whylabs/whylogs-profiler"
+    tag: "1.3.7"
+    pullPolicy: IfNotPresent
+
+  pushgatewayUrl: "http://prometheus-pushgateway.monitoring.svc:9091"
+  windowSeconds: 3600
+
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "300m"
+      memory: "512Mi"
+
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop: ["ALL"]
+
+# ---------------------------------------------------------------------------
+# Retrain-trigger webhook proxy — AWS delta: ECR image
+# ---------------------------------------------------------------------------
+retrainTrigger:
+  enabled: true
+  image:
+    # Build + push to ECR (ADR-0029 / ADR-0048 D5).
+    # cosign-sign + syft-sbom composites applied in ml-pipeline.yml (WS-B).
+    repository: "<account-id>.dkr.ecr.<region>.amazonaws.com/platform/ml-retrain-trigger"
+    tag: "0.1.0"
+    pullPolicy: IfNotPresent
+
+  port: 8080
+  replicas: 2
+  deduplicationWindowSeconds: 900
+
+  airflow:
+    baseUrl: "http://airflow-webserver.airflow.svc:8080"
+    dagId: "train_domain_adapter"
+    credentialsSecretName: "airflow-api-credentials"
+
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "128Mi"
+    limits:
+      cpu: "200m"
+      memory: "256Mi"
+
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop: ["ALL"]
+
+  service:
+    type: ClusterIP
+    port: 8080
+
+# ---------------------------------------------------------------------------
+# ExternalSecrets — AWS delta: AWS Secrets Manager key paths (ADR-0008)
+# The cluster-secret-store uses the AWS Secrets Manager provider.
+# Secret names follow: aws-ml-platform/<component>/<secret-name>
+# Rotation handled by ADR-0031 automation.
+# ---------------------------------------------------------------------------
+externalSecrets:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: cluster-secret-store
+    kind: ClusterSecretStore
+  airflowCredentials:
+    secretName: airflow-api-credentials
+    remoteRef:
+      # AWS Secrets Manager key (ADR-0031 rotation applied to this secret).
+      # GCP equivalent: ml-monitoring/airflow-api-credentials
+      key: aws-ml-platform/ml-monitoring/airflow-api-credentials
+  alertmanagerRetrainToken:
+    secretName: alertmanager-retrain-token
+    remoteRef:
+      key: aws-ml-platform/ml-monitoring/alertmanager-retrain-token
+
+# ---------------------------------------------------------------------------
+# ServiceMonitor — inherited ADR-0038 (cluster-agnostic)
+# ---------------------------------------------------------------------------
+serviceMonitor:
+  enabled: true
+  prometheusSelector:
+    prometheus: kube-prometheus
+  scrapeInterval: "30s"
+  scrapeTimeout: "10s"
+
+# ---------------------------------------------------------------------------
+# PrometheusRule — inherited thresholds from ADR-0038 (unchanged on AWS)
+# ---------------------------------------------------------------------------
+prometheusRule:
+  enabled: true
+  additionalLabels:
+    prometheus: kube-prometheus
+
+# ---------------------------------------------------------------------------
+# RBAC — AWS delta: EKS Pod Identity (ADR-0018) replaces GKE Workload Identity.
+#
+# EKS Pod Identity does NOT use a K8s annotation on the ServiceAccount.
+# The Pod Identity Association is created by the aws-eks-gpu Terraform module
+# (WS-A/WS-B) and references this ServiceAccount by name and namespace.
+# The IAM role ARN is injected via the EKS Pod Identity Agent sidecar.
+# Leave workloadIdentityAnnotation empty for AWS.
+# ---------------------------------------------------------------------------
+rbac:
+  create: true
+  serviceAccountName: ml-retrain-trigger
+  workloadIdentityAnnotation: ""
+
+# ---------------------------------------------------------------------------
+# NetworkPolicy — toggle default-off (same as GCP).
+# Set to true after confirming pushgateway + whylogs co-component allow rules.
+# ---------------------------------------------------------------------------
+networkPolicy:
+  enabled: false
+
+# ---------------------------------------------------------------------------
+# Model namespaces — populate per tenant/domain before applying (cluster-agnostic).
+# ---------------------------------------------------------------------------
+modelNamespaces: []
+# Example:
+# - namespace: ml-tenant-acme-hft
+#   modelName: domain-adapter-hft
+#   tenant: tenant-acme
+#   domain: hft
+#   thresholds: {}

--- a/apps/infra/observability/grafana-dashboards/templates/configmap-ml-drift-aws.yaml
+++ b/apps/infra/observability/grafana-dashboards/templates/configmap-ml-drift-aws.yaml
@@ -1,0 +1,391 @@
+---
+# Grafana Dashboard ConfigMap: ML Drift & Accuracy Monitoring — AWS (ADR-0048 D4)
+# AWS-specific variant of configmap-ml-drift.yaml (ADR-0038 D2).
+# Differences from the GCP variant (configmap-ml-drift.yaml):
+#   - dashboard uid: ml-drift-accuracy-aws-v1 (avoids UID conflict in federated Grafana)
+#   - title prefix: [AWS] for Grafana UI disambiguation
+#   - tags include "aws" for filtered dashboard search
+# PromQL expressions are identical (ml_monitoring_* metrics are cluster-agnostic).
+# Label grafana_dashboard=1 causes the Grafana sidecar to auto-import.
+# Note: Grafana template expressions like {{ "{{" }}model_name{{ "}}" }} are
+# escaped to prevent Helm from interpreting them.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-ml-drift-aws
+  namespace: {{ .Values.grafanaNamespace }}
+  labels:
+    {{- range $key, $val := .Values.dashboardLabels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    platform.system: "ml-monitoring"
+    platform.component: "grafana-dashboard"
+    platform.managed-by: "argocd"
+data:
+  ml-drift-accuracy-aws.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "[AWS EKS GPU] ML model drift detection, feature distribution shift, and accuracy degradation. Per-tenant/domain view. ADR-0048 D4 / ADR-0038.",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [
+        {
+          "asDropdown": true,
+          "icon": "external link",
+          "includeVars": true,
+          "keepTime": true,
+          "tags": ["ml-monitoring", "aws"],
+          "title": "ML Monitoring Dashboards",
+          "type": "dashboards"
+        }
+      ],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+          "id": 100,
+          "title": "Overview — AWS EKS GPU Cluster",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "Number of models currently in critical drift state on the aws-eks-gpu-* cluster",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "yellow", "value": 1},
+                  {"color": "red", "value": 3}
+                ]
+              },
+              "unit": "short"
+            }
+          },
+          "gridPos": {"h": 4, "w": 4, "x": 0, "y": 1},
+          "id": 1,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"]}
+          },
+          "pluginVersion": "10.0.0",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "{{ .Values.datasources.prometheus.uid }}"},
+              "expr": "ml_monitoring:models_in_critical_drift:count",
+              "legendFormat": "Models in critical drift",
+              "refId": "A"
+            }
+          ],
+          "title": "Models in Critical Drift",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "Total successful retrain triggers in last 24 hours",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "blue", "value": null}
+                ]
+              },
+              "unit": "short"
+            }
+          },
+          "gridPos": {"h": 4, "w": 4, "x": 4, "y": 1},
+          "id": 2,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"]}
+          },
+          "pluginVersion": "10.0.0",
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "{{ .Values.datasources.prometheus.uid }}"},
+              "expr": "ml_monitoring:retrain_triggers:total_24h",
+              "legendFormat": "Retrain triggers (24h)",
+              "refId": "A"
+            }
+          ],
+          "title": "Retrain Triggers (24h)",
+          "type": "stat"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 5},
+          "id": 101,
+          "title": "Dataset Drift",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "Evidently dataset drift score (0 = no drift, 1 = full drift). Warning 0.20, Critical 0.40.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "yellow", "value": 0.2},
+                  {"color": "red", "value": 0.4}
+                ]
+              },
+              "unit": "short",
+              "min": 0,
+              "max": 1
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 6},
+          "id": 10,
+          "options": {
+            "legend": {"displayMode": "list", "placement": "bottom"},
+            "tooltip": {"mode": "multi"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "{{ .Values.datasources.prometheus.uid }}"},
+              "expr": "ml_monitoring_dataset_drift_score{platform_system=\"ml-monitoring\", tenant=~\"$tenant\", domain=~\"$domain\"}",
+              "legendFormat": "{{ "{{" }}model_name{{ "}}" }} drift score",
+              "refId": "A"
+            }
+          ],
+          "title": "Dataset Drift Score",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "PSI (Population Stability Index) per feature. Warning >0.10, Critical >0.25.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"lineWidth": 1},
+              "unit": "short",
+              "min": 0
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 6},
+          "id": 11,
+          "options": {
+            "legend": {"displayMode": "list", "placement": "right"},
+            "tooltip": {"mode": "multi"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "{{ .Values.datasources.prometheus.uid }}"},
+              "expr": "ml_monitoring_feature_psi_score{platform_system=\"ml-monitoring\", tenant=~\"$tenant\", domain=~\"$domain\"}",
+              "legendFormat": "{{ "{{" }}feature{{ "}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Feature PSI by Feature",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 14},
+          "id": 102,
+          "title": "Model Accuracy & Quality",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "Model accuracy from Evidently test suite. Warning <0.85, Critical <0.75.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"lineWidth": 2},
+              "unit": "percentunit",
+              "min": 0,
+              "max": 1
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 15},
+          "id": 20,
+          "options": {
+            "legend": {"displayMode": "list", "placement": "bottom"},
+            "tooltip": {"mode": "multi"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "{{ .Values.datasources.prometheus.uid }}"},
+              "expr": "ml_monitoring_model_accuracy{platform_system=\"ml-monitoring\", tenant=~\"$tenant\", domain=~\"$domain\"}",
+              "legendFormat": "{{ "{{" }}model_name{{ "}}" }} accuracy",
+              "refId": "A"
+            }
+          ],
+          "title": "Model Accuracy",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "Model F1 score from Evidently test suite. Warning <0.80, Critical <0.65.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"lineWidth": 2},
+              "unit": "percentunit",
+              "min": 0,
+              "max": 1
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 15},
+          "id": 21,
+          "options": {
+            "legend": {"displayMode": "list", "placement": "bottom"},
+            "tooltip": {"mode": "multi"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "{{ .Values.datasources.prometheus.uid }}"},
+              "expr": "ml_monitoring_model_f1_score{platform_system=\"ml-monitoring\", tenant=~\"$tenant\", domain=~\"$domain\"}",
+              "legendFormat": "{{ "{{" }}model_name{{ "}}" }} F1",
+              "refId": "A"
+            }
+          ],
+          "title": "Model F1 Score",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 23},
+          "id": 103,
+          "title": "Retrain Trigger Activity",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "Rate of retrain triggers by outcome (success / airflow_error / k8s_fallback / deduped). Retrain trigger: Alertmanager webhook → Airflow REST POST /api/v1/dags/train_domain_adapter/dagRuns.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"lineWidth": 2},
+              "unit": "short"
+            }
+          },
+          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 24},
+          "id": 30,
+          "options": {
+            "legend": {"displayMode": "list", "placement": "bottom"},
+            "tooltip": {"mode": "multi"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "{{ .Values.datasources.prometheus.uid }}"},
+              "expr": "sum by (outcome, tenant, domain) (rate(ml_monitoring_retrain_triggers_total{platform_system=\"ml-monitoring\", tenant=~\"$tenant\", domain=~\"$domain\"}[5m]))",
+              "legendFormat": "{{ "{{" }}outcome{{ "}}" }} - {{ "{{" }}tenant{{ "}}" }}/{{ "{{" }}domain{{ "}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Retrain Trigger Rate by Outcome",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "1m",
+      "schemaVersion": 36,
+      "style": "dark",
+      "tags": ["ml-monitoring", "drift", "accuracy", "aws"],
+      "templating": {
+        "list": [
+          {
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{{ .Values.datasources.prometheus.uid }}"
+            },
+            "definition": "label_values(ml_monitoring_dataset_drift_score{platform_system=\"ml-monitoring\"}, tenant)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Tenant",
+            "multi": true,
+            "name": "tenant",
+            "query": {
+              "query": "label_values(ml_monitoring_dataset_drift_score{platform_system=\"ml-monitoring\"}, tenant)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{{ .Values.datasources.prometheus.uid }}"
+            },
+            "definition": "label_values(ml_monitoring_dataset_drift_score{platform_system=\"ml-monitoring\", tenant=~\"$tenant\"}, domain)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Domain",
+            "multi": true,
+            "name": "domain",
+            "query": {
+              "query": "label_values(ml_monitoring_dataset_drift_score{platform_system=\"ml-monitoring\", tenant=~\"$tenant\"}, domain)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {"from": "now-6h", "to": "now"},
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "[AWS] ML Drift & Accuracy Monitoring",
+      "uid": "ml-drift-accuracy-aws-v1",
+      "version": 1
+    }


### PR DESCRIPTION
## WS-C: AWS ML Observability / Drift (ADR-0048 D4)

**DESIGN-MOCK repo — apply-gated; do NOT merge until human review; base targets the design branch on purpose.**

This PR implements WS-C of the AWS GPU ML Platform plan: continuous monitoring of model accuracy + data/concept drift in production on the `aws-eks-gpu-*` EKS cluster, exporting Prometheus metrics into the **existing** Grafana/Thanos/Alertmanager stack (ADR-0026).

### ADRs cited
- **ADR-0048 D4** — drift monitor on EKS with AWS metrics backend (the governing ADR for WS-C)
- **ADR-0038** — Evidently/whylogs architecture (cluster-agnostic, inherited verbatim)
- **ADR-0028** — `platform:system = ml-monitoring` taxonomy on every resource
- **ADR-0018** — EKS Pod Identity (replaces GKE Workload Identity annotation)
- **ADR-0008** — ExternalSecrets Operator with AWS Secrets Manager provider
- **ADR-0029** — ECR pull-through cache for upstream Evidently/whylogs images
- **ADR-0026** — reuse of existing EKS Prometheus/Thanos/Grafana/Alertmanager stack

### Files created

| File | Purpose |
|------|---------|
| `apps/infra/ml-monitoring/values-aws.yaml` | AWS Helm value overrides: S3 reference bucket, ECR images (ADR-0029), EKS Pod Identity / no SA annotation (ADR-0018), AWS Secrets Manager ESO key paths (ADR-0008). All ADR-0038 thresholds inherited unchanged. |
| `apps/infra/ml-monitoring/argocd-application-aws.yaml` | ArgoCD Application for `aws-eks-gpu-*` cluster (ADR-0044). Sync-wave 20 (after prometheus-stack + mlflow-aws WS-B). Renders `values.yaml + values-aws.yaml`. |
| `apps/infra/ml-monitoring/alertmanager-routes-overlay-aws.yaml` | Alertmanager route + receiver patch instructions for the AWS cluster: `ml-drift-pagerduty` + `ml-retrain-webhook`. Documents cross-namespace ESO for `alertmanager-retrain-token` into the `monitoring` namespace. Routes identical to ADR-0038 D3 GCP overlay. |
| `apps/infra/observability/grafana-dashboards/templates/configmap-ml-drift-aws.yaml` | AWS Grafana dashboard ConfigMap (uid `ml-drift-accuracy-aws-v1`, tags `[aws]`). All PromQL cluster-agnostic. Disambiguated from GCP variant (`ml-drift-accuracy-v1`) for multi-cluster Grafana federation. |

### Files NOT touched (file-disjoint from other WS branches)
- `catalog/stacks/*.stack.hcl` — WS-A owns the stack scaffold
- `docs/adrs/README.md` — WS-A owns the ADR index
- `apps/infra/ml-monitoring/values.yaml` / `argocd-application.yaml` — GCP variant, WS-C GCP owns those
- Any WS-A, WS-B, WS-D, WS-E, WS-F files

### Verification results

| Gate | Status | Notes |
|------|--------|-------|
| `helm lint ml-monitoring --values values.yaml --values values-aws.yaml` | PASS | 0 errors, 1 INFO (icon recommended) |
| `helm template ml-monitoring` (modelNamespaces populated) | PASS | Renders Namespace, SA, Role, RoleBinding, 2×ExternalSecret, PrometheusRule, 2×ServiceMonitor, 2×Deployment cleanly |
| `helm lint grafana-dashboards/templates/configmap-ml-drift-aws.yaml` (isolated) | PASS | Pre-existing `configmap-dashboards.yaml` parse error (line 350, `{{label_karpenter_sh_capacity_type}}`) blocks full chart lint — this is a **pre-existing defect not introduced by WS-C** |
| `terraform plan` | SKIPPED — no Terraform modules in WS-C scope (ArgoCD app + Grafana dashboards only; no new AWS resources) |
| `tflint` / `checkov` | SKIPPED — not installed; no `.tf` files in WS-C scope |

### AWS delta from GCP WS-C (ADR-0048 D4)

| Concern | GCP (ADR-0038) | AWS (ADR-0048 D4) |
|---------|---------------|-------------------|
| Reference dataset bucket | `gs://your-project-ml-reference-data` | `s3://mlflow-reference-data-production-<account-id>` |
| Pod → cloud identity | GKE Workload Identity annotation | EKS Pod Identity (ADR-0018); no SA annotation |
| Secret backend | GCP Secret Manager | AWS Secrets Manager (key prefix: `aws-ml-platform/ml-monitoring/`) |
| Drift-exporter image | `evidently-ai/drift-exporter` (Docker Hub) | ECR pull-through cache (ADR-0029) |
| Retrain trigger | Airflow REST (cluster-agnostic) | Identical — no change |
| Alertmanager routes | GCP stack `monitoring` namespace | AWS stack `monitoring` namespace — identical |

### Acceptance criteria (from plan WS-C)
- [ ] Injected distribution shift raises `ml_monitoring_dataset_drift_score` metric
- [ ] Critical alert fires `ml-drift-pagerduty` + `ml-retrain-webhook` (after overlay merge)
- [ ] Retrain webhook triggers Airflow REST `POST /api/v1/dags/train_domain_adapter/dagRuns`
- [ ] Grafana dashboard `[AWS] ML Drift & Accuracy Monitoring` visible per model/tenant
- [ ] All resources carry `platform:system = ml-monitoring` (ADR-0028)
- [ ] No secrets in code — ESO pulls from AWS Secrets Manager (ADR-0008)

### Prerequisites before go-live
1. WS-A (EKS GPU cluster, ADR-0044) must land first
2. WS-B (Airflow + MLflow, ADR-0048 D1-D3) must land for the retrain trigger destination
3. Merge `alertmanager-routes-overlay-aws.yaml` patches into `prometheus-stack/values.yaml`
4. Replace `<account-id>` and `<region>` placeholders in `values-aws.yaml` (or use ArgoCD ApplicationSet parameter overrides)
5. Create cross-namespace ESO for `alertmanager-retrain-token` in `monitoring` namespace
