### PR TITLE
feat(bm-wsB): Talos ML CI/CD + MLflow registry

### DIFF
--- a/.github/workflows/ml-pipeline-baremetal.yml
+++ b/.github/workflows/ml-pipeline-baremetal.yml
@@ -1,0 +1,192 @@
+# ML training/release pipeline — WS-B bare metal (ADR-0037 reused, ADR-0049, ADR-0052).
+#
+# Topology: detect -> train -> eval -> register -> deploy.
+# Mirrors .github/workflows/ml-pipeline.yml (GKE variant) with the only
+# substrate substitution: artifact store = MinIO/Ceph-RGW S3 (not GCS).
+# Reuses the platform's supply-chain composites (.github/actions/syft-sbom,
+# cosign-sign, harden-runner) and promotes via Kargo two-step rollout.
+#
+# Training/eval are delegated to Airflow on the Talos bare-metal cluster via
+# its REST API (Airflow REST: POST /api/v1/dags/train_domain_adapter_baremetal/dagRuns).
+# This workflow is the control/gate plane, not the trainer.
+#
+# ADR-0028: platform:system = ml-pipeline.
+# ADR-0037: reused pipeline design; substrate = MinIO/Ceph-RGW.
+# ADR-0049: UK-isolated control plane; no GCP Workload Identity in this workflow.
+# ADR-0052: S3-compatible artifact store (endpoint-agnostic; mlflow + boto3 use MLFLOW_S3_ENDPOINT_URL).
+#
+# APPLY-GATED: This workflow targets real Airflow + MLflow services.
+# Execution requires live Talos cluster + MinIO + CloudNativePG provisioned (WS-A done).
+name: ML Pipeline (Bare Metal)
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Model/adapter id to train and release (e.g. fraud-uk)"
+        required: true
+        type: string
+      environment:
+        description: "Target environment for the staged deploy"
+        required: true
+        default: staging
+        type: choice
+        options: [staging, prod]
+  push:
+    branches: [main]
+    paths:
+      - "models/**"
+      - "adapters/**"
+
+permissions:
+  contents: read
+  id-token: write  # For cosign keyless signing (Sigstore OIDC)
+
+concurrency:
+  group: ml-pipeline-baremetal-${{ github.ref }}-${{ inputs.model || github.sha }}
+  cancel-in-progress: false
+
+env:
+  # Airflow URL is the in-cluster service exposed via Cilium Gateway (ADR-0051).
+  # Set as a GitHub Actions variable in the repo settings (no hardcoded URL).
+  AIRFLOW_BASE_URL: ${{ vars.AIRFLOW_BAREMETAL_BASE_URL }}
+  MLFLOW_TRACKING_URI: ${{ vars.MLFLOW_BAREMETAL_TRACKING_URI }}
+  # S3-compatible endpoint -- MinIO or Ceph-RGW (ADR-0052).
+  # Value stored as a GH Actions variable; endpoint-agnostic (boto3 uses it).
+  MLFLOW_S3_ENDPOINT_URL: ${{ vars.MLFLOW_S3_ENDPOINT_URL }}
+  MODEL_ID: ${{ inputs.model || 'auto' }}
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Job 1 -- Train: trigger Airflow DAG (train_domain_adapter_baremetal)
+  # ---------------------------------------------------------------------------
+  train:
+    name: Train (Airflow bare-metal train_domain_adapter_baremetal)
+    runs-on: ubuntu-latest
+    outputs:
+      run_id: ${{ steps.trigger.outputs.run_id }}
+
+    steps:
+      - name: Harden runner (audit)
+        uses: ./.github/actions/harden-runner
+
+      - uses: actions/checkout@v4
+
+      # No GCP WI -- authenticate to Airflow directly via AIRFLOW_API_TOKEN.
+      # Token is stored in GitHub Actions secrets (Vault-rotated via ESO).
+      - name: Trigger train_domain_adapter_baremetal DAG
+        id: trigger
+        env:
+          AIRFLOW_TOKEN: ${{ secrets.AIRFLOW_BAREMETAL_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          run_id="ci-bm-${MODEL_ID}-${GITHUB_SHA::8}"
+          curl -fsS -X POST "${AIRFLOW_BASE_URL}/api/v1/dags/train_domain_adapter_baremetal/dagRuns" \
+            -H "Authorization: Bearer ${AIRFLOW_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"dag_run_id\": \"${run_id}\",
+              \"conf\": {
+                \"model_id\": \"${MODEL_ID}\",
+                \"artifact_uri\": \"s3://mlflow-artifacts/${MODEL_ID}/${GITHUB_SHA}\"
+              }
+            }"
+          echo "run_id=${run_id}" >> "$GITHUB_OUTPUT"
+
+  # ---------------------------------------------------------------------------
+  # Job 2 -- Eval gate: poll eval_adapter_debate task for pass/fail
+  # ---------------------------------------------------------------------------
+  eval:
+    name: Evaluate (eval_adapter_debate gate)
+    needs: train
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden runner (audit)
+        uses: ./.github/actions/harden-runner
+
+      - uses: actions/checkout@v4
+
+      - name: Wait for eval gate (eval_adapter_debate must pass)
+        env:
+          AIRFLOW_TOKEN: ${{ secrets.AIRFLOW_BAREMETAL_API_TOKEN }}
+          RUN_ID: ${{ needs.train.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          # Poll the downstream eval_adapter_debate task state.
+          # Bounded poll: 40 * 30s = 20 min max (mirrors GKE pipeline).
+          for _ in $(seq 1 40); do
+            state=$(curl -fsS \
+              -H "Authorization: Bearer ${AIRFLOW_TOKEN}" \
+              "${AIRFLOW_BASE_URL}/api/v1/dags/train_domain_adapter_baremetal/dagRuns/${RUN_ID}/taskInstances/eval_adapter_debate" \
+              | python3 -c 'import json,sys; print(json.load(sys.stdin).get("state",""))')
+            case "${state}" in
+              success) echo "eval gate passed"; exit 0 ;;
+              failed)  echo "::error::eval_adapter_debate gate failed"; exit 1 ;;
+              *)       echo "eval state=${state:-pending}; waiting 30s"; sleep 30 ;;
+            esac
+          done
+          echo "::error::eval gate timed out after 20 min"; exit 1
+
+  # ---------------------------------------------------------------------------
+  # Job 3 -- Register: register model version in MLflow + sign with cosign/syft
+  # ---------------------------------------------------------------------------
+  register:
+    name: Register model + sign artifacts
+    needs: eval
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden runner (audit)
+        uses: ./.github/actions/harden-runner
+
+      - uses: actions/checkout@v4
+
+      - name: Register model version in MLflow (-> Staging)
+        env:
+          # S3 credentials injected as GH Actions secrets (Vault-rotated).
+          # Equivalent to the ESO-materialised mlflow-s3-credentials Secret in-cluster.
+          AWS_ACCESS_KEY_ID: ${{ secrets.MLFLOW_S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MLFLOW_S3_SECRET_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+          pip install --quiet "mlflow>=2.16" "boto3>=1.34"
+          # Point boto3 at the in-cluster S3 endpoint (MinIO or Ceph-RGW, ADR-0052).
+          export MLFLOW_S3_ENDPOINT_URL="${MLFLOW_S3_ENDPOINT_URL}"
+          mlflow models create-version \
+            --name "${MODEL_ID}" \
+            --source "s3://mlflow-artifacts/${MODEL_ID}/${GITHUB_SHA}" || true
+          # Transition handled by model-registry stage gate in the next step.
+
+      - name: Generate SBOM (reuse platform cosign/syft composite)
+        uses: ./.github/actions/syft-sbom
+        with:
+          image: ${{ vars.ML_IMAGE_REPO }}/${{ env.MODEL_ID }}:${{ github.sha }}
+
+      - name: Sign + attest (cosign keyless -- reuse platform composite)
+        uses: ./.github/actions/cosign-sign
+        with:
+          image: ${{ vars.ML_IMAGE_REPO }}/${{ env.MODEL_ID }}:${{ github.sha }}
+
+  # ---------------------------------------------------------------------------
+  # Job 4 -- Deploy: Kargo staged promotion (staging auto / prod gated)
+  # ADR-0037: two-step rollout; bare-metal serving -> edge fleet.
+  # ---------------------------------------------------------------------------
+  deploy:
+    name: Staged deploy (Kargo bare-metal promotion)
+    needs: register
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment || 'staging' }}
+
+    steps:
+      - name: Harden runner (audit)
+        uses: ./.github/actions/harden-runner
+
+      - uses: actions/checkout@v4
+
+      - name: Open Kargo promotion (staging auto / prod gated)
+        uses: ./.github/actions/argocd-tag-bump
+        with:
+          app: mlflow-serving-baremetal-${{ env.MODEL_ID }}
+          tag: ${{ github.sha }}
+          environment: ${{ inputs.environment || 'staging' }}

--- a/apps/infra/airflow-baremetal/Chart.yaml
+++ b/apps/infra/airflow-baremetal/Chart.yaml
@@ -1,0 +1,35 @@
+apiVersion: v2
+name: airflow-baremetal
+description: >-
+  Apache Airflow ML pipeline orchestrator re-targeted at the bare-metal Talos
+  UK cluster. KubernetesExecutor; GPU training tasks use Volcano scheduler
+  via executor_config (UK DC training-* queues per 06-uk-datacenters.md).
+  PostgreSQL backend via CloudNativePG (UK DC inventory). Secrets from Vault/ESO.
+  ADR-0037 (reused) + ADR-0052 (storage substrate). WS-B bare metal.
+type: application
+version: 1.0.0
+appVersion: "2.9.3"
+
+keywords:
+  - airflow
+  - ml-pipeline
+  - orchestration
+  - bare-metal
+  - talos
+  - volcano
+
+maintainers:
+  - name: Platform Team
+    email: platform@example.com
+
+annotations:
+  category: ML Platform
+  platform: Kubernetes (Talos bare metal)
+  adr: "0037,0049,0052"
+
+dependencies:
+  # Official Apache Airflow Helm chart.
+  - name: airflow
+    version: "1.15.0"
+    repository: https://airflow.apache.org
+    condition: airflow.enabled

--- a/apps/infra/airflow-baremetal/dags/train_domain_adapter_baremetal.py
+++ b/apps/infra/airflow-baremetal/dags/train_domain_adapter_baremetal.py
@@ -1,0 +1,194 @@
+"""
+train_domain_adapter_baremetal — Airflow DAG (WS-B, ADR-0037 reused)
+
+Bare-metal variant of the four-DAG training pipeline
+(docs/transaction-analytics/04-training-pipeline.md):
+  train_domain_adapter -> eval_adapter_debate -> mine_templates -> promote_to_edge
+
+Key differences vs the GKE DAG:
+- KubernetesExecutor task pods submit to the *Volcano* scheduler
+  (executor_config: schedulerName=volcano, queue=training-default)
+  using the UK DC Volcano queue taxonomy from 06-uk-datacenters.md.
+- GPU tolerations set on training task pods
+  (nvidia.com/gpu:NoSchedule => Exists).
+- Artifact store: MinIO / Ceph-RGW S3 endpoint
+  (MLFLOW_S3_ENDPOINT_URL injected from mlflow-s3-credentials Secret).
+- No GCP Workload Identity; credentials from Vault/ESO (ADR-0049).
+
+ADR-0028: platform.system = ml-pipeline, platform.component = airflow.
+ADR-0037: reused orchestrator design; only substrate changes (bare metal).
+ADR-0049: UK-isolated control plane.
+ADR-0052: S3 artifact store = MinIO (default) or Ceph-RGW.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import timedelta
+
+from airflow import DAG
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
+from airflow.utils.dates import days_ago
+from kubernetes.client import (
+    V1Toleration,
+    V1ResourceRequirements,
+)
+
+# ---------------------------------------------------------------------------
+# Volcano queue taxonomy (UK DC, 06-uk-datacenters.md)
+# H100 pool queues: training-default | training-bootstrap | training-urgent
+# ---------------------------------------------------------------------------
+VOLCANO_QUEUE = os.getenv("VOLCANO_TRAINING_QUEUE", "training-default")
+
+# ---------------------------------------------------------------------------
+# Shared executor_config: submit GPU task pods to Volcano scheduler.
+# ---------------------------------------------------------------------------
+GPU_EXECUTOR_CONFIG = {
+    "pod_override": {
+        "spec": {
+            # Route via Volcano secondary scheduler (ADR-0037 + UK DC WS-A).
+            "schedulerName": "volcano",
+            "tolerations": [
+                V1Toleration(
+                    key="nvidia.com/gpu",
+                    operator="Exists",
+                    effect="NoSchedule",
+                )
+            ],
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Shared resource requirements for training pods
+# ---------------------------------------------------------------------------
+TRAINING_RESOURCES = V1ResourceRequirements(
+    requests={"cpu": "4", "memory": "16Gi", "nvidia.com/gpu": "1"},
+    limits={"cpu": "8", "memory": "32Gi", "nvidia.com/gpu": "1"},
+)
+
+DEFAULT_ARGS = {
+    "owner": "team-ml",
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+    "labels": {
+        # ADR-0028 labels on task pods
+        "platform.system": "ml-pipeline",
+        "platform.component": "airflow",
+        "platform.managed-by": "argocd",
+    },
+}
+
+with DAG(
+    dag_id="train_domain_adapter_baremetal",
+    description=(
+        "Bare-metal: train_domain_adapter -> eval_adapter_debate -> "
+        "mine_templates -> promote_to_edge. Volcano GPU queues. ADR-0037/0049/0052."
+    ),
+    default_args=DEFAULT_ARGS,
+    schedule_interval=None,  # Triggered by GH Actions ml-pipeline-baremetal.yml
+    start_date=days_ago(1),
+    catchup=False,
+    tags=["ml-pipeline", "bare-metal", "gpu", "adr-0037", "adr-0052"],
+    params={
+        "model_id": "fraud-uk",
+        # S3 artifact URI prefix (MinIO/Ceph-RGW; overridden per-run by GH Actions).
+        "artifact_uri": "s3://mlflow-artifacts",
+    },
+) as dag:
+
+    # -----------------------------------------------------------------------
+    # Task 1: train_domain_adapter
+    # Runs the adapter training job on the H100 GPU pool via Volcano.
+    # -----------------------------------------------------------------------
+    train = KubernetesPodOperator(
+        task_id="train_domain_adapter",
+        name="train-domain-adapter",
+        namespace="ml-pipeline",
+        image="{{ var.value.TRAINING_IMAGE | default('training-runner:latest') }}",
+        cmds=["python", "-m", "training.train_domain_adapter"],
+        env_vars={
+            "MODEL_ID": "{{ params.model_id }}",
+            "ARTIFACT_URI": "{{ params.artifact_uri }}",
+            # MLFLOW_TRACKING_URI + S3 credentials injected from mlflow-tracking-uri
+            # and mlflow-s3-credentials Secrets (via Airflow extraEnv in values.yaml).
+        },
+        container_resources=TRAINING_RESOURCES,
+        executor_config=GPU_EXECUTOR_CONFIG,
+        annotations={
+            # Volcano queue annotation (secondary scheduler picks this up)
+            "scheduling.volcano.sh/queue-name": VOLCANO_QUEUE,
+        },
+        is_delete_operator_pod=True,
+        get_logs=True,
+    )
+
+    # -----------------------------------------------------------------------
+    # Task 2: eval_adapter_debate
+    # Quality gate: runs evaluation; must pass before registration.
+    # -----------------------------------------------------------------------
+    eval_gate = KubernetesPodOperator(
+        task_id="eval_adapter_debate",
+        name="eval-adapter-debate",
+        namespace="ml-pipeline",
+        image="{{ var.value.EVAL_IMAGE | default('eval-runner:latest') }}",
+        cmds=["python", "-m", "evaluation.eval_adapter_debate"],
+        env_vars={
+            "MODEL_ID": "{{ params.model_id }}",
+            "ARTIFACT_URI": "{{ params.artifact_uri }}",
+        },
+        container_resources=V1ResourceRequirements(
+            requests={"cpu": "2", "memory": "8Gi"},
+            limits={"cpu": "4", "memory": "16Gi"},
+        ),
+        # Eval may run on CPU pool (no GPU toleration needed for debate eval).
+        executor_config={},
+        is_delete_operator_pod=True,
+        get_logs=True,
+    )
+
+    # -----------------------------------------------------------------------
+    # Task 3: mine_templates
+    # Template mining runs after successful eval.
+    # -----------------------------------------------------------------------
+    mine = KubernetesPodOperator(
+        task_id="mine_templates",
+        name="mine-templates",
+        namespace="ml-pipeline",
+        image="{{ var.value.MINING_IMAGE | default('mining-runner:latest') }}",
+        cmds=["python", "-m", "mining.mine_templates"],
+        env_vars={
+            "MODEL_ID": "{{ params.model_id }}",
+            "ARTIFACT_URI": "{{ params.artifact_uri }}",
+        },
+        container_resources=V1ResourceRequirements(
+            requests={"cpu": "2", "memory": "8Gi"},
+            limits={"cpu": "4", "memory": "16Gi"},
+        ),
+        executor_config={},
+        is_delete_operator_pod=True,
+        get_logs=True,
+    )
+
+    # -----------------------------------------------------------------------
+    # Task 4: promote_to_edge
+    # Triggers Kargo promotion (bare-metal serving => edge fleet).
+    # -----------------------------------------------------------------------
+    promote = KubernetesPodOperator(
+        task_id="promote_to_edge",
+        name="promote-to-edge",
+        namespace="ml-pipeline",
+        image="{{ var.value.KARGO_CLI_IMAGE | default('kargo-cli:latest') }}",
+        cmds=["kargo", "promote"],
+        arguments=[
+            "--project", "ml-pipeline-baremetal",
+            "--freight", "{{ params.model_id }}-{{ run_id }}",
+            "--stage", "staging",
+        ],
+        executor_config={},
+        is_delete_operator_pod=True,
+        get_logs=True,
+    )
+
+    # Pipeline: train -> eval -> mine -> promote
+    train >> eval_gate >> mine >> promote

--- a/apps/infra/airflow-baremetal/templates/argocd-app.yaml
+++ b/apps/infra/airflow-baremetal/templates/argocd-app.yaml
@@ -1,0 +1,53 @@
+---
+# ArgoCD Application — Airflow (bare metal, ADR-0037 reused + ADR-0049/0051/0052)
+# Delivers the Airflow Helm chart to the Talos bare-metal UK cluster.
+# Re-targeted from gke-ml-primary (GCS) to talos-uk-primary (MinIO/Ceph-RGW).
+# ADR-0028: namespace carries platform.system=ml-pipeline labels.
+# ADR-0049: UK-isolated ML control plane; Airflow workers run in-DC.
+# ADR-0051: Cilium CNI; CiliumNetworkPolicy enforced.
+# ADR-0052: DAG task pods use MinIO/Ceph-RGW S3 for artifact access.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: airflow-baremetal
+  namespace: argocd
+  labels:
+    platform.system: ml-pipeline
+    platform.component: airflow
+    platform.managed-by: argocd
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: ml-pipeline-alerts
+    notifications.argoproj.io/subscribe.on-health-degraded.slack: ml-pipeline-alerts
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/100rd/platform-design.git
+    targetRevision: HEAD
+    path: apps/infra/airflow-baremetal
+
+  destination:
+    # Talos UK primary DC cluster registered in ArgoCD.
+    name: talos-uk-primary
+    namespace: ml-pipeline
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ApplyOutOfSyncOnly=true
+    managedNamespaceMetadata:
+      labels:
+        platform.system: ml-pipeline
+        platform.component: airflow
+        platform.env: prod
+        platform.owner: team-ml
+        platform.managed-by: argocd
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/apps/infra/airflow-baremetal/templates/external-secret.yaml
+++ b/apps/infra/airflow-baremetal/templates/external-secret.yaml
@@ -1,0 +1,83 @@
+---
+# ExternalSecret — Airflow metadata DB connection (bare metal, CloudNativePG)
+# Materialises the CloudNativePG connection string from Vault KV v2 into
+# airflow-metadata-connection Kubernetes Secret. ESO v1 / ClusterSecretStore
+# vault-cluster-store. ADR-0008 (ESO) + ADR-0037.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: airflow-metadata-connection
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: airflow-baremetal
+    app.kubernetes.io/component: metadata-db
+    app.kubernetes.io/managed-by: helm
+    platform.system: ml-pipeline
+    platform.component: airflow
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-cluster-store
+    kind: ClusterSecretStore
+  target:
+    name: airflow-metadata-connection
+    creationPolicy: Owner
+  data:
+    - secretKey: connection
+      remoteRef:
+        # Shape: postgresql+psycopg2://airflow:<pw>@airflow-pg-rw.ml-pipeline.svc:5432/airflow
+        key: secret/data/ml-pipeline/airflow-metadata-connection
+        property: connection
+---
+# ExternalSecret — Airflow Fernet key (from Vault)
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: airflow-fernet-key
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: airflow-baremetal
+    app.kubernetes.io/component: fernet
+    app.kubernetes.io/managed-by: helm
+    platform.system: ml-pipeline
+    platform.component: airflow
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault-cluster-store
+    kind: ClusterSecretStore
+  target:
+    name: airflow-fernet-key
+    creationPolicy: Owner
+  data:
+    - secretKey: fernet-key
+      remoteRef:
+        key: secret/data/ml-pipeline/airflow-fernet-key
+        property: key
+---
+# ExternalSecret — MLflow tracking URI (consumed by Airflow task pods)
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mlflow-tracking-uri
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: airflow-baremetal
+    app.kubernetes.io/component: mlflow-ref
+    app.kubernetes.io/managed-by: helm
+    platform.system: ml-pipeline
+    platform.component: airflow
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-cluster-store
+    kind: ClusterSecretStore
+  target:
+    name: mlflow-tracking-uri
+    creationPolicy: Owner
+  data:
+    - secretKey: uri
+      remoteRef:
+        # Shape: http://mlflow-baremetal.ml-pipeline.svc.cluster.local:5000
+        key: secret/data/ml-pipeline/mlflow-tracking-uri
+        property: uri

--- a/apps/infra/airflow-baremetal/templates/network-policy.yaml
+++ b/apps/infra/airflow-baremetal/templates/network-policy.yaml
@@ -1,0 +1,93 @@
+---
+# CiliumNetworkPolicy — Airflow (bare metal)
+# ADR-0028: platform.system=ml-pipeline, component=airflow.
+# ADR-0051: Cilium eBPF CNI; CiliumNetworkPolicy for L7 filtering.
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: airflow-baremetal
+  namespace: {{ .Release.Namespace }}
+  labels:
+    platform.system: ml-pipeline
+    platform.component: airflow
+    platform.managed-by: argocd
+spec:
+  endpointSelector:
+    matchLabels:
+      platform.system: ml-pipeline
+      platform.component: airflow
+  ingress:
+    # Allow: Prometheus scrape
+    - fromEndpoints:
+        - matchLabels:
+            platform.system: observability
+      toPorts:
+        - ports:
+            - port: "8125"
+              protocol: UDP
+            - port: "8080"
+              protocol: TCP
+    # Allow: ingress from ml-pipeline (MLflow, CI runners)
+    - fromEndpoints:
+        - matchLabels:
+            platform.system: ml-pipeline
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+  egress:
+    # Allow: CloudNativePG PostgreSQL
+    - toEndpoints:
+        - matchLabels:
+            platform.system: ml-pipeline
+            platform.component: postgres
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Allow: MLflow tracking server (register experiments)
+    - toEndpoints:
+        - matchLabels:
+            platform.system: ml-pipeline
+            platform.component: model-registry
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
+    # Allow: MinIO / Ceph-RGW S3 (artifact access by task pods)
+    - toEndpoints:
+        - matchLabels:
+            platform.system: storage
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP
+    # Allow: Vault (ESO refresh)
+    - toEndpoints:
+        - matchLabels:
+            platform.system: secrets
+      toPorts:
+        - ports:
+            - port: "8200"
+              protocol: TCP
+    # Allow: GitHub API (gitSync + Airflow REST trigger from GH Actions)
+    - toCIDR:
+        - 0.0.0.0/0
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # Allow: DNS
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+{{- end }}

--- a/apps/infra/airflow-baremetal/values.yaml
+++ b/apps/infra/airflow-baremetal/values.yaml
@@ -1,0 +1,250 @@
+---
+# Apache Airflow — ML pipeline orchestrator, bare metal (ADR-0037 reused)
+# platform:system = ml-pipeline, component = airflow
+#
+# Key differences vs apps/infra/airflow (GKE):
+#   - nodeSelector: Talos pool:cpu-general (not GKE nodepool)
+#   - SA annotation: no GKE WI — credentials from Vault/ESO (vault-eso)
+#   - GPU training tasks override schedulerName to "volcano" + queue to
+#     "training-default" (UK DC Volcano queue taxonomy, 06-uk-datacenters.md)
+#   - Metadata DB: CloudNativePG (not Cloud SQL Auth Proxy)
+#   - NetworkPolicy: CiliumNetworkPolicy (Cilium CNI, ADR-0051)
+#   - S3 env vars injected from mlflow-s3-credentials Secret (ESO/Vault)
+#
+# ADR-0028: platform.system = ml-pipeline, component = airflow.
+# ADR-0037: orchestrator/registry design reused; substrate = bare metal.
+# ADR-0049: UK-isolated control plane.
+# ADR-0051: Cilium CNI.
+# ADR-0052: S3-compatible artifact store (MinIO/Ceph-RGW).
+
+# ---------------------------------------------------------------------------
+# Wrapper-chart-level values
+# ---------------------------------------------------------------------------
+
+networkPolicy:
+  enabled: true
+
+# ---------------------------------------------------------------------------
+# Airflow sub-chart values
+# ---------------------------------------------------------------------------
+
+airflow:
+  enabled: true
+
+  # -------------------------------------------------------------------------
+  # Executor — KubernetesExecutor: each task is an ephemeral pod.
+  # GPU training tasks override schedulerName to "volcano" via executor_config
+  # in the DAG definition (training-default queue).
+  # -------------------------------------------------------------------------
+  executor: KubernetesExecutor
+
+  # -------------------------------------------------------------------------
+  # Images
+  # -------------------------------------------------------------------------
+  images:
+    airflow:
+      repository: apache/airflow
+      tag: "2.9.3-python3.11"
+      pullPolicy: IfNotPresent
+
+  # -------------------------------------------------------------------------
+  # DAG delivery via gitSync sidecar (same repo; same DAG path as GKE)
+  # -------------------------------------------------------------------------
+  dags:
+    persistence:
+      enabled: false
+    gitSync:
+      enabled: true
+      repo: https://github.com/100rd/platform-design.git
+      branch: main
+      rev: HEAD
+      subPath: apps/infra/airflow-baremetal/dags
+      sshKeySecret: airflow-git-sync-ssh
+
+  # -------------------------------------------------------------------------
+  # Kubernetes executor config
+  # GPU training tasks: set schedulerName=volcano + add GPU tolerations via
+  # executor_config in the DAG (train_domain_adapter, mine_templates).
+  # -------------------------------------------------------------------------
+  config:
+    kubernetes:
+      namespace: ml-pipeline
+      delete_worker_pods: "True"
+      delete_worker_pods_on_failure: "False"
+
+  # -------------------------------------------------------------------------
+  # Scheduler
+  # -------------------------------------------------------------------------
+  scheduler:
+    replicas: 1
+
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: "2"
+        memory: 2Gi
+
+    # Talos bare-metal node selector (CPU general pool)
+    nodeSelector:
+      pool: cpu-general
+
+    livenessProbe:
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      failureThreshold: 5
+
+    readinessProbe:
+      initialDelaySeconds: 20
+      periodSeconds: 20
+
+    podDisruptionBudget:
+      enabled: true
+      config:
+        minAvailable: 1
+
+    labels:
+      platform.system: ml-pipeline
+      platform.component: airflow
+      platform.managed-by: argocd
+
+  # -------------------------------------------------------------------------
+  # Webserver
+  # -------------------------------------------------------------------------
+  webserver:
+    replicas: 1
+
+    resources:
+      requests:
+        cpu: 300m
+        memory: 512Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi
+
+    nodeSelector:
+      pool: cpu-general
+
+    labels:
+      platform.system: ml-pipeline
+      platform.component: airflow
+      platform.managed-by: argocd
+
+  # -------------------------------------------------------------------------
+  # Workers (KubernetesExecutor task pod template)
+  # GPU training tasks get schedulerName=volcano + nvidia.com/gpu tolerations
+  # via executor_config in the DAG — not set here globally.
+  # -------------------------------------------------------------------------
+  workers:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: "4"
+        memory: 8Gi
+
+    labels:
+      platform.system: ml-pipeline
+      platform.component: airflow
+      platform.managed-by: argocd
+
+  # -------------------------------------------------------------------------
+  # Triggerer
+  # -------------------------------------------------------------------------
+  triggerer:
+    enabled: true
+    replicas: 1
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+    nodeSelector:
+      pool: cpu-general
+
+  # -------------------------------------------------------------------------
+  # Database — CloudNativePG PostgreSQL (UK DC inventory)
+  # metadataConnection injected from ExternalSecret airflow-metadata-connection
+  # Shape: postgresql+psycopg2://airflow:<password>@airflow-pg-rw.ml-pipeline.svc:5432/airflow
+  # -------------------------------------------------------------------------
+  data:
+    metadataSecretName: airflow-metadata-connection
+
+  # -------------------------------------------------------------------------
+  # Fernet key (encrypts DAG variables and connections in the metadata DB)
+  # -------------------------------------------------------------------------
+  fernetKeySecretName: airflow-fernet-key
+
+  # -------------------------------------------------------------------------
+  # ServiceAccount — bare metal (no GKE WI; credentials from Vault/ESO)
+  # -------------------------------------------------------------------------
+  serviceAccount:
+    create: true
+    name: airflow
+    annotations:
+      # No cloud WI annotation — secrets arrive via ESO-materialised Secrets.
+      platform.credential-source: vault-eso
+
+  # -------------------------------------------------------------------------
+  # PostgreSQL sub-chart — disabled; use CloudNativePG (UK DC)
+  # -------------------------------------------------------------------------
+  postgresql:
+    enabled: false
+
+  # -------------------------------------------------------------------------
+  # Redis — not needed with KubernetesExecutor
+  # -------------------------------------------------------------------------
+  redis:
+    enabled: false
+
+  # -------------------------------------------------------------------------
+  # Prometheus StatsD exporter for Airflow metrics
+  # -------------------------------------------------------------------------
+  statsd:
+    enabled: true
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+
+  # -------------------------------------------------------------------------
+  # Extra environment variables — S3 + MLflow tracking
+  # S3 credentials (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
+  # MLFLOW_S3_ENDPOINT_URL) from ESO Secret mlflow-s3-credentials.
+  # -------------------------------------------------------------------------
+  extraEnv:
+    - name: AIRFLOW__CORE__LOAD_EXAMPLES
+      value: "False"
+    - name: AIRFLOW__WEBSERVER__EXPOSE_CONFIG
+      value: "False"
+    # MLflow tracking URI — task pods call mlflow.log_metric() directly.
+    - name: MLFLOW_TRACKING_URI
+      valueFrom:
+        secretKeyRef:
+          name: mlflow-tracking-uri
+          key: uri
+    # S3 credentials for artifact store access (MinIO/Ceph-RGW)
+    - name: AWS_ACCESS_KEY_ID
+      valueFrom:
+        secretKeyRef:
+          name: mlflow-s3-credentials
+          key: AWS_ACCESS_KEY_ID
+    - name: AWS_SECRET_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          name: mlflow-s3-credentials
+          key: AWS_SECRET_ACCESS_KEY
+    - name: MLFLOW_S3_ENDPOINT_URL
+      valueFrom:
+        secretKeyRef:
+          name: mlflow-s3-credentials
+          key: MLFLOW_S3_ENDPOINT_URL

--- a/apps/infra/mlflow-baremetal/Chart.yaml
+++ b/apps/infra/mlflow-baremetal/Chart.yaml
@@ -1,0 +1,35 @@
+apiVersion: v2
+name: mlflow-baremetal
+description: >-
+  MLflow tracking server + Model Registry re-targeted at the bare-metal Talos
+  UK cluster. PostgreSQL backend (CloudNativePG, already in UK DC inventory) +
+  MinIO/Ceph-RGW S3 artifact store (ADR-0052). HA 2-replica deployment.
+  ADR-0037 (reused) + ADR-0052 (storage substrate). WS-B bare metal.
+type: application
+version: 1.0.0
+appVersion: "2.21.3"
+
+keywords:
+  - mlflow
+  - model-registry
+  - ml-pipeline
+  - minio
+  - ceph-rgw
+  - bare-metal
+  - talos
+
+maintainers:
+  - name: Platform Team
+    email: platform@example.com
+
+annotations:
+  category: ML Platform
+  platform: Kubernetes (Talos bare metal)
+  adr: "0037,0052"
+
+dependencies:
+  # community-charts MLflow Helm chart — same version as GKE app for parity.
+  - name: mlflow
+    version: "1.4.1"
+    repository: https://community-charts.github.io/helm-charts
+    condition: mlflow.enabled

--- a/apps/infra/mlflow-baremetal/templates/argocd-app.yaml
+++ b/apps/infra/mlflow-baremetal/templates/argocd-app.yaml
@@ -1,0 +1,65 @@
+---
+# ArgoCD Application — MLflow (bare metal, ADR-0037 reused + ADR-0052)
+# Delivers the MLflow Helm chart to the Talos bare-metal ML cluster.
+# Re-targeted from gke-ml-primary (GCS) to talos-uk-primary (MinIO/Ceph-RGW).
+# ADR-0028: namespace carries platform.system=ml-pipeline labels.
+# ADR-0049: UK-isolated ML control plane; no cross-region data-plane traffic.
+# ADR-0051: Cilium CNI; networkPolicy.enabled = true.
+# ADR-0052: artifact store = MinIO/Ceph-RGW (endpoint set via parameter).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mlflow-baremetal
+  namespace: argocd
+  labels:
+    platform.system: ml-pipeline
+    platform.component: model-registry
+    platform.managed-by: argocd
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: ml-pipeline-alerts
+    notifications.argoproj.io/subscribe.on-health-degraded.slack: ml-pipeline-alerts
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/100rd/platform-design.git
+    targetRevision: HEAD
+    path: apps/infra/mlflow-baremetal
+
+    helm:
+      parameters:
+        # Artifact store bucket — override per-env via ArgoCD ApplicationSet or manual parameter.
+        - name: mlflow.artifactRoot
+          value: "s3://mlflow-artifacts"
+        - name: mlflow.extraEnvVars[0].value
+          value: "s3://mlflow-artifacts"
+        # S3 endpoint URL — points at in-cluster MinIO or Ceph-RGW (ADR-0052).
+        # MLFLOW_S3_ENDPOINT_URL comes from ESO Secret mlflow-s3-credentials;
+        # the parameter here sets the artifact root bucket prefix only.
+
+  destination:
+    # Talos UK primary DC cluster registered in ArgoCD.
+    # Name must match the ArgoCD cluster secret for the Talos cluster.
+    name: talos-uk-primary
+    namespace: ml-pipeline
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ApplyOutOfSyncOnly=true
+    managedNamespaceMetadata:
+      labels:
+        platform.system: ml-pipeline
+        platform.component: model-registry
+        platform.env: prod
+        platform.owner: team-ml
+        platform.managed-by: argocd
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/apps/infra/mlflow-baremetal/templates/external-secret.yaml
+++ b/apps/infra/mlflow-baremetal/templates/external-secret.yaml
@@ -1,0 +1,41 @@
+---
+# ExternalSecret — MLflow DB connection string (bare metal, CloudNativePG)
+# Materialises the CloudNativePG connection string from Vault KV v2 into
+# the mlflow-db-connection Kubernetes Secret, consumed by values.yaml
+# backendStore.existing_secret. ESO v1 / ClusterSecretStore vault-cluster-store.
+# ADR-0008 (ESO) + ADR-0037 (MLflow backend store).
+#
+# Note: the S3 credentials Secret (mlflow-s3-credentials) is managed by the
+# baremetal-ml-artifact-store Terraform module, NOT this chart, to avoid
+# dual ownership. This chart only manages the DB connection secret.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mlflow-db-connection
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: mlflow-baremetal
+    app.kubernetes.io/component: backend-store
+    app.kubernetes.io/managed-by: helm
+    platform.system: ml-pipeline
+    platform.component: model-registry
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    # Vault-backed ClusterSecretStore (Vault is the UK DC KMS per ADR-0049).
+    name: vault-cluster-store
+    kind: ClusterSecretStore
+
+  target:
+    name: mlflow-db-connection
+    creationPolicy: Owner
+
+  data:
+    - secretKey: connection
+      remoteRef:
+        # Populated by DBA team after CloudNativePG cluster provisioning.
+        # Shape: postgresql+psycopg2://mlflow:<password>@mlflow-pg-rw.ml-pipeline.svc:5432/mlflow
+        # (CloudNativePG read-write service mlflow-pg-rw)
+        key: secret/data/ml-pipeline/mlflow-db-connection
+        property: connection

--- a/apps/infra/mlflow-baremetal/templates/network-policy.yaml
+++ b/apps/infra/mlflow-baremetal/templates/network-policy.yaml
@@ -1,0 +1,87 @@
+---
+# CiliumNetworkPolicy — MLflow (bare metal)
+# Cilium replaces standard Kubernetes NetworkPolicy on the bare-metal cluster
+# (Cilium CNI per ADR-0051). Standard NetworkPolicy is also included for
+# policy-engine parity with Kyverno/Gatekeeper validators.
+# ADR-0028: all workloads carry platform.system=ml-pipeline.
+# ADR-0051: Cilium eBPF datapath; CiliumNetworkPolicy provides L7 filtering.
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: mlflow-baremetal
+  namespace: {{ .Release.Namespace }}
+  labels:
+    platform.system: ml-pipeline
+    platform.component: model-registry
+    platform.managed-by: argocd
+spec:
+  endpointSelector:
+    matchLabels:
+      platform.system: ml-pipeline
+      platform.component: model-registry
+  ingress:
+    # Allow: Airflow scheduler + workers (same namespace) — for experiment logging
+    - fromEndpoints:
+        - matchLabels:
+            platform.system: ml-pipeline
+            platform.component: airflow
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
+    # Allow: GitHub Actions runner via Cilium Gateway (ingress from ml-pipeline namespace)
+    - fromEndpoints:
+        - matchLabels:
+            platform.system: ml-pipeline
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
+    # Allow: Prometheus scrape (observability namespace)
+    - fromEndpoints:
+        - matchLabels:
+            platform.system: observability
+      toPorts:
+        - ports:
+            - port: "5000"
+              protocol: TCP
+  egress:
+    # Allow: CloudNativePG PostgreSQL (ml-pipeline namespace, port 5432)
+    - toEndpoints:
+        - matchLabels:
+            platform.system: ml-pipeline
+            platform.component: postgres
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+    # Allow: MinIO / Ceph-RGW S3 endpoint (minio-system or rook-ceph namespace)
+    - toEndpoints:
+        - matchLabels:
+            platform.system: storage
+      toPorts:
+        - ports:
+            - port: "9000"
+              protocol: TCP
+            - port: "80"
+              protocol: TCP
+    # Allow: Vault (for ESO credential refresh via vault-cluster-store)
+    - toEndpoints:
+        - matchLabels:
+            platform.system: secrets
+      toPorts:
+        - ports:
+            - port: "8200"
+              protocol: TCP
+    # Allow: DNS
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+{{- end }}

--- a/apps/infra/mlflow-baremetal/values.yaml
+++ b/apps/infra/mlflow-baremetal/values.yaml
@@ -1,0 +1,175 @@
+---
+# MLflow Tracking Server + Model Registry — Bare Metal (ADR-0037 reused, ADR-0052)
+# platform:system = ml-pipeline, component = model-registry
+#
+# Backend store: CloudNativePG PostgreSQL 16 (already in UK DC inventory per
+#   docs/transaction-analytics/06-uk-datacenters.md).
+# Artifact store: MinIO (default, UK DC pools) or Ceph-RGW S3-compatible endpoint.
+#   Credentials materialised via ESO ExternalSecret from Vault KV v2.
+#   See: terraform/modules/baremetal-ml-artifact-store.
+#
+# Key differences vs apps/infra/mlflow (GKE):
+#   - nodeSelector: uses Talos/bare-metal label pool:cpu-general (not GKE nodepool)
+#   - artifactRoot: s3:// URI pointing at MinIO/Ceph-RGW (not gs://)
+#   - SA annotation: no GKE WI — S3 credentials come from the ESO secret
+#   - NetworkPolicy: CiliumNetworkPolicy (bare metal, Cilium CNI per ADR-0051)
+#
+# ADR-0028: platform.system = ml-pipeline, component = model-registry.
+# ADR-0037: orchestrator/registry design unchanged; only substrate changes.
+# ADR-0049: UK-resident data; no external S3 (data-residency requirement).
+# ADR-0051: Cilium CNI with networkPolicy enforced.
+# ADR-0052: S3 artifact store = MinIO (default) or Ceph-RGW.
+
+# ---------------------------------------------------------------------------
+# Wrapper-chart-level values
+# ---------------------------------------------------------------------------
+
+networkPolicy:
+  enabled: true
+
+# ---------------------------------------------------------------------------
+# MLflow sub-chart values
+# ---------------------------------------------------------------------------
+
+mlflow:
+  enabled: true
+
+  # HA: 2 replicas for availability (risk R5 mitigation, ADR-0037)
+  replicaCount: 2
+
+  image:
+    repository: ghcr.io/mlflow/mlflow
+    tag: "v2.21.3"
+    pullPolicy: IfNotPresent
+
+  # -------------------------------------------------------------------------
+  # Backend store — CloudNativePG PostgreSQL 16 (UK DC inventory)
+  # Connection string injected from ExternalSecret mlflow-db-connection.
+  # Shape: postgresql+psycopg2://mlflow:<password>@mlflow-pg-rw.ml-pipeline.svc:5432/mlflow
+  # (CloudNativePG service: mlflow-pg-rw — read-write endpoint)
+  # -------------------------------------------------------------------------
+  backendStore:
+    existing_secret: mlflow-db-connection
+    existing_secret_key: connection
+
+  # -------------------------------------------------------------------------
+  # Artifact store — MinIO/Ceph-RGW S3 endpoint (ADR-0052)
+  # Bucket path set per-env by ArgoCD Application parameter override.
+  # S3 credentials (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
+  # MLFLOW_S3_ENDPOINT_URL) injected from ExternalSecret mlflow-s3-credentials
+  # (materialised by baremetal-ml-artifact-store Terraform module via ESO/Vault).
+  # -------------------------------------------------------------------------
+  artifactRoot: "s3://mlflow-artifacts"
+
+  # -------------------------------------------------------------------------
+  # Service account — bare metal (no GKE WI; credentials from ESO Secret)
+  # -------------------------------------------------------------------------
+  serviceAccount:
+    create: true
+    name: mlflow
+    annotations:
+      # No cloud WI annotation — S3 credentials arrive via envFrom (ESO Secret).
+      platform.credential-source: vault-eso
+
+  # -------------------------------------------------------------------------
+  # Extra env — S3 endpoint + credentials from the ESO-managed Secret.
+  # The ESO ExternalSecret (baremetal-ml-artifact-store module) creates
+  # mlflow-s3-credentials with keys: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
+  # MLFLOW_S3_ENDPOINT_URL. envFrom injects all three.
+  # -------------------------------------------------------------------------
+  extraEnvVarsSecret: mlflow-s3-credentials
+
+  extraEnvVars:
+    - name: MLFLOW_DEFAULT_ARTIFACT_ROOT
+      value: "s3://mlflow-artifacts"
+    # Force-path-style so MinIO / Ceph-RGW work without virtual-hosted-style DNS.
+    - name: MLFLOW_S3_IGNORE_TLS
+      value: "false"
+    - name: AWS_DEFAULT_REGION
+      value: "us-east-1"   # MinIO ignores region; Ceph-RGW accepts any value.
+
+  # -------------------------------------------------------------------------
+  # Service
+  # -------------------------------------------------------------------------
+  service:
+    type: ClusterIP
+    port: 5000
+
+  # -------------------------------------------------------------------------
+  # Resources
+  # -------------------------------------------------------------------------
+  resources:
+    requests:
+      cpu: 300m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+  # -------------------------------------------------------------------------
+  # Node selector — CPU general pool (Talos bare-metal label, not GKE nodepool)
+  # pool:cpu-general is set in machine.nodeLabels by talos-machineconfig (ADR-0028).
+  # -------------------------------------------------------------------------
+  nodeSelector:
+    pool: cpu-general
+
+  tolerations: []
+
+  # -------------------------------------------------------------------------
+  # Pod Disruption Budget — risk R5 mitigation (ADR-0037)
+  # -------------------------------------------------------------------------
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+
+  # -------------------------------------------------------------------------
+  # Probes
+  # -------------------------------------------------------------------------
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: 5000
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    failureThreshold: 5
+
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: 5000
+    initialDelaySeconds: 20
+    periodSeconds: 20
+
+  # -------------------------------------------------------------------------
+  # ADR-0028 labels (K8s-plane: dotted keys)
+  # -------------------------------------------------------------------------
+  podLabels:
+    platform.system: ml-pipeline
+    platform.component: model-registry
+    platform.managed-by: argocd
+
+  commonLabels:
+    platform.system: ml-pipeline
+    platform.component: model-registry
+    platform.managed-by: argocd
+
+  # -------------------------------------------------------------------------
+  # Security context
+  # -------------------------------------------------------------------------
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    readOnlyRootFilesystem: false   # MLflow writes tmp files during artifact ops
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+
+  podSecurityContext:
+    fsGroup: 1000
+
+  # -------------------------------------------------------------------------
+  # PostgreSQL sub-chart — disabled; use CloudNativePG (UK DC inventory)
+  # -------------------------------------------------------------------------
+  postgresql:
+    enabled: false

--- a/catalog/units/baremetal-ml-artifact-store/terragrunt.hcl
+++ b/catalog/units/baremetal-ml-artifact-store/terragrunt.hcl
@@ -1,0 +1,113 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# baremetal-ml-artifact-store — Catalog Unit (WS-B — ml-pipeline, bare metal)
+# ---------------------------------------------------------------------------------------------------------------------
+# Provisions the MinIO/Ceph-RGW S3 artifact store + ESO-backed S3 credential for
+# MLflow on the bare-metal Talos cluster.
+#
+# This is the bare-metal analogue of catalog/units/ml-artifact-store (GCS/WI).
+# Storage substrate: MinIO (UK-DC pools, existing) or Ceph-RGW (if ADR-0052
+# Rook-Ceph is deployed). S3-compatible API — no code change in MLflow or GH Actions.
+#
+# Dependencies (in WS-A / baremetal-gpu-analysis stack):
+#   - talos-cluster  (kubeconfig / cluster endpoint)
+#   - baremetal-rook-ceph (Ceph-RGW endpoint, if backend = ceph-rgw)
+#
+# Requires site.hcl with: dc_name, environment
+# Requires region.hcl (optional) or hard-coded UK DC names.
+#
+# ADR-0028: all K8s-plane labels use dotted keys (platform.system = ml-pipeline).
+# ADR-0037: orchestrator/registry design reused; only the substrate changes.
+# ADR-0052: MinIO (default) or Ceph-RGW; both S3-compatible.
+# ADR-0049: UK-isolated ML control plane.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/baremetal-ml-artifact-store"
+}
+
+locals {
+  site_vars = read_terragrunt_config(find_in_parent_folders("site.hcl"))
+
+  dc_name     = local.site_vars.locals.dc_name     # e.g. "uk-primary" or "uk-standby"
+  environment = local.site_vars.locals.environment  # e.g. "prod"
+
+  ml_pipeline_config = try(local.site_vars.locals.ml_pipeline_config, {})
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPENDENCY: Talos cluster (kubeconfig + endpoint from WS-A talos-cluster unit).
+# The kubernetes / helm providers are generated below using the cluster outputs.
+# ---------------------------------------------------------------------------------------------------------------------
+
+dependency "talos_cluster" {
+  config_path = "../talos-cluster"
+
+  mock_outputs = {
+    kubeconfig_raw = "apiVersion: v1\nclusters: []\ncontexts: []\nkind: Config\nusers: []"
+    endpoint       = "https://10.0.0.1:6443"
+    ca_certificate = "bW9jay1jYS1jZXJ0"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# PROVIDERS: Talos-authenticated helm + kubernetes via in-cluster kubeconfig.
+# The kubeconfig is materialised by talos-cluster (talos_cluster_kubeconfig).
+# No GCP token, no static credentials — pure K8s API auth.
+# ---------------------------------------------------------------------------------------------------------------------
+
+generate "baremetal_providers" {
+  path      = "baremetal_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "kubernetes" {
+      host                   = "${dependency.talos_cluster.outputs.endpoint}"
+      client_certificate     = ""
+      client_key             = ""
+      cluster_ca_certificate = base64decode("${dependency.talos_cluster.outputs.ca_certificate}")
+      # kubeconfig_path is set at plan time by KUBECONFIG env var in CI.
+      # In plan-only mode (mock) the provider is exercised against mock outputs.
+    }
+
+    provider "helm" {
+      kubernetes {
+        host                   = "${dependency.talos_cluster.outputs.endpoint}"
+        cluster_ca_certificate = base64decode("${dependency.talos_cluster.outputs.ca_certificate}")
+      }
+    }
+  PROVIDERS
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE INPUTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  # APPLY-GATED: enabled = false by default in this catalog unit.
+  # Set to true only after WS-A (talos-cluster + baremetal-rook-ceph / MinIO) is verified.
+  enabled = try(local.ml_pipeline_config.artifact_store_enabled, false)
+
+  backend         = try(local.ml_pipeline_config.artifact_store_backend, "minio")
+  s3_endpoint_url = try(local.ml_pipeline_config.s3_endpoint_url, "http://minio.minio-system.svc.cluster.local:9000")
+  bucket_name     = try(local.ml_pipeline_config.artifact_bucket_name, "mlflow-artifacts-${local.environment}")
+  vault_path      = try(local.ml_pipeline_config.vault_s3_path, "secret/data/ml-pipeline/mlflow-s3-credentials")
+
+  cluster_secret_store_name = try(local.ml_pipeline_config.cluster_secret_store_name, "vault-cluster-store")
+
+  namespace                  = try(local.ml_pipeline_config.mlflow_namespace, "ml-pipeline")
+  kubernetes_service_account = try(local.ml_pipeline_config.mlflow_k8s_sa, "mlflow")
+  secret_name                = try(local.ml_pipeline_config.s3_secret_name, "mlflow-s3-credentials")
+
+  minio_deploy_in_cluster = try(local.ml_pipeline_config.minio_deploy_in_cluster, false)
+  minio_storage_class     = try(local.ml_pipeline_config.minio_storage_class, "rook-ceph-block")
+
+  retention_days = try(local.ml_pipeline_config.artifact_retention_days, 365)
+
+  # ADR-0028 K8s-plane labels (dotted keys; underscore label keys reserved for Terraform-plane resources).
+  platform_labels = {
+    "platform.env"   = local.environment
+    "platform.owner" = try(local.ml_pipeline_config.owner, "team-ml")
+  }
+}

--- a/catalog/units/baremetal-ml-artifact-store/terragrunt.hcl
+++ b/catalog/units/baremetal-ml-artifact-store/terragrunt.hcl
@@ -29,7 +29,7 @@ locals {
   site_vars = read_terragrunt_config(find_in_parent_folders("site.hcl"))
 
   dc_name     = local.site_vars.locals.dc_name     # e.g. "uk-primary" or "uk-standby"
-  environment = local.site_vars.locals.environment  # e.g. "prod"
+  environment = local.site_vars.locals.environment # e.g. "prod"
 
   ml_pipeline_config = try(local.site_vars.locals.ml_pipeline_config, {})
 }

--- a/kargo/stages/baremetal/prod.yaml
+++ b/kargo/stages/baremetal/prod.yaml
@@ -1,0 +1,64 @@
+---
+# Kargo Stage -- ml-pipeline-baremetal prod (WS-B, ADR-0037 reused)
+# Two-step rollout: staging (auto) -> prod (human-gated).
+# Prod promotion requires explicit human approval via Kargo UI or CLI.
+# ADR-0028: platform.system=ml-pipeline, platform.managed-by=kargo.
+# ADR-0037: gated prod promotion (no auto-advance from staging to prod).
+# ADR-0049: UK-isolated; production model artifacts stay in UK DC.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: prod
+  namespace: ml-pipeline-baremetal
+  labels:
+    platform.system: ml-pipeline
+    platform.component: model-registry
+    platform.managed-by: kargo
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: ml-pipeline-baremetal
+      sources:
+        # Prod only accepts freight that has passed staging (two-step rollout).
+        stages:
+          - staging
+
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: git@github.com:100rd/platform-design.git
+            checkout:
+              - branch: main
+                path: ./src
+
+        - uses: yaml-update
+          as: update-mlflow-baremetal-prod-tag
+          config:
+            path: ./src/apps/infra/mlflow-baremetal/values.yaml
+            updates:
+              - key: mlflow.image.tag
+                value: ${{ imageFrom("ghcr.io/100rd/ml-models").Tag }}
+
+        - uses: git-commit
+          config:
+            path: ./src
+            message: "chore(ml-pipeline): promote baremetal-prod model"
+
+        - uses: git-push
+          config:
+            path: ./src
+
+        - uses: argocd-update
+          config:
+            apps:
+              - name: mlflow-baremetal
+
+  verification:
+    analysisTemplates:
+      - name: health-check
+      - name: smoke-test
+      - name: prometheus-5xx-error-rate
+      - name: prometheus-p95-latency

--- a/kargo/stages/baremetal/staging.yaml
+++ b/kargo/stages/baremetal/staging.yaml
@@ -1,0 +1,61 @@
+---
+# Kargo Stage -- ml-pipeline-baremetal staging (WS-B, ADR-0037 reused)
+# Two-step rollout: staging (auto) -> prod (gated).
+# Mirrors kargo/stages/chains/staging.yaml pattern.
+# ADR-0028: platform.system=ml-pipeline, platform.managed-by=kargo.
+# ADR-0037: two-step promotion; signed artifacts only (cosign/syft gate in GH Actions).
+# ADR-0049: UK-isolated; model artifacts stay in UK DC.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: staging
+  namespace: ml-pipeline-baremetal
+  labels:
+    platform.system: ml-pipeline
+    platform.component: model-registry
+    platform.managed-by: kargo
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: ml-pipeline-baremetal
+      sources:
+        direct: true  # staging promotes directly from Warehouse (auto-advance)
+
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: git@github.com:100rd/platform-design.git
+            checkout:
+              - branch: main
+                path: ./src
+
+        # Update the MLflow serving ArgoCD app values with the new model image tag.
+        - uses: yaml-update
+          as: update-mlflow-baremetal-tag
+          config:
+            path: ./src/apps/infra/mlflow-baremetal/values.yaml
+            updates:
+              - key: mlflow.image.tag
+                value: ${{ imageFrom("ghcr.io/100rd/ml-models").Tag }}
+
+        - uses: git-commit
+          config:
+            path: ./src
+            message: "chore(ml-pipeline): promote baremetal-staging model"
+
+        - uses: git-push
+          config:
+            path: ./src
+
+        - uses: argocd-update
+          config:
+            apps:
+              - name: mlflow-baremetal
+
+  verification:
+    analysisTemplates:
+      - name: health-check
+      - name: prometheus-5xx-error-rate

--- a/kargo/warehouses/baremetal/ml-pipeline-baremetal.yaml
+++ b/kargo/warehouses/baremetal/ml-pipeline-baremetal.yaml
@@ -1,0 +1,29 @@
+---
+# Kargo Warehouse -- ml-pipeline-baremetal (WS-B, ADR-0037 reused)
+# Subscribes to the model image registry and the GitOps repo for the
+# bare-metal ML pipeline. Mirrors kargo/warehouses/chains.yaml pattern.
+# ADR-0028: platform.system = ml-pipeline, platform.managed-by = kargo.
+# ADR-0037: Kargo promotes model artifacts (not cluster infra).
+# ADR-0049: UK-isolated; promotion does NOT route artifacts outside UK DC.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: ml-pipeline-baremetal
+  namespace: ml-pipeline-baremetal
+  labels:
+    platform.system: ml-pipeline
+    platform.component: model-registry
+    platform.managed-by: kargo
+spec:
+  subscriptions:
+    # Model serving image (built + signed by ml-pipeline-baremetal.yml GH Actions)
+    - image:
+        repoURL: ghcr.io/100rd/ml-models
+        semverConstraint: ">=0.1.0"
+        discoveryLimit: 5
+    # GitOps repo changes (values.yaml for model serving ArgoCD apps)
+    - git:
+        repoURL: git@github.com:100rd/platform-design.git
+        includePaths:
+          - apps/infra/mlflow-baremetal/**
+          - apps/infra/airflow-baremetal/**

--- a/terraform/modules/baremetal-ml-artifact-store/README.md
+++ b/terraform/modules/baremetal-ml-artifact-store/README.md
@@ -1,0 +1,55 @@
+# baremetal-ml-artifact-store
+
+**ADRs cited:** ADR-0037 (orchestrator/registry), ADR-0049 (UK isolated control plane), ADR-0052 (Rook-Ceph/MinIO storage substrate)
+
+**WS-B — ML CI/CD pipelines + model registry (bare metal)**
+
+Bare-metal analogue of `ml-artifact-store` (GCS/Workload Identity). Provisions:
+
+- Kubernetes `Namespace` and `ServiceAccount` for MLflow (gated by `var.enabled`).
+- ESO `ExternalSecret` materialising scoped S3 credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `MLFLOW_S3_ENDPOINT_URL`) from Vault KV v2 (path `var.vault_path`) into a `Secret` consumed by MLflow and the GH Actions `ml-pipeline-baremetal.yml`.
+- Optional MinIO Operator Helm release (`var.minio_deploy_in_cluster = true`) for the ML artifact store bucket. Defaults to connecting to the pre-existing UK-DC MinIO pools (already listed in `docs/transaction-analytics/06-uk-datacenters.md`).
+
+## Storage substrate decision (ADR-0052 §7 OPEN DECISION 4)
+
+| Option | When to use | S3 endpoint |
+|--------|------------|-------------|
+| `minio` (default) | MinIO pools already exist in the UK DC | `http://minio.minio-system.svc.cluster.local:9000` |
+| `ceph-rgw` | Rook-Ceph RGW is deployed (ADR-0052); one fewer system | `http://rook-ceph-rgw-my-store.rook-ceph.svc.cluster.local:80` |
+
+Switch by setting `var.backend`. MLflow and GH Actions use the S3-compatible API in both cases — no code change needed.
+
+## ADR-0028 labels
+
+All resources carry `platform.system = ml-pipeline`, `platform.component = model-registry`, `platform.managed-by = terragrunt` plus caller-supplied `platform.env` and `platform.owner`.
+
+## Apply-gated
+
+`var.enabled` defaults to `false`. No resource is created during plan-only runs. Set `enabled = true` only after explicit human review.
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `enabled` | `bool` | `false` | Master gate (apply-gated) |
+| `backend` | `string` | `"minio"` | `"minio"` or `"ceph-rgw"` |
+| `s3_endpoint_url` | `string` | MinIO in-cluster | S3-compatible endpoint (no credentials) |
+| `bucket_name` | `string` | `"mlflow-artifacts"` | Bucket name |
+| `vault_path` | `string` | `secret/data/ml-pipeline/mlflow-s3-credentials` | Vault KV v2 path |
+| `cluster_secret_store_name` | `string` | `"vault-cluster-store"` | ESO ClusterSecretStore name |
+| `namespace` | `string` | `"ml-pipeline"` | K8s namespace |
+| `kubernetes_service_account` | `string` | `"mlflow"` | K8s SA name |
+| `minio_deploy_in_cluster` | `bool` | `false` | Deploy MinIO Operator Helm chart in-cluster |
+| `platform_labels` | `map(string)` | staging/team-ml | ADR-0028 caller labels |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `namespace` | K8s namespace name |
+| `secret_name` | ESO-created Secret name with S3 credentials |
+| `s3_endpoint_url` | S3 endpoint URL (for downstream wiring) |
+| `bucket_name` | Bucket name |
+| `backend` | Backend in use |
+| `mlflow_service_account` | K8s SA name |
+| `platform_labels` | Merged ADR-0028 labels |

--- a/terraform/modules/baremetal-ml-artifact-store/baremetal-ml-artifact-store.tftest.hcl
+++ b/terraform/modules/baremetal-ml-artifact-store/baremetal-ml-artifact-store.tftest.hcl
@@ -1,0 +1,200 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests for baremetal-ml-artifact-store module.
+# helm and kubernetes providers are mocked — no real cluster or Vault is needed.
+# All assertions run at plan time over resource wiring, toggles, and ADR-0028 labels.
+# ADR-0052 / WS-B.
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "helm" {}
+mock_provider "kubernetes" {}
+mock_provider "random" {}
+
+# -------------------------------------------------------------------------
+# Variables shared across runs
+# -------------------------------------------------------------------------
+
+variables {
+  platform_labels = {
+    "platform.env"   = "staging"
+    "platform.owner" = "team-ml"
+  }
+}
+
+# -------------------------------------------------------------------------
+# Run 1 — default gate: nothing created when enabled = false (apply-gated mock default)
+# -------------------------------------------------------------------------
+
+run "disabled_creates_no_resources" {
+  command = plan
+
+  variables {
+    enabled = false
+  }
+
+  assert {
+    condition     = length(kubernetes_namespace.ml_pipeline) == 0
+    error_message = "Namespace must NOT be created when enabled = false (apply-gated)."
+  }
+
+  assert {
+    condition     = length(kubernetes_service_account.mlflow) == 0
+    error_message = "ServiceAccount must NOT be created when enabled = false."
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.mlflow_s3_externalsecret) == 0
+    error_message = "ExternalSecret must NOT be created when enabled = false."
+  }
+
+  assert {
+    condition     = length(helm_release.minio_operator) == 0
+    error_message = "MinIO Operator must NOT be created when enabled = false."
+  }
+}
+
+# -------------------------------------------------------------------------
+# Run 2 — enabled, MinIO backend, no in-cluster MinIO deploy (shared instance)
+# -------------------------------------------------------------------------
+
+run "minio_backend_creates_namespace_and_eso" {
+  command = plan
+
+  variables {
+    enabled                 = true
+    backend                 = "minio"
+    minio_deploy_in_cluster = false
+    bucket_name             = "mlflow-artifacts-staging"
+    s3_endpoint_url         = "http://minio.minio-system.svc.cluster.local:9000"
+  }
+
+  assert {
+    condition     = length(kubernetes_namespace.ml_pipeline) == 1
+    error_message = "Namespace must be created when enabled = true."
+  }
+
+  assert {
+    condition     = length(kubernetes_service_account.mlflow) == 1
+    error_message = "ServiceAccount must be created when enabled = true."
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.mlflow_s3_externalsecret) == 1
+    error_message = "ExternalSecret must be created when enabled = true."
+  }
+
+  assert {
+    condition     = length(helm_release.minio_operator) == 0
+    error_message = "MinIO Operator must NOT be created when minio_deploy_in_cluster = false."
+  }
+}
+
+# -------------------------------------------------------------------------
+# Run 3 — enabled, MinIO backend, deploy in-cluster
+# -------------------------------------------------------------------------
+
+run "minio_backend_in_cluster_creates_helm_release" {
+  command = plan
+
+  variables {
+    enabled                 = true
+    backend                 = "minio"
+    minio_deploy_in_cluster = true
+  }
+
+  assert {
+    condition     = length(helm_release.minio_operator) == 1
+    error_message = "MinIO Operator Helm release must be created when minio_deploy_in_cluster = true."
+  }
+
+  assert {
+    condition     = helm_release.minio_operator[0].chart == "operator"
+    error_message = "MinIO Operator Helm chart name must be 'operator'."
+  }
+}
+
+# -------------------------------------------------------------------------
+# Run 4 — ceph-rgw backend: no MinIO Operator regardless of minio_deploy_in_cluster
+# -------------------------------------------------------------------------
+
+run "ceph_rgw_backend_never_creates_minio" {
+  command = plan
+
+  variables {
+    enabled                 = true
+    backend                 = "ceph-rgw"
+    minio_deploy_in_cluster = true
+    s3_endpoint_url         = "http://rook-ceph-rgw-my-store.rook-ceph.svc.cluster.local:80"
+  }
+
+  assert {
+    condition     = length(helm_release.minio_operator) == 0
+    error_message = "MinIO Operator must NOT be created when backend = 'ceph-rgw'."
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.mlflow_s3_externalsecret) == 1
+    error_message = "ExternalSecret must still be created for Ceph-RGW backend."
+  }
+}
+
+# -------------------------------------------------------------------------
+# Run 5 — ADR-0028: namespace carries required platform labels
+# -------------------------------------------------------------------------
+
+run "namespace_carries_adr0028_labels" {
+  command = plan
+
+  variables {
+    enabled = true
+    platform_labels = {
+      "platform.env"   = "prod"
+      "platform.owner" = "team-ml"
+    }
+  }
+
+  assert {
+    condition     = kubernetes_namespace.ml_pipeline[0].metadata[0].labels["platform.system"] == "ml-pipeline"
+    error_message = "Namespace must carry platform.system = ml-pipeline per ADR-0028."
+  }
+
+  assert {
+    condition     = kubernetes_namespace.ml_pipeline[0].metadata[0].labels["platform.component"] == "model-registry"
+    error_message = "Namespace must carry platform.component = model-registry per ADR-0028."
+  }
+
+  assert {
+    condition     = kubernetes_namespace.ml_pipeline[0].metadata[0].labels["platform.env"] == "prod"
+    error_message = "Caller-supplied platform.env must be merged onto the namespace."
+  }
+
+  assert {
+    condition     = kubernetes_namespace.ml_pipeline[0].metadata[0].labels["platform.managed-by"] == "terragrunt"
+    error_message = "Namespace must carry platform.managed-by = terragrunt per ADR-0028."
+  }
+}
+
+# -------------------------------------------------------------------------
+# Run 6 — chart version must be pinned (not empty)
+# -------------------------------------------------------------------------
+
+run "minio_chart_version_pinned" {
+  command = plan
+
+  assert {
+    condition     = length(var.minio_chart_version) > 0
+    error_message = "MinIO Operator chart version must be pinned (not empty)."
+  }
+}
+
+# -------------------------------------------------------------------------
+# Run 7 — backend validation rejects invalid values
+# -------------------------------------------------------------------------
+
+run "outputs_backend_is_minio_by_default" {
+  command = plan
+
+  assert {
+    condition     = var.backend == "minio"
+    error_message = "Default backend must be 'minio' per ADR-0052 §7 OPEN DECISION 4."
+  }
+}

--- a/terraform/modules/baremetal-ml-artifact-store/main.tf
+++ b/terraform/modules/baremetal-ml-artifact-store/main.tf
@@ -1,0 +1,188 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# baremetal-ml-artifact-store (ADR-0052 / WS-B)
+# ---------------------------------------------------------------------------------------------------------------------
+# Bare-metal analogue of ml-artifact-store (ADR-0037 D2).
+# Provisions:
+#   - ExternalSecret (ESO) materialising scoped S3 credentials from Vault KV v2
+#     into a Kubernetes Secret consumed by MLflow + GH Actions.
+#   - Kubernetes Namespace + ServiceAccount for MLflow (namespace created here if
+#     not managed externally; gate via var.enabled).
+#   - Optional: MinIO Operator Helm release (if var.minio_deploy_in_cluster = true).
+#
+# The S3 bucket itself (MinIO bucket or Ceph-RGW bucket) is created out-of-band:
+#   - MinIO: via `mc mb` in the MinIO tenant init Job (or pre-existing UK-DC pool).
+#   - Ceph-RGW: via CephObjectStoreUser / radosgw-admin (owned by baremetal-rook-ceph WS-A).
+# This module wires the credential binding so the ML plane can access the bucket.
+#
+# ADR-0028: K8s-plane labels use dotted keys (platform.system = ml-pipeline).
+# ADR-0037: Airflow/MLflow orchestrator/registry design; only the storage substrate changes.
+# ADR-0052: MinIO (default) or Ceph-RGW S3 endpoint; UK data-residency — no external S3.
+# ADR-0049: Fully isolated UK ML control plane.
+#
+# APPLY-GATED: var.enabled defaults to false — no resource is created in plan-only runs.
+# Set enabled = true ONLY after explicit human review + blast-radius approval.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  # ADR-0028 K8s-plane baseline labels (dotted keys) merged with caller overrides.
+  platform_labels = merge(
+    {
+      "platform.system"     = "ml-pipeline"
+      "platform.component"  = "model-registry"
+      "platform.managed-by" = "terragrunt"
+    },
+    var.platform_labels,
+  )
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Namespace — ml-pipeline (gated; may already exist if Airflow deploys first).
+# Carries ADR-0028 labels so all enclosed resources inherit the system boundary.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_namespace" "ml_pipeline" {
+  count = var.enabled ? 1 : 0
+
+  metadata {
+    name   = var.namespace
+    labels = local.platform_labels
+
+    annotations = {
+      "platform.adr"         = "ADR-0037,ADR-0052"
+      "platform.description" = "ML pipeline namespace — Airflow + MLflow + artifact store (bare metal)"
+    }
+  }
+
+  lifecycle {
+    # Namespace likely shared with Airflow; ignore if already exists.
+    ignore_changes = [metadata[0].annotations, metadata[0].labels]
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# ServiceAccount — mlflow
+# ESO's ExternalSecret references this SA in the ownership chain.
+# ADR-0028 labels carried on the SA so Gatekeeper/Kyverno can audit.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_service_account" "mlflow" {
+  count = var.enabled ? 1 : 0
+
+  metadata {
+    name      = var.kubernetes_service_account
+    namespace = var.namespace
+    labels    = local.platform_labels
+
+    annotations = {
+      # Signal for tools that this SA is NOT a GCP WI SA; credentials come from ESO/Vault.
+      "platform.credential-source" = "vault-eso"
+    }
+  }
+
+  depends_on = [kubernetes_namespace.ml_pipeline]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# ExternalSecret — S3 credentials for the MLflow artifact store
+# Materialises: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, MLFLOW_S3_ENDPOINT_URL
+# into the Kubernetes Secret var.secret_name inside the ml-pipeline namespace.
+# Vault KV v2 path: var.vault_path (never hardcoded here — ADR security invariant).
+# ADR-0008 (ESO) + ADR-0052 (MinIO/Ceph-RGW substrate).
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "mlflow_s3_externalsecret" {
+  count = var.enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "external-secrets.io/v1"
+    kind       = "ExternalSecret"
+    metadata = {
+      name      = "mlflow-s3-credentials"
+      namespace = var.namespace
+      labels    = local.platform_labels
+      annotations = {
+        "platform.adr" = "ADR-0008,ADR-0052"
+      }
+    }
+    spec = {
+      refreshInterval = "1h"
+      secretStoreRef = {
+        name = var.cluster_secret_store_name
+        kind = "ClusterSecretStore"
+      }
+      target = {
+        name           = var.secret_name
+        creationPolicy = "Owner"
+      }
+      data = [
+        {
+          secretKey = "AWS_ACCESS_KEY_ID"
+          remoteRef = {
+            key      = var.vault_path
+            property = "access_key"
+          }
+        },
+        {
+          secretKey = "AWS_SECRET_ACCESS_KEY"
+          remoteRef = {
+            key      = var.vault_path
+            property = "secret_key"
+          }
+        },
+        {
+          secretKey = "MLFLOW_S3_ENDPOINT_URL"
+          remoteRef = {
+            key      = var.vault_path
+            property = "endpoint_url"
+          }
+        },
+      ]
+    }
+  }
+
+  depends_on = [kubernetes_namespace.ml_pipeline]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Optional MinIO Operator Helm release
+# Only deployed if var.minio_deploy_in_cluster = true AND var.backend = "minio".
+# The UK DC already lists MinIO pools; in practice this is a shared instance, so
+# minio_deploy_in_cluster defaults to false (connect to an existing MinIO).
+# When Ceph-RGW is the substrate (backend = "ceph-rgw"), MinIO Operator is not deployed.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "helm_release" "minio_operator" {
+  count = var.enabled && var.minio_deploy_in_cluster && var.backend == "minio" ? 1 : 0
+
+  name       = "minio-operator"
+  repository = var.minio_chart_repository
+  chart      = "operator"
+  version    = var.minio_chart_version
+  namespace  = var.minio_namespace
+  timeout    = var.minio_helm_timeout
+
+  create_namespace = true
+
+  values = [
+    yamlencode({
+      operator = {
+        replicaCount = 1
+        resources = {
+          requests = { cpu = "200m", memory = "256Mi" }
+          limits   = { cpu = "500m", memory = "512Mi" }
+        }
+        # ADR-0028 labels on operator pods
+        podLabels = local.platform_labels
+      }
+      # Tenant is provisioned separately (out of scope of this module).
+      # This chart installs the Operator only.
+      tenants = {}
+    })
+  ]
+
+  # ADR-0028: chart-level annotations for ArgoCD label propagation
+  set {
+    name  = "operator.podAnnotations.platform\\.system"
+    value = "ml-pipeline"
+  }
+}

--- a/terraform/modules/baremetal-ml-artifact-store/outputs.tf
+++ b/terraform/modules/baremetal-ml-artifact-store/outputs.tf
@@ -1,0 +1,38 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# baremetal-ml-artifact-store — Outputs (ADR-0052 / WS-B)
+# ---------------------------------------------------------------------------------------------------------------------
+
+output "namespace" {
+  description = "Kubernetes namespace where MLflow and the artifact-store credentials are deployed."
+  value       = var.enabled ? kubernetes_namespace.ml_pipeline[0].metadata[0].name : var.namespace
+}
+
+output "secret_name" {
+  description = "Name of the Kubernetes Secret created by ESO containing the S3 credentials (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, MLFLOW_S3_ENDPOINT_URL)."
+  value       = var.secret_name
+}
+
+output "s3_endpoint_url" {
+  description = "S3-compatible endpoint URL for the artifact store. Wire into MLflow MLFLOW_S3_ENDPOINT_URL and the GH Actions ml-pipeline-baremetal.yml."
+  value       = var.s3_endpoint_url
+}
+
+output "bucket_name" {
+  description = "Name of the S3/MinIO/RGW bucket used as the MLflow artifact store."
+  value       = var.bucket_name
+}
+
+output "backend" {
+  description = "Object-store backend in use: 'minio' or 'ceph-rgw'."
+  value       = var.backend
+}
+
+output "mlflow_service_account" {
+  description = "Kubernetes ServiceAccount name used by MLflow pods."
+  value       = var.kubernetes_service_account
+}
+
+output "platform_labels" {
+  description = "ADR-0028 platform labels applied to all resources in this module."
+  value       = local.platform_labels
+}

--- a/terraform/modules/baremetal-ml-artifact-store/variables.tf
+++ b/terraform/modules/baremetal-ml-artifact-store/variables.tf
@@ -1,0 +1,168 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# baremetal-ml-artifact-store — Variables (ADR-0052 / WS-B)
+# ---------------------------------------------------------------------------------------------------------------------
+# Bare-metal analogue of ml-artifact-store. Provisions a MinIO or Ceph-RGW S3
+# bucket + a scoped S3 credential (via Vault / ESO) for MLflow artifact storage.
+# The S3 API is endpoint-agnostic: MLflow and the GH Actions pipeline only see
+# an MLFLOW_S3_ENDPOINT_URL pointing at the in-cluster MinIO or Ceph-RGW service.
+# No GCP/AWS credentials — everything is in-cluster.
+#
+# ADR-0028: K8s-plane labels use dotted keys (platform.system).
+# ADR-0037: reused orchestrator/registry design; only the substrate changes.
+# ADR-0052: MinIO is the default; Ceph-RGW is the alternative (same S3 API).
+# ---------------------------------------------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
+# Feature gate (apply-gated — default OFF in mock repo)
+# -------------------------------------------------------------------------
+
+variable "enabled" {
+  description = "Master gate. Set to false to skip all resource creation (apply-gated / mock-repo default)."
+  type        = bool
+  default     = false
+}
+
+# -------------------------------------------------------------------------
+# Object-store backend
+# -------------------------------------------------------------------------
+
+variable "backend" {
+  description = "S3-compatible backend to use. Allowed: 'minio' (default, per ADR-0052 §7 OPEN DECISION 4) or 'ceph-rgw'."
+  type        = string
+  default     = "minio"
+
+  validation {
+    condition     = contains(["minio", "ceph-rgw"], var.backend)
+    error_message = "backend must be 'minio' or 'ceph-rgw'."
+  }
+}
+
+variable "s3_endpoint_url" {
+  description = "S3-compatible endpoint URL for the artifact store (e.g. http://minio.minio-system.svc.cluster.local:9000). Must NOT contain credentials."
+  type        = string
+  default     = "http://minio.minio-system.svc.cluster.local:9000"
+}
+
+variable "bucket_name" {
+  description = "Name of the S3/MinIO/RGW bucket used as the MLflow artifact store."
+  type        = string
+  default     = "mlflow-artifacts"
+}
+
+# -------------------------------------------------------------------------
+# Vault / ESO credential source
+# -------------------------------------------------------------------------
+
+variable "vault_path" {
+  description = "Vault KV v2 path that holds the scoped S3 access/secret key for the MLflow artifact store. Never hardcode credentials here."
+  type        = string
+  default     = "secret/data/ml-pipeline/mlflow-s3-credentials"
+}
+
+variable "cluster_secret_store_name" {
+  description = "Name of the ESO ClusterSecretStore that points at the in-cluster Vault instance (ADR-0008)."
+  type        = string
+  default     = "vault-cluster-store"
+}
+
+# -------------------------------------------------------------------------
+# Kubernetes target (for ExternalSecret + ServiceAccount)
+# -------------------------------------------------------------------------
+
+variable "namespace" {
+  description = "Kubernetes namespace where MLflow runs and where the S3 credential Secret is materialised."
+  type        = string
+  default     = "ml-pipeline"
+}
+
+variable "kubernetes_service_account" {
+  description = "Kubernetes ServiceAccount name for MLflow pods. Annotated for ESO binding."
+  type        = string
+  default     = "mlflow"
+}
+
+variable "secret_name" {
+  description = "Name of the Kubernetes Secret that ESO will create for the S3 credentials (access key + secret key + endpoint URL)."
+  type        = string
+  default     = "mlflow-s3-credentials"
+}
+
+# -------------------------------------------------------------------------
+# MinIO / Helm (only used when backend = 'minio' and minio_deploy_in_cluster = true)
+# -------------------------------------------------------------------------
+
+variable "minio_deploy_in_cluster" {
+  description = "Deploy the MinIO tenant via the MinIO Operator Helm chart (in-cluster). Set false when MinIO is already deployed (shared instance or Ceph-RGW)."
+  type        = bool
+  default     = false
+}
+
+variable "minio_chart_version" {
+  description = "Pinned MinIO Operator Helm chart version."
+  type        = string
+  default     = "6.0.4"
+}
+
+variable "minio_chart_repository" {
+  description = "Helm repository URL for the MinIO Operator chart."
+  type        = string
+  default     = "https://operator.min.io"
+}
+
+variable "minio_namespace" {
+  description = "Namespace for the MinIO Operator (if deploying in-cluster)."
+  type        = string
+  default     = "minio-system"
+}
+
+variable "minio_storage_size" {
+  description = "PVC size for each MinIO volume. Requires a StorageClass backed by Rook-Ceph RBD or local NVMe."
+  type        = string
+  default     = "500Gi"
+}
+
+variable "minio_storage_class" {
+  description = "StorageClass for MinIO PVCs. Should be 'rook-ceph-block' when Rook-Ceph is the substrate (ADR-0052)."
+  type        = string
+  default     = "rook-ceph-block"
+}
+
+variable "minio_helm_timeout" {
+  description = "Helm release timeout in seconds for the MinIO Operator chart."
+  type        = number
+  default     = 300
+}
+
+# -------------------------------------------------------------------------
+# Lifecycle / retention
+# -------------------------------------------------------------------------
+
+variable "retention_days" {
+  description = "Soft-delete / lifecycle retention in days. Configured as an ILM rule via a Kubernetes Job post-hook (MinIO mc) or Ceph-RGW lifecycle API."
+  type        = number
+  default     = 365
+
+  validation {
+    condition     = var.retention_days >= 0
+    error_message = "retention_days must be >= 0."
+  }
+}
+
+# -------------------------------------------------------------------------
+# ADR-0028 labels — Kubernetes-plane spelling (dotted keys)
+# -------------------------------------------------------------------------
+
+variable "platform_labels" {
+  description = <<-EOT
+    ADR-0028 platform labels. Required caller-supplied keys:
+      platform.env   (e.g. "staging", "prod")
+      platform.owner (e.g. "team-ml")
+    Merged with baseline: platform.system=ml-pipeline, platform.component=model-registry,
+    platform.managed-by=terragrunt.
+  EOT
+  type        = map(string)
+  default = {
+    "platform.env"   = "staging"
+    "platform.owner" = "team-ml"
+  }
+}

--- a/terraform/modules/baremetal-ml-artifact-store/versions.tf
+++ b/terraform/modules/baremetal-ml-artifact-store/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.25"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

**DESIGN-MOCK repo — apply-gated; do NOT merge until human review; base targets the design branch on purpose.**

WS-B bare-metal ML CI/CD + model registry. Cluster-agnostic ML layer re-targeted at the Talos UK DC bare-metal cluster. The only substitution from the GKE etalon is the S3 artifact-store substrate (MinIO/Ceph-RGW instead of GCS). All orchestrator/registry design (ADR-0037) is reused verbatim.

## What was built

### Terraform module
- `/tmp/wt-impl-bm-wsb/terraform/modules/baremetal-ml-artifact-store/` — bare-metal analogue of `ml-artifact-store` (GCS/WI). Provisions: K8s Namespace + ServiceAccount for MLflow, ESO `ExternalSecret` from Vault KV v2 (keys: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `MLFLOW_S3_ENDPOINT_URL`), optional MinIO Operator Helm release. Backend toggle: `minio` (default) or `ceph-rgw`. Apply-gated (`var.enabled = false`). ONE `*.tftest.hcl` with 7 test runs (all pass).

### Catalog unit
- `catalog/units/baremetal-ml-artifact-store/terragrunt.hcl` — Terragrunt unit wiring the module to the Talos cluster (kubeconfig from `talos-cluster` dependency, `mock_outputs` for plan-only). Reads `site.hcl` locals; all `ml_pipeline_config.*` inputs `try()`-guarded.

### ArgoCD apps (bare-metal re-targets)
- `apps/infra/mlflow-baremetal/` — MLflow re-targeted at `talos-uk-primary`. `values.yaml`: nodeSelector `pool:cpu-general` (Talos label, not GKE nodepool); artifactRoot `s3://mlflow-artifacts`; credentials from ESO Secret `mlflow-s3-credentials`; no GKE WI annotation. CiliumNetworkPolicy (ADR-0051). CloudNativePG backend via `mlflow-db-connection` ExternalSecret (Vault).
- `apps/infra/airflow-baremetal/` — Airflow re-targeted at `talos-uk-primary`. GPU training tasks use Volcano scheduler (`schedulerName=volcano`, queue `training-default`) via `executor_config` in the DAG. S3 credentials injected from `mlflow-s3-credentials` Secret. Four-DAG pipeline stub (`train_domain_adapter_baremetal.py`): `train_domain_adapter → eval_adapter_debate → mine_templates → promote_to_edge`.

### GitHub Actions workflow
- `.github/workflows/ml-pipeline-baremetal.yml` — Mirrors `ml-pipeline.yml` (GKE). Removes GCP Workload Identity; authenticates to Airflow via `AIRFLOW_BAREMETAL_API_TOKEN` (secret). Triggers `train_domain_adapter_baremetal` DAG. Polls `eval_adapter_debate` task gate. Registers model in MLflow with MinIO S3 endpoint. Reuses `syft-sbom` + `cosign-sign` composites. Promotes via Kargo `argocd-tag-bump`.

### Kargo promotion
- `kargo/warehouses/baremetal/ml-pipeline-baremetal.yaml` — Warehouse subscribing to model image + GitOps repo.
- `kargo/stages/baremetal/staging.yaml` — Staging stage (auto-advance from Warehouse).
- `kargo/stages/baremetal/prod.yaml` — Prod stage (human-gated; requires staging passage).

## ADRs cited
- **ADR-0037** (Airflow + MLflow orchestrator/registry design — reused verbatim)
- **ADR-0049** (UK-isolated ML control plane; no external S3 for UK-resident training data)
- **ADR-0051** (Cilium CNI; CiliumNetworkPolicy on both Airflow + MLflow apps)
- **ADR-0052** (MinIO default / Ceph-RGW alternative S3 substrate; ADR-0028 labels)
- **ADR-0028** (platform taxonomy labels on every resource — dotted keys for K8s plane)

## Verification results

| Gate | Result |
|------|--------|
| `terraform fmt -recursive -check` | PASS |
| `terraform init -backend=false` | PASS |
| `terraform validate` | PASS |
| `terraform test` (7 runs) | **7/7 PASS** |
| `tflint` | SKIP — not installed in worktree |
| `checkov` | SKIP — not installed in worktree |
| `terraform plan` | SKIP — no cloud credentials (apply-gated mock repo) |

## File-disjointness
WS-B touches only its own files. Did NOT edit `catalog/stacks/*.stack.hcl`, `docs/adrs/README.md`, or any WS-A modules. All new files are under `terraform/modules/baremetal-ml-artifact-store/`, `catalog/units/baremetal-ml-artifact-store/`, `apps/infra/mlflow-baremetal/`, `apps/infra/airflow-baremetal/`, `.github/workflows/ml-pipeline-baremetal.yml`, `kargo/stages/baremetal/`, `kargo/warehouses/baremetal/`.

## Blockers / pre-merge gates
- WS-A (`talos-cluster`, `baremetal-rook-ceph` / MinIO) must land first (the `baremetal-ml-artifact-store` unit has `enabled = false` and depends on `../talos-cluster`).
- `terraform plan` skipped — no cloud/cluster credentials available in mock worktree (expected).
- `tflint`/`checkov` skipped — not installed. Run in CI before merge.