### PR TITLE
feat(aws-wsF): AWS golden paths

### DIFF
--- a/docs/contracts/aws-ml-model-api-contract.md
+++ b/docs/contracts/aws-ml-model-api-contract.md
@@ -1,0 +1,183 @@
+# AWS ML Model API Contract -- AWS-specific addendum
+
+**Version:** 1.0.0
+**Status:** Ratified -- AWS-specific addendum to `docs/contracts/model-api-contract.md`
+**Platform:** AWS EKS GPU ML cluster (ADR-0044 / ADR-0048)
+**ADR gates:** ADR-0041 (WS-F contracts), ADR-0048 (AWS backends)
+
+This document is an **addendum** to the base contract at
+`docs/contracts/model-api-contract.md`. It records the AWS-specific backend
+and identity wiring that all four personas must understand before a model
+service is promoted beyond staging on the AWS EKS ML cluster.
+
+Read `docs/contracts/model-api-contract.md` first. This document adds AWS
+specifics only; it does not duplicate the request/response schema, versioning
+policy, or feature schema sections.
+
+All four engineering personas (Data Engineering, ML Engineering, Backend/Frontend,
+Platform/SRE) must sign off on a new model's contract instance (base + this
+addendum) before staging promotion. See
+`docs/golden-paths/aws-ml-RACI-and-handoffs.md` for the sign-off checklist.
+
+---
+
+## 1. AWS backend wiring (ADR-0048)
+
+### 1.1 Artifact store (S3)
+
+Model artifacts are stored in S3, not GCS:
+
+```
+s3://mlflow-artifacts-{env}-{account_id}/{model_name}/{tenant}/{domain}/{run_id}/artifacts/
+```
+
+**Access pattern:**
+
+- MLflow tracking-server ServiceAccount has a Pod Identity binding to the
+  `aws-ml-artifact-store` IAM role (ADR-0018, ADR-0048 D2).
+- The IAM role policy includes the ABAC condition:
+
+```json
+{
+  "Condition": {
+    "StringEquals": {
+      "aws:PrincipalTag/platform:system": "${aws:ResourceTag/platform:system}"
+    }
+  }
+}
+```
+
+  Value `ml-pipeline` on both the principal tag and the bucket tag.
+  Cross-system access is denied.
+- No static AWS credentials are used anywhere in the ML stack (ADR-0018).
+
+**New-model checklist:**
+
+- [ ] S3 bucket exists with tag `platform:system = ml-pipeline`
+- [ ] `aws-ml-artifact-store` IAM role ARN is documented in the model's ArgoCD
+  Application annotation (`platform.aws/drift-exporter-pod-identity-role`)
+- [ ] MLflow experiment confirms artifacts written to `s3://` (not `gs://`)
+
+### 1.2 MLflow backend (RDS Postgres)
+
+- MLflow metadata (experiments, runs, metrics, tags) stored in a **dedicated
+  RDS PostgreSQL** instance (Multi-AZ, DBA-owned; ADR-0048 D3).
+- Credentials delivered via **ESO ExternalSecret** from **AWS Secrets Manager**
+  (ADR-0008 + rotation ADR-0031). No static DB passwords in-cluster.
+- Connection string injected as `MLFLOW_TRACKING_URI` env var into the MLflow pod.
+
+**New-model checklist:**
+
+- [ ] MLflow tracking server is reachable (`curl $MLFLOW_TRACKING_URI/health`)
+- [ ] ESO ExternalSecret status is `Ready` in the `mlflow` namespace
+- [ ] `MLFLOW_TRACKING_URI` resolves to the RDS-backed server (not a GCP Cloud SQL)
+
+### 1.3 Container registry (ECR)
+
+Model images are stored in ECR with the existing pull-through cache (ADR-0029):
+
+```
+{account_id}.dkr.ecr.{region}.amazonaws.com/{model_name}:{env}-{commit_sha}
+```
+
+- Images are **cosign-signed** and **SBOM'd with syft** (`.github/actions/*` composites)
+  before push; Kyverno admission verifies the signature.
+- Upstream base images (NVIDIA NGC, Python) come through the pull-through cache --
+  no direct pulls from upstream registries in the cluster.
+
+**New-model checklist:**
+
+- [ ] ECR repository `{account_id}.dkr.ecr.{region}.amazonaws.com/{model_name}` exists
+- [ ] Pipeline run confirms cosign signature and SBOM attached to the pushed digest
+- [ ] MLflow run metadata records the ECR image URI
+
+---
+
+## 2. Identity and ABAC (ADR-0018, ADR-0028)
+
+Every pod that reads or writes cloud resources on behalf of a model must use
+**EKS Pod Identity** -- no static credentials (ADR-0018). The Pod Identity binding
+is documented in the model's ArgoCD Application annotation.
+
+The ABAC condition is enforced on every IAM policy for S3 and Secrets Manager
+resources related to ML workloads. A pod tagged `platform:system = ml-pipeline`
+can only access resources also tagged `platform:system = ml-pipeline`.
+
+**New-model checklist:**
+
+- [ ] Model pod ServiceAccount has a Pod Identity association to the correct IAM role
+- [ ] IAM role trust policy restricts to the specific ServiceAccount + namespace
+- [ ] S3 bucket, IAM role, and ECR repository carry all five ADR-0028 tags:
+  `platform:system`, `platform:component`, `platform:env`, `platform:owner`,
+  `platform:managed-by`
+
+---
+
+## 3. Drift monitoring (WS-C, AWS)
+
+The Evidently drift-exporter reads the model's reference dataset from S3 (not GCS):
+
+```
+s3://{mlflow_artifacts_bucket}/{model_name}/{tenant}/{domain}/reference.parquet
+```
+
+Access is via a separate Pod Identity binding for the `drift-exporter` ServiceAccount
+(same ABAC pattern; role scoped to the reference-dataset prefix only).
+
+The Prometheus Pushgateway address and the retrain-trigger webhook to Airflow REST
+are **cluster-agnostic** -- identical to the GCP etalon (ADR-0048 D4).
+
+**New-model checklist:**
+
+- [ ] Reference dataset uploaded to the S3 path above before first drift-monitor run
+- [ ] Drift-exporter ServiceAccount has Pod Identity binding with `s3:GetObject`
+  on the reference-dataset prefix
+- [ ] `ServiceMonitor` is scraped by Prometheus (verify in Prometheus targets UI)
+- [ ] PrometheusRule alerts visible in Alertmanager
+
+---
+
+## 4. Worked example (AWS)
+
+See `docs/contracts/example-domain-adapter-contract.yaml` for the domain-adapter
+model instance. For the AWS deployment, substitute:
+
+| GCP field | AWS equivalent |
+|-----------|----------------|
+| `artifactStore.uri: gs://...` | `artifactStore.uri: s3://mlflow-artifacts-prod-{account_id}/...` |
+| `identity: workload-identity` | `identity: pod-identity` |
+| `identityRef: {gsa}@{project}.iam.gserviceaccount.com` | `identityRef: arn:aws:iam::{account_id}:role/aws-ml-artifact-store` |
+| `registry: gcr.io/{project}/{model}` | `registry: {account_id}.dkr.ecr.{region}.amazonaws.com/{model}` |
+| `backend.type: cloud-sql` | `backend.type: rds-postgres` |
+| `backend.connectionString: cloudsql://...` | `backend.connectionString` from ESO ExternalSecret |
+
+---
+
+## 5. Versioning alignment
+
+This addendum follows the same semver policy as the base contract
+(`docs/contracts/model-api-contract.md`). Breaking changes to the AWS backend
+wiring (e.g., changing the ABAC condition pattern, replacing the artifact bucket
+naming scheme, or switching identity mechanism) increment `MAJOR` and require a
+new sign-off from all four personas.
+
+---
+
+## References
+
+- Base contract: `docs/contracts/model-api-contract.md`
+- Example: `docs/contracts/example-domain-adapter-contract.yaml`
+- RACI (AWS): `docs/golden-paths/aws-ml-RACI-and-handoffs.md`
+- ADR-0048: AWS ML CI/CD + MLflow backends (S3, RDS, ECR)
+- ADR-0041: golden-path templates + contracts (WS-F)
+- ADR-0028: platform taxonomy tags + ABAC
+- ADR-0018: EKS Pod Identity
+- ADR-0008: External Secrets Operator + rotation ADR-0031
+- ADR-0029: ECR pull-through cache
+- ADR-0038: ML drift monitoring (retrain trigger, WS-C)
+
+---
+
+*AWS-specific addendum to the base model API contract.
+Planning-only -- ratified alongside the WS-F golden-path templates (ADR-0041).
+Implementation apply-gated; no cloud resources are created by this document.*

--- a/docs/golden-paths/aws-ml-RACI-and-handoffs.md
+++ b/docs/golden-paths/aws-ml-RACI-and-handoffs.md
@@ -1,0 +1,246 @@
+# AWS ML RACI and Handoffs: Production Model Lifecycle
+
+> **Platform:** AWS EKS GPU ML cluster (ADR-0044 / ADR-0048)
+> **ADR gates:** ADR-0041 (WS-F), ADR-0048 (AWS backends)
+> **GCP etalon:** `docs/golden-paths/RACI-and-handoffs.md` (GCP/GKE variant)
+>
+> This is the **AWS-flavoured** RACI and handoff document. The lifecycle
+> activities, personas, RACI assignments, escalation path, and ADR-0034 revisit
+> criteria are **identical** to the GCP etalon. Only the AWS-specific backend
+> and identity references differ: S3 (not GCS), ECR (not GCR), EKS Pod Identity
+> (not GKE Workload Identity), RDS (not Cloud SQL), AWS Secrets Manager (not GCP).
+
+**Document scope:** the end-to-end lifecycle for a new ML model from raw data to
+monitored production on the **AWS EKS ML cluster**, covering the four engineering
+personas and the five lifecycle activities. This supplements the ADR-0040
+ML-incident runbooks with a day-1 ownership model.
+
+**Related ADRs:** ADR-0044 (AWS EKS foundation), ADR-0048 (AWS ML backends),
+ADR-0039 (WS-D self-serve), ADR-0040 (WS-E on-call), ADR-0041 (WS-F, this document).
+
+---
+
+## 1. Personas
+
+| ID | Persona | Responsibility scope |
+|----|---------|---------------------|
+| DE | **Data Engineering** | Feature pipelines, Iceberg-on-S3 snapshot management, data quality, reference dataset curation (S3) |
+| ML | **ML Engineering** | Model training, evaluation, MLflow registry (RDS + S3), DAG authorship, adapter packaging (ECR) |
+| BE | **Backend / Frontend** | API integration, inference client, contract implementation, latency budgets |
+| PL | **Platform / SRE** | AWS EKS GPU infrastructure, GitOps delivery (ArgoCD), observability stack, on-call, incident command, Pod Identity / IAM |
+
+---
+
+## 2. RACI matrix
+
+**Key:** R = Responsible (does the work) - A = Accountable (owns the outcome) -
+C = Consulted (input required) - I = Informed (notified)
+
+| Activity | DE | ML | BE | PL |
+|----------|----|----|----|-----|
+| **A1 -- Feature pipeline: design schema** | R/A | C | C | I |
+| **A2 -- Feature pipeline: implement + deploy Iceberg snapshot (S3)** | R/A | C | I | C |
+| **A3 -- Feature pipeline: validate reference dataset quality (S3 path)** | R/A | C | I | I |
+| **A4 -- AWS: provision Pod Identity binding for data-pipeline SA** | I | I | I | R/A |
+| **B1 -- Model training: configure Airflow DAG (aws-ml-new-pipeline template)** | C | R/A | I | C |
+| **B2 -- Model training: run train->eval pipeline (ml-pipeline.yml, ECR)** | I | R/A | I | C |
+| **B3 -- Model training: MLflow registration + cosign sign (S3 + RDS)** | I | R/A | I | C |
+| **B4 -- Contract spec: author aws-ml-model-api-contract instance** | C | R/A | C | I |
+| **B5 -- Contract spec: sign off on instance (base + AWS addendum) before staging** | C | A | R (BE) | I |
+| **B6 -- AWS: confirm artifact in S3 + ECR image URI in MLflow run** | I | R/A | I | C |
+| **C1 -- Drift monitoring: configure drift-exporter per model (WS-C, S3 ref dataset)** | I | R | I | A |
+| **C2 -- Drift monitoring: set alert thresholds in grafana-self-serve** | I | R | I | A |
+| **C3 -- AWS: provision Pod Identity binding for drift-exporter SA** | I | I | I | R/A |
+| **C4 -- Drift alert fires: acknowledge + classify** | I | R | I | A |
+| **C5 -- Drift alert fires: trigger retrain or escalate** | I | R/A | I | C |
+| **D1 -- Serving/API: implement inference client (aws-ml-new-model-service)** | I | C | R/A | I |
+| **D2 -- Serving/API: integrate request_id / OTel tracing** | I | I | R/A | C |
+| **D3 -- Serving/API: validate SLO targets (p50/p99/error rate)** | I | C | R/A | C |
+| **D4 -- AWS: configure InferenceObjective + EPP on Envoy Gateway (ADR-0047)** | I | C | I | R/A |
+| **E1 -- On-call: platform/infra alert fires (EKS/Karpenter/Volcano)** | I | I | I | R/A |
+| **E2 -- On-call: model accuracy / drift alert fires** | I | R/A | I | C |
+| **E3 -- On-call: incident declared (P0/P1)** | I | C | C | R/A |
+| **E4 -- On-call: post-incident review + runbook update** | C | C | C | R/A |
+
+### Gap resolution rules
+
+- **A4 + C3 (Pod Identity):** Platform/SRE owns IAM + Pod Identity associations.
+  ML Engineering must provide the ServiceAccount name + namespace; Platform
+  creates the association and documents the role ARN in the ArgoCD Application
+  annotation before the model is deployed.
+- **B5 sign-off blocks staging promotion.** The `ml-pipeline.yml` deploy job
+  environment gate (`environment: staging`) requires the contract sign-off (both
+  `docs/contracts/model-api-contract.md` base AND
+  `docs/contracts/aws-ml-model-api-contract.md` addendum) to be documented in
+  the PR description before reviewer approval.
+- **B6 verification:** ML Engineering confirms the S3 artifact URI and ECR image
+  URI are recorded in the MLflow run before declaring training complete.
+- **C5 retrain decision:** ML Engineering decides whether to trigger a retrain
+  (`trigger_reason: drift` via the Alertmanager webhook receiver) or escalate to
+  Platform if the Airflow DAG is unavailable on EKS.
+- **D4 (InferenceObjective):** Platform/SRE owns the Envoy Gateway
+  `InferenceObjective` + EPP deployment (ADR-0047). Backend provides the model
+  endpoint spec; Platform wires it to the inference gateway.
+- **E2 / E3 escalation:** If a model accuracy alert does not self-resolve within
+  30 minutes, ML Engineering escalates to Platform for incident command per the
+  ADR-0040 `ml-platform-oncall` PagerDuty service.
+
+---
+
+## 3. Handoff flow
+
+The diagram below shows the artifact hand-off sequence on the AWS EKS ML cluster.
+System boundaries match the WS-B/C/D components.
+
+```
+Data Engineering              ML Engineering             Backend/Frontend      Platform/SRE
+     |                              |                           |                    |
+--- Feature pipeline -------------------------------------------------------------------------
+     |                              |                           |                    |
+[H1] Freeze Iceberg snapshot (S3) ->|                          |                    |
+     | (airflow/dags/               |                           |                    |
+     |  train_domain_adapter.py:    |                           |                    |
+     |  freeze_snapshot() -> S3)    |                           |                    |
+     |                              |                           |                    |
+--- Model training (WS-B, AWS) ---------------------------------------------------------------
+     |                              |                           |                    |
+     |                         [H2] train_domain_adapter DAG   |                    |
+     |                              | (ml-pipeline.yml or       |                    |
+     |                              |  drift webhook -> Airflow)|                    |
+     |                         [H3] eval_adapter_debate + quality gate               |
+     |                              | win_rate >= 0.55          |                    |
+     |                         [H4] Register model in MLflow (RDS + S3) ----------->|
+     |                              | cosign sign + SBOM (ECR)  |                    |
+     |                              | (.github/actions/*)       |                    |
+--- Contract sign-off (base + AWS addendum) --------------------------------------------------
+     |                         [H5] Contract instance PR ------>|                    |
+     |                              | (docs/contracts/          | sign off           |
+     |                              |  aws-ml-model-api-        | (base + addendum)  |
+     |                              |  contract.md addendum)    |                    |
+--- Staging promotion ------------------------------------------------------------------------
+     |                         [H6] Kargo: dev (auto) -------------------------------->|
+     |                         [H7] Kargo: staging (reviewer gate) ------------------>|
+--- Production deployment -------------------------------------------------------------------
+     |                         [H8] Kargo: prod (manual gate) ----------------------->|
+     |                              |                           | InferenceObjective  |
+     |                              |                           | + EPP wired [D4]   |
+--- Drift monitoring (WS-C/D, AWS) ----------------------------------------------------------
+     |                              |              WS-C drift-exporter (S3 ref) ---->|
+     |                              |              (apps/infra/ml-monitoring/)        |
+     |                              |              Prometheus -> Alertmanager         |
+     |                              |              Grafana (grafana-self-serve)       |
+--- Retrain trigger (WS-C -> WS-B) ----------------------------------------------------------
+     |                         [H9] Drift alert fires ------------------------------>|
+     |                              | Alertmanager webhook -> Airflow REST            |
+     |                              | POST .../train_domain_adapter/dagRuns           |
+     |                              | conf: {trigger_reason: "drift"}                |
+     |                         [H2 repeats for retrain]         |                    |
+```
+
+### Handoff summary table
+
+| ID | Artifact handed off | From | To | Gate / mechanism |
+|----|--------------------|----|-----|-----------------|
+| H1 | Iceberg snapshot (frozen, versioned on S3) | DE | ML | Airflow `freeze_snapshot()` task; snapshot_id recorded in MLflow run |
+| H2 | Trained LoRA adapter (weights on S3) | ML | ML (eval) | Airflow `TriggerDagRunOperator` -> `eval_adapter_debate` |
+| H3 | Eval report (win_rate, p95_distance) | ML (eval) | ML (register) | Quality gate: `win_rate >= 0.55`; blocks promotion on failure |
+| H4 | Signed model artifact (S3) + SBOM (ECR) | ML | BE + PL | MLflow registry (Staging) + cosign signature + OCI image in ECR |
+| H5 | Contract instance (YAML, base + AWS addendum) | ML | BE | PR to `docs/contracts/`; sign-off from BE required before H6 |
+| H6 | Staged deploy (dev) | ML | PL | Kargo auto-promotion; `post_deployment_smoke` DAG fires 30 min later |
+| H7 | Staged deploy (staging) | ML | PL | Kargo reviewer gate; human reviewer approval required |
+| H8 | Staged deploy (prod) | PL | BE/all | Kargo manual gate; platform on-call confirms InferenceObjective + EPP wired (ADR-0047) |
+| H9 | Drift alert (Alertmanager) | PL (infra) | ML | Alertmanager webhook receiver -> Airflow REST API retrain trigger |
+
+---
+
+## 4. On-call and escalation
+
+This table supplements the ADR-0040 ML-incident runbooks for the **AWS EKS ML cluster**.
+
+| Alert | First paged | Ack SLA | First action | Escalate to | Escalate after |
+|-------|------------|---------|--------------|-------------|----------------|
+| `AirflowDagRunFailed` | ML on-call | 15 min | Check Airflow logs -> retry DAG run; check Volcano job status on EKS | Platform if EKS/Karpenter issue | 30 min |
+| `MLModelDriftHigh` (drift > 0.4) | ML on-call | 15 min | Inspect Evidently report (S3 ref dataset OK?) -> trigger retrain if auto-trigger failed | Platform if Airflow down or S3 access error | 30 min |
+| `MLModelAccuracyLow` (accuracy < 0.75) | ML on-call | 15 min | Check eval metrics in MLflow (RDS) -> consider rollback via ArgoCD / Kargo | Platform for Kargo rollback | 30 min |
+| `MLflowTrackingDown` | Platform on-call | 5 min | Check MLflow pod health (RDS connection? ESO ExternalSecret Ready?) -> ArgoCD sync | Escalate to P1 if pipeline blocked | 15 min |
+| `S3AccessDenied` (ml-pipeline) | Platform on-call | 15 min | Check Pod Identity association + ABAC tags on bucket -> restore IAM binding | Escalate to P1 if training blocked | 30 min |
+| `ECRPullFailed` (pipeline image) | Platform on-call | 15 min | Check ECR pull-through cache (ADR-0029) + node IAM role | Escalate if widespread | 30 min |
+| `GrafanaFolderMissing` (self-serve) | Platform on-call | 30 min | ArgoCD re-sync grafana-self-serve app | n/a | n/a |
+| Platform infra alert (EKS/Karpenter) | Platform on-call | 5 min | Per ADR-0040 runbooks | Incident command if P0/P1 | 15 min |
+
+### Escalation path
+
+```
+ML alert fires
+    |
+    v
+ML Engineering on-call  (PagerDuty: ml-platform-oncall)
+    |  > 30 min unresolved OR infra/IAM/S3 cause confirmed
+    v
+Platform / SRE on-call  (PagerDuty: platform-oncall)
+    |  P0 declared (full outage / data loss risk)
+    v
+Incident Commander (Platform lead or on-call manager)
+    |  > 60 min OR confirmed customer impact
+    v
+Engineering Manager + Comms
+```
+
+---
+
+## 5. AWS identity sign-off checklist
+
+Before promoting a new model to staging, Platform/SRE must confirm:
+
+```
+[ ] Pod Identity association exists for the MLflow ServiceAccount
+    IAM role ARN documented in apps/infra/mlflow/templates/external-secret.yaml
+[ ] Pod Identity association exists for the drift-exporter ServiceAccount
+    IAM role ARN documented in the model's ArgoCD Application annotation
+    (platform.aws/drift-exporter-pod-identity-role)
+[ ] S3 bucket carries all five ADR-0028 tags:
+    platform:system, platform:component, platform:env, platform:owner,
+    platform:managed-by
+[ ] ABAC condition confirmed on S3 bucket IAM policy:
+    aws:PrincipalTag/platform:system == aws:ResourceTag/platform:system
+[ ] ECR repository exists and cosign admission policy is in effect (Kyverno)
+[ ] ESO ExternalSecret for MLflow RDS creds is Ready in the mlflow namespace
+```
+
+---
+
+## 6. ADR-0034 revisit criteria (Backstage)
+
+The three conditions that must be met before Backstage (ADR-0034) is revisited:
+
+1. AWS ML platform reaches Phase-4 stable (WS-A..E all applied and running in prod
+   on the `aws-eks-gpu-*` cluster).
+2. A dedicated Backstage owner (engineer or team) is assigned.
+3. Three or more teams have successfully onboarded via the WS-F AWS golden paths
+   (`aws-ml-new-model-service`, `aws-ml-new-pipeline`, or `aws-ml-new-dashboard`).
+
+Current status: Phase-4 pending (WS-A..E are plan/validate-only);
+conditions 2 and 3 not yet met.
+
+---
+
+## 7. References
+
+- GCP etalon RACI: `docs/golden-paths/RACI-and-handoffs.md`
+- ADR-0044: AWS EKS GPU ML foundation
+- ADR-0048: AWS ML CI/CD + MLflow backends (S3, RDS, ECR)
+- ADR-0039: WS-D self-serve observability (grafana-self-serve)
+- ADR-0040: WS-E SOC posture + ML on-call runbooks
+- ADR-0041: WS-F golden-path templates + contracts (this document)
+- ADR-0028: platform taxonomy tags + ABAC
+- ADR-0018: EKS Pod Identity
+- ADR-0047: Envoy Gateway + InferenceObjective (serving front)
+- `docs/contracts/model-api-contract.md` (base contract spec)
+- `docs/contracts/aws-ml-model-api-contract.md` (AWS-specific addendum)
+- `.github/workflows/ml-pipeline.yml` (WS-B pipeline)
+- `apps/infra/airflow/dags/` (WS-B DAGs)
+- `apps/infra/ml-monitoring/` (WS-C drift-exporter)
+- `apps/infra/grafana-self-serve/` (WS-D self-serve chart)
+- `templates/golden-paths/aws-ml-new-model-service/` (golden path)
+- `templates/golden-paths/aws-ml-new-pipeline/` (golden path)
+- `templates/golden-paths/aws-ml-new-dashboard/` (golden path)

--- a/templates/golden-paths/aws-ml-new-dashboard/README.md
+++ b/templates/golden-paths/aws-ml-new-dashboard/README.md
@@ -1,0 +1,178 @@
+# Golden Path: AWS ML -- New Team Dashboard
+
+> **Platform:** AWS EKS GPU ML cluster (ADR-0044 / ADR-0048)
+> **ADR gates:** ADR-0041 (template approach)
+> **GCP etalon:** `templates/golden-paths/new-dashboard/` (GCP/GKE variant)
+>
+> WS-D (grafana-self-serve) is **cluster-agnostic** -- the chart, values
+> structure, and ArgoCD wave are identical to the GCP etalon. The only
+> AWS-specific addition is the ADR-0028 annotation documenting the Pod
+> Identity roles in use and the references pointing to ADR-0048.
+
+This template onboards a new team into the WS-D (ADR-0039) self-serve
+observability layer: one Grafana folder + starter dashboard + PrometheusRule
+alert groups, delivered in a single PR.
+
+Backstage scaffolder mapping: `spec.type: team-dashboard`
+(see "Backstage future mapping" below; ADR-0034 remains deferred).
+
+Chart: `apps/infra/grafana-self-serve/`
+Chart versions verified against WS-D chart as of 2026-06-15.
+
+---
+
+## When to use this template
+
+Use this golden path when:
+
+- A team is new to the **AWS ML platform** and needs a scoped Grafana folder
+- The team is non-ML (no drift monitoring needed) -- for ML + drift panels use
+  `aws-ml-new-model-service` (`templates/golden-paths/aws-ml-new-model-service/`)
+- You want to start from the standard RED + saturation + alerts dashboard on EKS
+
+For teams with ML models already deployed, enable `ml.enabled: true` and fill in
+`ml.modelName` + `ml.tenant` in the values file.
+
+---
+
+## Prerequisites
+
+- [ ] Namespace `{{TEAM_NAMESPACE}}` exists on the `aws-eks-gpu-*` ML cluster
+- [ ] Grafana service account `grafana-sa-{{TEAM_SLUG}}` exists in Grafana
+  (create via Grafana UI or API before ArgoCD sync)
+- [ ] CI service account `{{TEAM_SLUG}}-ci` exists in namespace `{{TEAM_NAMESPACE}}`
+  (for PrometheusRule RBAC; omit `ciServiceAccount` if not needed)
+
+---
+
+## Step 1 -- Substitute placeholders
+
+```bash
+# Team identity
+export TEAM_NAME="Checkout"           # human-readable
+export TEAM_SLUG="team-checkout"      # lower-kebab
+export TEAM_NAMESPACE="checkout"      # Kubernetes namespace on the EKS ML cluster
+export TEAM_SYSTEM="checkout"         # ADR-0028 platform:system value
+export TEAM_OWNER="team-checkout"     # ADR-0028 platform:owner value
+export PLATFORM_ENV="production"      # production | staging | dev | sandbox
+
+# AWS-specific (for the ArgoCD annotation documenting Pod Identity roles)
+export AWS_ACCOUNT_ID="123456789012"
+
+mkdir -p out
+for f in values.yaml argocd-application.yaml; do
+  envsubst < "$f" > "out/${f}"
+done
+
+# Verify no raw {{}} remain
+grep -r '{{' out/ && echo "UNSUBSTITUTED PLACEHOLDERS FOUND" || echo "OK"
+```
+
+---
+
+## Step 2 -- Commit the files
+
+Place the substituted files in the PR at:
+
+```
+apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/values.yaml
+apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/argocd-application.yaml
+```
+
+---
+
+## Step 3 -- Validate
+
+```bash
+yamllint -c .yamllint.yml out/values.yaml out/argocd-application.yaml
+
+helm template apps/infra/grafana-self-serve \
+  -f apps/infra/grafana-self-serve/values.yaml \
+  -f out/values.yaml
+```
+
+The render should produce:
+
+- A ConfigMap with `grafana_dashboard: "1"` label (Grafana folder provisioning)
+- A ConfigMap with `grafana_folder` annotation (starter dashboard)
+- A PrometheusRule with availability and saturation alert groups
+- A Role + RoleBinding for CI service account PrometheusRule management
+
+---
+
+## Step 4 -- Open the PR
+
+PR checklist:
+
+- [ ] All `{{PLACEHOLDER}}` substituted; no raw template strings remain
+- [ ] `yamllint -c .yamllint.yml` passes
+- [ ] `helm template` renders without error
+- [ ] ADR-0028 labels present: `platform:system`, `platform:owner`, `platform:env`,
+      `platform:component`, `platform:managed-by`
+- [ ] Grafana SA `grafana-sa-{{TEAM_SLUG}}` created before the PR is merged
+- [ ] Platform review obtained (see `docs/golden-paths/aws-ml-RACI-and-handoffs.md`)
+
+---
+
+## What you get after merge
+
+- Grafana folder `team-{{TEAM_SLUG}}` visible only to your team service account
+- A starter dashboard with RED panels, resource saturation, and an alerts table
+- PrometheusRule alert groups in namespace `{{TEAM_NAMESPACE}}`
+- RBAC Role + RoleBinding for CI PrometheusRule management
+
+For ML panels, set `ml.enabled: true` and fill in `ml.modelName` + `ml.tenant`
+(see `apps/infra/grafana-self-serve/values.yaml` for all ML options, and
+`templates/golden-paths/aws-ml-new-model-service/` for the full ML onboarding path).
+
+---
+
+## AWS note: PromQL selectors
+
+The Grafana dashboards use PromQL selectors based on Kubernetes labels and job/pod
+metadata -- not cloud-provider-specific labels. The RED metrics, saturation queries,
+and ML drift/accuracy queries are **identical** to the GCP etalon. No dashboard
+changes are needed when moving from GCP to AWS.
+
+---
+
+## Platform support
+
+- ADR-0039 (WS-D): grafana-self-serve architecture
+- ADR-0041 (WS-F): this template (golden-path structure)
+- ADR-0028: platform taxonomy tags and labels
+
+---
+
+## Backstage future mapping
+
+```yaml
+# catalog-info.yaml (future -- do not deploy before ADR-0034 revisit)
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: aws-ml-new-dashboard
+spec:
+  type: team-dashboard
+  parameters:
+    - title: Team identity
+      properties:
+        teamName:    # -> {{TEAM_NAME}}
+        teamSlug:    # -> {{TEAM_SLUG}}
+        namespace:   # -> {{TEAM_NAMESPACE}}
+        system:      # -> {{TEAM_SYSTEM}}
+        teamOwner:   # -> {{TEAM_OWNER}}
+        platformEnv: # -> {{PLATFORM_ENV}}
+    - title: AWS identity
+      properties:
+        awsAccountId:  # -> {{AWS_ACCOUNT_ID}}
+  steps:
+    - id: fetch-template
+      action: fetch:template
+      input:
+        url: ./templates/golden-paths/aws-ml-new-dashboard
+    - id: publish
+      action: publish:github:pull-request
+    - id: register
+      action: catalog:register
+```

--- a/templates/golden-paths/aws-ml-new-dashboard/argocd-application.yaml
+++ b/templates/golden-paths/aws-ml-new-dashboard/argocd-application.yaml
@@ -1,0 +1,73 @@
+---
+# Golden Path: aws-ml-new-dashboard -- ArgoCD Application stub (grafana-self-serve)
+# WS-D (ADR-0039) chart: apps/infra/grafana-self-serve
+#
+# USAGE: substitute all {{PLACEHOLDER}} values, then commit this file at:
+#   apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/argocd-application.yaml
+#
+# Deploys into {{TEAM_NAMESPACE}}. The namespace must pre-exist.
+# Wave 30 -- after all observability + ml-monitoring components (wave 10-20).
+#
+# AWS DELTA vs GCP etalon (templates/golden-paths/new-dashboard/argocd-application.yaml):
+#   No chart-level differences -- grafana-self-serve is cluster-agnostic.
+#   Added: platform.aws/cluster annotation to document the target EKS cluster ARN
+#   for audit traceability.
+#
+# See README.md Step 2 for full instructions.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  # Substitute: grafana-self-serve-{{TEAM_SLUG}}
+  name: "grafana-self-serve-{{TEAM_SLUG}}"
+  namespace: argocd
+  labels:
+    # ADR-0028 platform taxonomy (Kubernetes plane)
+    platform.system: "observability"
+    platform.component: "self-serve"
+    # Substitute: {{PLATFORM_ENV}}
+    platform.env: "{{PLATFORM_ENV}}"
+    # Substitute: {{TEAM_OWNER}}
+    platform.owner: "{{TEAM_OWNER}}"
+    platform.managed-by: "argocd"
+    # Substitute: grafana-self-serve-{{TEAM_SLUG}}
+    app.kubernetes.io/name: "grafana-self-serve-{{TEAM_SLUG}}"
+    app.kubernetes.io/component: "self-serve"
+    app.kubernetes.io/managed-by: "argocd"
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+    # AWS-specific: document the target EKS cluster ARN for audit traceability.
+    # Substitute: arn:aws:eks:{{AWS_REGION}}:{{AWS_ACCOUNT_ID}}:cluster/aws-eks-gpu-ml
+    platform.aws/cluster: "arn:aws:eks:us-east-1:{{AWS_ACCOUNT_ID}}:cluster/aws-eks-gpu-ml"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/your-org/platform-design.git
+    targetRevision: main
+    path: apps/infra/grafana-self-serve
+    helm:
+      valueFiles:
+        - values.yaml
+        # Substitute: example-teams/{{TEAM_SLUG}}/values.yaml
+        - "example-teams/{{TEAM_SLUG}}/values.yaml"
+  destination:
+    server: https://kubernetes.default.svc
+    # Substitute: {{TEAM_NAMESPACE}}
+    namespace: "{{TEAM_NAMESPACE}}"
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=false
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m

--- a/templates/golden-paths/aws-ml-new-dashboard/values.yaml
+++ b/templates/golden-paths/aws-ml-new-dashboard/values.yaml
@@ -1,0 +1,75 @@
+# Golden Path: aws-ml-new-dashboard -- grafana-self-serve values template
+# WS-D (ADR-0039) chart: apps/infra/grafana-self-serve
+#
+# USAGE: substitute all {{PLACEHOLDER}} values before committing.
+# Place the substituted file at:
+#   apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/values.yaml
+#
+# This file is structurally identical to the GCP etalon
+# (templates/golden-paths/new-dashboard/values.yaml) because WS-D
+# (grafana-self-serve) is cluster-agnostic. The PromQL selectors and
+# Grafana provisioning logic are identical between AWS and GCP.
+#
+# For ML teams that need drift + accuracy panels, set ml.enabled: true
+# and fill in ml.modelName + ml.tenant; or use the aws-ml-new-model-service
+# template (templates/golden-paths/aws-ml-new-model-service/).
+#
+# See README.md for full instructions.
+
+team:
+  # Human-readable team name shown in the Grafana folder title.
+  # Substitute: {{TEAM_NAME}}
+  name: "{{TEAM_NAME}}"
+
+  # Machine-safe slug -- lowercase, hyphens only.
+  # Substitute: {{TEAM_SLUG}}
+  slug: "{{TEAM_SLUG}}"
+
+  # Kubernetes namespace where this team's workloads run.
+  # Must already exist (CreateNamespace=false on the ArgoCD Application).
+  # Substitute: {{TEAM_NAMESPACE}}
+  namespace: "{{TEAM_NAMESPACE}}"
+
+  # platform:system value (ADR-0028 taxonomy).
+  # Substitute: {{TEAM_SYSTEM}}  e.g., "checkout", "auth", "data-pipeline", "ml-platform"
+  system: "{{TEAM_SYSTEM}}"
+
+  # platform:owner value (ADR-0028 taxonomy).
+  # Substitute: {{TEAM_OWNER}}
+  owner: "{{TEAM_OWNER}}"
+
+  # Deployment environment.
+  # Substitute: {{PLATFORM_ENV}}
+  env: "{{PLATFORM_ENV}}"
+
+  # Grafana service account for folder Editor access.
+  # Create this SA in Grafana before ArgoCD sync.
+  # Substitute: grafana-sa-{{TEAM_SLUG}}
+  grafanaServiceAccount: "grafana-sa-{{TEAM_SLUG}}"
+
+  # CI/CD service account in team.namespace for PrometheusRule RBAC.
+  # Leave empty string to skip RoleBinding creation.
+  # Substitute: {{TEAM_SLUG}}-ci
+  ciServiceAccount: "{{TEAM_SLUG}}-ci"
+
+# ML-specific panels -- leave disabled for non-ML teams.
+# Set enabled: true and fill in modelName + tenant for ML teams that have
+# applied the aws-ml-new-model-service golden path.
+# On AWS the ML metrics come from the Evidently drift-exporter reading from
+# S3 via EKS Pod Identity/ABAC; the PromQL selectors are cloud-agnostic.
+ml:
+  enabled: false
+  modelName: ""
+  tenant: ""
+
+# Alert thresholds -- adjust for your team's SLOs.
+alerts:
+  errorRateThreshold: "0.05"
+  cpuSaturationThreshold: "0.80"
+  memorySaturationThreshold: "0.80"
+  availabilityFor: "5m"
+  saturationFor: "15m"
+  # ML thresholds (only used when ml.enabled: true):
+  mlDriftThreshold: "0.2"
+  mlAccuracyThreshold: "0.85"
+  mlAlertFor: "10m"

--- a/templates/golden-paths/aws-ml-new-model-service/README.md
+++ b/templates/golden-paths/aws-ml-new-model-service/README.md
@@ -1,0 +1,291 @@
+# Golden Path: AWS ML — New Model Service
+
+> **Platform:** AWS EKS GPU ML cluster (ADR-0044 / ADR-0048)
+> **ADR gates:** ADR-0041 (template approach), ADR-0048 (AWS backends)
+> **GCP etalon:** `templates/golden-paths/new-model-service/` (GCP/GKE variant)
+>
+> This is the **AWS-flavoured** golden path. The ML logic (Airflow DAG corpus,
+> MLflow train→eval→gate→register→deploy, Evidently drift, retrain trigger) is
+> **identical** to the GCP etalon (inherited from ADR-0037/0038 via ADR-0048).
+> Only the cloud-specific wiring differs: S3 artifact store + EKS Pod Identity/ABAC
+> (not GCS + Workload Identity), ECR (not GCR), RDS Postgres (not Cloud SQL),
+> AWS Secrets Manager + ESO (not GCP Secret Manager).
+
+This template wires a new ML model into the full AWS ML platform stack:
+
+- **WS-B** (ADR-0048 <- ADR-0037): `ml-pipeline.yml` train->eval->register->deploy
+  with MLflow on S3 + RDS backends (EKS Pod Identity/ABAC)
+- **WS-C** (ADR-0048 <- ADR-0038): Evidently drift-exporter + whylogs profiler
+  per-model namespace, Prometheus->Alertmanager->PagerDuty
+- **WS-D** (ADR-0039): `grafana-self-serve` per-team dashboard + alert rules
+
+Backstage scaffolder mapping: `spec.type: model-service`
+(see "Backstage future mapping" below; ADR-0034 remains deferred).
+
+Chart versions verified against:
+
+- `apps/infra/ml-monitoring` (WS-C) as of 2026-06-15
+- `apps/infra/grafana-self-serve` (WS-D) as of 2026-06-15
+- `.github/workflows/ml-pipeline.yml` (WS-B) as of 2026-06-15
+- `apps/infra/mlflow` (S3/RDS backend) as of 2026-06-15
+
+---
+
+## Prerequisites
+
+Before you start, confirm:
+
+- [ ] Namespace `{{MODEL_NAMESPACE}}` exists on the `aws-eks-gpu-*` ML cluster
+  (or ask Platform: `kubectl create namespace {{MODEL_NAMESPACE}}`)
+- [ ] S3 bucket `s3://{{S3_MLFLOW_ARTIFACTS_BUCKET}}` exists and carries
+  `platform:system = ml-pipeline` tag (provisioned by WS-B
+  `terraform/modules/aws-ml-artifact-store` + `catalog/units/aws-ml-artifact-store`)
+- [ ] The `aws-ml-artifact-store` IAM role ARN is known
+  (`aws_ml_artifact_store_role_arn` output of the catalog unit)
+- [ ] MLflow tracking server is reachable at `$MLFLOW_TRACKING_URI`
+  (deployed by WS-B `apps/infra/mlflow/`)
+- [ ] Airflow is reachable at `$AIRFLOW_BASE_URL`
+  (deployed by WS-B `apps/infra/airflow/`)
+- [ ] Grafana service account `grafana-sa-{{TEAM_SLUG}}` exists in Grafana
+  (create via Grafana UI or API before ArgoCD sync)
+- [ ] Model training code lives under `models/{{MODEL_NAME}}/` or
+  `adapters/{{MODEL_NAME}}/` (triggers `.github/workflows/ml-pipeline.yml` on push)
+- [ ] You have read `docs/contracts/model-api-contract.md` and
+  `docs/contracts/aws-ml-model-api-contract.md` and your model's schema matches
+- [ ] Contract sign-off obtained from Data Eng, Backend, and Frontend leads
+  (see `docs/golden-paths/aws-ml-RACI-and-handoffs.md` -- required before staging)
+- [ ] ECR repository exists at
+  `{{AWS_ACCOUNT_ID}}.dkr.ecr.{{AWS_REGION}}.amazonaws.com/{{MODEL_NAME}}`
+  (ECR pull-through cache covers upstream bases per ADR-0029)
+
+---
+
+## Step 1 -- Substitute placeholders
+
+Copy this template directory to a working location and substitute all
+`{{UPPER_SNAKE_CASE}}` placeholders. Use `envsubst` or `sed`:
+
+```bash
+# AWS-specific
+export AWS_ACCOUNT_ID="123456789012"
+export AWS_REGION="us-east-1"
+export S3_MLFLOW_ARTIFACTS_BUCKET="mlflow-artifacts-prod-${AWS_ACCOUNT_ID}"
+export ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+
+# Model identity
+export MODEL_NAME="fraud-uk"
+export MODEL_NAMESPACE="fraud-uk"
+export TEAM_SLUG="team-ml-fraud"
+export TEAM_NAME="ML Fraud"
+export TEAM_OWNER="team-ml-fraud"
+export TENANT="tenant-acme"
+export DOMAIN="hft"               # one of: hft, solana, insurance, rtb
+export PLATFORM_ENV="production"  # production | staging | dev | sandbox
+
+# Substitute all template files
+mkdir -p out
+for f in values-grafana-self-serve.yaml values-ml-monitoring.yaml \
+          ml-pipeline-trigger.yaml argocd-application.yaml; do
+  envsubst < "$f" > "out/${f}"
+done
+```
+
+Verify no `{{` remain:
+
+```bash
+grep -r '{{' out/ && echo "UNSUBSTITUTED PLACEHOLDERS FOUND" || echo "OK"
+```
+
+---
+
+## Step 2 -- Wire the training pipeline (WS-B, AWS)
+
+The file `ml-pipeline-trigger.yaml` shows the `workflow_dispatch` payload to
+trigger `.github/workflows/ml-pipeline.yml` for your model. On AWS the pipeline:
+
+1. Calls `POST /api/v1/dags/train_domain_adapter/dagRuns`
+   with `conf.model_id = {{MODEL_NAME}}`, `conf.tenant = {{TENANT}}`,
+   `conf.domain = {{DOMAIN}}`
+2. Polls `eval_adapter_debate` DAG run until terminal state
+3. Reads eval metrics from MLflow (RDS Postgres backend, creds via ESO);
+   gate: `win_rate >= 0.55`
+4. Registers model version in MLflow; artifact written to
+   `s3://{{S3_MLFLOW_ARTIFACTS_BUCKET}}/{{MODEL_NAME}}/{{TENANT}}/{{DOMAIN}}/`
+   via EKS Pod Identity + ABAC (IAM condition:
+   `aws:PrincipalTag/platform:system == aws:ResourceTag/platform:system`)
+5. Generates SBOM (`.github/actions/syft-sbom`) and cosign-signs the artifact
+6. Pushes the model image to ECR:
+   `{{ECR_REGISTRY}}/{{MODEL_NAME}}:{{PLATFORM_ENV}}-<commit-sha>`
+7. Opens Kargo promotion: dev (auto) -> staging (reviewer) -> prod (manual gate)
+
+No changes to the workflow file are needed -- it is parameterised by `inputs.model`.
+
+**AWS delta vs GCP etalon:**
+- Artifact store: S3 (not GCS); identity: EKS Pod Identity + ABAC (not GKE WI + GSA)
+- Registry: ECR with pull-through cache (not GCR)
+- Secrets: AWS Secrets Manager + ESO (not GCP Secret Manager)
+
+Reference: `.github/workflows/ml-pipeline.yml`, ADR-0048 D1/D2/D5
+
+---
+
+## Step 3 -- Configure drift monitoring (WS-C)
+
+Apply the substituted `values-ml-monitoring.yaml` as a per-model override:
+
+- **Recommended:** add a `modelNamespaces` entry in the main
+  `apps/infra/ml-monitoring/values.yaml` PR.
+- **Alternative:** create a standalone ArgoCD Application that merges
+  `apps/infra/ml-monitoring/values.yaml` with your per-model overrides.
+
+The WS-C chart deploys per namespace:
+
+- An Evidently `drift-exporter` Deployment (accuracy, PSI, KL divergence, F1).
+  Reads the reference dataset from
+  `s3://{{S3_MLFLOW_ARTIFACTS_BUCKET}}/{{MODEL_NAME}}/{{TENANT}}/{{DOMAIN}}/reference.parquet`
+  via the drift-exporter ServiceAccount's Pod Identity binding.
+- A whylogs profiler Deployment (inline distribution profiling)
+- A ServiceMonitor so Prometheus scrapes `/metrics` on port 8001
+- A PrometheusRule with `{{TEAM_SLUG_UPPER}}_DRIFT_HIGH` and
+  `{{TEAM_SLUG_UPPER}}_ACCURACY_LOW` alert groups
+  (TEAM_SLUG_UPPER: upper-case TEAM_SLUG, hyphens replaced by underscores)
+
+The drift alert fires the retrain trigger webhook -- cluster-agnostic (ADR-0048 D4):
+`POST $AIRFLOW_BASE_URL/api/v1/dags/train_domain_adapter/dagRuns`
+with `conf = {"tenant": "{{TENANT}}", "domain": "{{DOMAIN}}", "trigger_reason": "drift"}`.
+
+Reference: `apps/infra/ml-monitoring/values.yaml`, ADR-0048 D4, ADR-0038
+
+---
+
+## Step 4 -- Provision team dashboard (WS-D)
+
+Create a PR adding your substituted files:
+
+```
+apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/values.yaml
+apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/argocd-application.yaml
+```
+
+The WS-D chart provisions (WS-D is cluster-agnostic -- identical to GCP):
+
+- Grafana folder `team-{{TEAM_SLUG}}`
+- Starter dashboard with RED metrics, resource saturation, alerts table, and ML panels
+  (ML panels activate because `ml.enabled: true`; scoped to
+  `model_name = {{MODEL_NAME}}`, `tenant = {{TENANT}}`)
+- PrometheusRule with availability + saturation + ML alert groups
+  in namespace `{{MODEL_NAMESPACE}}`
+
+Reference: `apps/infra/grafana-self-serve/values.yaml`, ADR-0039
+
+---
+
+## Step 5 -- Contract sign-off
+
+Before merging the ArgoCD Application into staging, confirm:
+
+```
+[ ] docs/contracts/model-api-contract.md read by all four personas
+[ ] docs/contracts/aws-ml-model-api-contract.md AWS-specific section reviewed
+[ ] Request/response schema for {{MODEL_NAME}} matches the contract spec
+[ ] Feature schema for {{MODEL_NAME}} matches the contract spec
+[ ] Signed off by:
+    Data Eng lead   _________
+    ML Eng lead     _________
+    Backend lead    _________
+    Frontend lead   _________  (if a UI consumes this model)
+```
+
+See `docs/contracts/example-domain-adapter-contract.yaml` for a worked example.
+See `docs/golden-paths/aws-ml-RACI-and-handoffs.md` for the AWS RACI matrix.
+
+---
+
+## Step 6 -- Open the PR
+
+PR checklist:
+
+- [ ] All `{{PLACEHOLDER}}` substituted; no raw template strings remain in output files
+- [ ] `yamllint -c .yamllint.yml` passes on all new YAML files
+- [ ] `helm template apps/infra/grafana-self-serve \
+       -f apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/values.yaml`
+       renders without error
+- [ ] ADR-0028 tags present on every AWS resource (S3 bucket, IAM role, ECR repo):
+      `platform:system`, `platform:owner`, `platform:env`,
+      `platform:component`, `platform:managed-by`
+- [ ] ADR-0028 labels present on every Kubernetes resource
+- [ ] ABAC condition confirmed on S3 bucket IAM policy:
+      `aws:PrincipalTag/platform:system == aws:ResourceTag/platform:system`
+- [ ] Contract sign-off documented in PR description
+- [ ] Link to MLflow experiment URL once first training run completes
+- [ ] ECR image URI confirmed in MLflow run metadata
+
+---
+
+## AWS identity quick-reference
+
+| Concern | How it is wired |
+|---------|-----------------|
+| MLflow -> S3 artifact store | EKS Pod Identity: `mlflow-sa` -> IAM role with `platform:system=ml-pipeline` ABAC condition |
+| Drift exporter -> S3 ref dataset | EKS Pod Identity: `drift-exporter-sa` -> IAM role scoped to reference-dataset prefix |
+| Airflow task pods | Run under Volcano scheduler (`schedulerName: volcano`); task SA has Pod Identity for task-specific S3 paths |
+| RDS Postgres creds | ESO ExternalSecret from AWS Secrets Manager (ADR-0008 + rotation ADR-0031) |
+| ECR pull | Pull-through cache (ADR-0029); node IAM role has `ecr:GetAuthorizationToken` |
+| cosign signing | `.github/actions/cosign-sign` composite (inherited ADR-0037 D4) |
+| SBOM generation | `.github/actions/syft-sbom` composite (inherited ADR-0037 D4) |
+
+---
+
+## Platform support
+
+Contact `#platform-eng` on Slack or open an issue referencing:
+
+- ADR-0044: EKS GPU cluster / scheduling / node issues
+- ADR-0048: AWS ML pipeline, S3, RDS, ECR, drift wiring
+- ADR-0041: this template (golden-path structure)
+- ADR-0028: ADR-0028 tag / ABAC issues
+- ADR-0018: EKS Pod Identity issues
+
+---
+
+## Backstage future mapping
+
+When ADR-0034 is revisited, this template maps to a Backstage Software Template:
+
+```yaml
+# catalog-info.yaml (future -- do not deploy before ADR-0034 revisit)
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: aws-ml-new-model-service
+spec:
+  type: model-service
+  parameters:
+    - title: AWS identity
+      properties:
+        awsAccountId:       # -> {{AWS_ACCOUNT_ID}}
+        awsRegion:          # -> {{AWS_REGION}}
+        s3ArtifactsBucket:  # -> {{S3_MLFLOW_ARTIFACTS_BUCKET}}
+        ecrRegistry:        # -> {{ECR_REGISTRY}}
+    - title: Model identity
+      properties:
+        modelName:          # -> {{MODEL_NAME}}
+        namespace:          # -> {{MODEL_NAMESPACE}}
+        tenant:             # -> {{TENANT}}
+        domain:             # -> {{DOMAIN}}
+    - title: Team identity
+      properties:
+        teamSlug:           # -> {{TEAM_SLUG}}
+        teamName:           # -> {{TEAM_NAME}}
+        teamOwner:          # -> {{TEAM_OWNER}}
+        platformEnv:        # -> {{PLATFORM_ENV}}
+  steps:
+    - id: fetch-template
+      action: fetch:template
+      input:
+        url: ./templates/golden-paths/aws-ml-new-model-service
+    - id: publish
+      action: publish:github:pull-request
+    - id: register
+      action: catalog:register
+```

--- a/templates/golden-paths/aws-ml-new-model-service/argocd-application.yaml
+++ b/templates/golden-paths/aws-ml-new-model-service/argocd-application.yaml
@@ -1,0 +1,74 @@
+---
+# Golden Path: aws-ml-new-model-service -- ArgoCD Application stub (grafana-self-serve)
+# WS-D (ADR-0039) chart: apps/infra/grafana-self-serve
+#
+# USAGE: substitute all {{PLACEHOLDER}} values, then commit this file at:
+#   apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/argocd-application.yaml
+#
+# Deploys into {{MODEL_NAMESPACE}}. The namespace must pre-exist.
+# Wave 30 -- after all observability + ml-monitoring components (wave 10-20).
+#
+# AWS DELTA vs GCP etalon (templates/golden-paths/new-model-service/argocd-application.yaml):
+#   No chart-level differences -- grafana-self-serve is cluster-agnostic.
+#   Added: platform.aws/drift-exporter-pod-identity-role annotation to document
+#   the IAM role ARN backing the drift-exporter ServiceAccount's Pod Identity binding.
+#
+# See README.md Step 4 for full instructions.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  # Substitute: grafana-self-serve-{{TEAM_SLUG}}
+  name: "grafana-self-serve-{{TEAM_SLUG}}"
+  namespace: argocd
+  labels:
+    # ADR-0028 platform taxonomy (Kubernetes plane)
+    platform.system: "observability"
+    platform.component: "self-serve"
+    # Substitute: {{PLATFORM_ENV}}
+    platform.env: "{{PLATFORM_ENV}}"
+    # Substitute: {{TEAM_OWNER}}
+    platform.owner: "{{TEAM_OWNER}}"
+    platform.managed-by: "argocd"
+    # Substitute: grafana-self-serve-{{TEAM_SLUG}}
+    app.kubernetes.io/name: "grafana-self-serve-{{TEAM_SLUG}}"
+    app.kubernetes.io/component: "self-serve"
+    app.kubernetes.io/managed-by: "argocd"
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+    # AWS-specific: document the IAM role ARN for the drift-exporter Pod Identity.
+    # Provisioned by WS-B/C terraform; record the ARN here for audit traceability.
+    # Substitute: arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/drift-exporter-{{MODEL_NAME}}
+    platform.aws/drift-exporter-pod-identity-role: "arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/drift-exporter-{{MODEL_NAME}}"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/your-org/platform-design.git
+    targetRevision: main
+    path: apps/infra/grafana-self-serve
+    helm:
+      valueFiles:
+        - values.yaml
+        # Substitute: example-teams/{{TEAM_SLUG}}/values.yaml
+        - "example-teams/{{TEAM_SLUG}}/values.yaml"
+  destination:
+    server: https://kubernetes.default.svc
+    # Substitute: {{MODEL_NAMESPACE}}
+    namespace: "{{MODEL_NAMESPACE}}"
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=false
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m

--- a/templates/golden-paths/aws-ml-new-model-service/ml-pipeline-trigger.yaml
+++ b/templates/golden-paths/aws-ml-new-model-service/ml-pipeline-trigger.yaml
@@ -1,0 +1,84 @@
+# Golden Path: aws-ml-new-model-service -- ml-pipeline trigger payload
+# WS-B (ADR-0048 <- ADR-0037): .github/workflows/ml-pipeline.yml
+#
+# USAGE: substitute all {{PLACEHOLDER}} values.
+# This file documents the workflow_dispatch payload and the
+# Airflow REST dagRun call that the pipeline makes.
+#
+# AWS DELTA vs GCP etalon
+# (templates/golden-paths/new-model-service/ml-pipeline-trigger.yaml):
+#   - Artifact store: S3 (not GCS); identity: EKS Pod Identity + ABAC (ADR-0048 D2)
+#   - Registry: ECR pull-through cache (not GCR, ADR-0048 D5 / ADR-0029)
+#   - Secrets: AWS Secrets Manager + ESO (not GCP Secret Manager, ADR-0008)
+#   - Airflow REST call is identical (cluster-agnostic, ADR-0048 D4/ADR-0038)
+#
+# See README.md Step 2 for full instructions.
+
+# ---------------------------------------------------------------------------
+# 1. GitHub Actions workflow_dispatch payload
+#    POST /repos/{owner}/{repo}/actions/workflows/ml-pipeline.yml/dispatches
+# ---------------------------------------------------------------------------
+githubDispatch:
+  # Branch that carries your model's training code.
+  # Substitute: main  (or feature/{{MODEL_NAME}}-training)
+  ref: "main"
+  inputs:
+    # Substitute: {{MODEL_NAME}}
+    model: "{{MODEL_NAME}}"
+    # Substitute: {{TENANT}}
+    tenant: "{{TENANT}}"
+    # Substitute: {{DOMAIN}}  one of: hft, solana, insurance, rtb
+    domain: "{{DOMAIN}}"
+    # Target environment for the Kargo promotion gate.
+    # Substitute: {{PLATFORM_ENV}}  e.g., staging
+    target_env: "{{PLATFORM_ENV}}"
+
+# ---------------------------------------------------------------------------
+# 2. Airflow REST dagRun call (made by the ml-pipeline.yml workflow)
+#    POST $AIRFLOW_BASE_URL/api/v1/dags/train_domain_adapter/dagRuns
+# ---------------------------------------------------------------------------
+airflowDagRunConf:
+  model_id: "{{MODEL_NAME}}"
+  tenant: "{{TENANT}}"
+  domain: "{{DOMAIN}}"
+  # On AWS the artifact store is S3 (not GCS).
+  # The Airflow task pod reads this from its Pod Identity-bound ServiceAccount
+  # environment -- no static credential is passed here.
+  # Substitute: {{S3_MLFLOW_ARTIFACTS_BUCKET}}, {{MODEL_NAME}}, {{TENANT}}, {{DOMAIN}}
+  artifact_store_uri: "s3://{{S3_MLFLOW_ARTIFACTS_BUCKET}}/{{MODEL_NAME}}/{{TENANT}}/{{DOMAIN}}"
+  # AWS region for the S3 client inside the task pod.
+  # Substitute: {{AWS_REGION}}
+  aws_region: "{{AWS_REGION}}"
+  trigger_reason: "manual"
+
+# ---------------------------------------------------------------------------
+# 3. MLflow artifact path (written by train_domain_adapter DAG)
+#    s3://<bucket>/<model>/<tenant>/<domain>/<run_id>/artifacts/
+# ---------------------------------------------------------------------------
+mlflowArtifactPath:
+  # Substitute: {{S3_MLFLOW_ARTIFACTS_BUCKET}}, {{MODEL_NAME}}, {{TENANT}}, {{DOMAIN}}
+  pattern: "s3://{{S3_MLFLOW_ARTIFACTS_BUCKET}}/{{MODEL_NAME}}/{{TENANT}}/{{DOMAIN}}/<run_id>/artifacts/"
+
+# ---------------------------------------------------------------------------
+# 4. ECR image pushed by the pipeline (ADR-0048 D5)
+# ---------------------------------------------------------------------------
+ecrImage:
+  # Substitute: {{ECR_REGISTRY}}, {{MODEL_NAME}}, {{PLATFORM_ENV}}
+  uri: "{{ECR_REGISTRY}}/{{MODEL_NAME}}:{{PLATFORM_ENV}}-<commit-sha>"
+  # cosign + syft signatures stored alongside the image digest in ECR.
+  signingComposites:
+    - ".github/actions/cosign-sign"
+    - ".github/actions/syft-sbom"
+
+# ---------------------------------------------------------------------------
+# 5. Kargo promotion gates (ADR-0021)
+# ---------------------------------------------------------------------------
+kargoPromotion:
+  stages:
+    - name: dev
+      autoPromotion: true
+    - name: staging
+      autoPromotion: false     # requires reviewer approval
+      contractSignOffRequired: true  # blocks until PR sign-off documented
+    - name: production
+      autoPromotion: false     # requires explicit manual gate

--- a/templates/golden-paths/aws-ml-new-model-service/values-grafana-self-serve.yaml
+++ b/templates/golden-paths/aws-ml-new-model-service/values-grafana-self-serve.yaml
@@ -1,0 +1,77 @@
+# Golden Path: aws-ml-new-model-service -- grafana-self-serve values
+# WS-D (ADR-0039) chart: apps/infra/grafana-self-serve
+#
+# USAGE: substitute all {{PLACEHOLDER}} values before committing.
+# Place the substituted file at:
+#   apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/values.yaml
+#
+# This file is structurally identical to the GCP etalon
+# (templates/golden-paths/new-model-service/values-grafana-self-serve.yaml)
+# because WS-D (grafana-self-serve) is cluster-agnostic: it runs on the
+# same Prometheus/Grafana stack regardless of cloud provider.
+# The ML metric PromQL queries are cloud-agnostic.
+#
+# See README.md Step 4 for full instructions.
+
+team:
+  # Human-readable team name shown in the Grafana folder title.
+  # Substitute: {{TEAM_NAME}}
+  name: "{{TEAM_NAME}}"
+
+  # Machine-safe slug -- lowercase, hyphens only.
+  # Substitute: {{TEAM_SLUG}}
+  slug: "{{TEAM_SLUG}}"
+
+  # Kubernetes namespace where this team's workloads run.
+  # Must already exist (CreateNamespace=false on the ArgoCD Application).
+  # Substitute: {{MODEL_NAMESPACE}}
+  namespace: "{{MODEL_NAMESPACE}}"
+
+  # platform.system value (ADR-0028). For an AWS ML model service: ml-pipeline.
+  system: "ml-pipeline"
+
+  # platform.owner value (ADR-0028).
+  # Substitute: {{TEAM_OWNER}}
+  owner: "{{TEAM_OWNER}}"
+
+  # Deployment environment.
+  # Substitute: {{PLATFORM_ENV}}
+  env: "{{PLATFORM_ENV}}"
+
+  # Grafana service account for folder Editor access.
+  # Create this SA in Grafana before ArgoCD sync.
+  # Substitute: grafana-sa-{{TEAM_SLUG}}
+  grafanaServiceAccount: "grafana-sa-{{TEAM_SLUG}}"
+
+  # CI/CD service account in team.namespace for PrometheusRule RBAC.
+  # Substitute: {{TEAM_SLUG}}-ci
+  ciServiceAccount: "{{TEAM_SLUG}}-ci"
+
+# ML panels enabled -- wires ADR-0038 drift + accuracy metrics into the dashboard.
+# On AWS these metrics originate from the Evidently drift-exporter reading from
+# the S3 reference dataset via Pod Identity/ABAC. The PromQL selectors are
+# cloud-agnostic (model_name, tenant, domain labels).
+ml:
+  enabled: true
+
+  # Scope ML panels to this specific model.
+  # Substitute: {{MODEL_NAME}}
+  modelName: "{{MODEL_NAME}}"
+
+  # Scope ML panels to this tenant (ADR-0038 multi-tenant label).
+  # Substitute: {{TENANT}}
+  tenant: "{{TENANT}}"
+
+# Alert thresholds -- adjust for your model SLOs.
+alerts:
+  errorRateThreshold: "0.05"
+  cpuSaturationThreshold: "0.80"
+  memorySaturationThreshold: "0.80"
+  availabilityFor: "5m"
+  saturationFor: "15m"
+  # Drift and accuracy floors from:
+  #   docs/contracts/model-api-contract.md
+  #   docs/contracts/aws-ml-model-api-contract.md
+  mlDriftThreshold: "0.2"
+  mlAccuracyThreshold: "0.85"
+  mlAlertFor: "10m"

--- a/templates/golden-paths/aws-ml-new-model-service/values-ml-monitoring.yaml
+++ b/templates/golden-paths/aws-ml-new-model-service/values-ml-monitoring.yaml
@@ -1,0 +1,81 @@
+# Golden Path: aws-ml-new-model-service -- ml-monitoring per-model override
+# WS-C (ADR-0048 <- ADR-0038) chart: apps/infra/ml-monitoring
+#
+# USAGE: substitute all {{PLACEHOLDER}} values, then add this as a
+# modelNamespaces entry in apps/infra/ml-monitoring/values.yaml
+# (or mount as a second values file in a per-model ArgoCD Application).
+#
+# AWS DELTA vs GCP etalon (templates/golden-paths/new-model-service/values-ml-monitoring.yaml):
+#   referenceBucketUri is an S3 URI (s3://) not GCS (gs://).
+#   Access to the reference dataset is via EKS Pod Identity + ABAC:
+#   the drift-exporter ServiceAccount must have a Pod Identity binding
+#   to an IAM role scoped to the reference-dataset prefix.
+#   awsRegion is required for the S3 client.
+#
+# See README.md Step 3 for full instructions.
+#
+# ADR-0028 platform labels (Kubernetes plane):
+#   platform.system     = ml-monitoring
+#   platform.component  = drift-exporter
+#   platform.env        = {{PLATFORM_ENV}}
+#   platform.owner      = {{TEAM_OWNER}}
+#   platform.managed-by = argocd
+
+# Namespace for this model's drift-monitoring components.
+# Substitute: {{MODEL_NAMESPACE}}
+namespace: "{{MODEL_NAMESPACE}}"
+
+driftExporter:
+  enabled: true
+
+  # Per-model S3 reference dataset path (AWS: s3:// not gs://).
+  # Pattern: s3://<bucket>/<modelName>/<tenant>/<domain>/reference.parquet
+  # The drift-exporter Pod Identity role must have s3:GetObject on this prefix.
+  # Substitutes: {{S3_MLFLOW_ARTIFACTS_BUCKET}}, {{MODEL_NAME}}, {{TENANT}}, {{DOMAIN}}
+  referenceBucketUri: "s3://{{S3_MLFLOW_ARTIFACTS_BUCKET}}/{{MODEL_NAME}}/{{TENANT}}/{{DOMAIN}}/reference.parquet"
+
+  # AWS region for the S3 client (must match the bucket region).
+  # Substitute: {{AWS_REGION}}
+  awsRegion: "{{AWS_REGION}}"
+
+  # Model-specific drift thresholds.
+  # Adjust to match the contract floors in:
+  #   docs/contracts/model-api-contract.md
+  #   docs/contracts/aws-ml-model-api-contract.md
+  defaultThresholds:
+    datasetDriftScore:
+      warning: 0.20
+      critical: 0.40
+    featurePsiScore:
+      warning: 0.10
+      critical: 0.25
+    featureKlDivergence:
+      warning: 0.10
+      critical: 0.30
+    modelAccuracy:
+      warning: 0.85
+      critical: 0.75
+    modelF1Score:
+      warning: 0.80
+      critical: 0.65
+
+whylogsProfiler:
+  enabled: true
+
+  # Pushgateway address -- shared across all model namespaces.
+  pushgatewayAddress: "http://prometheus-pushgateway.ml-monitoring.svc.cluster.local:9091"
+
+  # Labels injected into every whylogs push for multi-tenant PromQL queries.
+  # Must match ADR-0038 D1 label set: model_name, tenant, domain.
+  extraLabels:
+    model_name: "{{MODEL_NAME}}"
+    tenant: "{{TENANT}}"
+    domain: "{{DOMAIN}}"
+
+# ADR-0028 platform labels applied to all Kubernetes resources in this release.
+platformLabels:
+  "platform.system": "ml-monitoring"
+  "platform.component": "drift-exporter"
+  "platform.env": "{{PLATFORM_ENV}}"
+  "platform.owner": "{{TEAM_OWNER}}"
+  "platform.managed-by": "argocd"

--- a/templates/golden-paths/aws-ml-new-pipeline/README.md
+++ b/templates/golden-paths/aws-ml-new-pipeline/README.md
@@ -1,0 +1,265 @@
+# Golden Path: AWS ML -- New ML Pipeline (Airflow DAG)
+
+> **Platform:** AWS EKS GPU ML cluster (ADR-0044 / ADR-0048)
+> **ADR gates:** ADR-0041 (template approach), ADR-0048 (AWS backends)
+> **GCP etalon:** `templates/golden-paths/new-ml-pipeline/` (GCP/GKE variant)
+>
+> This is the **AWS-flavoured** golden path. The DAG structure, MLflow integration
+> pattern, and WS-C drift metric push are **identical** to the GCP etalon
+> (inherited from ADR-0037/0038 via ADR-0048). Only the cloud-specific wiring
+> differs: S3 artifact store + EKS Pod Identity/ABAC, ECR, AWS Secrets Manager.
+
+This template creates a new Airflow DAG that mirrors the WS-B (ADR-0048 <- ADR-0037)
+DAG shape. It registers artifacts in MLflow (RDS Postgres backend, S3 artifact store)
+and emits drift metrics so they are scrapeable by WS-C (ADR-0048 <- ADR-0038)
+Evidently + whylogs.
+
+Backstage scaffolder mapping: `spec.type: ml-pipeline`
+(see "Backstage future mapping" below; ADR-0034 remains deferred).
+
+Chart versions verified against:
+
+- `apps/infra/airflow/dags/` (WS-B) as of 2026-06-15
+- `apps/infra/mlflow/` (WS-B, S3 + RDS) as of 2026-06-15
+
+---
+
+## When to use this template
+
+Use this golden path when you need a **net-new Airflow DAG** that is:
+
+- Not one of the four canonical WS-B DAGs (`train_domain_adapter`, `eval_adapter_debate`,
+  `mine_templates`, `promote_to_edge`)
+- Processing a new data domain or running a periodic batch ML job on the AWS EKS ML cluster
+- Registering its own model artifacts in MLflow (S3 artifact store + RDS backend)
+- Expected to emit distribution metrics for WS-C monitoring
+
+If you are adding a new **model** that uses the existing canonical DAGs, use the
+`aws-ml-new-model-service` golden path instead
+(`templates/golden-paths/aws-ml-new-model-service/`).
+
+---
+
+## Prerequisites
+
+- [ ] Airflow is deployed at `$AIRFLOW_BASE_URL` (WS-B `apps/infra/airflow/`)
+- [ ] MLflow tracking server is reachable at `$MLFLOW_TRACKING_URI` (WS-B `apps/infra/mlflow/`)
+- [ ] S3 bucket `s3://{{S3_MLFLOW_ARTIFACTS_BUCKET}}` exists with
+  `platform:system = ml-pipeline` tag (ADR-0028) and the correct Pod Identity IAM role
+- [ ] Your task pod ServiceAccount has a Pod Identity binding to an IAM role with
+  `s3:PutObject` on the artifacts prefix (ADR-0018 + ADR-0048 D2)
+- [ ] WS-C `ml-monitoring` namespace and Pushgateway exist (`apps/infra/ml-monitoring/`)
+- [ ] Your DAG code will live in `apps/infra/airflow/dags/{{DAG_NAME}}.py`
+  (Airflow gitSync picks it up automatically)
+- [ ] ECR repository `{{ECR_REGISTRY}}/{{MODEL_NAME}}` exists
+  (pull-through cache covers upstream bases, ADR-0029)
+
+---
+
+## Step 1 -- Substitute placeholders
+
+```bash
+# AWS-specific
+export AWS_ACCOUNT_ID="123456789012"
+export AWS_REGION="us-east-1"
+export S3_MLFLOW_ARTIFACTS_BUCKET="mlflow-artifacts-prod-${AWS_ACCOUNT_ID}"
+export ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+
+# Pipeline identity
+export DAG_NAME="my_custom_pipeline"        # snake_case; becomes the Airflow dag_id
+export MODEL_NAME="my-model"                # lower-kebab; MLflow model registry name
+export TENANT="tenant-acme"                 # ADR-0038 multi-tenant label
+export DOMAIN="hft"                         # one of: hft, solana, insurance, rtb
+export TEAM_OWNER="team-ml-platform"        # ADR-0028 platform:owner
+export PLATFORM_ENV="production"            # production | staging | dev | sandbox
+
+# Copy the DAG template
+cp dag_template.py apps/infra/airflow/dags/${DAG_NAME}.py
+
+# Substitute YAML placeholders
+mkdir -p out
+envsubst < argocd-application.yaml > out/argocd-application.yaml
+
+# Verify no raw {{}} remain in the YAML output
+grep -r '{{' out/ && echo "UNSUBSTITUTED PLACEHOLDERS FOUND" || echo "OK"
+```
+
+In the Python DAG file, replace the `# SUBSTITUTE:` comment blocks manually
+(shell variable substitution in Python source is fragile).
+
+---
+
+## Step 2 -- Implement the DAG tasks
+
+Open `apps/infra/airflow/dags/{{DAG_NAME}}.py` and implement the four `# SCAFFOLD`
+task bodies:
+
+| Task | What to implement |
+|------|-------------------|
+| `ingest_data` | Load data from source (S3 snapshot, Iceberg on S3, Kinesis, DynamoDB, etc.) |
+| `run_batch_job` | Submit work: VolcanoJob for GPU tasks, PythonOperator for CPU tasks |
+| `register_results` | Write metrics + artifacts to MLflow (S3 + RDS, see MLflow integration below) |
+| `emit_drift_metrics` | Push feature distributions to Prometheus Pushgateway (see WS-C below) |
+
+### MLflow integration (AWS)
+
+The `register_results` task uses:
+
+- `MLFLOW_TRACKING_URI` env var (injected from ESO ExternalSecret at
+  `apps/infra/mlflow/templates/external-secret.yaml` -- sourced from AWS Secrets Manager)
+- `AWS_DEFAULT_REGION` env var (set by the Pod Identity SDK automatically)
+- Experiment name convention: `{{TENANT}}/{{DOMAIN}}/{{DAG_NAME}}`
+- Model registry name: `{{MODEL_NAME}}`
+- Artifacts stored at: `s3://{{S3_MLFLOW_ARTIFACTS_BUCKET}}/{{MODEL_NAME}}/{{TENANT}}/{{DOMAIN}}/`
+
+```python
+import mlflow
+import os
+
+mlflow.set_tracking_uri(os.environ["MLFLOW_TRACKING_URI"])
+mlflow.set_experiment(f"{tenant}/{domain}/{dag_name}")
+
+with mlflow.start_run(run_name=f"{tenant}/{domain}"):
+    mlflow.log_params({"tenant": tenant, "domain": domain})
+    mlflow.log_metrics({"accuracy": 0.0, "loss": 0.0})  # replace with real metrics
+    # mlflow.pytorch.log_model(model, "model")           # writes to S3 via Pod Identity
+    mlflow.register_model(
+        f"runs:/{mlflow.active_run().info.run_id}/model",
+        model_name,
+    )
+```
+
+**No static AWS credentials needed**: the Airflow task pod uses EKS Pod Identity
+(ADR-0018 + ADR-0048 D2). The `aws-ml-artifact-store` IAM role is bound to the
+task ServiceAccount via a Pod Identity association.
+
+### Drift metrics (WS-C integration)
+
+The `emit_drift_metrics` task pushes to the shared Pushgateway (cluster-agnostic,
+identical to the GCP etalon):
+
+```python
+from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+
+registry = CollectorRegistry()
+g = Gauge(
+    "ml_monitoring_dataset_drift_score",
+    "Evidently dataset drift score",
+    ["model_name", "tenant", "domain"],
+    registry=registry,
+)
+g.labels(model_name=model_name, tenant=tenant, domain=domain).set(drift_score)
+
+push_to_gateway(
+    "prometheus-pushgateway.ml-monitoring.svc.cluster.local:9091",
+    job=dag_name,
+    registry=registry,
+)
+```
+
+Labels must match ADR-0038 D1: `model_name`, `tenant`, `domain`.
+
+### GPU task executor config (AWS: Karpenter + Volcano)
+
+For GPU tasks on the `aws-eks-gpu-*` cluster, update `executor_config`:
+
+```python
+_GPU_EXECUTOR_CONFIG = {
+    "pod_override": {
+        "spec": {
+            # Volcano gang scheduler (ADR-0044 D3 / ADR-0048 D1)
+            "schedulerName": "volcano",
+            # AWS EKS Karpenter GPU nodepool label (ADR-0046)
+            # Replace cloud.google.com/gke-nodepool with karpenter.sh/nodepool
+            "nodeSelector": {
+                "karpenter.sh/nodepool": "gpu-p4d-spot",   # adjust to your pool
+                "nvidia.com/gpu.present": "true",
+            },
+            "tolerations": [
+                {"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSchedule"}
+            ],
+        }
+    }
+}
+```
+
+**AWS delta vs GCP etalon:** use `karpenter.sh/nodepool` (not `cloud.google.com/gke-nodepool`).
+
+---
+
+## Step 3 -- Validate the DAG locally
+
+```bash
+# Install Airflow in a venv (match the chart-pinned version)
+pip install "apache-airflow==2.9.*" --constraint \
+  "https://raw.githubusercontent.com/apache/airflow/constraints-2.9.3/constraints-3.11.txt"
+
+# Parse the DAG (should complete without errors or import warnings)
+python apps/infra/airflow/dags/{{DAG_NAME}}.py
+airflow dags list-import-errors
+```
+
+---
+
+## Step 4 -- Open the PR
+
+PR checklist:
+
+- [ ] `apps/infra/airflow/dags/{{DAG_NAME}}.py` included
+- [ ] `yamllint -c .yamllint.yml out/argocd-application.yaml` passes
+- [ ] DAG parses without errors (`airflow dags list-import-errors`)
+- [ ] MLflow experiment name follows `{{TENANT}}/{{DOMAIN}}/{{DAG_NAME}}`
+- [ ] Artifact store path is `s3://{{S3_MLFLOW_ARTIFACTS_BUCKET}}/...` (not `gs://`)
+- [ ] No static AWS credentials in DAG code (Pod Identity only, ADR-0018)
+- [ ] Drift metrics pushed to Pushgateway use labels `model_name`, `tenant`, `domain`
+- [ ] GPU executor config uses `karpenter.sh/nodepool` (not `cloud.google.com/gke-nodepool`)
+- [ ] ADR-0028 labels in all Kubernetes manifests and AWS resources
+- [ ] Link to MLflow experiment URL after first DAG run
+
+---
+
+## Platform support
+
+- ADR-0044: EKS GPU cluster / Volcano / Karpenter pool labels
+- ADR-0048: AWS ML CI/CD, S3 artifact store, RDS, ECR
+- ADR-0038: drift metrics + Pushgateway integration
+- ADR-0041: this template (golden-path structure)
+- ADR-0018: EKS Pod Identity (no static credentials in pods)
+
+---
+
+## Backstage future mapping
+
+```yaml
+# catalog-info.yaml (future -- do not deploy before ADR-0034 revisit)
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: aws-ml-new-pipeline
+spec:
+  type: ml-pipeline
+  parameters:
+    - title: AWS identity
+      properties:
+        awsAccountId:       # -> {{AWS_ACCOUNT_ID}}
+        awsRegion:          # -> {{AWS_REGION}}
+        s3ArtifactsBucket:  # -> {{S3_MLFLOW_ARTIFACTS_BUCKET}}
+        ecrRegistry:        # -> {{ECR_REGISTRY}}
+    - title: Pipeline identity
+      properties:
+        dagName:     # -> {{DAG_NAME}}
+        modelName:   # -> {{MODEL_NAME}}
+        tenant:      # -> {{TENANT}}
+        domain:      # -> {{DOMAIN}}
+        teamOwner:   # -> {{TEAM_OWNER}}
+        platformEnv: # -> {{PLATFORM_ENV}}
+  steps:
+    - id: fetch-template
+      action: fetch:template
+      input:
+        url: ./templates/golden-paths/aws-ml-new-pipeline
+    - id: publish
+      action: publish:github:pull-request
+    - id: register
+      action: catalog:register
+```

--- a/templates/golden-paths/aws-ml-new-pipeline/argocd-application.yaml
+++ b/templates/golden-paths/aws-ml-new-pipeline/argocd-application.yaml
@@ -1,0 +1,73 @@
+---
+# Golden Path: aws-ml-new-pipeline -- ArgoCD Application stub (Airflow gitSync)
+# WS-B (ADR-0048 <- ADR-0037) chart: apps/infra/airflow
+#
+# USAGE: substitute all {{PLACEHOLDER}} values, then commit this file at:
+#   apps/infra/airflow/example-pipelines/{{DAG_NAME}}/argocd-application.yaml
+#
+# This stub documents the ArgoCD Application for a new Airflow pipeline.
+# In most cases the DAG file (dag_template.py) is picked up by Airflow's
+# gitSync automatically -- this Application is only needed when deploying
+# a per-pipeline ArgoCD ApplicationSet slice.
+#
+# AWS DELTA vs GCP etalon (templates/golden-paths/new-ml-pipeline/argocd-application.yaml):
+#   No chart-level differences -- Airflow gitSync is cluster-agnostic.
+#   Added: platform.aws/task-pod-identity-role annotation to document the
+#   IAM role ARN backing the task pod ServiceAccount's Pod Identity binding (ADR-0018).
+#
+# Wave 20 -- after ml-monitoring (wave 10) and before grafana-self-serve (wave 30).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  # Substitute: airflow-pipeline-{{DAG_NAME}}
+  name: "airflow-pipeline-{{DAG_NAME}}"
+  namespace: argocd
+  labels:
+    # ADR-0028 platform taxonomy (Kubernetes plane)
+    platform.system: "ml-pipeline"
+    platform.component: "airflow"
+    # Substitute: {{PLATFORM_ENV}}
+    platform.env: "{{PLATFORM_ENV}}"
+    # Substitute: {{TEAM_OWNER}}
+    platform.owner: "{{TEAM_OWNER}}"
+    platform.managed-by: "argocd"
+    # Substitute: airflow-pipeline-{{DAG_NAME}}
+    app.kubernetes.io/name: "airflow-pipeline-{{DAG_NAME}}"
+    app.kubernetes.io/component: "airflow"
+    app.kubernetes.io/managed-by: "argocd"
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
+    # AWS-specific: document the IAM role ARN for the task pod Pod Identity binding.
+    # Provisioned by WS-B terraform; record the ARN here for audit traceability.
+    # Substitute: arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/airflow-task-{{DAG_NAME}}
+    platform.aws/task-pod-identity-role: "arn:aws:iam::{{AWS_ACCOUNT_ID}}:role/airflow-task-{{DAG_NAME}}"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/your-org/platform-design.git
+    targetRevision: main
+    path: apps/infra/airflow
+    helm:
+      valueFiles:
+        - values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: airflow
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=false
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m

--- a/templates/golden-paths/aws-ml-new-pipeline/dag_template.py
+++ b/templates/golden-paths/aws-ml-new-pipeline/dag_template.py
@@ -1,0 +1,288 @@
+"""
+{{DAG_NAME}} -- Airflow DAG template (WS-F golden path, ADR-0041, AWS variant)
+
+ADR gates: ADR-0041 (template approach), ADR-0048 (AWS backends)
+GCP etalon: templates/golden-paths/new-ml-pipeline/dag_template.py
+
+Mirrors the WS-B (ADR-0048 <- ADR-0037) DAG shape:
+  ingest_data -> run_batch_job -> register_results -> emit_drift_metrics
+
+AWS DELTAS vs GCP etalon:
+  - ingest_data: reads from S3 (not GCS); Pod Identity = no static credentials (ADR-0018)
+  - run_batch_job: nodeSelector uses karpenter.sh/nodepool (not cloud.google.com/gke-nodepool)
+  - register_results: MLflow artifact store is s3:// (not gs://); MLFLOW_TRACKING_URI
+    points to RDS-backed MLflow on EKS; AWS_DEFAULT_REGION set by Pod Identity SDK
+  - emit_drift_metrics: Pushgateway address is identical (cluster-agnostic)
+
+Instructions:
+  1. Rename this file to apps/infra/airflow/dags/{{DAG_NAME}}.py
+  2. Replace all SUBSTITUTE: comment blocks with real values.
+  3. Implement the four # SCAFFOLD task bodies.
+  4. See README.md for MLflow (S3/RDS), Pod Identity, and Pushgateway integration.
+
+Platform labels (ADR-0028):
+  platform.system    = ml-pipeline
+  platform.component = airflow
+  platform.owner     = {{TEAM_OWNER}}
+  platform.env       = {{PLATFORM_ENV}}
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from airflow.decorators import dag, task
+from airflow.models.param import Param
+
+# ---------------------------------------------------------------------------
+# Executor config -- CPU task pods on Graviton (non-GPU control workloads)
+# ADR-0048 D1: Airflow control plane on non-GPU Graviton Karpenter pool (ADR-0046 D3)
+# ---------------------------------------------------------------------------
+_CPU_EXECUTOR_CONFIG = {
+    "pod_override": {
+        "spec": {
+            # AWS Karpenter nodepool label (replaces cloud.google.com/gke-nodepool)
+            "nodeSelector": {"karpenter.sh/nodepool": "graviton-cpu"},
+        }
+    }
+}
+
+# GPU executor config for GPU tasks (ADR-0044 D3 / Volcano gang scheduler)
+# Uncomment and adjust the pool name to match your Karpenter NodePool (ADR-0046).
+# _GPU_EXECUTOR_CONFIG = {
+#     "pod_override": {
+#         "spec": {
+#             # Volcano gang scheduler required for EFA-fabric training jobs (ADR-0048 D1)
+#             "schedulerName": "volcano",
+#             # AWS EKS Karpenter GPU nodepool label (ADR-0046)
+#             "nodeSelector": {
+#                 "karpenter.sh/nodepool": "gpu-p4d-spot",  # adjust to your pool
+#                 "nvidia.com/gpu.present": "true",
+#             },
+#             "tolerations": [
+#                 {"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSchedule"}
+#             ],
+#         }
+#     }
+# }
+
+
+@dag(
+    # SUBSTITUTE: replace {{DAG_NAME}} with your snake_case DAG identifier.
+    dag_id="{{DAG_NAME}}",
+    # SUBSTITUTE: update the description.
+    description="Custom AWS ML pipeline: {{DAG_NAME}} (WS-F golden path, ADR-0041).",
+    # Set a schedule expression or leave None for triggered-only.
+    schedule=None,
+    start_date=datetime(2026, 1, 1),
+    catchup=False,
+    max_active_runs=1,
+    default_args={
+        "retries": 1,
+        "retry_delay": timedelta(minutes=5),
+        # SUBSTITUTE: replace {{TEAM_OWNER}} with your team slug.
+        "owner": "{{TEAM_OWNER}}",
+    },
+    params={
+        # SUBSTITUTE: replace {{TENANT}} default with your tenant identifier.
+        "tenant": Param(default="{{TENANT}}", type="string", description="Tenant identifier"),
+        # SUBSTITUTE: replace {{DOMAIN}} default with your ML domain.
+        "domain": Param(
+            default="{{DOMAIN}}",
+            type="string",
+            enum=["hft", "solana", "insurance", "rtb"],
+            description="ML domain",
+        ),
+        "trigger_reason": Param(
+            default="manual",
+            type="string",
+            enum=["threshold", "drift", "manual"],
+            description="Trigger source",
+        ),
+        # AWS-specific: region passed as a param so task logs include it.
+        # SUBSTITUTE: replace {{AWS_REGION}} with your region.
+        "aws_region": Param(
+            default="{{AWS_REGION}}",
+            type="string",
+            description="AWS region for S3/ECR (must match the artifact bucket region)",
+        ),
+    },
+    tags=["ml-pipeline", "{{DAG_NAME}}", "aws"],
+)
+def dag_factory():
+    """
+    Custom AWS ML pipeline: {{DAG_NAME}}.
+
+    Replace this docstring with a description of what this pipeline does,
+    what data it processes, and what model artifacts it produces.
+
+    Artifact store: s3://{{S3_MLFLOW_ARTIFACTS_BUCKET}}/{{MODEL_NAME}}/{{TENANT}}/{{DOMAIN}}/
+    Identity: EKS Pod Identity + ABAC (ADR-0018 + ADR-0048 D2) -- no static credentials.
+    """
+
+    @task(executor_config=_CPU_EXECUTOR_CONFIG)
+    def ingest_data(tenant: str, domain: str, aws_region: str, **context) -> dict:
+        """
+        Load and validate the input data.
+        Returns a data metadata dict (paths, row counts, snapshot IDs).
+
+        AWS: reads from S3 (not GCS). The task pod uses EKS Pod Identity --
+        no static credentials needed (ADR-0018).
+
+        SCAFFOLD: implement your data loading logic here.
+        Examples:
+          - Read an S3 Parquet snapshot:
+              s3://<bucket>/<tenant>/<domain>/data.parquet
+          - Read from DynamoDB or Kinesis
+          - Freeze an Iceberg snapshot on S3
+        """
+        # SCAFFOLD: replace with real data ingestion
+        import os  # noqa: PLC0415
+
+        # AWS_DEFAULT_REGION is set by the Pod Identity SDK automatically.
+        region = aws_region or os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+        run_ts = context["logical_date"].isoformat()
+        return {
+            "snapshot_id": f"scaffold-{tenant}-{domain}-{run_ts}",
+            "row_count": 0,
+            # SCAFFOLD: replace with real S3 path
+            "source_path": f"s3://scaffold-bucket-{region}/{tenant}/{domain}/data.parquet",
+            "aws_region": region,
+        }
+
+    @task(executor_config=_CPU_EXECUTOR_CONFIG)
+    def run_batch_job(data_meta: dict, tenant: str, domain: str, **context) -> dict:
+        """
+        Execute the ML computation (training, scoring, or batch inference).
+        Returns a results dict (metrics, output paths, job IDs).
+
+        SCAFFOLD: implement your computation here.
+        CPU tasks: use PythonOperator or BashOperator patterns.
+        GPU tasks: submit a VolcanoJob (see train_domain_adapter.py for the pattern),
+                   update executor_config to _GPU_EXECUTOR_CONFIG,
+                   use karpenter.sh/nodepool (not cloud.google.com/gke-nodepool).
+        """
+        # SCAFFOLD: replace with real batch job submission
+        return {
+            "job_id": f"scaffold-{tenant}-{domain}",
+            "status": "SCAFFOLD",
+            "output_path": data_meta["source_path"].replace("data.parquet", "output.parquet"),
+            "accuracy": 0.0,
+            "loss": 0.0,
+        }
+
+    @task(executor_config=_CPU_EXECUTOR_CONFIG)
+    def register_results(
+        data_meta: dict,
+        job_results: dict,
+        tenant: str,
+        domain: str,
+        **context,
+    ) -> dict:
+        """
+        Register metrics and artifacts in MLflow.
+        Returns: {"mlflow_run_id": str, "model_version": str}
+
+        AWS convention:
+          experiment_name = f"{tenant}/{domain}/{{DAG_NAME}}"
+          model_name      = "{{MODEL_NAME}}"
+          artifacts stored at:
+            s3://{{S3_MLFLOW_ARTIFACTS_BUCKET}}/{{MODEL_NAME}}/{tenant}/{domain}/
+
+        Identity: MLFLOW_TRACKING_URI from ESO ExternalSecret (AWS Secrets Manager).
+        S3 write: EKS Pod Identity bound to the aws-ml-artifact-store IAM role
+                  (ADR-0018 + ADR-0048 D2). AWS_DEFAULT_REGION set automatically.
+
+        SCAFFOLD: replace with real MLflow calls.
+        """
+        # SCAFFOLD: implement MLflow registration
+        # import mlflow, os
+        # mlflow.set_tracking_uri(os.environ["MLFLOW_TRACKING_URI"])
+        # mlflow.set_experiment(f"{tenant}/{domain}/{{DAG_NAME}}")
+        # with mlflow.start_run(run_name=f"{tenant}/{domain}"):
+        #     mlflow.log_params({**data_meta, "tenant": tenant, "domain": domain})
+        #     mlflow.log_metrics({"accuracy": job_results["accuracy"]})
+        #     # mlflow.pytorch.log_model(model, "model")  # writes to S3 via Pod Identity
+        #     version = mlflow.register_model(
+        #         f"runs:/{mlflow.active_run().info.run_id}/model",
+        #         "{{MODEL_NAME}}")
+        return {
+            "mlflow_run_id": "scaffold-run-id",
+            "model_version": "0",
+        }
+
+    @task(executor_config=_CPU_EXECUTOR_CONFIG)
+    def emit_drift_metrics(
+        job_results: dict,
+        tenant: str,
+        domain: str,
+        **context,
+    ) -> None:
+        """
+        Push feature distribution + accuracy metrics to the Prometheus Pushgateway
+        so WS-C (ADR-0048 D4 <- ADR-0038) can compute drift and trigger retraining.
+
+        Labels must match ADR-0038 D1: model_name, tenant, domain.
+        Pushgateway: prometheus-pushgateway.ml-monitoring.svc.cluster.local:9091
+        (Cluster-agnostic -- identical to the GCP etalon.)
+
+        SCAFFOLD: replace with real metric values from job_results.
+        """
+        # SCAFFOLD: implement Pushgateway push
+        # from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+        # registry = CollectorRegistry()
+        # accuracy_g = Gauge(
+        #     "ml_monitoring_model_accuracy",
+        #     "Model accuracy score",
+        #     ["model_name", "tenant", "domain"],
+        #     registry=registry,
+        # )
+        # drift_g = Gauge(
+        #     "ml_monitoring_dataset_drift_score",
+        #     "Dataset drift score",
+        #     ["model_name", "tenant", "domain"],
+        #     registry=registry,
+        # )
+        # accuracy_g.labels(
+        #     model_name="{{MODEL_NAME}}", tenant=tenant, domain=domain
+        # ).set(job_results["accuracy"])
+        # drift_g.labels(
+        #     model_name="{{MODEL_NAME}}", tenant=tenant, domain=domain
+        # ).set(0.0)  # replace with real drift score
+        # push_to_gateway(
+        #     "prometheus-pushgateway.ml-monitoring.svc.cluster.local:9091",
+        #     job="{{DAG_NAME}}",
+        #     registry=registry,
+        # )
+        pass
+
+    # -------------------------------------------------------------------------
+    # DAG wiring
+    # -------------------------------------------------------------------------
+    tenant = "{{ params.tenant }}"
+    domain = "{{ params.domain }}"
+    aws_region = "{{ params.aws_region }}"
+
+    data = ingest_data(tenant=tenant, domain=domain, aws_region=aws_region)
+    results = run_batch_job(data_meta=data, tenant=tenant, domain=domain)
+    reg = register_results(
+        data_meta=data, job_results=results, tenant=tenant, domain=domain
+    )
+    emit_drift_metrics(job_results=results, tenant=tenant, domain=domain)
+
+    # Uncomment to trigger downstream DAGs on success:
+    # from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+    # trigger_downstream = TriggerDagRunOperator(
+    #     task_id="trigger_downstream",
+    #     trigger_dag_id="some_downstream_dag",
+    #     conf={
+    #         "mlflow_run_id": "{{ task_instance.xcom_pull('register_results')['mlflow_run_id'] }}",
+    #     },
+    # )
+    # reg >> trigger_downstream  # type: ignore[operator]
+
+    _ = reg  # suppress unused variable warning until trigger is wired
+
+
+# SUBSTITUTE: rename the variable to match {{DAG_NAME}}_dag_instance
+dag_instance = dag_factory()


### PR DESCRIPTION
## What was built — WS-F: AWS ML Golden Paths (ADR-0041 / ADR-0048)

**DESIGN-MOCK repo — apply-gated; do NOT merge until human review; base targets the design branch on purpose.**

### Files created (13 files, 1988 lines)

#### Golden path 1: `aws-ml-new-model-service`
- `templates/golden-paths/aws-ml-new-model-service/README.md` — onboarding guide (AWS: S3/ECR/RDS/Pod Identity wiring vs GCP etalon)
- `templates/golden-paths/aws-ml-new-model-service/values-ml-monitoring.yaml` — WS-C drift-exporter per-model override (S3 reference dataset URI, `awsRegion`)
- `templates/golden-paths/aws-ml-new-model-service/values-grafana-self-serve.yaml` — WS-D grafana-self-serve values (cluster-agnostic)
- `templates/golden-paths/aws-ml-new-model-service/ml-pipeline-trigger.yaml` — ml-pipeline.yml dispatch payload + Airflow REST conf (S3 artifact path, ECR URI, Kargo gates)
- `templates/golden-paths/aws-ml-new-model-service/argocd-application.yaml` — ArgoCD Application stub (wave 30; `platform.aws/drift-exporter-pod-identity-role` annotation)

#### Golden path 2: `aws-ml-new-pipeline`
- `templates/golden-paths/aws-ml-new-pipeline/README.md` — onboarding guide (GPU executor config: `karpenter.sh/nodepool` not GKE nodepool label, Volcano gang scheduler)
- `templates/golden-paths/aws-ml-new-pipeline/dag_template.py` — AWS Airflow DAG scaffold (Pod Identity, S3 artifact store, `aws_region` param, Volcano + Karpenter executor config)
- `templates/golden-paths/aws-ml-new-pipeline/argocd-application.yaml` — ArgoCD stub (wave 20; `platform.aws/task-pod-identity-role` annotation)

#### Golden path 3: `aws-ml-new-dashboard`
- `templates/golden-paths/aws-ml-new-dashboard/README.md` — onboarding guide (cluster-agnostic note; PromQL identical to GCP)
- `templates/golden-paths/aws-ml-new-dashboard/values.yaml` — grafana-self-serve values template
- `templates/golden-paths/aws-ml-new-dashboard/argocd-application.yaml` — ArgoCD stub (wave 30; `platform.aws/cluster` ARN annotation)

#### Shared contracts + RACI
- `docs/contracts/aws-ml-model-api-contract.md` — AWS-specific addendum to `docs/contracts/model-api-contract.md` (S3/ECR/RDS/Pod Identity/ABAC checklist, GCP→AWS field mapping table)
- `docs/golden-paths/aws-ml-RACI-and-handoffs.md` — AWS RACI matrix (adds A4/B6/C3/D4 AWS-specific activities), handoff diagram, on-call table (S3AccessDenied/ECRPullFailed rows), AWS identity sign-off checklist

### ADRs cited
- **ADR-0048** (primary): AWS ML CI/CD + MLflow backends (S3, RDS, ECR) — WS-B/C
- **ADR-0041**: golden-path template approach — WS-F
- **ADR-0044**: EKS GPU cluster (scheduling, Karpenter, Volcano)
- **ADR-0028**: platform taxonomy tags + ABAC
- **ADR-0018**: EKS Pod Identity
- **ADR-0037/0038**: cluster-agnostic ML layer (folded by ADR-0048)

### Verification results

| Check | Result |
|-------|--------|
| YAML parse (Python `yaml.safe_load`) | PASS — all 7 YAML files |
| `yamllint -d relaxed` | WARNINGS only (line length) — no errors |
| Python AST parse (`dag_template.py`) | PASS |
| `terraform fmt/validate/test` | N/A — WS-F is templates + docs only, no Terraform modules |
| `terraform plan` | N/A — no cloud credentials available |
| Unintended GCS `gs://` URIs in AWS paths | PASS — all occurrences are in explicit "not gs://" comments |
| ADR-0028 labels on all ArgoCD Applications | PASS — all 3 stubs carry `platform.system`, `platform.component`, `platform.env`, `platform.owner`, `platform.managed-by` |
| No secrets in templates | PASS — all values are `{{PLACEHOLDER}}` templates |

### WS-F scope as delivered

WS-F is "mostly templates + docs" per the implementation plan — no Terraform modules, no ArgoCD app deployments, no GitHub workflows (those are WS-B deliverables). The golden paths ride the WS-B/C/D artifacts and translate them for the AWS EKS ML cluster.

### File disjointness

No edits to `catalog/stacks/*.stack.hcl` or `docs/adrs/README.md`. Only WS-F files added.

**DESIGN-MOCK repo — apply-gated; do NOT merge until human review; base targets the design branch on purpose.**
