### PR TITLE
feat(aws-wsD): AWS self-serve observability

### DIFF
--- a/apps/infra/grafana-self-serve/example-teams/team-ml-platform-aws/argocd-application.yaml
+++ b/apps/infra/grafana-self-serve/example-teams/team-ml-platform-aws/argocd-application.yaml
@@ -1,0 +1,58 @@
+---
+# ArgoCD Application: team-ml-platform-aws self-serve observability
+# Onboarded via ADR-0039 template PR.
+# Deploys into the ml-platform namespace (must pre-exist, created by WS-A/WS-B).
+# Wave 30 — after all observability + ml-monitoring components (wave 10-20) and
+#            after the aws-eks-gpu-* cluster + dcgm-exporter (wave 20).
+#
+# ADR-0028: platform:system = observability (self-serve scaffolding label).
+# ADR-0039: Self-Serve Observability — templated per-team Grafana folder + alerts.
+# ADR-0048: AWS ML CI/CD + drift (GPU/EFA/Karpenter/ML-pipeline panels reference
+#           metrics from the WS-B Airflow + MLflow + WS-C Evidently stacks).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: grafana-self-serve-team-ml-platform-aws
+  namespace: argocd
+  labels:
+    platform.system: "observability"
+    platform.component: "self-serve"
+    platform.env: "production"
+    platform.owner: "team-ml-platform-aws"
+    platform.managed-by: "argocd"
+    app.kubernetes.io/name: "grafana-self-serve-team-ml-platform-aws"
+    app.kubernetes.io/component: "self-serve"
+    app.kubernetes.io/managed-by: "argocd"
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/your-org/platform-design.git
+    targetRevision: main
+    path: apps/infra/grafana-self-serve
+    helm:
+      valueFiles:
+        - values.yaml
+        - example-teams/team-ml-platform-aws/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ml-platform
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=false
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m

--- a/apps/infra/grafana-self-serve/example-teams/team-ml-platform-aws/values.yaml
+++ b/apps/infra/grafana-self-serve/example-teams/team-ml-platform-aws/values.yaml
@@ -1,0 +1,96 @@
+# Example: team-ml-platform-aws (AWS ML Platform team)
+# Template PR example for the AWS ML Platform team.
+#
+# This example extends the base chart (apps/infra/grafana-self-serve) with:
+#   - GPU compute panels: DCGM utilisation, GPU memory, GPU power, XID errors
+#   - EFA fabric panels: network throughput, packet rate (sourced from node_exporter
+#     on EFA interfaces exposed via the DCGM / YACE stack)
+#   - Karpenter provisioner panels: node provisioning latency, spot interruption rate,
+#     disruption budget usage
+#   - ML pipeline panels: ADR-0048 AWS-side ML metrics (Airflow task lag, MLflow
+#     experiment count, S3 artifact write throughput)
+#   - ML observability panels (ml.enabled: true): ADR-0038/0048 drift + accuracy
+#
+# Reuses: apps/infra/grafana-self-serve (ADR-0039), existing Prometheus/Grafana/Loki/
+#          Tempo/Alertmanager stack (ADR-0026). No new operators.
+# ADR-0028: platform:system = ml-platform (AWS ML cluster workloads).
+# ADR-0039: Self-Serve Observability.
+# ADR-0048: AWS ML CI/CD + MLflow registry + drift.
+
+team:
+  name: "ML Platform (AWS)"
+  slug: "team-ml-platform-aws"
+  namespace: "ml-platform"
+  # platform:system for AWS ML cluster workloads. Matches the value used
+  # by the aws-eks-gpu-* resources (ADR-0028, WS-A).
+  system: "ml-platform"
+  owner: "team-ml-platform-aws"
+  env: "production"
+  # Optional: Grafana service account for Editor access to this team's folder.
+  # Create the service account in the Grafana UI before deploying.
+  grafanaServiceAccount: "grafana-sa-team-ml-platform-aws"
+  # Optional: CI/CD service account for PrometheusRule management RBAC.
+  ciServiceAccount: "ml-platform-aws-ci"
+
+# Enable ML observability panels (ADR-0038 drift + accuracy metrics).
+ml:
+  enabled: true
+  # Scope ML panels to a specific model. Remove or leave empty to show all models.
+  modelName: ""
+  # Scope ML panels to a specific tenant. Remove or leave empty to show all tenants.
+  tenant: ""
+
+# AWS GPU + ML-specific extensions to the base self-serve chart.
+# These keys are consumed by the aws-specific dashboard/alert overlays in
+# templates/aws-gpu-dashboard.yaml and templates/aws-gpu-prometheusrule.yaml.
+aws:
+  # GPU compute panels (sourced from DCGM Exporter — apps/infra/dcgm-exporter).
+  # Set to false to disable the GPU panel row (e.g. for non-GPU teams reusing
+  # this template).
+  gpuPanels:
+    enabled: true
+    # Node selector label used by the DCGM exporter DaemonSet. Used in PromQL
+    # label selectors to scope panels to the AWS ML GPU pool.
+    # Matches aws-eks-gpu-* Karpenter NodePool labels (ADR-0044/ADR-0046).
+    nodePoolLabel: "aws-eks-gpu"
+    # DCGM metric prefix. Default matches the DCGM exporter helm chart defaults.
+    dcgmMetricPrefix: "DCGM_FI_DEV"
+
+  # EFA fabric panels (sourced from node_exporter on EFA network interfaces,
+  # exported via YACE or node_exporter with interface=eth0/rdma0).
+  # Only meaningful on EFA-enabled pools (ADR-0045).
+  efaPanels:
+    enabled: true
+    # Network interface name used by EFA on the GPU instances.
+    # Typical: "eth0" (EFA device on p4d/p5/p5en). Override if your AMI differs.
+    efaInterface: "eth0"
+
+  # Karpenter provisioner panels (sourced from Karpenter controller metrics).
+  karpenterPanels:
+    enabled: true
+    # NodePool name for the GPU pool managed by WS-A (ADR-0046).
+    gpuNodePoolName: "aws-eks-gpu-spot"
+
+  # ML pipeline panels (AWS-specific: ADR-0048).
+  mlPipelinePanels:
+    enabled: true
+    # Airflow namespace. Matches apps/infra/airflow destination namespace.
+    airflowNamespace: "ml-pipeline"
+    # MLflow namespace. Matches apps/infra/mlflow destination namespace.
+    mlflowNamespace: "ml-pipeline"
+
+# Thresholds — tighter tolerances for GPU/ML workloads.
+alerts:
+  errorRateThreshold: "0.02"
+  cpuSaturationThreshold: "0.85"
+  memorySaturationThreshold: "0.90"
+  availabilityFor: "5m"
+  saturationFor: "10m"
+  # ML drift/accuracy thresholds (ml.enabled: true).
+  mlDriftThreshold: "0.2"
+  mlAccuracyThreshold: "0.85"
+  mlAlertFor: "10m"
+  # GPU-specific alert thresholds (aws.gpuPanels.enabled: true).
+  gpuUtilLowThreshold: "0.10"
+  gpuMemSaturationThreshold: "0.90"
+  gpuXidErrorThreshold: "0"

--- a/apps/infra/grafana-self-serve/templates/aws-gpu-dashboard.yaml
+++ b/apps/infra/grafana-self-serve/templates/aws-gpu-dashboard.yaml
@@ -1,0 +1,437 @@
+---
+# Grafana self-serve: AWS GPU + EFA + Karpenter + ML-pipeline dashboard ConfigMap
+#
+# Gated by .Values.aws.gpuPanels.enabled (absent/false = this template produces nothing).
+# Only rendered for teams that set aws.gpuPanels.enabled: true in their values.yaml.
+# Non-AWS and non-GPU teams are entirely unaffected.
+#
+# Produces ONE additional ConfigMap per qualifying team:
+#   <team-slug>-grafana-aws-gpu  — GPU compute + EFA fabric + Karpenter + ML-pipeline
+#
+# Metric sources:
+#   - DCGM Exporter DaemonSet (apps/infra/dcgm-exporter, WS-A, ADR-0044 D2):
+#       DCGM_FI_DEV_GPU_UTIL, DCGM_FI_DEV_FB_USED, DCGM_FI_DEV_FB_FREE,
+#       DCGM_FI_DEV_POWER_USAGE, DCGM_FI_DEV_XID_ERRORS
+#   - node_exporter (EFA fabric, ADR-0045):
+#       node_network_receive_bytes_total, node_network_transmit_bytes_total,
+#       node_network_receive_packets_total, node_network_transmit_packets_total
+#   - Karpenter controller metrics (ADR-0046):
+#       karpenter_nodes_allocatable, karpenter_disruptions_disrupted_pod_count_total
+#   - Airflow StatsD/OpenMetrics exporter (ADR-0048, WS-B):
+#       airflow_dag_run_duration_success_bucket, airflow_task_instance_created_count,
+#       airflow_task_instance_failed_count
+#
+# ADR-0039: Self-Serve Observability — templated dashboard extension.
+# ADR-0028: platform.system = observability (mandatory on every resource).
+# ADR-0044: AWS EKS GPU ML foundation (DCGM integration, aws-eks-gpu-* labels).
+# ADR-0045: AWS EFA fabric (EFA interface panels).
+# ADR-0046: Node strategy — Karpenter GPU pools (provisioner panels).
+# ADR-0048: AWS ML CI/CD (Airflow DAG + task panels).
+{{- include "grafana-self-serve.validate" . }}
+{{- if and .Values.aws .Values.aws.gpuPanels .Values.aws.gpuPanels.enabled }}
+{{- $folderUid   := include "grafana-self-serve.folderUid" . }}
+{{- $dcgmPrefix  := .Values.aws.gpuPanels.dcgmMetricPrefix | default "DCGM_FI_DEV" }}
+{{- $nodePool    := .Values.aws.gpuPanels.nodePoolLabel | default "aws-eks-gpu" }}
+{{- $efaEnabled  := and .Values.aws.efaPanels .Values.aws.efaPanels.enabled }}
+{{- $efaIface    := "" }}
+{{- if and .Values.aws.efaPanels .Values.aws.efaPanels.efaInterface }}
+{{- $efaIface = .Values.aws.efaPanels.efaInterface }}
+{{- else }}
+{{- $efaIface = "eth0" }}
+{{- end }}
+{{- $karpenterEnabled := and .Values.aws.karpenterPanels .Values.aws.karpenterPanels.enabled }}
+{{- $karpenterPool    := "" }}
+{{- if and .Values.aws.karpenterPanels .Values.aws.karpenterPanels.gpuNodePoolName }}
+{{- $karpenterPool = .Values.aws.karpenterPanels.gpuNodePoolName }}
+{{- else }}
+{{- $karpenterPool = "aws-eks-gpu-spot" }}
+{{- end }}
+{{- $mlPipelineEnabled := and .Values.aws.mlPipelinePanels .Values.aws.mlPipelinePanels.enabled }}
+{{- $airflowNs := "" }}
+{{- if and .Values.aws.mlPipelinePanels .Values.aws.mlPipelinePanels.airflowNamespace }}
+{{- $airflowNs = .Values.aws.mlPipelinePanels.airflowNamespace }}
+{{- else }}
+{{- $airflowNs = "ml-pipeline" }}
+{{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.team.slug }}-grafana-aws-gpu
+  namespace: {{ .Values.grafanaNamespace }}
+  labels:
+    {{- include "grafana-self-serve.dashboardLabels" . | nindent 4 }}
+  annotations:
+    grafana_folder: {{ printf "team-%s" .Values.team.slug | quote }}
+data:
+  {{ printf "%s-aws-gpu.json" .Values.team.slug }}: |
+    {
+      "annotations": {"list": []},
+      "description": "AWS GPU + EFA + Karpenter + ML-pipeline — {{ .Values.team.name }}. system={{ .Values.team.system }}. ADR-0039/0044/0045/0046/0048.",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+          "id": 300,
+          "title": "GPU Compute (DCGM — ADR-0044)",
+          "type": "row"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+              "max": 100, "min": 0, "unit": "percent"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 1},
+          "id": 301,
+          "options": {
+            "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "expr": "{{ $dcgmPrefix }}_GPU_UTIL{kubernetes_node=~\".*{{ $nodePool }}.*\"}",
+              "legendFormat": "{{ "{{gpu}}" }} / {{ "{{kubernetes_node}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "GPU Utilisation (%)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+              "unit": "bytes"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 1},
+          "id": 302,
+          "options": {
+            "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "expr": "{{ $dcgmPrefix }}_FB_USED{kubernetes_node=~\".*{{ $nodePool }}.*\"} * 1048576",
+              "legendFormat": "used {{ "{{gpu}}" }}",
+              "refId": "A"
+            },
+            {
+              "expr": "{{ $dcgmPrefix }}_FB_FREE{kubernetes_node=~\".*{{ $nodePool }}.*\"} * 1048576",
+              "legendFormat": "free {{ "{{gpu}}" }}",
+              "refId": "B"
+            }
+          ],
+          "title": "GPU Framebuffer Memory (used / free)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+              "unit": "watt"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 9},
+          "id": 303,
+          "options": {
+            "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "expr": "{{ $dcgmPrefix }}_POWER_USAGE{kubernetes_node=~\".*{{ $nodePool }}.*\"}",
+              "legendFormat": "{{ "{{gpu}}" }} / {{ "{{kubernetes_node}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "GPU Power Draw (W)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "custom": {"align": "auto", "cellOptions": {"type": "color-background"}},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "red", "value": 1}
+                ]
+              },
+              "unit": "short"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 9},
+          "id": 304,
+          "options": {"cellHeight": "sm", "showHeader": true},
+          "targets": [
+            {
+              "expr": "{{ $dcgmPrefix }}_XID_ERRORS{kubernetes_node=~\".*{{ $nodePool }}.*\"}",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "GPU XID Errors (non-zero = hardware fault)",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {"Time": true, "__name__": true},
+                "renameByName": {"gpu": "GPU", "kubernetes_node": "Node", "Value": "XID Errors"}
+              }
+            }
+          ],
+          "type": "table"
+        }
+        {{- if $efaEnabled }},
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 17},
+          "id": 400,
+          "title": "EFA Fabric Network (ADR-0045)",
+          "type": "row"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+              "unit": "Bps"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 18},
+          "id": 401,
+          "options": {
+            "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "expr": "sum by (instance) (rate(node_network_receive_bytes_total{device=\"{{ $efaIface }}\",instance=~\".*{{ $nodePool }}.*\"}[5m]))",
+              "legendFormat": "rx {{ "{{instance}}" }}",
+              "refId": "A"
+            },
+            {
+              "expr": "sum by (instance) (rate(node_network_transmit_bytes_total{device=\"{{ $efaIface }}\",instance=~\".*{{ $nodePool }}.*\"}[5m]))",
+              "legendFormat": "tx {{ "{{instance}}" }}",
+              "refId": "B"
+            }
+          ],
+          "title": "EFA Network Throughput (Rx / Tx)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+              "unit": "pps"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 18},
+          "id": 402,
+          "options": {
+            "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "expr": "sum by (instance) (rate(node_network_receive_packets_total{device=\"{{ $efaIface }}\",instance=~\".*{{ $nodePool }}.*\"}[5m]))",
+              "legendFormat": "rx {{ "{{instance}}" }}",
+              "refId": "A"
+            },
+            {
+              "expr": "sum by (instance) (rate(node_network_transmit_packets_total{device=\"{{ $efaIface }}\",instance=~\".*{{ $nodePool }}.*\"}[5m]))",
+              "legendFormat": "tx {{ "{{instance}}" }}",
+              "refId": "B"
+            }
+          ],
+          "title": "EFA Packet Rate (pps)",
+          "type": "timeseries"
+        }
+        {{- end }}
+        {{- if $karpenterEnabled }},
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 26},
+          "id": 500,
+          "title": "Karpenter GPU Pool (ADR-0046)",
+          "type": "row"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+              "unit": "short"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 27},
+          "id": 501,
+          "options": {
+            "legend": {"calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "expr": "karpenter_nodes_allocatable{nodepool=\"{{ $karpenterPool }}\",resource=\"nvidia.com/gpu\"}",
+              "legendFormat": "allocatable GPU",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(kube_pod_container_resource_requests{resource=\"nvidia.com/gpu\",namespace=\"{{ .Values.team.namespace }}\"})",
+              "legendFormat": "requested GPU",
+              "refId": "B"
+            }
+          ],
+          "title": "GPU Capacity vs Requests (pool: {{ $karpenterPool }})",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"drawStyle": "bars", "fillOpacity": 80, "lineWidth": 1, "showPoints": "never"},
+              "unit": "short"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 27},
+          "id": 502,
+          "options": {
+            "legend": {"calcs": ["sum"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "expr": "increase(karpenter_disruptions_disrupted_pod_count_total{nodepool=\"{{ $karpenterPool }}\"}[1h])",
+              "legendFormat": "disrupted pods/hr",
+              "refId": "A"
+            }
+          ],
+          "title": "Karpenter Spot Disruptions (pods/hr)",
+          "type": "timeseries"
+        }
+        {{- end }}
+        {{- if $mlPipelineEnabled }},
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 35},
+          "id": 600,
+          "title": "ML Pipeline (Airflow + MLflow — ADR-0048)",
+          "type": "row"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+              "unit": "s"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 36},
+          "id": 601,
+          "options": {
+            "legend": {"calcs": ["mean", "p95"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le, dag_id) (rate(airflow_dag_run_duration_success_bucket{namespace=\"{{ $airflowNs }}\"}[15m])))",
+              "legendFormat": "P50 {{ "{{dag_id}}" }}",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le, dag_id) (rate(airflow_dag_run_duration_success_bucket{namespace=\"{{ $airflowNs }}\"}[15m])))",
+              "legendFormat": "P95 {{ "{{dag_id}}" }}",
+              "refId": "B"
+            }
+          ],
+          "title": "Airflow DAG Run Duration (P50 / P95)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+              "unit": "short"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 36},
+          "id": 602,
+          "options": {
+            "legend": {"calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom"},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "expr": "airflow_task_instance_created_count{namespace=\"{{ $airflowNs }}\"}",
+              "legendFormat": "created {{ "{{task_id}}" }}",
+              "refId": "A"
+            },
+            {
+              "expr": "airflow_task_instance_failed_count{namespace=\"{{ $airflowNs }}\"}",
+              "legendFormat": "failed {{ "{{task_id}}" }}",
+              "refId": "B"
+            }
+          ],
+          "title": "Airflow Task Instances (created vs failed)",
+          "type": "timeseries"
+        }
+        {{- end }}
+      ],
+      "refresh": "{{ .Values.defaultRefresh }}",
+      "schemaVersion": 38,
+      "style": "dark",
+      "tags": ["self-serve", "{{ .Values.team.slug }}", "gpu", "efa", "aws", "ml-pipeline", "karpenter"],
+      "templating": {
+        "list": [
+          {
+            "current": {"selected": false, "text": "{{ .Values.datasource.name }}", "value": "{{ .Values.datasource.name }}"},
+            "hide": 0,
+            "includeAll": false,
+            "label": "Datasource",
+            "multi": false,
+            "name": "DS_PROMETHEUS",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "skipUrlSync": false,
+            "type": "datasource"
+          }
+        ]
+      },
+      "time": {
+        "from": "{{ .Values.defaultTimeRange.from }}",
+        "to": "{{ .Values.defaultTimeRange.to }}"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "{{ .Values.team.name }} — AWS GPU + EFA + ML Pipeline",
+      "uid": "{{ printf "aws-gpu-%s" .Values.team.slug | trunc 40 }}",
+      "version": 1,
+      "weekStart": ""
+    }
+{{- end }}

--- a/apps/infra/grafana-self-serve/templates/aws-gpu-prometheusrule.yaml
+++ b/apps/infra/grafana-self-serve/templates/aws-gpu-prometheusrule.yaml
@@ -1,0 +1,223 @@
+---
+# Grafana self-serve: AWS GPU + EFA + ML-pipeline alert-rules-as-code
+#
+# Gated by .Values.aws.gpuPanels.enabled (absent/false = produces nothing).
+# Non-AWS and non-GPU teams are entirely unaffected.
+#
+# Produces ONE additional PrometheusRule per qualifying team, deployed into
+# team.namespace alongside the base PrometheusRule from prometheusrule.yaml.
+#
+# Alert groups added:
+#   <team-slug>-gpu-compute    — GPU utilisation low, GPU memory saturation, XID error
+#   <team-slug>-efa-fabric     — EFA interface receive saturation (aws.efaPanels.enabled)
+#   <team-slug>-ml-pipeline    — Airflow task failure rate (aws.mlPipelinePanels.enabled)
+#
+# Alert naming: all names carry the team slug prefix in UPPER_CASE (same convention
+# as prometheusrule.yaml) to prevent alertname collisions across teams.
+#
+# ADR-0039: Self-Serve Observability — alert-rules-as-code extension.
+# ADR-0028: platform.system = observability (mandatory on every resource).
+# ADR-0044: AWS EKS GPU ML foundation (DCGM-sourced GPU alerts).
+# ADR-0045: AWS EFA fabric (EFA throughput saturation alert).
+# ADR-0048: AWS ML CI/CD (Airflow task failure alert).
+{{- include "grafana-self-serve.validate" . }}
+{{- if and .Values.aws .Values.aws.gpuPanels .Values.aws.gpuPanels.enabled }}
+{{- $alertPrefix       := include "grafana-self-serve.alertPrefix" . }}
+{{- $dcgmPrefix        := .Values.aws.gpuPanels.dcgmMetricPrefix | default "DCGM_FI_DEV" }}
+{{- $nodePool          := .Values.aws.gpuPanels.nodePoolLabel | default "aws-eks-gpu" }}
+{{- $efaEnabled        := and .Values.aws.efaPanels .Values.aws.efaPanels.enabled }}
+{{- $efaIface          := "" }}
+{{- if and .Values.aws.efaPanels .Values.aws.efaPanels.efaInterface }}
+{{- $efaIface = .Values.aws.efaPanels.efaInterface }}
+{{- else }}
+{{- $efaIface = "eth0" }}
+{{- end }}
+{{- $mlPipelineEnabled := and .Values.aws.mlPipelinePanels .Values.aws.mlPipelinePanels.enabled }}
+{{- $airflowNs         := "" }}
+{{- if and .Values.aws.mlPipelinePanels .Values.aws.mlPipelinePanels.airflowNamespace }}
+{{- $airflowNs = .Values.aws.mlPipelinePanels.airflowNamespace }}
+{{- else }}
+{{- $airflowNs = "ml-pipeline" }}
+{{- end }}
+{{- $gpuUtilLow    := .Values.alerts.gpuUtilLowThreshold      | default "0.10" }}
+{{- $gpuMemSat     := .Values.alerts.gpuMemSaturationThreshold | default "0.90" }}
+{{- $gpuXidThresh  := .Values.alerts.gpuXidErrorThreshold      | default "0" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Values.team.slug }}-aws-gpu-alerts
+  namespace: {{ .Values.team.namespace }}
+  labels:
+    {{- include "grafana-self-serve.labels" (dict "root" . "component" "aws-gpu-alert-rules") | nindent 4 }}
+    prometheus: kube-prometheus
+spec:
+  groups:
+    # ---------------------------------------------------------------------------
+    # GPU compute — low utilisation, memory saturation, XID hardware errors.
+    # Sources: DCGM Exporter (apps/infra/dcgm-exporter, ADR-0044 D2).
+    # ---------------------------------------------------------------------------
+    - name: {{ .Values.team.slug }}-gpu-compute
+      interval: 60s
+      rules:
+        - alert: {{ $alertPrefix }}_GPULowUtilisation
+          expr: |
+            avg by (gpu, kubernetes_node) (
+              {{ $dcgmPrefix }}_GPU_UTIL{
+                kubernetes_node=~".*{{ $nodePool }}.*"
+              }
+            ) / 100 < {{ $gpuUtilLow }}
+          for: 30m
+          labels:
+            severity: warning
+            team: {{ .Values.team.slug | quote }}
+            namespace: {{ .Values.team.namespace | quote }}
+            platform_system: "observability"
+            platform_owner: {{ .Values.team.slug | quote }}
+            alert_type: gpu-efficiency
+          annotations:
+            summary: >-
+              GPU under-utilised — {{ .Values.team.name }}
+              node {{ "{{ $labels.kubernetes_node }}" }} GPU {{ "{{ $labels.gpu }}" }}
+            description: >-
+              GPU utilisation {{ "{{ $value | humanizePercentage }}" }} is below
+              threshold {{ $gpuUtilLow }} for 30 minutes.
+              Check for idle training jobs or Karpenter scale-down opportunities.
+            runbook_url: "https://runbooks.internal.example.com/teams/{{ .Values.team.slug }}/gpu-low-utilisation"
+
+        - alert: {{ $alertPrefix }}_GPUMemorySaturation
+          expr: |
+            (
+              {{ $dcgmPrefix }}_FB_USED{
+                kubernetes_node=~".*{{ $nodePool }}.*"
+              }
+              /
+              (
+                {{ $dcgmPrefix }}_FB_USED{
+                  kubernetes_node=~".*{{ $nodePool }}.*"
+                }
+                + {{ $dcgmPrefix }}_FB_FREE{
+                  kubernetes_node=~".*{{ $nodePool }}.*"
+                }
+              )
+            ) > {{ $gpuMemSat }}
+          for: 10m
+          labels:
+            severity: critical
+            team: {{ .Values.team.slug | quote }}
+            namespace: {{ .Values.team.namespace | quote }}
+            platform_system: "observability"
+            platform_owner: {{ .Values.team.slug | quote }}
+            alert_type: gpu-memory
+          annotations:
+            summary: >-
+              GPU framebuffer memory saturated — {{ .Values.team.name }}
+              node {{ "{{ $labels.kubernetes_node }}" }} GPU {{ "{{ $labels.gpu }}" }}
+            description: >-
+              GPU memory fill ratio {{ "{{ $value | humanizePercentage }}" }} exceeds
+              {{ $gpuMemSat }}. OOM kill or training crash imminent.
+              Check for model code memory leaks or oversized batch sizes.
+            runbook_url: "https://runbooks.internal.example.com/teams/{{ .Values.team.slug }}/gpu-memory-saturation"
+
+        - alert: {{ $alertPrefix }}_GPUXIDError
+          expr: |
+            {{ $dcgmPrefix }}_XID_ERRORS{
+              kubernetes_node=~".*{{ $nodePool }}.*"
+            } > {{ $gpuXidThresh }}
+          for: 0m
+          labels:
+            severity: critical
+            team: {{ .Values.team.slug | quote }}
+            namespace: {{ .Values.team.namespace | quote }}
+            platform_system: "observability"
+            platform_owner: {{ .Values.team.slug | quote }}
+            alert_type: gpu-hardware
+          annotations:
+            summary: >-
+              GPU XID error — {{ .Values.team.name }}
+              node {{ "{{ $labels.kubernetes_node }}" }} GPU {{ "{{ $labels.gpu }}" }}
+            description: >-
+              XID error count {{ "{{ $value }}" }} on GPU {{ "{{ $labels.gpu }}" }}.
+              XID errors indicate hardware faults. Cordon the node immediately
+              and open an AWS Support case for the affected EC2 instance.
+            runbook_url: "https://runbooks.internal.example.com/teams/{{ .Values.team.slug }}/gpu-xid-error"
+
+    {{- if $efaEnabled }}
+    # ---------------------------------------------------------------------------
+    # EFA fabric — interface receive throughput saturation (ADR-0045).
+    # Sources: node_exporter network counters on EFA interface.
+    # 100 Gbps = 12.5 GBps = 1.25e10 Bps. Alert at ~80% = 1e10 Bps.
+    # ---------------------------------------------------------------------------
+    - name: {{ .Values.team.slug }}-efa-fabric
+      interval: 60s
+      rules:
+        - alert: {{ $alertPrefix }}_EFAReceiveSaturation
+          expr: |
+            rate(node_network_receive_bytes_total{
+              device="{{ $efaIface }}",
+              instance=~".*{{ $nodePool }}.*"
+            }[5m]) > 1e10
+          for: 5m
+          labels:
+            severity: warning
+            team: {{ .Values.team.slug | quote }}
+            namespace: {{ .Values.team.namespace | quote }}
+            platform_system: "observability"
+            platform_owner: {{ .Values.team.slug | quote }}
+            alert_type: efa-saturation
+          annotations:
+            summary: >-
+              EFA receive saturation — {{ .Values.team.name }}
+              instance {{ "{{ $labels.instance }}" }}
+            description: >-
+              EFA receive throughput {{ "{{ $value | humanize }}" }}Bps exceeds
+              ~80% of 100 Gbps line rate on interface {{ $efaIface }}
+              sustained for 5 minutes. Check for NCCL all-reduce congestion
+              or runaway data-parallel jobs (ADR-0045).
+            runbook_url: "https://runbooks.internal.example.com/teams/{{ .Values.team.slug }}/efa-saturation"
+    {{- end }}
+
+    {{- if $mlPipelineEnabled }}
+    # ---------------------------------------------------------------------------
+    # ML pipeline — Airflow task failure rate (ADR-0048).
+    # Sources: Airflow StatsD / OpenMetrics exporter in airflowNs.
+    # ---------------------------------------------------------------------------
+    - name: {{ .Values.team.slug }}-ml-pipeline
+      interval: 60s
+      rules:
+        - alert: {{ $alertPrefix }}_AirflowHighTaskFailureRate
+          expr: |
+            (
+              rate(airflow_task_instance_failed_count{
+                namespace="{{ $airflowNs }}"
+              }[15m])
+              /
+              (
+                rate(airflow_task_instance_failed_count{
+                  namespace="{{ $airflowNs }}"
+                }[15m])
+                + rate(airflow_task_instance_created_count{
+                  namespace="{{ $airflowNs }}"
+                }[15m])
+              )
+            ) > 0.10
+          for: 5m
+          labels:
+            severity: warning
+            team: {{ .Values.team.slug | quote }}
+            namespace: {{ .Values.team.namespace | quote }}
+            platform_system: "observability"
+            platform_owner: {{ .Values.team.slug | quote }}
+            alert_type: ml-pipeline
+          annotations:
+            summary: >-
+              High Airflow task failure rate — {{ .Values.team.name }}
+              (namespace: {{ $airflowNs }})
+            description: >-
+              Airflow task failure rate {{ "{{ $value | humanizePercentage }}" }}
+              exceeds 10% over 15 minutes in namespace {{ $airflowNs }}.
+              Check train/eval/gate DAG logs and the ml-monitoring drift stack
+              (ADR-0048/ADR-0038).
+            runbook_url: "https://runbooks.internal.example.com/teams/{{ .Values.team.slug }}/airflow-task-failures"
+    {{- end }}
+{{- end }}

--- a/docs/self-serve-observability-aws.md
+++ b/docs/self-serve-observability-aws.md
@@ -1,0 +1,265 @@
+# Self-Serve Observability — AWS ML Platform Onboarding
+
+> **ADR reference:** [ADR-0039](adrs/0039-self-serve-observability.md) (cluster-agnostic;
+> this doc is the AWS-specific companion to [docs/self-serve-observability.md](self-serve-observability.md))
+> **Scope:** WS-D of the AWS ML Platform plan (`docs/aws-ml-platform/IMPLEMENTATION_PLAN.md`).
+> **Backstage:** explicitly deferred — see ADR-0034 and the revisit conditions in ADR-0039.
+> **Platform taxonomy:** ADR-0028 — every resource carries `platform:system = observability`.
+
+AWS ML Platform teams (GPU training, inference serving, model pipeline, data, SRE)
+follow the same self-serve path as GCP teams. This document covers the **AWS-specific
+extension**: the `team-ml-platform-aws` example values, the GPU + EFA + Karpenter +
+ML-pipeline dashboard panels, and the GPU alert rules.
+
+---
+
+## What you get (AWS extension)
+
+In addition to the base self-serve resources (Grafana folder + starter dashboard +
+base PrometheusRule + RBAC), AWS ML Platform teams with `aws.gpuPanels.enabled: true`
+get:
+
+| Resource | Kind | Namespace | Source ADR |
+|---|---|---|---|
+| `<team-slug>-grafana-aws-gpu` | ConfigMap (Grafana dashboard) | `observability` | ADR-0039/0044/0045/0046/0048 |
+| `<team-slug>-aws-gpu-alerts` | PrometheusRule | Your workload namespace | ADR-0039/0044/0045/0048 |
+
+### Dashboard panels (by section)
+
+| Section | Panels | Metric source |
+|---|---|---|
+| GPU Compute | GPU Utilisation %, Framebuffer Memory used/free, Power Draw (W), XID Errors table | DCGM Exporter (ADR-0044 D2) |
+| EFA Fabric (`efaPanels.enabled: true`) | Network throughput Rx/Tx (Bps), Packet rate Rx/Tx (pps) | `node_exporter` on EFA interface (ADR-0045) |
+| Karpenter GPU Pool (`karpenterPanels.enabled: true`) | GPU Capacity vs Requests, Spot Disruptions (pods/hr) | Karpenter controller metrics (ADR-0046) |
+| ML Pipeline (`mlPipelinePanels.enabled: true`) | Airflow DAG Run Duration P50/P95, Task Instances created vs failed | Airflow StatsD/OpenMetrics exporter (ADR-0048) |
+| ML Observability (`ml.enabled: true`) | Dataset Drift Score, Model Accuracy, Retrain Triggers | Evidently / whylogs drift-exporter (ADR-0038/0048) |
+
+### Alert rules (by group)
+
+| Group | Alert | Severity | Condition |
+|---|---|---|---|
+| `<slug>-gpu-compute` | `<PREFIX>_GPULowUtilisation` | warning | GPU util < 10% for 30 min |
+| `<slug>-gpu-compute` | `<PREFIX>_GPUMemorySaturation` | critical | GPU FB memory fill > 90% for 10 min |
+| `<slug>-gpu-compute` | `<PREFIX>_GPUXIDError` | critical | XID error count > 0 (immediate) |
+| `<slug>-efa-fabric` | `<PREFIX>_EFAReceiveSaturation` | warning | EFA Rx > ~80% of 100 Gbps for 5 min |
+| `<slug>-ml-pipeline` | `<PREFIX>_AirflowHighTaskFailureRate` | warning | Airflow task failure rate > 10% for 5 min |
+
+Thresholds are overridable in your team `values.yaml` via the `alerts.*` keys.
+
+---
+
+## Prerequisites
+
+Before raising a PR, satisfy all base prerequisites from
+[docs/self-serve-observability.md](self-serve-observability.md#prerequisites), plus:
+
+4. **`aws-eks-gpu-*` cluster deployed (WS-A).** The DCGM Exporter DaemonSet
+   (`apps/infra/dcgm-exporter`) must be running on the GPU NodePool. GPU panels
+   show "No data" until the DCGM exporter is scraped by Prometheus.
+
+5. **EFA interface name confirmed.** Check the interface name on your GPU instances:
+   ```bash
+   kubectl debug node/<node-name> -it --image=nicolaka/netshoot -- ip link show
+   ```
+   Default is `eth0`; override `aws.efaPanels.efaInterface` if your AMI differs.
+
+6. **Airflow/MLflow deployed (WS-B).** Panels in the ML Pipeline section query
+   `airflow_task_instance_*` metrics from the Airflow StatsD exporter. Set
+   `aws.mlPipelinePanels.enabled: false` if WS-B is not yet deployed.
+
+7. **Namespace exists.** The `ml-platform` namespace (for the `team-ml-platform-aws`
+   example) is created by WS-B. For a new team, bootstrap the namespace in a
+   separate PR first with ADR-0028 labels on the Namespace object.
+
+---
+
+## Step-by-step: raise a template PR
+
+### 1. Copy the AWS example directory
+
+```bash
+cp -r apps/infra/grafana-self-serve/example-teams/team-ml-platform-aws \
+       apps/infra/grafana-self-serve/example-teams/<your-team-slug>
+```
+
+### 2. Edit `values.yaml`
+
+Fill in every required base field (see
+[docs/self-serve-observability.md](self-serve-observability.md#2-edit-valuesyaml)),
+then configure the AWS extensions:
+
+```yaml
+team:
+  name: "Your Team Name"
+  slug: "team-your-slug"          # lowercase, hyphens only
+  namespace: "your-namespace"     # must already exist
+  system: "your-system"           # ADR-0028 platform:system value
+  owner: "team-your-slug"
+  env: "production"
+  grafanaServiceAccount: ""
+  ciServiceAccount: "your-ci-sa"
+
+ml:
+  enabled: true                   # Set false until ml-monitoring (WS-C) is deployed
+  modelName: ""                   # optional label filter
+  tenant: ""                      # optional label filter
+
+aws:
+  gpuPanels:
+    enabled: true                 # Set false for non-GPU AWS teams
+    nodePoolLabel: "aws-eks-gpu"  # must match karpenter.sh/nodepool label (ADR-0046)
+    dcgmMetricPrefix: "DCGM_FI_DEV"
+
+  efaPanels:
+    enabled: true                 # Set false if not on EFA pools (ADR-0045)
+    efaInterface: "eth0"          # EFA interface name on GPU instances
+
+  karpenterPanels:
+    enabled: true
+    gpuNodePoolName: "aws-eks-gpu-spot"  # Karpenter NodePool name (ADR-0046)
+
+  mlPipelinePanels:
+    enabled: true                 # Set false until Airflow/MLflow (WS-B) is deployed
+    airflowNamespace: "ml-pipeline"
+    mlflowNamespace: "ml-pipeline"
+
+alerts:
+  errorRateThreshold: "0.02"
+  cpuSaturationThreshold: "0.85"
+  memorySaturationThreshold: "0.90"
+  availabilityFor: "5m"
+  saturationFor: "10m"
+  mlDriftThreshold: "0.2"
+  mlAccuracyThreshold: "0.85"
+  mlAlertFor: "10m"
+  # GPU thresholds — override per your team's GPU SLOs.
+  gpuUtilLowThreshold: "0.10"
+  gpuMemSaturationThreshold: "0.90"
+  gpuXidErrorThreshold: "0"
+```
+
+### 3. Edit `argocd-application.yaml`
+
+Replace all `team-ml-platform-aws` references with your slug, and update
+`spec.destination.namespace`:
+
+```yaml
+metadata:
+  name: grafana-self-serve-<your-team-slug>
+  labels:
+    platform.owner: "<your-team-slug>"
+spec:
+  source:
+    helm:
+      valueFiles:
+        - values.yaml
+        - example-teams/<your-team-slug>/values.yaml
+  destination:
+    namespace: <your-namespace>
+```
+
+### 4. Raise the PR
+
+```bash
+git checkout -b feat/grafana-self-serve-<your-team-slug>
+git add apps/infra/grafana-self-serve/example-teams/<your-team-slug>/
+git commit -m "feat(observability): self-serve dashboards + alerts for <your-team-slug> (ADR-0039)"
+gh pr create \
+  --base main \
+  --title "feat(observability): self-serve onboarding <your-team-slug>" \
+  --body "ADR-0039 template PR. Team: <your-team-slug>. AWS GPU panels: yes/no. ml.enabled: yes/no."
+```
+
+### 5. Post-merge: apply ArgoCD Application
+
+```bash
+# Dry-run first (plan-only gate — apply is human-approved):
+kubectl apply --dry-run=server \
+  -f apps/infra/grafana-self-serve/example-teams/<your-team-slug>/argocd-application.yaml
+
+# After human approval:
+kubectl apply \
+  -f apps/infra/grafana-self-serve/example-teams/<your-team-slug>/argocd-application.yaml
+```
+
+ArgoCD syncs at wave 30 (after all observability components at wave 10-20).
+
+---
+
+## Verify your onboarding
+
+After the ArgoCD Application syncs:
+
+1. **Dashboards visible in Grafana:**
+   Navigate to **Dashboards > team-`<your-slug>`**. You should see:
+   - `<your-slug>-starter.json` — base RED metrics + resource saturation
+   - `<your-slug>-aws-gpu.json` — GPU + EFA + Karpenter + ML pipeline (if enabled)
+
+2. **PrometheusRules loaded:**
+   ```bash
+   kubectl get prometheusrule -n <your-namespace>
+   # Expect: <your-slug>-alerts  AND  <your-slug>-aws-gpu-alerts
+   ```
+
+3. **GPU metrics in Prometheus:**
+   In Grafana Explore:
+   ```promql
+   DCGM_FI_DEV_GPU_UTIL{kubernetes_node=~".*aws-eks-gpu.*"}
+   ```
+   Should return time-series if DCGM Exporter is running.
+
+4. **Alertmanager routing:**
+   ```bash
+   kubectl exec -n observability deploy/alertmanager -- \
+     amtool alert query --alertname=TEAM_<YOUR_SLUG_UPPER>
+   ```
+
+---
+
+## Troubleshooting
+
+### GPU panels show "No data"
+
+1. Check DCGM Exporter: `kubectl get ds -n gpu-monitoring dcgm-exporter`
+2. Verify Prometheus scrapes it: query `DCGM_FI_DEV_GPU_UTIL` in Grafana Explore.
+3. Verify `aws.gpuPanels.nodePoolLabel` matches the actual `karpenter.sh/nodepool`
+   label on your nodes: `kubectl get node -l karpenter.sh/nodepool=<your-pool> -o name`.
+4. Confirm WS-A is deployed and the cluster is healthy.
+
+### EFA panels show "No data"
+
+1. Verify `aws.efaPanels.efaInterface` matches the EFA interface name on your
+   GPU instances.
+2. Check node_exporter scrape configuration includes network interfaces.
+
+### Karpenter panels show "No data"
+
+1. Verify Karpenter metrics endpoint: `kubectl get svc -n karpenter karpenter -o yaml | grep metrics`.
+2. Verify `aws.karpenterPanels.gpuNodePoolName` matches your NodePool:
+   `kubectl get nodepools`.
+
+### Airflow panels show "No data"
+
+1. Confirm WS-B (`apps/infra/airflow`) is deployed in `aws.mlPipelinePanels.airflowNamespace`.
+2. Check the Airflow StatsD exporter: `kubectl get svc -n ml-pipeline | grep statsd`.
+3. Set `aws.mlPipelinePanels.enabled: false` if WS-B is not yet deployed.
+
+---
+
+## Reference
+
+- [ADR-0039](adrs/0039-self-serve-observability.md) — self-serve observability decision
+- [ADR-0034](adrs/0034-backstage-idp.md) — Backstage deferred (revisit criteria)
+- [ADR-0028](adrs/0028-unified-platform-tagging-and-labeling-taxonomy.md) — platform taxonomy
+- [ADR-0044](adrs/0044-aws-eks-gpu-ml-foundation-multiregion.md) — EKS GPU ML foundation (DCGM)
+- [ADR-0045](adrs/0045-aws-efa-gpu-fabric-placement-groups.md) — EFA fabric
+- [ADR-0046](adrs/0046-eks-node-strategy-karpenter-spot.md) — node strategy / Karpenter pools
+- [ADR-0048](adrs/0048-aws-ml-cicd-registry-drift.md) — AWS ML CI/CD (Airflow/MLflow)
+- [ADR-0026](adrs/0026-observability-target-architecture.md) — observability stack
+- [ADR-0038](adrs/0038-ml-observability-drift.md) — ML drift/accuracy metrics
+- [docs/self-serve-observability.md](self-serve-observability.md) — base onboarding runbook
+- Chart: `apps/infra/grafana-self-serve/`
+- AWS example: `apps/infra/grafana-self-serve/example-teams/team-ml-platform-aws/`
+- AWS templates: `apps/infra/grafana-self-serve/templates/aws-gpu-dashboard.yaml`,
+  `apps/infra/grafana-self-serve/templates/aws-gpu-prometheusrule.yaml`
+- AWS ML Platform plan: `docs/aws-ml-platform/IMPLEMENTATION_PLAN.md` §4 WS-D


### PR DESCRIPTION
## Summary

WS-D self-serve observability + team enablement for the AWS EKS GPU ML platform. Reuses the existing `apps/infra/grafana-self-serve` chart (ADR-0039) and the Prometheus/Grafana/Loki/Tempo/Alertmanager stack (ADR-0026). No new operators, no new Terraform modules.

**DESIGN-MOCK repo — apply-gated; do NOT merge until human review; base targets the design branch on purpose.**

## Files created

| Path | Description |
|---|---|
| `apps/infra/grafana-self-serve/example-teams/team-ml-platform-aws/values.yaml` | AWS ML Platform team values: GPU/EFA/Karpenter/ML-pipeline panel toggles, tighter GPU/ML alert thresholds, ADR-0028 `platform:system = ml-platform` |
| `apps/infra/grafana-self-serve/example-teams/team-ml-platform-aws/argocd-application.yaml` | ArgoCD Application at sync-wave 30; `CreateNamespace=false`; destination `ml-platform` |
| `apps/infra/grafana-self-serve/templates/aws-gpu-dashboard.yaml` | Helm template (gated: `aws.gpuPanels.enabled`). Produces ConfigMap with GPU Compute (DCGM), EFA Fabric (node_exporter), Karpenter pool, and Airflow ML Pipeline dashboard panels. Non-AWS/non-GPU teams produce no output. |
| `apps/infra/grafana-self-serve/templates/aws-gpu-prometheusrule.yaml` | Helm template (gated: `aws.gpuPanels.enabled`). Produces PrometheusRule with GPU compute, EFA saturation, and Airflow task failure alert groups. Alert names carry UPPER_CASE slug prefix (ADR-0039 collision convention). |
| `docs/self-serve-observability-aws.md` | AWS-specific onboarding runbook: templated PR path, AWS prerequisites, panel/alert tables, troubleshooting guide. |

## ADRs cited

- ADR-0039 — Self-Serve Observability (the base mechanism; reused)
- ADR-0028 — Platform taxonomy (`platform:system = observability` on every resource)
- ADR-0044 — AWS EKS GPU ML foundation (DCGM integration, GPU labels)
- ADR-0045 — AWS EFA fabric (EFA interface panels)
- ADR-0046 — Node strategy / Karpenter GPU pools (Karpenter provisioner panels)
- ADR-0048 — AWS ML CI/CD (Airflow/MLflow ML pipeline panels)

## Verification results

| Gate | Result |
|---|---|
| `helm lint` (team-ml-platform-aws values) | PASS — 0 failures, 1 INFO (icon recommended) |
| `helm template` render | PASS — 7 resources: 3 ConfigMaps, 1 Role, 1 RoleBinding, 2 PrometheusRules |
| `kubeconform --strict` on rendered output | PASS — 5 valid, 2 skipped (PrometheusRule CRDs, expected) |
| `helm lint` team-checkout (regression) | PASS — no GPU resources rendered (gate works) |
| `helm lint` team-ml-platform (regression) | PASS — no AWS resources rendered (gate works) |
| `terraform fmt -recursive -check` | PASS — no WS-D TF files; pre-existing file unchanged |
| `terraform plan` | SKIPPED — no TF module for WS-D; no cloud credentials required |
| `tflint` | SKIPPED — not installed; no WS-D TF files |
| `checkov` | SKIPPED — not installed; no WS-D TF files |

## What is NOT included (scope discipline)

- No Terraform module (WS-D plan lists none; all delivery is Helm/ArgoCD)
- No edits to `catalog/stacks/*.stack.hcl` (WS-A scope)
- No edits to `docs/adrs/README.md` (WS-A scope; ADR-0039 already indexed)
- No ArgoCD Application in `apps/infra/` root (WS-D uses the example-teams pattern)

## Apply gate

No `terraform apply`, no `helm install`, no `kubectl apply` has been run. The ArgoCD Application and PrometheusRule manifests are plan/validate-only. Apply requires explicit human approval after this PR merges to the design branch and the platform team executes `kubectl apply` on the ArgoCD Application.

## Test plan

- [ ] `helm lint` with team-ml-platform-aws values — run before merge
- [ ] `helm template` renders expected 7 resources — verified above
- [ ] `kubeconform` on rendered output — verified above
- [ ] Verify GPU panel gate: `helm template team-checkout` produces no `aws-gpu` ConfigMap
- [ ] Verify ArgoCD Application schema (manual: `kubectl apply --dry-run=server` after cluster is available)
- [ ] After WS-A deploys: confirm `DCGM_FI_DEV_GPU_UTIL` metrics appear in Prometheus
- [ ] After WS-B deploys: confirm Airflow panel data populates
- [ ] After WS-C deploys: confirm ML drift/accuracy panel data populates