### PR TITLE
feat(aws-wsB): AWS ML CI/CD + MLflow registry

### DIFF
--- a/.github/workflows/ml-pipeline-aws.yml
+++ b/.github/workflows/ml-pipeline-aws.yml
@@ -1,0 +1,184 @@
+# ML training/release pipeline — WS-B (ADR-0048 D1/D4/D5), AWS backend.
+#
+# AWS delta from .github/workflows/ml-pipeline.yml (GCP):
+#   - Authentication: aws-actions/configure-aws-credentials (OIDC, ADR-0018)
+#     instead of google-github-actions/auth (GCP WIF)
+#   - Container registry: ECR (ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com)
+#     via pull-through cache (ADR-0029 / ADR-0048 D5)
+#   - ML logic (train->eval->gate->register->deploy topology, DAG names, gate
+#     polling, MLflow register call, cosign/syft signing, Kargo promotion) is
+#     IDENTICAL to ml-pipeline.yml — ADR-0048 D6 scope guard (cluster-agnostic).
+#
+# platform:system = ml-pipeline (ADR-0028).
+name: ML Pipeline (AWS)
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Model/adapter id to train and release (e.g. fraud-uk)"
+        required: true
+        type: string
+      environment:
+        description: "Target environment for the staged deploy"
+        required: true
+        default: dev
+        type: choice
+        options: [dev, staging, prod]
+  push:
+    branches: [main]
+    paths:
+      - "models/**"
+      - "adapters/**"
+
+permissions:
+  contents: read
+  id-token: write  # AWS OIDC token + cosign keyless signing
+
+concurrency:
+  group: ml-pipeline-aws-${{ github.ref }}-${{ inputs.model || github.sha }}
+  cancel-in-progress: false
+
+env:
+  AIRFLOW_BASE_URL: ${{ vars.AIRFLOW_BASE_URL }}
+  MLFLOW_TRACKING_URI: ${{ vars.MLFLOW_TRACKING_URI }}
+  MODEL_ID: ${{ inputs.model || 'auto' }}
+  # ECR registry endpoint — pull-through cache (ADR-0029 / ADR-0048 D5).
+  ECR_REGISTRY: ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com
+  ML_IMAGE_REPO: ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/ml
+
+jobs:
+  train:
+    name: Train (Airflow train_domain_adapter)
+    runs-on: ubuntu-latest
+    outputs:
+      run_id: ${{ steps.trigger.outputs.run_id }}
+    steps:
+      - name: Harden runner (audit)
+        uses: ./.github/actions/harden-runner
+
+      - uses: actions/checkout@v4
+
+      # AWS OIDC authentication replaces GCP Workload Identity Federation.
+      # IAM role scoped to this repo via GitHub OIDC conditions (ADR-0018).
+      - name: Authenticate to AWS (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_CI_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      # Airflow REST call is cluster-agnostic — identical to ml-pipeline.yml.
+      - name: Trigger train_domain_adapter DAG
+        id: trigger
+        env:
+          AIRFLOW_TOKEN: ${{ secrets.AIRFLOW_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          run_id="ci-${MODEL_ID}-${GITHUB_SHA::8}"
+          curl -fsS -X POST "${AIRFLOW_BASE_URL}/api/v1/dags/train_domain_adapter/dagRuns" \
+            -H "Authorization: Bearer ${AIRFLOW_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"dag_run_id\":\"${run_id}\",\"conf\":{\"model_id\":\"${MODEL_ID}\"}}"
+          echo "run_id=${run_id}" >> "$GITHUB_OUTPUT"
+
+  eval:
+    name: Evaluate (eval_adapter_debate gate)
+    needs: train
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner (audit)
+        uses: ./.github/actions/harden-runner
+
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to AWS (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_CI_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      # eval gate logic is cluster-agnostic — identical to ml-pipeline.yml.
+      - name: Wait for eval gate (eval_adapter_debate must pass)
+        env:
+          AIRFLOW_TOKEN: ${{ secrets.AIRFLOW_API_TOKEN }}
+          RUN_ID: ${{ needs.train.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 40); do
+            state=$(curl -fsS \
+              -H "Authorization: Bearer ${AIRFLOW_TOKEN}" \
+              "${AIRFLOW_BASE_URL}/api/v1/dags/eval_adapter_debate/dagRuns/${RUN_ID}" \
+              | python3 -c 'import json,sys; print(json.load(sys.stdin).get("state",""))')
+            case "${state}" in
+              success) echo "eval gate passed"; exit 0 ;;
+              failed)  echo "::error::eval_adapter_debate gate failed"; exit 1 ;;
+              *)       echo "eval state=${state:-pending}; waiting"; sleep 30 ;;
+            esac
+          done
+          echo "::error::eval gate timed out"; exit 1
+
+  register:
+    name: Register model + sign artifacts (ECR)
+    needs: eval
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner (audit)
+        uses: ./.github/actions/harden-runner
+
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to AWS (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_CI_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      # Log in to ECR pull-through cache registry (ADR-0029 / ADR-0048 D5).
+      - name: Login to ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      # MLflow register call is cluster-agnostic — identical to ml-pipeline.yml.
+      - name: Register model version in MLflow (-> Staging)
+        run: |
+          set -euo pipefail
+          pip install --quiet "mlflow>=2.16"
+          mlflow models create-version \
+            --name "${MODEL_ID}" \
+            --source "${MLFLOW_TRACKING_URI}/artifacts/${MODEL_ID}/${GITHUB_SHA}" || true
+
+      # Reuse the repo's supply-chain composites (ADR-0037 D4 / ADR-0048 D5).
+      - name: Generate SBOM
+        uses: ./.github/actions/syft-sbom
+        with:
+          image: ${{ env.ML_IMAGE_REPO }}/${{ env.MODEL_ID }}:${{ github.sha }}
+
+      - name: Sign + attest (cosign keyless)
+        uses: ./.github/actions/cosign-sign
+        with:
+          image: ${{ env.ML_IMAGE_REPO }}/${{ env.MODEL_ID }}:${{ github.sha }}
+
+  deploy:
+    name: Staged deploy (Kargo promotion)
+    needs: register
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment || 'dev' }}
+    steps:
+      - name: Harden runner (audit)
+        uses: ./.github/actions/harden-runner
+
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to AWS (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_CI_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      # Kargo promotion is cluster-agnostic — identical to ml-pipeline.yml.
+      - name: Open Kargo promotion (dev auto / staging+prod gated)
+        uses: ./.github/actions/argocd-tag-bump
+        with:
+          app: mlflow-serving-${{ env.MODEL_ID }}
+          tag: ${{ github.sha }}
+          environment: ${{ inputs.environment || 'dev' }}

--- a/apps/infra/airflow-aws/Chart.yaml
+++ b/apps/infra/airflow-aws/Chart.yaml
@@ -1,0 +1,38 @@
+apiVersion: v2
+name: airflow-aws
+description: >-
+  Apache Airflow 2.9 on EKS — ML pipeline orchestrator for the
+  train_domain_adapter -> eval_adapter_debate -> mine_templates -> promote_to_edge
+  DAG chain on the greenfield AWS EKS GPU ML cluster. KubernetesExecutor; task
+  pods scheduled via Volcano (ADR-0044 D3); control plane on a non-GPU Graviton
+  Karpenter pool (ADR-0046 D3). EKS Pod Identity provides credential-less AWS
+  Secrets Manager access (ADR-0018). ADR-0048 D1 + ADR-0037 (cluster-agnostic
+  ML logic inherited unchanged).
+type: application
+version: 1.0.0
+appVersion: "2.9.3"
+
+keywords:
+  - airflow
+  - ml-pipeline
+  - orchestrator
+  - eks
+  - aws
+
+maintainers:
+  - name: Platform Team
+    email: platform@example.com
+
+annotations:
+  category: ML Platform
+  platform: Kubernetes
+  adr: "0048"
+
+dependencies:
+  # Apache Airflow — official Helm chart
+  # https://airflow.apache.org/docs/helm-chart/
+  # Pinned to 1.15.x (Airflow 2.9); bump after staging validation.
+  - name: airflow
+    version: "1.15.0"
+    repository: https://airflow.apache.org
+    condition: airflow.enabled

--- a/apps/infra/airflow-aws/templates/argocd-app.yaml
+++ b/apps/infra/airflow-aws/templates/argocd-app.yaml
@@ -1,0 +1,183 @@
+---
+# ArgoCD Application — Apache Airflow on EKS (ADR-0048 D1)
+# Delivers the Airflow Helm chart to the AWS EKS GPU ML cluster.
+# Inherits the ADR-0037 shape; AWS deltas: cluster destination + SA annotation.
+# ADR-0028: namespace carries platform.system=ml-pipeline labels.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: airflow-aws
+  namespace: argocd
+  labels:
+    platform.system: ml-pipeline
+    platform.component: airflow
+    platform.managed-by: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "15"
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: ml-pipeline-alerts
+    notifications.argoproj.io/subscribe.on-health-degraded.slack: ml-pipeline-alerts
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/100rd/platform-design.git
+    targetRevision: HEAD
+    path: apps/infra/airflow-aws
+
+    helm:
+      values: |
+        airflow:
+          serviceAccount:
+            annotations:
+              # IAM role ARN from aws-ml-artifact-store unit output.
+              # Populated via ArgoCD Application parameter override at deploy time.
+              eks.amazonaws.com/role-arn: ""
+
+  destination:
+    # AWS EKS GPU ML cluster registered in ArgoCD as "eks-ml-primary" (ADR-0044).
+    name: eks-ml-primary
+    namespace: ml-pipeline
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ApplyOutOfSyncOnly=true
+    managedNamespaceMetadata:
+      labels:
+        platform.system: ml-pipeline
+        platform.component: airflow
+        platform.env: staging
+        platform.owner: team-ml
+        platform.managed-by: argocd
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+---
+# ExternalSecret — Airflow DB connection (RDS PostgreSQL via AWS Secrets Manager)
+# ESO v1 / ClusterSecretStore aws-secrets-manager (ADR-0008 / ADR-0048 D3).
+# Shape: postgresql+psycopg2://airflow:<password>@<rds-host>:5432/airflow
+# RDS provisioned out-of-band by DBA team (ADR-0048 D3); no credentials in code.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: airflow-metadata-connection
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: airflow
+    app.kubernetes.io/component: metadata-db
+    app.kubernetes.io/managed-by: helm
+    platform.system: ml-pipeline
+    platform.component: airflow
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+
+  target:
+    name: airflow-metadata-connection
+    creationPolicy: Owner
+
+  data:
+    - secretKey: connection
+      remoteRef:
+        key: /ml-pipeline/airflow-db-connection
+        property: connection
+---
+# ExternalSecret — Airflow Fernet key
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: airflow-fernet-key
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: airflow
+    app.kubernetes.io/component: fernet-key
+    app.kubernetes.io/managed-by: helm
+    platform.system: ml-pipeline
+    platform.component: airflow
+spec:
+  refreshInterval: 24h
+
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+
+  target:
+    name: airflow-fernet-key
+    creationPolicy: Owner
+
+  data:
+    - secretKey: fernet-key
+      remoteRef:
+        key: /ml-pipeline/airflow-fernet-key
+        property: fernet-key
+---
+# ExternalSecret — git-sync SSH key
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: airflow-git-sync-ssh
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: airflow
+    app.kubernetes.io/component: git-sync
+    app.kubernetes.io/managed-by: helm
+    platform.system: ml-pipeline
+    platform.component: airflow
+spec:
+  refreshInterval: 24h
+
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+
+  target:
+    name: airflow-git-sync-ssh
+    creationPolicy: Owner
+
+  data:
+    - secretKey: gitSshKey
+      remoteRef:
+        key: /ml-pipeline/airflow-git-sync-ssh
+        property: gitSshKey
+---
+# ExternalSecret — MLflow tracking URI (so Airflow task pods can call mlflow.log_metric)
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mlflow-tracking-uri
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: airflow
+    app.kubernetes.io/component: mlflow-ref
+    app.kubernetes.io/managed-by: helm
+    platform.system: ml-pipeline
+    platform.component: airflow
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+
+  target:
+    name: mlflow-tracking-uri
+    creationPolicy: Owner
+
+  data:
+    - secretKey: uri
+      remoteRef:
+        key: /ml-pipeline/mlflow-tracking-uri
+        property: uri
+---
+# NetworkPolicy stub — Airflow on EKS (ADR-0048 D1)
+# Full CiliumNetworkPolicy tracked in network-policies/ml-pipeline/
+# per network-policies/gpu-inference/00-default-deny.yaml pattern.

--- a/apps/infra/airflow-aws/values.yaml
+++ b/apps/infra/airflow-aws/values.yaml
@@ -1,0 +1,209 @@
+# Apache Airflow on EKS — ML pipeline orchestrator (ADR-0048 D1, inheriting ADR-0037)
+# platform:system = ml-pipeline, component = airflow
+#
+# AWS deltas from apps/infra/airflow/ (GCP):
+#   - nodeSelector: kubernetes.io/arch=arm64 + karpenter.sh/nodepool=ml-graviton
+#     (non-GPU Graviton pool, plan §7 OD-7 / ADR-0046 D3 / R2 mitigation)
+#   - serviceAccount annotation: eks.amazonaws.com/role-arn (Pod Identity, ADR-0018)
+#     instead of iam.gke.io/gcp-service-account
+#   - ESO ClusterSecretStore: aws-secrets-manager (not gcp-secrets-manager)
+#   - Task pods use schedulerName: volcano via executor_config in DAG definition
+#
+# ML logic (DAGs, executors, gate thresholds) is IDENTICAL to apps/infra/airflow/
+# — ADR-0048 D6 scope guard (cluster-agnostic ML layer inherited from ADR-0037).
+
+networkPolicy:
+  enabled: true
+
+airflow:
+  enabled: true
+
+  # -------------------------------------------------------------------------
+  # Executor
+  # -------------------------------------------------------------------------
+  executor: KubernetesExecutor
+
+  # -------------------------------------------------------------------------
+  # Images — pulled through ECR pull-through cache (ADR-0029 / ADR-0048 D5).
+  # -------------------------------------------------------------------------
+  images:
+    airflow:
+      repository: apache/airflow
+      tag: "2.9.3-python3.11"
+      pullPolicy: IfNotPresent
+
+  # -------------------------------------------------------------------------
+  # DAG delivery via gitSync sidecar — unchanged from ADR-0037.
+  # -------------------------------------------------------------------------
+  dags:
+    persistence:
+      enabled: false
+    gitSync:
+      enabled: true
+      repo: https://github.com/100rd/platform-design.git
+      branch: main
+      rev: HEAD
+      subPath: apps/infra/airflow/dags
+      sshKeySecret: airflow-git-sync-ssh
+
+  # -------------------------------------------------------------------------
+  # KubernetesExecutor config
+  # GPU training task pods: add schedulerName=volcano via executor_config in
+  # the DAG definition (cluster-agnostic pattern inherited from ADR-0037).
+  # -------------------------------------------------------------------------
+  config:
+    kubernetes:
+      namespace: ml-pipeline
+      delete_worker_pods: "True"
+      delete_worker_pods_on_failure: "False"
+
+  # -------------------------------------------------------------------------
+  # Scheduler — non-GPU Graviton Karpenter pool (ADR-0046 D3 / plan §7 OD-7).
+  # -------------------------------------------------------------------------
+  scheduler:
+    replicas: 1
+
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: "2"
+        memory: 2Gi
+
+    nodeSelector:
+      kubernetes.io/arch: arm64
+      karpenter.sh/nodepool: ml-graviton
+
+    livenessProbe:
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      failureThreshold: 5
+
+    readinessProbe:
+      initialDelaySeconds: 20
+      periodSeconds: 20
+
+    podDisruptionBudget:
+      enabled: true
+      config:
+        minAvailable: 1
+
+    labels:
+      platform.system: ml-pipeline
+      platform.component: airflow
+      platform.managed-by: argocd
+
+    podAnnotations:
+      platform.system: ml-pipeline
+
+  # -------------------------------------------------------------------------
+  # Webserver — Graviton pool.
+  # -------------------------------------------------------------------------
+  webserver:
+    replicas: 1
+
+    resources:
+      requests:
+        cpu: 300m
+        memory: 512Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi
+
+    nodeSelector:
+      kubernetes.io/arch: arm64
+      karpenter.sh/nodepool: ml-graviton
+
+    labels:
+      platform.system: ml-pipeline
+      platform.component: airflow
+      platform.managed-by: argocd
+
+  # -------------------------------------------------------------------------
+  # Workers (KubernetesExecutor task pod template).
+  # -------------------------------------------------------------------------
+  workers:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: "4"
+        memory: 8Gi
+
+    labels:
+      platform.system: ml-pipeline
+      platform.component: airflow
+      platform.managed-by: argocd
+
+  # -------------------------------------------------------------------------
+  # Triggerer — Graviton pool.
+  # -------------------------------------------------------------------------
+  triggerer:
+    enabled: true
+    replicas: 1
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+    nodeSelector:
+      kubernetes.io/arch: arm64
+      karpenter.sh/nodepool: ml-graviton
+
+  # -------------------------------------------------------------------------
+  # Database — dedicated RDS PostgreSQL via ESO ExternalSecret (ADR-0048 D3).
+  # Connection injected from aws-secrets-manager ClusterSecretStore; shape:
+  # postgresql+psycopg2://airflow:<password>@<rds-host>:5432/airflow
+  # RDS provisioned out-of-band by DBA team.
+  # -------------------------------------------------------------------------
+  data:
+    metadataSecretName: airflow-metadata-connection
+
+  fernetKeySecretName: airflow-fernet-key
+
+  # -------------------------------------------------------------------------
+  # ServiceAccount — EKS Pod Identity (ADR-0018).
+  # The IAM role ARN is set per-cluster via ArgoCD Application parameter.
+  # -------------------------------------------------------------------------
+  serviceAccount:
+    create: true
+    name: airflow
+    annotations:
+      # Set by ArgoCD Application parameter override.
+      # Value: ARN from catalog/units/aws-ml-artifact-store output
+      # mlflow_pod_identity_role_arn (re-used for airflow access to same S3 bucket).
+      eks.amazonaws.com/role-arn: ""
+
+  postgresql:
+    enabled: false
+
+  redis:
+    enabled: false
+
+  statsd:
+    enabled: true
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+
+  extraEnv:
+    - name: AIRFLOW__CORE__LOAD_EXAMPLES
+      value: "False"
+    - name: AIRFLOW__WEBSERVER__EXPOSE_CONFIG
+      value: "False"
+    # MLflow tracking URI from ESO ExternalSecret (aws-secrets-manager).
+    - name: MLFLOW_TRACKING_URI
+      valueFrom:
+        secretKeyRef:
+          name: mlflow-tracking-uri
+          key: uri

--- a/apps/infra/mlflow-aws/Chart.yaml
+++ b/apps/infra/mlflow-aws/Chart.yaml
@@ -1,0 +1,36 @@
+apiVersion: v2
+name: mlflow-aws
+description: >-
+  MLflow tracking server + Model Registry on EKS — ML model versioning and
+  artifact storage for the train->eval->gate->deploy pipeline. S3 artifact store
+  + dedicated RDS PostgreSQL backend. HA 2-replica deployment. EKS Pod Identity
+  provides credential-less S3 access (ADR-0018). ADR-0048 D2/D3 + ADR-0037
+  (cluster-agnostic ML logic inherited unchanged).
+type: application
+version: 1.0.0
+appVersion: "2.21.3"
+
+keywords:
+  - mlflow
+  - model-registry
+  - ml-pipeline
+  - s3
+  - aws
+
+maintainers:
+  - name: Platform Team
+    email: platform@example.com
+
+annotations:
+  category: ML Platform
+  platform: Kubernetes
+  adr: "0048"
+
+dependencies:
+  # community-charts MLflow Helm chart
+  # https://github.com/community-charts/helm-charts/tree/main/charts/mlflow
+  # Pinned to 1.4.x (MLflow 2.21.x); bump after staging validation.
+  - name: mlflow
+    version: "1.4.1"
+    repository: https://community-charts.github.io/helm-charts
+    condition: mlflow.enabled

--- a/apps/infra/mlflow-aws/templates/argocd-app.yaml
+++ b/apps/infra/mlflow-aws/templates/argocd-app.yaml
@@ -1,0 +1,101 @@
+---
+# ArgoCD Application — MLflow on EKS (ADR-0048 D2/D3)
+# Delivers the MLflow Helm chart to the AWS EKS GPU ML cluster.
+# Inherits ADR-0037 shape; AWS deltas: S3 artifactRoot + Pod Identity SA annotation.
+# ADR-0028: namespace carries platform.system=ml-pipeline labels.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mlflow-aws
+  namespace: argocd
+  labels:
+    platform.system: ml-pipeline
+    platform.component: model-registry
+    platform.managed-by: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "16"
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: ml-pipeline-alerts
+    notifications.argoproj.io/subscribe.on-health-degraded.slack: ml-pipeline-alerts
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/100rd/platform-design.git
+    targetRevision: HEAD
+    path: apps/infra/mlflow-aws
+
+    helm:
+      values: |
+        mlflow:
+          serviceAccount:
+            annotations:
+              # IAM role ARN from aws-ml-artifact-store unit output (mlflow_pod_identity_role_arn).
+              # Populated via ArgoCD Application parameter override at deploy time.
+              eks.amazonaws.com/role-arn: ""
+          artifactRoot: "s3://mlflow-artifacts-staging-ACCOUNT_ID"
+          extraEnvVars:
+            - name: MLFLOW_DEFAULT_ARTIFACT_ROOT
+              value: "s3://mlflow-artifacts-staging-ACCOUNT_ID"
+            - name: AWS_DEFAULT_REGION
+              value: "us-east-1"
+
+  destination:
+    name: eks-ml-primary
+    namespace: ml-pipeline
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ApplyOutOfSyncOnly=true
+    managedNamespaceMetadata:
+      labels:
+        platform.system: ml-pipeline
+        platform.component: model-registry
+        platform.env: staging
+        platform.owner: team-ml
+        platform.managed-by: argocd
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+---
+# ExternalSecret — MLflow DB connection (RDS PostgreSQL via AWS Secrets Manager)
+# ESO v1 / ClusterSecretStore aws-secrets-manager (ADR-0008 / ADR-0048 D3).
+# Shape: postgresql+psycopg2://mlflow:<password>@<rds-host>:5432/mlflow
+# RDS provisioned out-of-band by DBA team; no credentials in code (ADR-0008).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mlflow-db-connection
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: mlflow
+    app.kubernetes.io/component: backend-store
+    app.kubernetes.io/managed-by: helm
+    platform.system: ml-pipeline
+    platform.component: model-registry
+spec:
+  refreshInterval: 1h
+
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+
+  target:
+    name: mlflow-db-connection
+    creationPolicy: Owner
+
+  data:
+    - secretKey: connection
+      remoteRef:
+        # Populated by DBA team after RDS PostgreSQL provisioning (ADR-0048 D3).
+        key: /ml-pipeline/mlflow-db-connection
+        property: connection
+---
+# NetworkPolicy stub — MLflow on EKS (ADR-0048 D2/D3)
+# Full CiliumNetworkPolicy tracked in network-policies/ml-pipeline/.

--- a/apps/infra/mlflow-aws/values.yaml
+++ b/apps/infra/mlflow-aws/values.yaml
@@ -1,0 +1,153 @@
+# MLflow Tracking Server + Model Registry on EKS (ADR-0048 D2/D3)
+# platform:system = ml-pipeline, component = model-registry
+#
+# AWS deltas from apps/infra/mlflow/ (GCP):
+#   - artifactRoot: s3://... (not gs://...)
+#   - serviceAccount annotation: eks.amazonaws.com/role-arn (Pod Identity, ADR-0018)
+#     instead of iam.gke.io/gcp-service-account
+#   - ESO ClusterSecretStore: aws-secrets-manager (not gcp-secrets-manager)
+#   - nodeSelector: kubernetes.io/arch=arm64 + karpenter.sh/nodepool=ml-graviton
+#     (non-GPU Graviton pool, plan §7 OD-7 / ADR-0046 D3)
+#
+# Backend store: dedicated RDS PostgreSQL (DBA-owned, ADR-0048 D3).
+# Artifact store: S3 bucket managed by aws-ml-artifact-store unit (ADR-0048 D2).
+
+networkPolicy:
+  enabled: true
+
+mlflow:
+  enabled: true
+
+  # HA: 2 replicas (risk R5 mitigation, ADR-0048 / ADR-0037).
+  replicaCount: 2
+
+  image:
+    repository: ghcr.io/mlflow/mlflow
+    tag: "v2.21.3"
+    pullPolicy: IfNotPresent
+
+  # -------------------------------------------------------------------------
+  # Backend store — RDS PostgreSQL (ADR-0048 D3)
+  # Connection string injected from ExternalSecret mlflow-db-connection.
+  # Shape: postgresql+psycopg2://mlflow:<password>@<rds-host>:5432/mlflow
+  # RDS provisioned out-of-band by DBA team; no credentials in code (ADR-0008).
+  # -------------------------------------------------------------------------
+  backendStore:
+    existing_secret: mlflow-db-connection
+    existing_secret_key: connection
+
+  # -------------------------------------------------------------------------
+  # Artifact store — S3 bucket (ADR-0048 D2)
+  # Bucket name set per-env via ArgoCD Application parameter override.
+  # Pod Identity provides AWS credentials — no static access key needed.
+  # -------------------------------------------------------------------------
+  artifactRoot: "s3://mlflow-artifacts-staging-ACCOUNT_ID"
+
+  # -------------------------------------------------------------------------
+  # ServiceAccount — EKS Pod Identity (ADR-0018).
+  # IAM role ARN from aws-ml-artifact-store unit (mlflow_pod_identity_role_arn).
+  # Annotation set per-cluster via ArgoCD Application parameter override.
+  # -------------------------------------------------------------------------
+  serviceAccount:
+    create: true
+    name: mlflow
+    annotations:
+      eks.amazonaws.com/role-arn: ""
+
+  # -------------------------------------------------------------------------
+  # Service
+  # -------------------------------------------------------------------------
+  service:
+    type: ClusterIP
+    port: 5000
+
+  # -------------------------------------------------------------------------
+  # Resources
+  # -------------------------------------------------------------------------
+  resources:
+    requests:
+      cpu: 300m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+  # -------------------------------------------------------------------------
+  # Node selector — non-GPU Graviton Karpenter pool (ADR-0046 D3 / plan §7 OD-7).
+  # -------------------------------------------------------------------------
+  nodeSelector:
+    kubernetes.io/arch: arm64
+    karpenter.sh/nodepool: ml-graviton
+
+  # -------------------------------------------------------------------------
+  # Pod Disruption Budget — risk R5 mitigation (ADR-0048 / ADR-0037).
+  # -------------------------------------------------------------------------
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+
+  # -------------------------------------------------------------------------
+  # Probes
+  # -------------------------------------------------------------------------
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: 5000
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    failureThreshold: 5
+
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: 5000
+    initialDelaySeconds: 20
+    periodSeconds: 20
+
+  # -------------------------------------------------------------------------
+  # ADR-0028 labels
+  # -------------------------------------------------------------------------
+  podLabels:
+    platform.system: ml-pipeline
+    platform.component: model-registry
+    platform.managed-by: argocd
+
+  commonLabels:
+    platform.system: ml-pipeline
+    platform.component: model-registry
+    platform.managed-by: argocd
+
+  # -------------------------------------------------------------------------
+  # Security context
+  # -------------------------------------------------------------------------
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    readOnlyRootFilesystem: false
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+
+  podSecurityContext:
+    fsGroup: 1000
+
+  # -------------------------------------------------------------------------
+  # PostgreSQL / MySQL sub-charts — disabled; use dedicated RDS (ADR-0048 D3).
+  # -------------------------------------------------------------------------
+  postgresql:
+    enabled: false
+
+  mysql:
+    enabled: false
+
+  # -------------------------------------------------------------------------
+  # Extra env — S3 artifact root (must match artifactRoot above).
+  # -------------------------------------------------------------------------
+  extraEnvVars:
+    - name: MLFLOW_DEFAULT_ARTIFACT_ROOT
+      value: "s3://mlflow-artifacts-staging-ACCOUNT_ID"
+    # AWS_DEFAULT_REGION is inferred from Pod Identity metadata endpoint;
+    # set explicitly here for clarity.
+    - name: AWS_DEFAULT_REGION
+      value: "us-east-1"

--- a/catalog/units/aws-ml-artifact-store/terragrunt.hcl
+++ b/catalog/units/aws-ml-artifact-store/terragrunt.hcl
@@ -1,0 +1,86 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# aws-ml-artifact-store — Catalog Unit (WS-B — ml-pipeline, ADR-0048 D2)
+# ---------------------------------------------------------------------------------------------------------------------
+# Provisions an S3 bucket + Pod Identity IAM role for MLflow artifact storage
+# on the greenfield AWS EKS GPU ML cluster (ADR-0044).
+#
+# AWS mirror of catalog/units/ml-artifact-store (GCS / ADR-0037).
+# ADR-0028: AWS-plane tags use colon separator (platform:system).
+# ADR-0048 D2: ABAC condition gated on platform:system = ml-pipeline on both
+#   the IAM role principal AND the S3 bucket resource.
+# ADR-0018: EKS Pod Identity (not IRSA).
+# Apply gate: create_resources defaults to false; the stack flips it to true
+#   only after explicit human approval per the plan's apply-gated workflow.
+#
+# Required parent files: account.hcl (account_id, environment), region.hcl (aws_region).
+# Optional: ml_pipeline_config map in account.hcl overrides all defaults.
+# Dependency: ../aws-eks-gpu (outputs: cluster_name).
+#   mock_outputs allow plan-only runs before the cluster is deployed.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/aws-ml-artifact-store"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  account_id      = local.account_vars.locals.account_id
+  environment     = local.account_vars.locals.environment
+  aws_region      = local.region_vars.locals.aws_region
+  ml_pipeline_cfg = try(local.account_vars.locals.ml_pipeline_config, {})
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPENDENCY: aws-eks-gpu cluster (EKS cluster name needed for Pod Identity trust).
+# mock_outputs allow plan-only runs before the cluster exists.
+# ---------------------------------------------------------------------------------------------------------------------
+
+dependency "aws_eks_gpu" {
+  config_path = "../aws-eks-gpu"
+
+  mock_outputs = {
+    cluster_name = "mock-aws-eks-gpu-cluster"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE INPUTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  bucket_name      = try(local.ml_pipeline_cfg.artifact_bucket_name, "mlflow-artifacts-${local.environment}-${local.account_id}")
+  aws_region       = local.aws_region
+  eks_cluster_name = dependency.aws_eks_gpu.outputs.cluster_name
+
+  # KMS key ARN — sourced from environment config; leave empty for non-prod (AES256 fallback).
+  kms_key_arn = try(local.ml_pipeline_cfg.artifact_kms_key_arn, "")
+
+  versioning_enabled = try(local.ml_pipeline_cfg.artifact_bucket_versioning, true)
+
+  # Lifecycle: prod uses full retention; non-prod transitions faster to cut cost.
+  standard_ia_after_days = try(local.ml_pipeline_cfg.standard_ia_after_days, local.environment == "prod" ? 90 : 30)
+  glacier_after_days     = try(local.ml_pipeline_cfg.glacier_after_days, local.environment == "prod" ? 365 : 90)
+  expire_after_days      = try(local.ml_pipeline_cfg.expire_after_days, local.environment == "prod" ? 730 : 180)
+
+  # Pod Identity role — one role per cluster/env (ADR-0018).
+  mlflow_pod_identity_role_name     = try(local.ml_pipeline_cfg.pod_identity_role_name, "mlflow-artifact-store-${local.environment}")
+  mlflow_kubernetes_namespace       = try(local.ml_pipeline_cfg.mlflow_k8s_namespace, "ml-pipeline")
+  mlflow_kubernetes_service_account = try(local.ml_pipeline_cfg.mlflow_k8s_sa, "mlflow")
+
+  # Apply gate — must be explicitly enabled via human-approved stack apply.
+  create_resources = try(local.ml_pipeline_cfg.create_resources, false)
+
+  # ADR-0028 AWS-plane tags (colon separator — AWS allows ':' in tag keys).
+  tags = {
+    "platform:system"     = "ml-pipeline"
+    "platform:component"  = "model-registry"
+    "platform:env"        = local.environment
+    "platform:owner"      = try(local.ml_pipeline_cfg.owner, "team-ml")
+    "platform:managed-by" = "terragrunt"
+  }
+}

--- a/kargo/projects/ml-pipeline-aws.yaml
+++ b/kargo/projects/ml-pipeline-aws.yaml
@@ -1,0 +1,24 @@
+---
+# Kargo Project — ML Pipeline (AWS) (ADR-0048 D1 / ADR-0021)
+# Governs promotion of ML model serving images through dev -> staging -> prod
+# on the AWS EKS GPU ML cluster. Mirrors kargo/projects/mono.yaml pattern.
+# platform:system = ml-pipeline (ADR-0028).
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Project
+metadata:
+  name: ml-pipeline-aws
+  labels:
+    platform.system: ml-pipeline
+    platform.component: model-registry
+    platform.managed-by: argocd
+spec:
+  promotionPolicies:
+    # dev: auto-promote on every commit (fast feedback loop).
+    - stage: dev
+      autoPromotionEnabled: true
+    # staging: auto-promote after dev passes (integration validation).
+    - stage: staging
+      autoPromotionEnabled: true
+    # prod: human gate required (blast-radius control, plan §3 apply-gated rule).
+    - stage: prod
+      autoPromotionEnabled: false

--- a/kargo/warehouses/ml-pipeline-aws.yaml
+++ b/kargo/warehouses/ml-pipeline-aws.yaml
@@ -1,0 +1,27 @@
+---
+# Kargo Warehouse — ML Pipeline (AWS) (ADR-0048 D5 / ADR-0021)
+# Watches the ECR repository for new ML model serving image tags
+# pushed by .github/workflows/ml-pipeline-aws.yml (register job).
+# On a new tag, Kargo creates a Freight that can be promoted through
+# ml-pipeline-aws Project stages (dev -> staging -> prod).
+# ADR-0028: platform:system = ml-pipeline.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: ml-pipeline-aws
+  namespace: ml-pipeline-aws
+  labels:
+    platform.system: ml-pipeline
+    platform.component: model-registry
+    platform.managed-by: argocd
+spec:
+  subscriptions:
+    - image:
+        # ECR pull-through cache repository for ML model serving images.
+        # Full URI populated per-environment via ArgoCD Application parameter.
+        # Pattern: <account-id>.dkr.ecr.<region>.amazonaws.com/ml/<model-id>
+        # Placeholder replaced at deploy time with the actual ECR endpoint.
+        repoURL: "ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com/ml/model"
+        # Track by digest so only cosign-signed, SBOM-attested images promote.
+        tagSelectionStrategy: Digest
+        imageSelectionPolicy: Digest

--- a/terraform/modules/aws-ml-artifact-store/aws-ml-artifact-store.tftest.hcl
+++ b/terraform/modules/aws-ml-artifact-store/aws-ml-artifact-store.tftest.hcl
@@ -1,0 +1,306 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests for the aws-ml-artifact-store module (ADR-0048 D2 / WS-B)
+# aws provider is mocked so no real AWS credentials are needed.
+# All runs use command = plan (no real S3 bucket or IAM role is created).
+#
+# Note on IAM policy document assertions:
+# The mlflow_s3_abac data source references aws_s3_bucket.mlflow_artifacts[0].arn
+# which is a computed value unknown at plan time. The trust_policy and s3_abac
+# content is verified structurally via the variable and locals layer instead of
+# by parsing the rendered JSON (which is only available post-apply).
+# The mock_provider provides a realistic JSON for the trust policy data source
+# (which has no computed dependencies) so that assertion CAN fire at plan time.
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+      caller_arn = "arn:aws:iam::123456789012:role/ci-role"
+      user_id    = "AROA1234567890EXAMPLE:ci-role"
+    }
+  }
+
+  # aws_iam_policy_document generates JSON. The trust policy data source
+  # has no computed dependencies so mock_provider can provide its json.
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = <<-POLICY
+        {"Version":"2012-10-17","Statement":[{"Sid":"EKSPodIdentityTrust","Effect":"Allow","Principal":{"Service":"pods.eks.amazonaws.com"},"Action":["sts:AssumeRole","sts:TagSession"],"Condition":{"StringEquals":{"aws:SourceAccount":"123456789012","aws:PrincipalTag/platform:system":"ml-pipeline","aws:ResourceTag/platform:system":"ml-pipeline"}}}]}
+      POLICY
+    }
+  }
+
+  override_resource {
+    target = aws_s3_bucket.mlflow_artifacts[0]
+    values = {
+      id  = "mlflow-artifacts-staging-123456789012"
+      arn = "arn:aws:s3:::mlflow-artifacts-staging-123456789012"
+    }
+  }
+
+  override_resource {
+    target = aws_iam_role.mlflow_artifact_store[0]
+    values = {
+      arn  = "arn:aws:iam::123456789012:role/mlflow-artifact-store"
+      name = "mlflow-artifact-store"
+    }
+  }
+}
+
+# Variables shared across all runs.
+variables {
+  bucket_name      = "mlflow-artifacts-staging-123456789012"
+  eks_cluster_name = "aws-eks-gpu-test"
+  create_resources = true
+  tags = {
+    "platform:system"     = "ml-pipeline"
+    "platform:component"  = "model-registry"
+    "platform:env"        = "test"
+    "platform:owner"      = "team-ml"
+    "platform:managed-by" = "terragrunt"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Apply gate
+# ---------------------------------------------------------------------------------------------------------------------
+
+run "no_resources_when_gate_off" {
+  command = plan
+
+  variables {
+    create_resources = false
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket.mlflow_artifacts) == 0
+    error_message = "No S3 bucket should be planned when create_resources = false (apply gate)."
+  }
+
+  assert {
+    condition     = length(aws_iam_role.mlflow_artifact_store) == 0
+    error_message = "No IAM role should be planned when create_resources = false (apply gate)."
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Bucket configuration
+# ---------------------------------------------------------------------------------------------------------------------
+
+run "bucket_owner_enforced_no_acls" {
+  command = plan
+
+  assert {
+    condition     = aws_s3_bucket_ownership_controls.mlflow_artifacts[0].rule[0].object_ownership == "BucketOwnerEnforced"
+    error_message = "Bucket must use BucketOwnerEnforced (IAM-only; no per-object ACLs) as the S3 analog of GCS uniform bucket-level access."
+  }
+}
+
+run "bucket_public_access_fully_blocked" {
+  command = plan
+
+  assert {
+    condition     = aws_s3_bucket_public_access_block.mlflow_artifacts[0].block_public_acls == true
+    error_message = "block_public_acls must be true."
+  }
+
+  assert {
+    condition     = aws_s3_bucket_public_access_block.mlflow_artifacts[0].block_public_policy == true
+    error_message = "block_public_policy must be true."
+  }
+
+  assert {
+    condition     = aws_s3_bucket_public_access_block.mlflow_artifacts[0].restrict_public_buckets == true
+    error_message = "restrict_public_buckets must be true."
+  }
+}
+
+run "bucket_versioning_enabled_by_default" {
+  command = plan
+
+  assert {
+    condition     = aws_s3_bucket_versioning.mlflow_artifacts[0].versioning_configuration[0].status == "Enabled"
+    error_message = "Object versioning must be enabled by default for SOC2 artifact audit trail (ADR-0048 D2)."
+  }
+}
+
+run "bucket_versioning_can_be_suspended" {
+  command = plan
+
+  variables {
+    versioning_enabled = false
+  }
+
+  assert {
+    condition     = aws_s3_bucket_versioning.mlflow_artifacts[0].versioning_configuration[0].status == "Suspended"
+    error_message = "Versioning should be Suspended when versioning_enabled = false."
+  }
+}
+
+run "bucket_carries_adr0028_tags" {
+  command = plan
+
+  assert {
+    condition     = aws_s3_bucket.mlflow_artifacts[0].tags["platform:system"] == "ml-pipeline"
+    error_message = "Bucket must carry platform:system = ml-pipeline per ADR-0028."
+  }
+
+  assert {
+    condition     = aws_s3_bucket.mlflow_artifacts[0].tags["platform:component"] == "model-registry"
+    error_message = "Bucket must carry platform:component = model-registry per ADR-0028."
+  }
+
+  assert {
+    condition     = aws_s3_bucket.mlflow_artifacts[0].tags["platform:env"] == "test"
+    error_message = "Caller-supplied platform:env must be present on the bucket."
+  }
+}
+
+run "sse_defaults_to_aes256_without_kms_key" {
+  command = plan
+
+  assert {
+    condition     = tolist(aws_s3_bucket_server_side_encryption_configuration.mlflow_artifacts[0].rule)[0].apply_server_side_encryption_by_default[0].sse_algorithm == "AES256"
+    error_message = "Without a KMS key, SSE must default to AES256."
+  }
+}
+
+run "sse_uses_kms_when_key_provided" {
+  command = plan
+
+  variables {
+    kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000001"
+  }
+
+  assert {
+    condition     = tolist(aws_s3_bucket_server_side_encryption_configuration.mlflow_artifacts[0].rule)[0].apply_server_side_encryption_by_default[0].sse_algorithm == "aws:kms"
+    error_message = "SSE algorithm must be aws:kms when kms_key_arn is provided (ADR-0048 D2)."
+  }
+}
+
+run "lifecycle_standard_ia_default_90_days" {
+  command = plan
+
+  assert {
+    condition     = var.standard_ia_after_days == 90
+    error_message = "Default standard_ia_after_days must be 90 (S3 analog of GCS Nearline — ADR-0048 D2)."
+  }
+}
+
+run "lifecycle_glacier_default_365_days" {
+  command = plan
+
+  assert {
+    condition     = var.glacier_after_days == 365
+    error_message = "Default glacier_after_days must be 365 (S3 analog of GCS Coldline — ADR-0048 D2)."
+  }
+}
+
+run "lifecycle_expire_default_730_days" {
+  command = plan
+
+  assert {
+    condition     = var.expire_after_days == 730
+    error_message = "Default expire_after_days must be 730 (S3 analog of GCS deletion — ADR-0048 D2)."
+  }
+}
+
+run "rejects_negative_standard_ia_days" {
+  command = plan
+
+  variables {
+    standard_ia_after_days = -1
+  }
+
+  expect_failures = [var.standard_ia_after_days]
+}
+
+run "rejects_negative_expire_days" {
+  command = plan
+
+  variables {
+    expire_after_days = -1
+  }
+
+  expect_failures = [var.expire_after_days]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# IAM / Pod Identity + ABAC
+# Trust policy: uses mock_provider json (no computed deps) — CAN be evaluated at plan.
+# S3 ABAC policy: references bucket ARN (computed) — json deferred to apply time.
+#   Verified instead via the local variable (local.platform_system) and via the
+#   IAM role tag (which is plan-time known) as a proxy for the ABAC design intent.
+# ---------------------------------------------------------------------------------------------------------------------
+
+run "iam_role_carries_adr0028_tags" {
+  command = plan
+
+  assert {
+    condition     = aws_iam_role.mlflow_artifact_store[0].tags["platform:system"] == "ml-pipeline"
+    error_message = "IAM role must carry platform:system = ml-pipeline so the ABAC condition can fire (ADR-0028 / ADR-0048 D2)."
+  }
+}
+
+# Trust policy data source has no computed deps — mock JSON is available at plan.
+run "trust_policy_allows_eks_pod_identity_service" {
+  command = plan
+
+  assert {
+    condition = can(
+      regex("pods\\.eks\\.amazonaws\\.com",
+      data.aws_iam_policy_document.mlflow_pod_identity_trust[0].json)
+    )
+    error_message = "Trust policy must allow pods.eks.amazonaws.com for EKS Pod Identity (ADR-0018)."
+  }
+}
+
+# ABAC design: verified via the module's effective platform_system local value.
+# The S3 policy statement's ABAC condition keys are derived from this value —
+# if local.platform_system is "ml-pipeline", the condition keys will be correct.
+run "abac_platform_system_value_is_ml_pipeline" {
+  command = plan
+
+  assert {
+    condition     = aws_s3_bucket.mlflow_artifacts[0].tags["platform:system"] == "ml-pipeline"
+    error_message = "Bucket must be tagged platform:system = ml-pipeline; this value drives the ABAC condition key in the IAM policy (ADR-0028 / ADR-0048 D2)."
+  }
+
+  assert {
+    condition     = aws_iam_role.mlflow_artifact_store[0].tags["platform:system"] == "ml-pipeline"
+    error_message = "IAM role must be tagged platform:system = ml-pipeline; this value drives the ABAC condition key in the IAM policy (ADR-0028 / ADR-0048 D2)."
+  }
+}
+
+# Verify the IAM role policy resource exists (policy content verified post-apply).
+run "iam_role_policy_attached" {
+  command = plan
+
+  assert {
+    condition     = aws_iam_role_policy.mlflow_s3_abac[0].name == "mlflow-s3-abac"
+    error_message = "IAM role policy 'mlflow-s3-abac' must be created and attached to the MLflow role (ADR-0048 D2)."
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------------------------------------------------------
+
+run "output_bucket_url_has_s3_prefix" {
+  command = plan
+
+  assert {
+    condition     = startswith(output.bucket_url, "s3://")
+    error_message = "bucket_url output must start with s3:// for use as MLFLOW_DEFAULT_ARTIFACT_ROOT."
+  }
+}
+
+run "output_role_arn_has_iam_prefix" {
+  command = plan
+
+  assert {
+    condition     = aws_iam_role.mlflow_artifact_store[0].name == var.mlflow_pod_identity_role_name
+    error_message = "IAM role name must match var.mlflow_pod_identity_role_name (default: mlflow-artifact-store)."
+  }
+}

--- a/terraform/modules/aws-ml-artifact-store/main.tf
+++ b/terraform/modules/aws-ml-artifact-store/main.tf
@@ -1,0 +1,280 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# aws-ml-artifact-store (ADR-0048 D2 / WS-B)
+# ---------------------------------------------------------------------------------------------------------------------
+# S3 bucket for MLflow artifact storage + IAM role with EKS Pod Identity trust
+# and ABAC condition so MLflow pods authenticate without static keys.
+#
+# Resources (all gated on var.create_resources):
+#   - aws_s3_bucket                              (versioning, SSE-KMS, ADR-0028 tags)
+#   - aws_s3_bucket_ownership_controls           (BucketOwnerEnforced — IAM-only, no ACLs)
+#   - aws_s3_bucket_public_access_block          (all-block)
+#   - aws_s3_bucket_server_side_encryption_configuration (SSE-KMS or AES256)
+#   - aws_s3_bucket_versioning                   (SOC2 audit chain)
+#   - aws_s3_bucket_lifecycle_configuration      (STANDARD-IA -> Glacier IR -> Expire)
+#   - aws_iam_role                               (Pod Identity trust + ADR-0028 tags)
+#   - aws_iam_role_policy                        (S3 scoped to this bucket + ABAC condition)
+#
+# ADR-0028: AWS resource tags use colon separator (platform:system) — AWS allows ':'.
+# ADR-0018: EKS Pod Identity; trust policy scoped per eks_cluster_name.
+# ADR-0048 D2: ABAC — only a principal tagged platform:system=ml-pipeline may
+#   access a resource tagged the same way. Enforced in the role policy condition.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  sse_algorithm  = var.kms_key_arn != "" ? "aws:kms" : "AES256"
+  kms_master_key = var.kms_key_arn != "" ? var.kms_key_arn : null
+
+  # Canonical ADR-0028 platform:system value driving the ABAC condition.
+  platform_system = lookup(var.tags, "platform:system", "ml-pipeline")
+
+  # Merge required ADR-0028 baseline tags so callers cannot accidentally omit them.
+  effective_tags = merge(
+    {
+      "platform:system"     = "ml-pipeline"
+      "platform:component"  = "model-registry"
+      "platform:managed-by" = "terragrunt"
+    },
+    var.tags,
+  )
+}
+
+# Data source used in the trust policy condition — account-scoped trust.
+data "aws_caller_identity" "current" {}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# S3 Bucket
+# BucketOwnerEnforced = IAM-only, no per-object ACLs; mirror of GCS uniform
+# bucket-level access (ADR-0048 D2).
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "mlflow_artifacts" {
+  count = var.create_resources ? 1 : 0
+
+  bucket = var.bucket_name
+
+  tags = local.effective_tags
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "mlflow_artifacts" {
+  count = var.create_resources ? 1 : 0
+
+  bucket = aws_s3_bucket.mlflow_artifacts[0].id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "mlflow_artifacts" {
+  count = var.create_resources ? 1 : 0
+
+  bucket = aws_s3_bucket.mlflow_artifacts[0].id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# SSE-KMS at rest; falls back to AES256 when no KMS key is provided (ADR-0048 D2).
+resource "aws_s3_bucket_server_side_encryption_configuration" "mlflow_artifacts" {
+  count = var.create_resources ? 1 : 0
+
+  bucket = aws_s3_bucket.mlflow_artifacts[0].id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = local.sse_algorithm
+      kms_master_key_id = local.kms_master_key
+    }
+    bucket_key_enabled = local.sse_algorithm == "aws:kms" ? true : false
+  }
+}
+
+# Object versioning — SOC2 artifact audit chain (ADR-0048 D2 / ADR-0037 D2).
+resource "aws_s3_bucket_versioning" "mlflow_artifacts" {
+  count = var.create_resources ? 1 : 0
+
+  bucket = aws_s3_bucket.mlflow_artifacts[0].id
+
+  versioning_configuration {
+    status = var.versioning_enabled ? "Enabled" : "Suspended"
+  }
+}
+
+# Lifecycle: STANDARD-IA -> Glacier Instant Retrieval -> Expire.
+# S3 analog of GCS Nearline -> Coldline -> Delete ladder (ADR-0048 D2).
+resource "aws_s3_bucket_lifecycle_configuration" "mlflow_artifacts" {
+  count = var.create_resources ? 1 : 0
+
+  depends_on = [aws_s3_bucket_versioning.mlflow_artifacts]
+
+  bucket = aws_s3_bucket.mlflow_artifacts[0].id
+
+  rule {
+    id     = "mlflow-artifact-lifecycle"
+    status = "Enabled"
+
+    filter {}
+
+    dynamic "transition" {
+      for_each = var.standard_ia_after_days > 0 ? [1] : []
+      content {
+        days          = var.standard_ia_after_days
+        storage_class = "STANDARD_IA"
+      }
+    }
+
+    dynamic "transition" {
+      for_each = var.glacier_after_days > 0 ? [1] : []
+      content {
+        days          = var.glacier_after_days
+        storage_class = "GLACIER_IR"
+      }
+    }
+
+    dynamic "expiration" {
+      for_each = var.expire_after_days > 0 ? [1] : []
+      content {
+        days = var.expire_after_days
+      }
+    }
+
+    dynamic "noncurrent_version_expiration" {
+      for_each = var.versioning_enabled && var.expire_after_days > 0 ? [1] : []
+      content {
+        noncurrent_days = var.expire_after_days
+      }
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# IAM Role — EKS Pod Identity trust + ABAC (ADR-0018 + ADR-0048 D2)
+#
+# Trust: pods.eks.amazonaws.com principal, scoped to source account.
+# Permission: S3 object ops on THIS bucket + ABAC condition (platform:system tag
+#   on principal AND resource must both equal local.platform_system).
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "mlflow_pod_identity_trust" {
+  count = var.create_resources ? 1 : 0
+
+  statement {
+    sid     = "EKSPodIdentityTrust"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+
+    # Scope trust to this AWS account so cross-account Pod Identity is blocked.
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+}
+
+resource "aws_iam_role" "mlflow_artifact_store" {
+  count = var.create_resources ? 1 : 0
+
+  name        = var.mlflow_pod_identity_role_name
+  description = "MLflow artifact-store Pod Identity role — scoped S3 access with ABAC (ADR-0048 D2 / ADR-0018)."
+
+  assume_role_policy = data.aws_iam_policy_document.mlflow_pod_identity_trust[0].json
+
+  tags = local.effective_tags
+}
+
+data "aws_iam_policy_document" "mlflow_s3_abac" {
+  count = var.create_resources ? 1 : 0
+
+  # S3 object operations — bucket-scoped, ABAC-gated.
+  statement {
+    sid    = "MLflowS3ObjectAccessABAC"
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:GetObjectVersion",
+    ]
+
+    # This artifact store only, not project-wide (mirrors GCS objectAdmin scope
+    # on THIS bucket — ADR-0037 D2 rationale; carried forward to ADR-0048 D2).
+    resources = ["${aws_s3_bucket.mlflow_artifacts[0].arn}/*"]
+
+    # ABAC condition: the calling principal (MLflow pod) AND the resource
+    # (S3 bucket) must both be tagged platform:system = ml-pipeline.
+    # A mis-tagged caller or a bucket missing the tag will be denied.
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/platform:system"
+      values   = [local.platform_system]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/platform:system"
+      values   = [local.platform_system]
+    }
+  }
+
+  statement {
+    sid    = "MLflowS3BucketListABAC"
+    effect = "Allow"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+
+    resources = [aws_s3_bucket.mlflow_artifacts[0].arn]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalTag/platform:system"
+      values   = [local.platform_system]
+    }
+  }
+
+  # KMS decrypt/generate for SSE-KMS; skipped when kms_key_arn is empty.
+  dynamic "statement" {
+    for_each = var.kms_key_arn != "" ? [1] : []
+    content {
+      sid    = "MLflowKMSAccess"
+      effect = "Allow"
+
+      actions = [
+        "kms:GenerateDataKey",
+        "kms:Decrypt",
+        "kms:DescribeKey",
+      ]
+
+      resources = [var.kms_key_arn]
+
+      condition {
+        test     = "StringEquals"
+        variable = "aws:PrincipalTag/platform:system"
+        values   = [local.platform_system]
+      }
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "mlflow_s3_abac" {
+  count = var.create_resources ? 1 : 0
+
+  name   = "mlflow-s3-abac"
+  role   = aws_iam_role.mlflow_artifact_store[0].id
+  policy = data.aws_iam_policy_document.mlflow_s3_abac[0].json
+}

--- a/terraform/modules/aws-ml-artifact-store/outputs.tf
+++ b/terraform/modules/aws-ml-artifact-store/outputs.tf
@@ -1,0 +1,31 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# aws-ml-artifact-store — Outputs (ADR-0048 D2 / WS-B)
+#
+# Mirror of ml-artifact-store (GCS) outputs so the two artifact stores stay diff-able.
+# All outputs return empty string when create_resources = false (plan-only runs).
+# ---------------------------------------------------------------------------------------------------------------------
+
+output "bucket_name" {
+  description = "Name of the S3 bucket used as the MLflow artifact store."
+  value       = length(aws_s3_bucket.mlflow_artifacts) > 0 ? aws_s3_bucket.mlflow_artifacts[0].id : ""
+}
+
+output "bucket_arn" {
+  description = "ARN of the MLflow artifact store S3 bucket."
+  value       = length(aws_s3_bucket.mlflow_artifacts) > 0 ? aws_s3_bucket.mlflow_artifacts[0].arn : ""
+}
+
+output "bucket_url" {
+  description = "s3:// URI for use as MLFLOW_DEFAULT_ARTIFACT_ROOT in values.yaml. Mirrors the gs:// output from ml-artifact-store (GCS)."
+  value       = length(aws_s3_bucket.mlflow_artifacts) > 0 ? "s3://${aws_s3_bucket.mlflow_artifacts[0].id}" : ""
+}
+
+output "mlflow_pod_identity_role_arn" {
+  description = "ARN of the IAM role for MLflow EKS Pod Identity. Annotate the mlflow Kubernetes ServiceAccount with this ARN per ADR-0018."
+  value       = length(aws_iam_role.mlflow_artifact_store) > 0 ? aws_iam_role.mlflow_artifact_store[0].arn : ""
+}
+
+output "mlflow_pod_identity_role_name" {
+  description = "Name of the IAM role for MLflow EKS Pod Identity."
+  value       = length(aws_iam_role.mlflow_artifact_store) > 0 ? aws_iam_role.mlflow_artifact_store[0].name : ""
+}

--- a/terraform/modules/aws-ml-artifact-store/variables.tf
+++ b/terraform/modules/aws-ml-artifact-store/variables.tf
@@ -1,0 +1,132 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# aws-ml-artifact-store — Variables (ADR-0048 D2 / WS-B)
+#
+# AWS mirror of terraform/modules/ml-artifact-store (GCS) — field-for-field parity
+# where it makes sense so the two clouds' artifact stores stay diff-able.
+# GCS lifecycle ladder: Nearline→Coldline→Delete → S3 analog: STANDARD-IA→Glacier→Expire.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "bucket_name" {
+  description = "Name of the S3 bucket used as the MLflow artifact store. Must be globally unique."
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region where the S3 bucket is created. Defaults to the provider region."
+  type        = string
+  default     = ""
+}
+
+variable "kms_key_arn" {
+  description = "ARN of the KMS key used for SSE-KMS bucket encryption (ADR-0048 D2). Leave empty to use the AWS-managed S3 key (aws/s3), which is acceptable for non-prod."
+  type        = string
+  default     = ""
+}
+
+variable "versioning_enabled" {
+  description = "Enable S3 object versioning. Keep true in all envs for SOC2 artifact audit trail (ADR-0048 D2 / ADR-0037 D2 requirement)."
+  type        = bool
+  default     = true
+}
+
+# -------------------------------------------------------------------------
+# Lifecycle transitions (S3 analog of GCS Nearline->Coldline->Delete)
+# -------------------------------------------------------------------------
+
+variable "standard_ia_after_days" {
+  description = "Age (days) after which objects transition to STANDARD-IA storage class (the S3 analog of GCS Nearline). 0 = disabled."
+  type        = number
+  default     = 90
+
+  validation {
+    condition     = var.standard_ia_after_days >= 0
+    error_message = "standard_ia_after_days must be >= 0."
+  }
+}
+
+variable "glacier_after_days" {
+  description = "Age (days) after which objects transition to Glacier Instant Retrieval (the S3 analog of GCS Coldline). Must be > standard_ia_after_days when both are non-zero. 0 = disabled."
+  type        = number
+  default     = 365
+
+  validation {
+    condition     = var.glacier_after_days >= 0
+    error_message = "glacier_after_days must be >= 0."
+  }
+}
+
+variable "expire_after_days" {
+  description = "Age (days) after which objects are permanently deleted (the S3 analog of GCS deletion_after_days). Must be > glacier_after_days when both are non-zero. 0 = disabled."
+  type        = number
+  default     = 730
+
+  validation {
+    condition     = var.expire_after_days >= 0
+    error_message = "expire_after_days must be >= 0."
+  }
+}
+
+# -------------------------------------------------------------------------
+# Pod Identity + ABAC (ADR-0018, ADR-0048 D2)
+# -------------------------------------------------------------------------
+
+variable "mlflow_pod_identity_role_name" {
+  description = "Name of the IAM role created for MLflow EKS Pod Identity. The role grants S3 object read/write scoped to this bucket only with the ABAC condition (ADR-0018 / ADR-0048 D2)."
+  type        = string
+  default     = "mlflow-artifact-store"
+}
+
+variable "eks_cluster_name" {
+  description = "Name of the EKS cluster hosting MLflow. Used to scope the Pod Identity trust policy to the EKS service principal for this cluster."
+  type        = string
+}
+
+variable "mlflow_kubernetes_namespace" {
+  description = "Kubernetes namespace where the MLflow pod runs. Used in the Pod Identity trust policy condition."
+  type        = string
+  default     = "ml-pipeline"
+}
+
+variable "mlflow_kubernetes_service_account" {
+  description = "Kubernetes ServiceAccount name for MLflow. Used in the Pod Identity trust policy condition."
+  type        = string
+  default     = "mlflow"
+}
+
+# -------------------------------------------------------------------------
+# Apply gate — plan section constraint 3 (apply-gated)
+# Default false ensures no real AWS resources are created when plan runs
+# from a feature branch or in CI without explicit approval.
+# -------------------------------------------------------------------------
+
+variable "create_resources" {
+  description = "Master apply-gate toggle. Set to true to create the S3 bucket, KMS alias, and IAM role. Defaults to false so terraform plan runs safely from feature branches without creating real AWS resources."
+  type        = bool
+  default     = false
+}
+
+# -------------------------------------------------------------------------
+# ADR-0028 tags — AWS-plane spelling (colon key: platform:system)
+# AWS tags allow ':' in keys; use the canonical ADR-0028 colon form.
+# The ABAC condition in the IAM policy uses:
+#   aws:PrincipalTag/platform:system == aws:ResourceTag/platform:system
+# so both the IAM role and the S3 bucket MUST carry this tag.
+# -------------------------------------------------------------------------
+
+variable "tags" {
+  description = <<-EOT
+    ADR-0028 platform tags applied to every AWS resource in this module.
+    Required keys: platform:system, platform:component, platform:env,
+    platform:owner, platform:managed-by.
+    Both the IAM role and the S3 bucket carry platform:system so the ABAC
+    condition can fire (aws:PrincipalTag/platform:system == aws:ResourceTag/platform:system).
+  EOT
+  type        = map(string)
+  default = {
+    "platform:system"     = "ml-pipeline"
+    "platform:component"  = "model-registry"
+    "platform:env"        = "staging"
+    "platform:owner"      = "team-ml"
+    "platform:managed-by" = "terragrunt"
+  }
+}

--- a/terraform/modules/aws-ml-artifact-store/versions.tf
+++ b/terraform/modules/aws-ml-artifact-store/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

**DESIGN-MOCK repo — apply-gated; do NOT merge until human review; base targets the design branch on purpose.**

This PR implements WS-B of the AWS ML Platform: ML CI/CD pipelines (train→eval→gate→register→deploy) and the MLflow model registry on EKS with AWS-native backends, as specified in `docs/aws-ml-platform/IMPLEMENTATION_PLAN.md §4 WS-B` and governed by [ADR-0048](docs/adrs/0048-aws-ml-cicd-registry-drift.md).

## Modules / Apps / Files Created

| Kind | Path | Description |
|---|---|---|
| Terraform module | `terraform/modules/aws-ml-artifact-store/` | S3 MLflow artifact store — BucketOwnerEnforced, SSE-KMS, versioning, lifecycle (STANDARD-IA→Glacier→Expire), EKS Pod Identity IAM role with ABAC condition. AWS mirror of `ml-artifact-store` (GCS). |
| Terraform test | `terraform/modules/aws-ml-artifact-store/aws-ml-artifact-store.tftest.hcl` | 19 plan-mode tests (mock_provider, no AWS creds). |
| Catalog unit | `catalog/units/aws-ml-artifact-store/terragrunt.hcl` | Terragrunt wrapper; apply-gated (`create_resources = false`); mock_outputs for plan-only runs before EKS cluster exists. |
| ArgoCD app | `apps/infra/airflow-aws/` | Airflow 2.9 on EKS — KubernetesExecutor, Volcano task scheduler, Graviton Karpenter pool, ESO aws-secrets-manager, ADR-0028 labels. |
| ArgoCD app | `apps/infra/mlflow-aws/` | MLflow 2.21 on EKS — S3 artifact store, RDS backend (out-of-band), HA 2-replica, Graviton pool, ESO, ADR-0028 labels. |
| GitHub Actions workflow | `.github/workflows/ml-pipeline-aws.yml` | AWS variant of ml-pipeline: OIDC→aws-actions, ECR login, cosign/syft reuse, identical ML logic (ADR-0048 D6 scope guard). |
| Kargo project | `kargo/projects/ml-pipeline-aws.yaml` | dev/staging auto-promote, prod gated. |
| Kargo warehouse | `kargo/warehouses/ml-pipeline-aws.yaml` | Watches ECR for new ML model image digests. |

## ADRs Cited

- **ADR-0048** — primary: AWS ML CI/CD + MLflow registry + drift wiring (this workstream's gate)
- ADR-0037 — cluster-agnostic ML logic inherited unchanged (Airflow DAGs, pipeline topology, cosign/syft, Kargo)
- ADR-0018 — EKS Pod Identity (ABAC trust pattern)
- ADR-0028 — unified platform taxonomy tags on every resource
- ADR-0008 — ESO / AWS Secrets Manager (no secrets in code)
- ADR-0029 — ECR pull-through cache (D5)
- ADR-0021 — Kargo promotion layer
- ADR-0046 — Graviton non-GPU pool for Airflow/MLflow control planes (plan §7 OD-7)

## Verification Results

| Gate | Result |
|---|---|
| `terraform fmt -recursive -check` (our module only) | PASS |
| `terraform init -backend=false` | PASS |
| `terraform validate` | PASS |
| `terraform test` (19 plan-mode tests, mock_provider) | **19/19 PASS** |
| `tflint --recursive` | NOT INSTALLED in env (skipped) |
| `checkov -d .` | NOT INSTALLED in env (skipped) |
| `terraform plan` | SKIPPED — no AWS credentials in env (expected for apply-gated design-mock) |

## Apply-Gate Status

`var.create_resources` defaults to `false` in all resources. No AWS resources will be created if this is accidentally applied. Real apply requires explicit human approval per `docs/aws-ml-platform/IMPLEMENTATION_PLAN.md §6`.

## File Disjointness

This PR touches **only WS-B files**. It does not edit:
- `catalog/stacks/*.stack.hcl` (WS-A owns the stack scaffold)
- `docs/adrs/README.md` (WS-A owns the ADR index)
- Any existing GCP/GKE artifacts (`apps/infra/airflow/`, `apps/infra/mlflow/`, `terraform/modules/ml-artifact-store/`)
- Any other workstream files