### PR TITLE
feat(aws-wsE): AWS SOC posture + on-call + OPA

### DIFF
--- a/apps/infra/ml-policy/Chart.yaml
+++ b/apps/infra/ml-policy/Chart.yaml
@@ -1,0 +1,32 @@
+apiVersion: v2
+name: ml-policy
+description: >-
+  WS-E in-cluster policy enforcement for the greenfield AWS EKS GPU/ML estate —
+  Kyverno ClusterPolicies + a Gatekeeper constraint that require the ADR-0028
+  platform taxonomy labels on the net-new ML/GPU workload kinds and forbid
+  privileged GPU pods. The in-cluster parity to the SCP/OPA control plane
+  (aws-ml-scp-parity, tests/opa/platform_tags_ml.rego).
+version: 0.1.0
+appVersion: "1.0.0"
+type: application
+
+# This chart ships only ClusterPolicy / Constraint manifests (no upstream
+# dependency). Kyverno (ADR-0020, apps/infra/kyverno) and Gatekeeper
+# (apps/infra/gatekeeper) provide the admission engines these objects target.
+
+maintainers:
+  - name: Platform Team
+    email: platform@example.com
+
+keywords:
+  - policy
+  - security
+  - ml
+  - gpu
+  - platform-taxonomy
+  - abac
+
+annotations:
+  category: Security
+  platform: Kubernetes
+  adr: ADR-0020,ADR-0028,ADR-0044,ADR-0048

--- a/apps/infra/ml-policy/README.md
+++ b/apps/infra/ml-policy/README.md
@@ -1,0 +1,44 @@
+# App: `ml-policy`
+
+> **ADRs:** [0020](../../../docs/adrs/0020-kyverno-and-vap-policy-engine.md)
+> (Kyverno + VAP / Gatekeeper engines),
+> [0028](../../../docs/adrs/0028-unified-platform-tagging-and-labeling-taxonomy.md)
+> (taxonomy + ABAC), [0044](../../../docs/adrs/0044-aws-eks-gpu-ml-foundation-multiregion.md)
+> (GPU/ML estate), [0048](../../../docs/adrs/0048-aws-ml-cicd-registry-drift.md) (ML layer).
+
+WS-E **in-cluster policy enforcement** for the greenfield AWS EKS GPU/ML estate — the
+admission-plane parity to the cloud-plane control set
+(`terraform/modules/aws-ml-scp-parity` SCPs, `tests/opa/platform_tags_ml.rego` plan-time
+OPA). It **reuses the existing Kyverno and Gatekeeper engines** (apps/infra/kyverno,
+apps/infra/gatekeeper) — it ships only policy objects, no engine.
+
+## What it ships (`helm template` → 3 manifests)
+
+| Manifest | Engine | Effect |
+|---|---|---|
+| `require-ml-platform-labels` (ClusterPolicy) | Kyverno | ML/GPU Jobs/Deployments/StatefulSets in the ML namespaces must carry the 3 ADR-0028 platform labels |
+| `no-privileged-gpu-pods` (ClusterPolicy) | Kyverno | denies privileged / privilege-escalating containers on ML/GPU pods (SOC2 CC6.1) |
+| `ml-block-privileged-containers` (Constraint) | Gatekeeper | second engine, **reuses** the existing `K8sBlockPrivileged` ConstraintTemplate, ML-namespace-scoped |
+
+Two engines on the privileged-pod control (ADR-0020 belt-and-suspenders): if one webhook
+is unavailable the other still denies.
+
+## Apply-gated / phased rollout
+
+Ships **Audit-first** (`values.enforcement.platformLabels=Audit`,
+`values.enforcement.noPrivilegedGpu=Audit`; Gatekeeper `dryrun`). No workload is blocked
+until a human promotes to `Enforce` after a clean soak window (the ADR-0020 pattern). The
+`kyverno.enabled` / `gatekeeper.enabled` toggles render the chart inert per-engine if an
+engine is absent.
+
+## ADR-0028 taxonomy
+
+The Application and every policy object carry `platform.system=security`,
+`platform.component=ml-policy`, `platform.owner=team-sec`, `platform.env=production`,
+`platform.managed-by=argocd`.
+
+## Validation (plan/validate-only)
+
+`helm template apps/infra/ml-policy/` renders 3 valid manifests; `yamllint` clean on the
+static YAML. **No `kubectl apply` / `helm install` / ArgoCD sync** is performed — delivery
+is apply-gated behind the ArgoCD sync gate and human promotion to Enforce.

--- a/apps/infra/ml-policy/argocd-application.yaml
+++ b/apps/infra/ml-policy/argocd-application.yaml
@@ -1,0 +1,63 @@
+---
+# ArgoCD Application — ml-policy (WS-E, ADR-0020/0028/0044/0048)
+#
+# In-cluster ML/GPU policy enforcement: Kyverno ClusterPolicies (require platform
+# taxonomy labels on ML/GPU workloads; forbid privileged GPU pods) + a Gatekeeper
+# Constraint reusing the existing K8sBlockPrivileged template. The admission-plane parity
+# to the SCP/OPA control plane (terraform/modules/aws-ml-scp-parity,
+# tests/opa/platform_tags_ml.rego).
+#
+# Sync wave 6 — AFTER kyverno (wave 5) and gatekeeper so the ClusterPolicy / Constraint
+# CRDs exist; before ML workloads land.
+#
+# Apply-gated posture: ships Audit-first (values.enforcement.*=Audit); no workload is
+# blocked until a human promotes to Enforce after a clean soak window.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ml-policy
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: ml-policy
+    app.kubernetes.io/component: policy-enforcement
+    platform.system: security
+    platform.component: ml-policy
+    platform.env: production
+    platform.owner: team-sec
+    platform.managed-by: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "6"
+    adr: ADR-0020,ADR-0028,ADR-0044,ADR-0048
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/100rd/platform-design.git
+    targetRevision: HEAD
+    path: apps/infra/ml-policy
+    helm:
+      valueFiles:
+        - values.yaml
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kyverno
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=false
+      - ServerSideApply=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/apps/infra/ml-policy/templates/gatekeeper-ml-block-privileged.yaml
+++ b/apps/infra/ml-policy/templates/gatekeeper-ml-block-privileged.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.gatekeeper.enabled }}
+---
+# Gatekeeper Constraint — block privileged containers on the ML/GPU serving nodes.
+#
+# REUSES the existing K8sBlockPrivileged ConstraintTemplate shipped by
+# apps/infra/gatekeeper/.../block-privileged-containers.yaml — we add a SECOND, ML-scoped
+# Constraint instance rather than redefine the template. This gives belt-and-suspenders
+# coverage alongside the Kyverno no-privileged-gpu policy (two engines, ADR-0020): if one
+# admission webhook is unavailable the other still denies.
+#
+# enforcementAction is driven by values.enforcement.noPrivilegedGpu: "Audit" maps to
+# Gatekeeper "dryrun" (observe), "Enforce" maps to "deny". Default Audit/dryrun.
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sBlockPrivileged
+metadata:
+  name: ml-block-privileged-containers
+  labels:
+    platform.system: {{ .Values.platformLabels.system | quote }}
+    platform.component: {{ .Values.platformLabels.component | quote }}
+    platform.owner: {{ .Values.platformLabels.owner | quote }}
+    platform.env: {{ .Values.platformLabels.env | quote }}
+    platform.managed-by: {{ .Values.platformLabels.managedBy | quote }}
+  annotations:
+    adr: ADR-0020,ADR-0028,ADR-0044
+    description: ML-namespace-scoped block on privileged GPU pods (parity with Kyverno no-privileged-gpu)
+spec:
+  enforcementAction: {{ if eq .Values.enforcement.noPrivilegedGpu "Enforce" }}deny{{ else }}dryrun{{ end }}
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    namespaces:
+      {{- range .Values.mlNamespaces }}
+      - {{ . }}
+      {{- end }}
+    excludedNamespaces:
+      {{- range .Values.excludedNamespaces }}
+      - {{ . }}
+      {{- end }}
+  parameters:
+    # Vendor driver / device-plugin images that legitimately need privileged mode.
+    # The ML serving / batch workloads themselves match none of these.
+    allowedImages:
+      - "^nvcr.io/nvidia/.*"
+      - "^registry.k8s.io/.*"
+      - "^602401143452.dkr.ecr.*.amazonaws.com/amazon-k8s-cni.*"
+{{- end }}

--- a/apps/infra/ml-policy/templates/kyverno-no-privileged-gpu.yaml
+++ b/apps/infra/ml-policy/templates/kyverno-no-privileged-gpu.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.kyverno.enabled }}
+---
+# ClusterPolicy — forbid privileged containers on GPU/ML serving & batch pods.
+#
+# GPU workloads have no legitimate need for privileged: true (the NVIDIA driver /
+# device-plugin DaemonSets that DO are excluded by namespace). A privileged GPU pod is
+# a node-takeover primitive on an expensive, internet-adjacent serving node — WS-E
+# closes that with an admission deny. SOC2 CC6.1/CC6.8 (logical access / change mgmt).
+#
+# Phase: {{ .Values.enforcement.noPrivilegedGpu }} (values.enforcement.noPrivilegedGpu).
+# Audit-first so any legitimately-privileged DaemonSet is allow-listed (by namespace)
+# before promotion to Enforce.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: no-privileged-gpu-pods
+  labels:
+    platform.system: {{ .Values.platformLabels.system | quote }}
+    platform.component: {{ .Values.platformLabels.component | quote }}
+    platform.owner: {{ .Values.platformLabels.owner | quote }}
+    platform.env: {{ .Values.platformLabels.env | quote }}
+    platform.managed-by: {{ .Values.platformLabels.managedBy | quote }}
+  annotations:
+    policies.kyverno.io/title: Forbid privileged GPU/ML pods
+    policies.kyverno.io/category: Pod Security
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Denies privileged containers (and privilege escalation) on Pods in the ML/GPU
+      namespaces. Vendor driver/device-plugin namespaces are excluded. SOC2 CC6.1.
+    adr: ADR-0020,ADR-0028,ADR-0044
+spec:
+  validationFailureAction: {{ .Values.enforcement.noPrivilegedGpu }}
+  failurePolicy: Ignore
+  background: true
+  rules:
+    - name: forbid-privileged-gpu-containers
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              namespaces:
+                {{- range .Values.mlNamespaces }}
+                - {{ . }}
+                {{- end }}
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range .Values.excludedNamespaces }}
+                - {{ . }}
+                {{- end }}
+      validate:
+        message: >-
+          Privileged containers are not permitted on GPU/ML pods (ADR-0044 / SOC2 CC6.1).
+          Set securityContext.privileged=false and allowPrivilegeEscalation=false. If a
+          driver DaemonSet legitimately needs privilege, run it in an excluded namespace.
+        pattern:
+          spec:
+            =(initContainers):
+              - =(securityContext):
+                  =(privileged): "false"
+            containers:
+              - =(securityContext):
+                  =(privileged): "false"
+                  =(allowPrivilegeEscalation): "false"
+{{- end }}

--- a/apps/infra/ml-policy/templates/kyverno-require-ml-platform-labels.yaml
+++ b/apps/infra/ml-policy/templates/kyverno-require-ml-platform-labels.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.kyverno.enabled }}
+---
+# ClusterPolicy — require ADR-0028 platform taxonomy labels on the NET-NEW ML/GPU
+# workload kinds (WS-E in-cluster parity to tests/opa/platform_tags_ml.rego).
+#
+# The existing apps/infra/kyverno/.../require-platform-labels.yaml covers Pod / Service /
+# Deployment / Rollout cluster-wide. This policy ADDS the ML/GPU-specific kinds the
+# greenfield estate introduces — Volcano batch jobs (ADR-0044 D3), GPU-serving
+# Deployments/StatefulSets, and the Gateway API Inference Extension objects (ADR-0047) —
+# scoped to the ML namespaces, so the taxonomy is enforced on the workloads the OPA/SCP
+# planes cannot see (they govern Terraform/cloud resources, not in-cluster CRDs).
+#
+# Phase: {{ .Values.enforcement.platformLabels }} (values.enforcement.platformLabels).
+# Ships Audit-first (ADR-0020 soak pattern); promote to Enforce after a clean window.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-ml-platform-labels
+  labels:
+    platform.system: {{ .Values.platformLabels.system | quote }}
+    platform.component: {{ .Values.platformLabels.component | quote }}
+    platform.owner: {{ .Values.platformLabels.owner | quote }}
+    platform.env: {{ .Values.platformLabels.env | quote }}
+    platform.managed-by: {{ .Values.platformLabels.managedBy | quote }}
+  annotations:
+    policies.kyverno.io/title: Require platform taxonomy labels on ML/GPU workloads
+    policies.kyverno.io/category: Platform Governance
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Job,Deployment,StatefulSet,InferencePool,InferenceObjective
+    policies.kyverno.io/description: >-
+      Validates that ML/GPU workloads (Volcano/batch Jobs, GPU-serving Deployments and
+      StatefulSets, and Gateway API Inference Extension objects) in the ML namespaces
+      carry the three required ADR-0028 platform taxonomy labels. In-cluster parity to
+      tests/opa/platform_tags_ml.rego (WS-E gap closure). Audit-first.
+    adr: ADR-0020,ADR-0028,ADR-0044,ADR-0047
+spec:
+  validationFailureAction: {{ .Values.enforcement.platformLabels }}
+  failurePolicy: Ignore
+  background: true
+  rules:
+    - name: require-ml-platform-labels-workloads
+      match:
+        any:
+          - resources:
+              kinds:
+                - Job
+                - Deployment
+                - StatefulSet
+              namespaces:
+                {{- range .Values.mlNamespaces }}
+                - {{ . }}
+                {{- end }}
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range .Values.excludedNamespaces }}
+                - {{ . }}
+                {{- end }}
+      validate:
+        message: >-
+          ML/GPU workload is missing required platform taxonomy labels (ADR-0028).
+          Every ML workload must carry platform.system, platform.component, and
+          platform.owner with non-empty values. See
+          docs/adrs/0028-unified-platform-tagging-and-labeling-taxonomy.md and the
+          OPA parity tests/opa/platform_tags_ml.rego.
+        pattern:
+          metadata:
+            labels:
+              platform.system: "?*"
+              platform.component: "?*"
+              platform.owner: "?*"
+{{- end }}

--- a/apps/infra/ml-policy/values.yaml
+++ b/apps/infra/ml-policy/values.yaml
@@ -1,0 +1,55 @@
+# ml-policy — WS-E in-cluster ML/GPU policy enforcement (ADR-0020/0028/0044/0048)
+#
+# Phased rollout (mirrors apps/infra/kyverno ADR-0020 posture): ship in Audit/observe
+# so existing GPU workloads are not blocked, then promote to Enforce after a clean soak.
+# Default-OFF for hard-block rules so nothing is enforced until a human flips it.
+
+# Engine availability toggles — the cluster must already run these engines
+# (apps/infra/kyverno, apps/infra/gatekeeper). When false, that engine's manifests
+# are not rendered, keeping this chart inert if an engine is absent.
+kyverno:
+  enabled: true
+gatekeeper:
+  enabled: true
+
+# Enforcement phase for the platform-taxonomy ClusterPolicy.
+#   Audit   — record violations in PolicyReports / Grafana, do NOT block (DEFAULT).
+#   Enforce — block admission of non-compliant ML/GPU workloads.
+# Promote to Enforce only after a clean Audit window (ADR-0020 soak pattern).
+enforcement:
+  platformLabels: Audit
+  # Forbidding privileged GPU pods is security-critical; still ships Audit-first so a
+  # legitimate privileged DaemonSet (e.g. the NVIDIA driver) can be allow-listed before
+  # promotion. Flip to Enforce after the allow-list is confirmed.
+  noPrivilegedGpu: Audit
+
+# Namespaces the ML/GPU workloads live in (label requirement applies here). System and
+# infra namespaces are excluded — they do not carry workload taxonomy labels.
+mlNamespaces:
+  - ml-platform
+  - ml-pipeline
+  - ml-monitoring
+  - gpu-serving
+
+excludedNamespaces:
+  - kube-system
+  - kube-public
+  - kube-node-lease
+  - kyverno
+  - cert-manager
+  - gatekeeper-system
+  - external-secrets
+  - argocd
+  - monitoring
+  # GPU operator / device-plugin namespaces run vendor DaemonSets that legitimately
+  # need privileged/hostPath access and are taxonomy-labelled by their own charts.
+  - gpu-operator
+  - nvidia-device-plugin
+
+# ADR-0028 taxonomy stamped on the policy objects themselves.
+platformLabels:
+  system: security
+  component: ml-policy
+  owner: team-sec
+  env: production
+  managedBy: argocd

--- a/catalog/units/aws-ml-abac-iam/terragrunt.hcl
+++ b/catalog/units/aws-ml-abac-iam/terragrunt.hcl
@@ -1,0 +1,47 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# aws-ml-abac-iam — Catalog Unit (WS-E)
+# ---------------------------------------------------------------------------------------------------------------------
+# Least-privilege + ABAC IAM role (EKS Pod Identity) for ML workloads on the greenfield
+# EKS GPU cluster (ADR-0018/0028/0048). Deploy in the GPU/ML workload account.
+#
+# Cross-unit wiring: the S3 artifact-store / KMS / Secrets ARNs come from the WS-B
+# aws-ml-artifact-store unit via `dependency` blocks with mock_outputs for plan-time —
+# wired here as empty defaults until that unit exists (this WS does not own it).
+#
+# APPLY-GATED: `enabled = false` by default — plan/validate creates no IAM. Enable only
+# behind an explicit human apply (IAM is identity-critical).
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/aws-ml-abac-iam"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  environment  = local.account_vars.locals.environment
+}
+
+inputs = {
+  # apply-gated OFF until a human enables it with a reviewed plan.
+  enabled = false
+
+  name            = "ml-platform-workload"
+  platform_system = "ml-platform"
+
+  # TODO: wire from the WS-B aws-ml-artifact-store unit via dependency.outputs when it
+  # lands (bucket/kms/secret ARNs). Empty until then so plan-time stays inert.
+  artifact_bucket_arns = []
+  kms_key_arns         = []
+  secret_arns          = []
+
+  # TODO: set to the greenfield EKS GPU cluster name (ADR-0044) to create the Pod
+  # Identity association; empty leaves the role assumable but unbound.
+  eks_cluster_name          = ""
+  service_account_namespace = "ml-platform"
+  service_account_name      = "ml-platform-workload"
+
+  tags = {
+    "platform:env"        = local.environment
+    "platform:managed-by" = "terragrunt"
+  }
+}

--- a/catalog/units/aws-ml-scp-parity/terragrunt.hcl
+++ b/catalog/units/aws-ml-scp-parity/terragrunt.hcl
@@ -1,0 +1,46 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# aws-ml-scp-parity — Catalog Unit (WS-E)
+# ---------------------------------------------------------------------------------------------------------------------
+# ML-OU-scoped SCP deny-list plane for the greenfield AWS GPU/ML estate (ADR-0044/0048,
+# AWS analog of the GCP org-policy plane in ADR-0040 D1). Deploy in the MANAGEMENT
+# account (SCPs are an Organizations-level resource).
+#
+# APPLY-GATED: `enabled = false` by default — plan/validate is inert and creates no SCP.
+# Set `enabled = true` and populate `ml_target_ou_ids` only behind an explicit human
+# apply + blast-radius review (SCPs are org-wide).
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/project/platform-design/terraform/modules/aws-ml-scp-parity"
+}
+
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  environment  = local.account_vars.locals.environment
+}
+
+inputs = {
+  project = "platform-design"
+
+  # apply-gated OFF until a human enables it with a reviewed plan.
+  enabled = false
+
+  # TODO: populate with the GPU/ML OU id(s) when enabling (e.g. ["ou-xxxx-mlgpu01"]).
+  ml_target_ou_ids = []
+
+  allowed_gpu_regions = ["eu-west-1", "us-east-1", "us-west-2"]
+
+  # Per-policy toggles (all on; the master `enabled` gate still defaults the unit OFF).
+  require_imdsv2              = true
+  require_ebs_encryption      = true
+  deny_long_lived_access_keys = true
+  restrict_gpu_regions        = true
+
+  tags = {
+    "platform:system"     = "security"
+    "platform:component"  = "scp-parity"
+    "platform:owner"      = "team-sec"
+    "platform:env"        = local.environment
+    "platform:managed-by" = "terragrunt"
+  }
+}

--- a/docs/compliance/soc2-control-matrix-aws-ml.md
+++ b/docs/compliance/soc2-control-matrix-aws-ml.md
@@ -1,0 +1,142 @@
+# SOC2 Control-to-Evidence Matrix — AWS GPU/ML Platform (WS-E)
+
+> **Status:** Design-target (WS-E of the **AWS** ML Platform plan,
+> `docs/aws-ml-platform/IMPLEMENTATION_PLAN.md` §4). This matrix maps the SOC2 **Trust
+> Services Criteria (TSC, 2017 revised — Common Criteria CC-series)** to the controls
+> that satisfy each criterion **for the greenfield AWS GPU/ML estate** (ADRs 0044–0048),
+> plus the WS-E-added control plane. It is the AWS-side companion to the existing
+> GCP-oriented [`soc2-control-matrix.md`](soc2-control-matrix.md) (WS-E of the GCP plan,
+> ADR-0040) — same TSC structure, AWS-native controls.
+>
+> "Evidence" = a repo artifact (Terraform module / ArgoCD app / GitHub Action / runbook)
+> and the runtime signal it produces (an SCP/Config/admission deny, a CloudTrail log, a
+> signed-image attestation, a fired alert, an OPA plan-gate failure). **Nothing in this
+> matrix is applied without the apply gate** — it describes the intended control surface
+> and flags what is still a **gap**.
+
+## How to read this
+
+- **Plane** — `AWS` (Terragrunt/Terraform control plane), `K8s` (ArgoCD/Helm workload
+  plane), `CI` (GitHub Actions supply chain + OPA plan gate), or `Org` (Organizations/SCP).
+- **Status** — `evidenced` (control exists in-repo and produces an auditable signal),
+  `partial` (control exists, coverage incomplete), `gap` (no control yet; a follow-up
+  closes it), `inherited` (AWS shared-responsibility).
+- Every control carries the [ADR-0028](../adrs/0028-unified-platform-tagging-and-labeling-taxonomy.md)
+  `platform:system` taxonomy so evidence is attributable on the Grafana `$system` axis.
+
+---
+
+## CC1 — Control Environment
+
+| Criterion | Control (repo artifact) | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC1.1 Org structure | OU split + the GPU/ML OU (`terraform/modules/organization`, `aws-ml-scp-parity` targets the ML OU) | Org | OU tree; ML-OU SCP attachment | evidenced |
+| CC1.3 Authority & responsibility | ADR-0028 `platform:owner` on every ML resource (`team-ml-platform` / `team-sec`) | AWS+K8s | `owner` tag/label per resource | partial |
+| CC1.4 Competence / on-call | ML on-call rotation + tabletop ([oncall-rotation-escalation-aws.md](../runbooks/oncall-rotation-escalation-aws.md)) | — | PagerDuty schedule; tabletop record | evidenced (WS-E) |
+
+## CC2 — Communication & Information
+
+| Criterion | Control | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC2.1 Quality information | The existing observability stack (ADR-0026) reused for ML metrics (`apps/infra/ml-monitoring`, `apps/infra/observability`) | K8s | Metrics/logs/traces with ADR-0028 labels | evidenced |
+| CC2.2 Internal comms | ML runbooks ([ml-incident-runbook-aws.md](../runbooks/ml-incident-runbook-aws.md), [oncall…aws.md](../runbooks/oncall-rotation-escalation-aws.md)) | — | Runbook docs; `#ml-incidents` templates | evidenced (WS-E) |
+
+## CC3 — Risk Assessment
+
+| Criterion | Control | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC3.1 / CC3.2 Risk ID & analysis | The AWS plan risk register (R1–R8) + per-ADR Risks sections (0044–0048) | — | Plan §9; ADR "Risks" sections | evidenced |
+
+## CC4 — Monitoring Activities
+
+| Criterion | Control | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC4.1 Continuous evaluation | AWS Config + Security Hub (`terraform/modules/aws-config`), GuardDuty | AWS | Config rule evaluations; GuardDuty findings | partial |
+| CC4.1 Plan-time policy gate | **`tests/opa/platform_tags_ml.rego`** — taxonomy + ABAC floor on the net-new `aws-eks-gpu-*`/`aws-ml-*` types (conftest-opa CI) | CI | OPA `deny` on a PR plan (8/8 unit tests) | evidenced (WS-E) |
+
+## CC5 — Control Activities
+
+| Criterion | Control | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC5.2 Tech control deployment (preventive, cloud) | **`terraform/modules/aws-ml-scp-parity`** — ML-OU SCPs: IMDSv2, EBS-encryption, no-access-keys, region-restrict | Org | SCP deny on a violating API call | evidenced (WS-E, apply-gated) |
+| CC5.2 Tech control deployment (admission) | **`apps/infra/ml-policy`** — Kyverno + Gatekeeper: require ML taxonomy labels, forbid privileged GPU pods | K8s | PolicyReport / admission deny | evidenced (WS-E, Audit-first) |
+
+## CC6 — Logical & Physical Access
+
+| Criterion | Control | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC6.1 Logical access (least-priv + ABAC) | **`terraform/modules/aws-ml-abac-iam`** — least-privilege role, ABAC `platform:system` tag-match on S3/KMS/Secrets; EKS Pod Identity (ADR-0018) | AWS | IAM policy sim; CloudTrail `AssumeRole`; ABAC denial | evidenced (WS-E, apply-gated) |
+| CC6.1 IMDSv2 enforced on GPU nodes | `aws-ml-scp-parity` `require_imdsv2` SCP | Org | SCP deny of metadata-v1 RunInstances | evidenced (WS-E) |
+| CC6.1 Encryption at rest | `aws-ml-scp-parity` `require_ebs_encryption`; SSE-KMS on the ML S3 store (ADR-0048 D2) | Org+AWS | SCP deny; bucket SSE-KMS config | evidenced (WS-E) / partial |
+| CC6.3 No static credentials | `aws-ml-scp-parity` `deny_access_keys` (deny `iam:CreateAccessKey`); Pod Identity is the only path | Org | SCP deny of `CreateAccessKey` | evidenced (WS-E) |
+| CC6.6 Network boundary | GPU VPC private subnets + EFA SG (ADR-0044/0045, WS-A); Cilium NetworkPolicy (`platform.system` scoped) | AWS+K8s | SG/NACL config; default-deny netpol | partial (WS-A owns) |
+| CC6.7 Data-in-transit | Envoy Gateway + AWS WAF on the inference front (ADR-0047, WS-A); TLS | K8s | Gateway/WAF config | partial (WS-A owns) |
+| CC6.8 Unauthorized software | cosign keyless verify + syft SBOM (`.github/actions/cosign-sign`, `syft-sbom`, ADR-0029); `no-privileged-gpu` admission | CI+K8s | Image attestation; admission deny | evidenced |
+
+## CC7 — System Operations
+
+| Criterion | Control | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC7.2 Incident detection | DCGM/GPU + ML-drift alerts → Alertmanager → PagerDuty (ADR-0038, `apps/infra/ml-monitoring`) | K8s | Fired alert; PagerDuty incident | evidenced |
+| CC7.3 / CC7.4 Incident response | **[ML-incident runbook](../runbooks/ml-incident-runbook-aws.md)** (drift / training / serving) + escalation | — | Runbook + incident timeline | evidenced (WS-E) |
+| CC7.1 Audit logging | CloudTrail multi-region + the EKS control-plane audit log (ADR per WS-A) | AWS | CloudTrail/audit events | partial |
+
+## CC8 — Change Management
+
+| Criterion | Control | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC8.1 Change control | ADR-first + PR-based, apply-gated workflow; OPA + fmt/validate/test CI gates | CI | PR checks; ADR ratification | evidenced |
+
+## CC9 — Risk Mitigation
+
+| Criterion | Control | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC9.1 Risk mitigation | AWS Budgets 80/100/120% + FORECASTED on GPU spend (`terraform/modules/budgets`, ADR-0044 D4, WS-A) | AWS | Budget alert | partial (WS-A owns) |
+
+## Availability / Confidentiality (in-scope extras)
+
+| Criterion | Control | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| A1.2 Availability / failover | Multi-region EKS + Route 53 failover (`failover-controller`, ADR-0044 D5, WS-A) | AWS | Health-check failover event | partial (WS-A owns) |
+| C1.1 Data residency | `aws-ml-scp-parity` `restrict_regions` (GPU regions only) | Org | SCP deny outside allowed regions | evidenced (WS-E) |
+| C1.2 Confidential disposal | S3 lifecycle + versioning on the ML store (ADR-0048 D2, WS-B) | AWS | Lifecycle config | gap (WS-B owns) |
+
+---
+
+## Still-gap list (honest, first-class)
+
+A matrix is not an audit. The following are **not yet evidenced** and are tracked:
+
+1. **AWS Config / Security Hub continuous evaluation across all GPU regions** — `partial`
+   (CC4.1); breadth of conformance packs for the new ML resource types is WS-A/follow-up.
+2. **Cross-cloud WIF (GCP↔AWS)** — the inverse of ADR-0040 D2; decision ratified, the
+   pool/provider module is a follow-up (CC6.1/CC6.3 for cross-cloud).
+3. **`ml-platform-oncall` PagerDuty service provisioning** — the dedicated routing key is
+   the first tabletop action item (CC1.4); until then ML alerts fall back to the shared
+   receiver.
+4. **Data-disposal proof** for the ML artifact store (C1.2) — lifecycle config exists in
+   the WS-B design but the deletion-evidence trail is not yet wired.
+5. **EKS control-plane audit-log export + retention** for the greenfield cluster (CC7.1) —
+   WS-A owns the cluster; this matrix will flip to `evidenced` when that lands.
+
+## Evidence-collection model (repo-anchored, pull-based)
+
+No separate GRC tool (YAGNI, mirrors ADR-0040 D3). An auditor request resolves to (1) the
+ADR (0044–0048), (2) the module/app/action (this matrix's "Control" column), (3) the
+`*.tftest.hcl` / `opa test` / `helm template` run proving behavior, and (4) the runtime
+signal (SCP/Config/admission/OPA deny, CloudTrail, fired alert) — all attributable on the
+ADR-0028 `$system` axis. The repo + observability stack **is** the evidence store.
+
+## References
+
+- AWS ML Platform plan — `docs/aws-ml-platform/IMPLEMENTATION_PLAN.md` (WS-E, §7 #13)
+- [ADR-0040](../adrs/0040-soc-posture-and-oncall.md) — the GCP etalon (SOC posture + WIF)
+- [ADR-0044](../adrs/0044-aws-eks-gpu-ml-foundation-multiregion.md) /
+  [ADR-0048](../adrs/0048-aws-ml-cicd-registry-drift.md) — the AWS GPU/ML estate
+- [ADR-0028](../adrs/0028-unified-platform-tagging-and-labeling-taxonomy.md) — taxonomy + ABAC
+- [ADR-0018](../adrs/0018-eks-pod-identity-as-default-workload-identity.md) — Pod Identity
+- WS-E artifacts: `terraform/modules/aws-ml-scp-parity`, `terraform/modules/aws-ml-abac-iam`,
+  `apps/infra/ml-policy`, `tests/opa/platform_tags_ml.rego`,
+  [ML-incident runbook](../runbooks/ml-incident-runbook-aws.md),
+  [on-call rotation](../runbooks/oncall-rotation-escalation-aws.md)
+- SOC2 Trust Services Criteria (2017, revised) — Common Criteria CC1–CC9.

--- a/docs/runbooks/ml-incident-runbook-aws.md
+++ b/docs/runbooks/ml-incident-runbook-aws.md
@@ -1,0 +1,105 @@
+# Runbook: ML-Platform Incident Response — AWS EKS GPU Platform
+
+> **Scope:** ML-specific incidents on the **greenfield AWS EKS GPU ML platform**
+> (ADRs 0044–0048) — model drift / accuracy regression, training-pipeline failure, and
+> serving outage. This is the AWS-side companion to
+> [`ml-incident-runbook.md`](ml-incident-runbook.md) (the GKE/ADR-0040 D4 runbook); the
+> ML-domain decision trees are cluster-agnostic, the AWS deltas are GPU-on-EKS specifics
+> (DCGM, EFA, Karpenter, Pod Identity, the Envoy + AWS WAF inference front). Follow the
+> general [SRE runbook](../sre-runbook.md) and
+> [on-call rotation & escalation (AWS)](oncall-rotation-escalation-aws.md) for generic
+> triage, PagerDuty ACK, and comms templates.
+>
+> **System / owner (ADR-0028):** `platform.system = ml-monitoring` / `ml-platform`;
+> `platform.owner = team-ml-platform`. Alerts carry `platform_system` so they route on
+> the same Grafana `$system` axis across AWS + GCP.
+>
+> **Wiring (reuse, not new):** drift/accuracy alerts fire via the ADR-0038 Alertmanager
+> route to the `ml-drift-pagerduty` receiver and, on `severity=critical`, to the
+> `ml-retrain-webhook` (Airflow REST `dagRuns`, K8s Job fallback). The dedicated
+> **`ml-platform-oncall` PagerDuty service** is the WS-E formalization (see the on-call
+> doc); until provisioned, ML alerts fall back to the shared platform receiver.
+
+## Severity definitions (ML, AWS)
+
+| Severity | Definition | PagerDuty | ACK SLA |
+|---|---|---|---|
+| **SEV1** | Production model serving down / erroring behind the Envoy + WAF front; user-facing | Page `ml-platform-oncall` immediately | 5 min |
+| **SEV2** | Accuracy/drift breach on a production model, or a training pipeline blocking a scheduled retrain/release | Page ML on-call | 15 min |
+| **SEV3** | Drift warning trend, non-blocking pipeline failure, staging-only, single Karpenter GPU node lost | Notify Slack `#ml-incidents` | 1 h |
+
+---
+
+## Scenario 1 — Model drift / accuracy regression
+
+**Trigger:** `MLDrift*` / `MLAccuracyBreach` alert (Evidently/whylogs → Prometheus,
+ADR-0038) for a model `platform_system`.
+
+1. **Confirm scope.** Grafana drift dashboard filtered to the model's `$system`. Is it
+   one model/tenant (namespace-per-model isolation) or many (shared feature pipeline)?
+2. **Classify drift.** Data drift (input distribution) vs concept drift (label
+   relationship) vs pipeline bug (a feature went null/constant). A single feature pinned
+   to a constant is usually an upstream data bug, not real drift — fix the source, do not
+   retrain.
+3. **Decide retrain.** SEV2 if a production model breaches its accuracy gate. The
+   `ml-retrain-webhook` may have already opened an Airflow `dagRun` — confirm in the
+   Airflow UI; do not double-fire.
+4. **Mitigate.** If accuracy is user-impacting, roll the serving deployment back to the
+   last-good MLflow model version (Kargo promotion / ArgoCD rollback) while the retrain
+   runs.
+5. **Recover.** Verify the retrained model passes the eval gate, is signed (cosign), and
+   promotes; confirm drift metric returns to band.
+
+## Scenario 2 — Training-pipeline failure (Airflow on EKS)
+
+**Trigger:** Airflow DAG failure alert, or a scheduled retrain not completing.
+
+1. **Locate the failed task.** Airflow UI → the DAG run → failed task logs.
+2. **AWS-delta triage:**
+   - **GPU unavailable / Karpenter not scaling:** check the GPU `NodePool` /
+     `EC2NodeClass` — Capacity Block exhausted, spot interrupted mid-job (training pools
+     should be off-spot, ADR R7), or per-region GPU quota hit (R4). `kubectl describe`
+     the pending pod for the scheduling reason.
+   - **S3 / MLflow access denied:** the workload role is `aws-ml-abac-iam` — an
+     `AccessDenied` to the artifact bucket usually means the resource is **not tagged**
+     with the role's `platform:system` (the ABAC tag-match fails by design). Tag the
+     bucket/object or check the pod's Pod Identity association.
+   - **Secrets unavailable:** MLflow RDS creds come via ESO (ADR-0008/0031) — check the
+     ExternalSecret sync status and the Secrets Manager secret.
+3. **Volcano gang-scheduling stuck:** a multi-pod training job stuck `Pending` is often a
+   gang that cannot fully schedule (insufficient GPUs). Check the Volcano `PodGroup`.
+4. **Recover.** Re-run the task once the cause is cleared; if it was a transient spot
+   interruption, confirm the pool moved to on-demand/Capacity Blocks for the rerun.
+
+## Scenario 3 — Serving outage (Envoy + Gateway API Inference Extension + AWS WAF)
+
+**Trigger:** SEV1 — `MLServingDown` / 5xx spike / latency SLO burn behind the inference
+front (ADR-0047).
+
+1. **Front vs backend.** Is the Envoy Gateway / `InferencePool` healthy, or are the model
+   pods failing? Check the gateway, the `InferencePool` endpoints, and the Endpoint
+   Picker (EPP) ext-proc (separately deployed — ADR-0047) health.
+2. **AWS WAF check.** A sudden 4xx/403 spike at the front may be a WAF rule in block mode
+   over-matching legitimate traffic (ADR R8 says rules ship count-then-block). Inspect the
+   `terraform/modules/waf` WebACL sampled requests before disabling anything.
+3. **GPU node health.** DCGM exporter (`apps/infra/dcgm-exporter`) — XID errors, ECC,
+   thermal throttling, or a node auto-tainted by the DCGM health check. A bad GPU node is
+   drained by Karpenter; confirm a replacement scheduled.
+4. **Mitigate.** Shift traffic to a healthy canary `InferencePool` / revert to `ClusterIP`
+   (ADR R8 keeps it revertible); scale the serving pool; in a regional outage, trigger the
+   Route 53 cross-region failover (`failover-controller`, ADR-0044 D5).
+5. **Recover.** Confirm SLO back in band, WAF back to count where it over-matched, and the
+   GPU node fleet healthy in the DCGM dashboard.
+
+---
+
+## Cross-references
+
+- [On-call rotation & escalation (AWS)](oncall-rotation-escalation-aws.md) — rotations,
+  L1→L3 timers, tabletop, comms.
+- [SOC2 control matrix (AWS ML)](../compliance/soc2-control-matrix-aws-ml.md) — CC7.3/7.4.
+- [ADR-0038](../adrs/0038-ml-observability-drift.md) — drift → Alertmanager → retrain.
+- [ADR-0047](../adrs/0047-eks-inference-serving-front-waf.md) — Envoy + inference
+  extension + AWS WAF serving front.
+- [ADR-0044](../adrs/0044-aws-eks-gpu-ml-foundation-multiregion.md) — DCGM, Karpenter,
+  EFA, multi-region failover.

--- a/docs/runbooks/oncall-rotation-escalation-aws.md
+++ b/docs/runbooks/oncall-rotation-escalation-aws.md
@@ -1,0 +1,76 @@
+# On-Call Rotation & Escalation — AWS EKS GPU ML Platform (WS-E)
+
+> **Scope:** the on-call rotation, escalation policy, and quarterly tabletop for the
+> **greenfield AWS EKS GPU ML platform** (ADRs 0044–0048). AWS-side companion to
+> [`oncall-rotation-escalation.md`](oncall-rotation-escalation.md) (the GKE/ADR-0040 D4
+> doc). It **ties into the existing PagerDuty + Alertmanager wiring** (ADR-0026/0038), not
+> a new one — it formalizes the dedicated **ML** rotation that ADR-0038 D3 deferred to
+> WS-E.
+>
+> **System / owner (ADR-0028):** `platform.system = ml-platform`,
+> `platform.owner = team-ml-platform`. The escalation policy itself is `system = security`
+> / `component = oncall`.
+
+## Rotations
+
+Two PagerDuty rotations, both 1-week, primary + secondary:
+
+| Rotation | PagerDuty service | Covers | Routing |
+|---|---|---|---|
+| `platform-oncall` | existing platform service | cluster/infra, network, supply chain, non-ML SEV | existing Alertmanager `pagerduty` receiver |
+| `ml-platform-oncall` | **`ml-platform-oncall`** (WS-E formalization) | ML drift/accuracy, training pipeline, GPU serving, DCGM/EFA GPU-node health | ADR-0038 `ml-drift-pagerduty` receiver + the `MLServing*`/`GPUNode*` routes |
+
+> **Provisioning status:** the `ml-platform-oncall` PagerDuty **service + routing key** is
+> the dedicated key ADR-0038 D3 deferred. Until it is provisioned (the **first tabletop
+> action item**; tracked as a `partial` row in the
+> [SOC2 matrix CC1.4](../compliance/soc2-control-matrix-aws-ml.md)), ML alerts fall back to
+> the shared `platform-oncall` receiver. The routing key is sourced via ESO
+> (`alertmanager-pagerduty-secret`, ADR-0008) — **never** committed.
+
+## Escalation policy (L1 → L3)
+
+| Level | Who | Trigger / timer |
+|---|---|---|
+| **L1** | primary on-call for the rotation | paged on the SEV; ACK within the SEV's ACK SLA (SEV1 5 min / SEV2 15 min / SEV3 1 h, per the [ML runbook](ml-incident-runbook-aws.md)) |
+| **L2** | secondary on-call | auto-escalate if L1 has not ACKed within the ACK SLA, or on L1 request |
+| **L3** | team lead + (SEV1) the platform/ML eng manager | SEV1 not mitigated within 30 min, or any incident crossing two domains (e.g. GPU-node failure cascading into a serving outage) |
+
+Cross-domain incidents (an ML serving outage rooted in a cluster/network fault) page
+**both** rotations; the SEV1 commander coordinates. A regional GPU outage that triggers
+Route 53 failover (ADR-0044 D5) is automatically L3.
+
+## Severity → action quick map
+
+| SEV | Page | Mitigation entry point |
+|---|---|---|
+| SEV1 serving down | `ml-platform-oncall` immediately | [ML runbook Scenario 3](ml-incident-runbook-aws.md#scenario-3--serving-outage-envoy--gateway-api-inference-extension--aws-waf) |
+| SEV2 drift/accuracy/training | `ml-platform-oncall` | [Scenario 1](ml-incident-runbook-aws.md#scenario-1--model-drift--accuracy-regression) / [Scenario 2](ml-incident-runbook-aws.md#scenario-2--training-pipeline-failure-airflow-on-eks) |
+| SEV3 trend/staging | Slack `#ml-incidents` | triage during business hours |
+
+## Comms templates
+
+- **Internal (Slack `#ml-incidents`):** `SEV{n} — {model/$system} — {one-line impact} —
+  commander @{name} — status: investigating/mitigating/recovered`.
+- **Stakeholder (SEV1/SEV2):** model affected, user-facing impact, current mitigation, ETA,
+  next update time. Posted by the commander, not the responder.
+- **Status page:** only for SEV1 user-facing serving impact, owned by the commander.
+
+## Quarterly tabletop
+
+A quarterly tabletop exercise (the SOC2 CC1.4 evidence signal) walks one scenario from each
+domain (drift, training, serving) end-to-end against this doc + the
+[ML runbook](ml-incident-runbook-aws.md). **Output:** a dated exercise record + an action
+list. The **standing first action item** is provisioning the `ml-platform-oncall` PagerDuty
+service so ML pages stop falling back to the shared receiver.
+
+| Tabletop date | Scenario rehearsed | Action items | Status |
+|---|---|---|---|
+| _(pending first run)_ | drift → retrain; serving 5xx + WAF; training GPU-quota stall | provision `ml-platform-oncall` service | open |
+
+## Cross-references
+
+- [ML-incident runbook (AWS)](ml-incident-runbook-aws.md)
+- [SOC2 control matrix (AWS ML)](../compliance/soc2-control-matrix-aws-ml.md) — CC1.4 / CC2.2 / CC7.3
+- [ADR-0038](../adrs/0038-ml-observability-drift.md) — drift → PagerDuty (ML key deferred to WS-E)
+- [ADR-0026](../adrs/0026-observability-target-architecture.md) — Alertmanager → PagerDuty wiring
+- [ADR-0008](../adrs/0008-external-secrets-operator.md) — ESO-sourced PagerDuty routing key

--- a/terraform/modules/aws-ml-abac-iam/README.md
+++ b/terraform/modules/aws-ml-abac-iam/README.md
@@ -1,0 +1,59 @@
+# Module: `aws-ml-abac-iam`
+
+> **ADRs:** [0018](../../../docs/adrs/0018-eks-pod-identity-as-default-workload-identity.md)
+> (EKS Pod Identity as default workload identity),
+> [0028](../../../docs/adrs/0028-unified-platform-tagging-and-labeling-taxonomy.md)
+> (the ABAC condition `aws:PrincipalTag/platform:system == aws:ResourceTag/platform:system`),
+> [0048](../../../docs/adrs/0048-aws-ml-cicd-registry-drift.md) (the S3 artifact store /
+> RDS-Secrets backends this role reaches). WS-E owns the least-privilege + ABAC delta.
+
+WS-E **IAM least-privilege + ABAC** role for ML workloads on the greenfield EKS GPU
+cluster. Provides an EKS **Pod Identity** role whose permission policy is **scoped to a
+single `platform:system` axis** by the ADR-0028 ABAC condition, so a pod may only act on
+S3 / KMS / Secrets resources tagged with its own system — cross-system access is denied
+even when the ARN is explicitly listed.
+
+## Apply-gated / default-OFF
+
+**With default inputs, `terraform plan` creates ZERO IAM.** The role, policy, attachment,
+and Pod Identity association are all gated on `var.enabled` (default `false`) via `count`.
+IAM is identity-critical; enabling requires an explicit human apply.
+
+## Least-privilege + ABAC contract
+
+- **Least-privilege:** only the S3 (`GetObject`/`PutObject`/`DeleteObject`/`ListBucket`/
+  `GetBucketLocation`), KMS (`Decrypt`/`GenerateDataKey`), and Secrets Manager
+  (`GetSecretValue`/`DescribeSecret`) actions the ML pipeline needs — **no `Action:*`,
+  no `Resource:*`**. Each statement is emitted only when its resource list is non-empty.
+- **ABAC:** every grant carries
+  `aws:ResourceTag/platform:system == ${aws:PrincipalTag/platform:system}`. The role's
+  `platform:system` principal tag (derived from `var.platform_system`) is what EKS Pod
+  Identity surfaces in the session, so the tag-match is enforced at request time.
+- **Keyless:** the trust policy admits only `pods.eks.amazonaws.com` (Pod Identity); the
+  companion `aws-ml-scp-parity` SCP denies `iam:CreateAccessKey` org-side, so static keys
+  are not a fallback (ADR-0018 forcing function).
+- **No secrets in code:** the module references Secrets Manager ARNs (MLflow RDS creds via
+  ESO, ADR-0008/0031) — it never embeds secret material.
+
+## Inputs of note
+
+| Variable | Purpose |
+|---|---|
+| `platform_system` | the `$system` axis the role is scoped to (ABAC match key) |
+| `artifact_bucket_arns` / `kms_key_arns` / `secret_arns` | resource scoping (ABAC adds ownership scoping) |
+| `eks_cluster_name` / `service_account_*` | Pod Identity association (created only when cluster name set) |
+
+## ADR-0028 taxonomy
+
+Role + policy + association carry `platform:system` (from `var.platform_system`),
+`platform:component=ml-iam`, `platform:owner=team-ml-platform`,
+`platform:managed-by=terragrunt`; overridable via `var.tags`. Surfaced on `platform_tags`.
+
+## Validation (plan/validate-only)
+
+`terraform fmt`, `terraform init -backend=false`, `terraform validate`, and
+`terraform test` (mocked `aws` provider, **5/5 pass**) — default-OFF gate, ABAC condition
+present in every grant, no wildcard action/resource, taxonomy tags, Pod-Identity gating.
+The ABAC-condition *generation* from the `statement` blocks is additionally enforced by
+`terraform validate` and `tests/opa/platform_tags_ml.rego` against the real plan JSON in
+CI. **No `terraform apply`, no IAM created** at plan/validate time.

--- a/terraform/modules/aws-ml-abac-iam/aws-ml-abac-iam.tftest.hcl
+++ b/terraform/modules/aws-ml-abac-iam/aws-ml-abac-iam.tftest.hcl
@@ -1,0 +1,169 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests — aws-ml-abac-iam (mocked AWS provider; plan-only, no apply, no real IAM)
+# ---------------------------------------------------------------------------------------------------------------------
+# Verifies: apply-gated default-OFF; the ADR-0028 ABAC tag-match condition is present in
+# every grant; least-privilege (no wildcard action/resource); ADR-0028 taxonomy tags;
+# Pod Identity association gated on cluster name. ADR-0018/0028/0048.
+# Synthetic ARNs only (AWS docs reserved example account 111122223333).
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "aws" {
+  # aws_iam_policy_document is provider-computed; the default mock returns a random
+  # string that fails IAM's JSON-policy validator. Supply valid documents so the IAM
+  # resources validate. The supplied permission doc carries the ABAC tag-match condition
+  # so the wiring assertions (strcontains on the resource policy) remain meaningful; the
+  # condition *generation* from statement blocks is checked by `terraform validate` and
+  # the OPA rego (tests/opa/platform_tags_ml.rego) against the real plan JSON in CI.
+  override_data {
+    target = data.aws_iam_policy_document.assume
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"EksPodIdentityAssume\",\"Effect\":\"Allow\",\"Action\":[\"sts:AssumeRole\",\"sts:TagSession\"],\"Principal\":{\"Service\":\"pods.eks.amazonaws.com\"}}]}"
+    }
+  }
+
+  override_data {
+    target = data.aws_iam_policy_document.permissions
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"ArtifactStoreObjectsAbac\",\"Effect\":\"Allow\",\"Action\":[\"s3:GetObject\",\"s3:PutObject\",\"s3:DeleteObject\"],\"Resource\":\"arn:aws:s3:::ml-artifacts-test/*\",\"Condition\":{\"StringEquals\":{\"aws:ResourceTag/platform:system\":\"$${aws:PrincipalTag/platform:system}\"}}}]}"
+    }
+  }
+}
+
+# --- 1. DEFAULT OFF: no IAM at all -----------------------------------------------------------------------------------
+run "default_is_apply_gated_off" {
+  command = plan
+
+  assert {
+    condition     = var.enabled == false
+    error_message = "Module must default to apply-gated OFF (enabled=false)."
+  }
+
+  assert {
+    condition     = length(aws_iam_role.this) == 0
+    error_message = "Default (gated off) must create no IAM role."
+  }
+
+  assert {
+    condition     = length(aws_iam_policy.this) == 0
+    error_message = "Default (gated off) must create no IAM policy."
+  }
+
+  assert {
+    condition     = length(aws_eks_pod_identity_association.this) == 0
+    error_message = "Default (gated off) must create no Pod Identity association."
+  }
+
+  assert {
+    condition     = output.abac_enforced == false
+    error_message = "abac_enforced must be false when gated off."
+  }
+}
+
+# --- 2. ENABLED with S3 + KMS + Secrets: ABAC condition present in every grant ----------------------------------------
+run "enabled_grants_carry_abac_condition" {
+  command = plan
+
+  variables {
+    enabled              = true
+    name                 = "ml-platform-workload"
+    platform_system      = "ml-platform"
+    artifact_bucket_arns = ["arn:aws:s3:::ml-artifacts-test"]
+    kms_key_arns         = ["arn:aws:kms:us-east-1:111122223333:key/abcd-1234"]
+    secret_arns          = ["arn:aws:secretsmanager:us-east-1:111122223333:secret:mlflow/rds-AbCdEf"]
+  }
+
+  assert {
+    condition     = length(aws_iam_role.this) == 1
+    error_message = "Enabling the gate must create the IAM role."
+  }
+
+  # The ABAC tag-match must appear in the generated permission-policy JSON.
+  assert {
+    condition     = strcontains(aws_iam_policy.this[0].policy, "aws:ResourceTag/platform:system")
+    error_message = "Every grant must carry the ABAC aws:ResourceTag/platform:system condition (ADR-0028)."
+  }
+
+  assert {
+    condition     = strcontains(aws_iam_policy.this[0].policy, "$${aws:PrincipalTag/platform:system}")
+    error_message = "ABAC condition must match ResourceTag against the PrincipalTag platform:system."
+  }
+
+  assert {
+    condition     = output.abac_enforced == true
+    error_message = "abac_enforced must be true when at least one resource class is granted."
+  }
+}
+
+# --- 3. Least-privilege: no wildcard action and no wildcard resource --------------------------------------------------
+run "least_privilege_no_wildcards" {
+  command = plan
+
+  variables {
+    enabled              = true
+    platform_system      = "ml-platform"
+    artifact_bucket_arns = ["arn:aws:s3:::ml-artifacts-test"]
+  }
+
+  assert {
+    condition     = !strcontains(aws_iam_policy.this[0].policy, "\"Action\":\"*\"")
+    error_message = "Permission policy must not grant Action '*' (least-privilege)."
+  }
+
+  assert {
+    condition     = !strcontains(aws_iam_policy.this[0].policy, "\"Resource\":\"*\"")
+    error_message = "Permission policy must not grant Resource '*' (least-privilege)."
+  }
+}
+
+# --- 4. ADR-0028 taxonomy on the role + platform_system scoping -------------------------------------------------------
+run "taxonomy_and_scoping" {
+  command = plan
+
+  variables {
+    enabled              = true
+    platform_system      = "ml-pipeline"
+    artifact_bucket_arns = ["arn:aws:s3:::ml-artifacts-test"]
+  }
+
+  assert {
+    condition     = aws_iam_role.this[0].tags["platform:system"] == "ml-pipeline"
+    error_message = "platform:system tag must follow var.platform_system (ADR-0028)."
+  }
+
+  assert {
+    condition     = aws_iam_role.this[0].tags["platform:component"] == "ml-iam"
+    error_message = "platform:component must be 'ml-iam'."
+  }
+
+  assert {
+    condition     = aws_iam_role.this[0].tags["platform:owner"] == "team-ml-platform"
+    error_message = "platform:owner must be 'team-ml-platform'."
+  }
+
+  assert {
+    condition     = output.platform_system == "ml-pipeline"
+    error_message = "platform_system output must reflect the scoped system."
+  }
+}
+
+# --- 5. Pod Identity association is gated on the cluster name ----------------------------------------------------------
+run "pod_identity_gated_on_cluster" {
+  command = plan
+
+  variables {
+    enabled              = true
+    platform_system      = "ml-platform"
+    artifact_bucket_arns = ["arn:aws:s3:::ml-artifacts-test"]
+    eks_cluster_name     = "aws-eks-gpu-use1"
+  }
+
+  assert {
+    condition     = length(aws_eks_pod_identity_association.this) == 1
+    error_message = "Supplying an EKS cluster name must create the Pod Identity association."
+  }
+
+  assert {
+    condition     = aws_eks_pod_identity_association.this[0].namespace == "ml-platform"
+    error_message = "Pod Identity association must target the configured namespace."
+  }
+}

--- a/terraform/modules/aws-ml-abac-iam/main.tf
+++ b/terraform/modules/aws-ml-abac-iam/main.tf
@@ -1,0 +1,195 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# aws-ml-abac-iam — least-privilege + ABAC IAM role for ML workloads (EKS Pod Identity)
+# ---------------------------------------------------------------------------------------------------------------------
+# ADR-0018 (EKS Pod Identity as the default workload identity) + ADR-0028 (the ABAC
+# condition: aws:PrincipalTag/platform:system == aws:ResourceTag/platform:system) +
+# ADR-0048 (the S3 artifact store / RDS-Secrets this role reaches). WS-E owns the
+# least-privilege + ABAC delta; the broad keyless posture is ADR-0018.
+#
+# The permission policy is least-privilege (only the S3/KMS/Secrets actions the ML
+# pipeline needs) AND every statement carries the ABAC tag-match condition, so a pod
+# bound to this role may only act on resources whose `platform:system` ResourceTag
+# equals the role's `platform:system` PrincipalTag — cross-system access is denied even
+# if the ARN is listed.
+#
+# APPLY-GATED / DEFAULT-OFF: gated by `var.enabled` (default false) via `count`. With
+# defaults, `terraform plan` creates ZERO IAM. IAM is identity-critical; enabling
+# requires an explicit human apply.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  create              = var.enabled
+  role_name           = "${var.name}-role"
+  policy_name         = "${var.name}-policy"
+  create_pod_identity = var.enabled && var.eks_cluster_name != ""
+  has_buckets         = length(var.artifact_bucket_arns) > 0
+  has_kms             = length(var.kms_key_arns) > 0
+  has_secrets         = length(var.secret_arns) > 0
+  bucket_object_arns  = [for arn in var.artifact_bucket_arns : "${arn}/*"]
+
+  # ADR-0028 taxonomy: derive defaults from platform_system; allow caller override via var.tags.
+  base_tags = {
+    "platform:system"     = var.platform_system
+    "platform:component"  = "ml-iam"
+    "platform:owner"      = "team-ml-platform"
+    "platform:managed-by" = "terragrunt"
+  }
+  effective_tags = merge(local.base_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Trust policy — EKS Pod Identity (pods.eks.amazonaws.com) assumes the role and is
+# stamped with the platform:system session tag used by the ABAC condition (ADR-0018).
+# ---------------------------------------------------------------------------------------------------------------------
+data "aws_iam_policy_document" "assume" {
+  statement {
+    sid     = "EksPodIdentityAssume"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+
+    # Pod Identity injects the principal tag platform:system from the role's own tag;
+    # this condition asserts the session is tagged with the expected system.
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/platform:system"
+      values   = [var.platform_system]
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  count = local.create ? 1 : 0
+
+  name                 = local.role_name
+  assume_role_policy   = data.aws_iam_policy_document.assume.json
+  max_session_duration = 3600
+
+  tags = local.effective_tags
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Least-privilege permission policy — only the actions the ML pipeline needs, each
+# statement carrying the ADR-0028 ABAC tag-match condition so access is scoped to the
+# role's own platform:system. Statements are emitted only when their resource list is
+# non-empty (no wildcard, no empty-resource statements).
+# ---------------------------------------------------------------------------------------------------------------------
+data "aws_iam_policy_document" "permissions" {
+  # S3 object read/write on the artifact store, ABAC-scoped.
+  dynamic "statement" {
+    for_each = local.has_buckets ? [1] : []
+    content {
+      sid    = "ArtifactStoreObjectsAbac"
+      effect = "Allow"
+      actions = [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+      ]
+      resources = local.bucket_object_arns
+
+      condition {
+        test     = "StringEquals"
+        variable = "aws:ResourceTag/platform:system"
+        values   = ["$${aws:PrincipalTag/platform:system}"]
+      }
+    }
+  }
+
+  # S3 bucket-level list on the artifact store, ABAC-scoped.
+  dynamic "statement" {
+    for_each = local.has_buckets ? [1] : []
+    content {
+      sid    = "ArtifactStoreListAbac"
+      effect = "Allow"
+      actions = [
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+      ]
+      resources = var.artifact_bucket_arns
+
+      condition {
+        test     = "StringEquals"
+        variable = "aws:ResourceTag/platform:system"
+        values   = ["$${aws:PrincipalTag/platform:system}"]
+      }
+    }
+  }
+
+  # KMS decrypt/data-key for SSE-KMS, ABAC-scoped.
+  dynamic "statement" {
+    for_each = local.has_kms ? [1] : []
+    content {
+      sid    = "ArtifactStoreKmsAbac"
+      effect = "Allow"
+      actions = [
+        "kms:Decrypt",
+        "kms:GenerateDataKey",
+      ]
+      resources = var.kms_key_arns
+
+      condition {
+        test     = "StringEquals"
+        variable = "aws:ResourceTag/platform:system"
+        values   = ["$${aws:PrincipalTag/platform:system}"]
+      }
+    }
+  }
+
+  # Secrets Manager read (MLflow RDS creds via ESO), ABAC-scoped.
+  dynamic "statement" {
+    for_each = local.has_secrets ? [1] : []
+    content {
+      sid    = "MlSecretsReadAbac"
+      effect = "Allow"
+      actions = [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret",
+      ]
+      resources = var.secret_arns
+
+      condition {
+        test     = "StringEquals"
+        variable = "aws:ResourceTag/platform:system"
+        values   = ["$${aws:PrincipalTag/platform:system}"]
+      }
+    }
+  }
+}
+
+resource "aws_iam_policy" "this" {
+  count = local.create ? 1 : 0
+
+  name        = local.policy_name
+  description = "Least-privilege + ABAC (platform:system tag-match) permissions for ${var.platform_system} ML workloads (ADR-0018/0028/0048)"
+  policy      = data.aws_iam_policy_document.permissions.json
+
+  tags = local.effective_tags
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  count = local.create ? 1 : 0
+
+  role       = aws_iam_role.this[0].name
+  policy_arn = aws_iam_policy.this[0].arn
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# EKS Pod Identity association — binds the workload ServiceAccount to the role (ADR-0018).
+# Only created when an EKS cluster name is supplied; the role tag platform:system is
+# what Pod Identity surfaces as the ABAC principal tag.
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_eks_pod_identity_association" "this" {
+  count = local.create_pod_identity ? 1 : 0
+
+  cluster_name    = var.eks_cluster_name
+  namespace       = var.service_account_namespace
+  service_account = var.service_account_name
+  role_arn        = aws_iam_role.this[0].arn
+
+  tags = local.effective_tags
+}

--- a/terraform/modules/aws-ml-abac-iam/outputs.tf
+++ b/terraform/modules/aws-ml-abac-iam/outputs.tf
@@ -1,0 +1,33 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Outputs — aws-ml-abac-iam
+# ---------------------------------------------------------------------------------------------------------------------
+
+output "role_arn" {
+  description = "ARN of the ML workload IAM role. Null when the module is gated off (var.enabled=false)."
+  value       = try(aws_iam_role.this[0].arn, null)
+}
+
+output "role_name" {
+  description = "Name of the ML workload IAM role. Null when gated off."
+  value       = try(aws_iam_role.this[0].name, null)
+}
+
+output "policy_arn" {
+  description = "ARN of the least-privilege + ABAC permission policy. Null when gated off."
+  value       = try(aws_iam_policy.this[0].arn, null)
+}
+
+output "platform_system" {
+  description = "The platform:system value this role's ABAC condition matches on. Surfaced so the SOC2 evidence matrix and consuming stacks can confirm the role is scoped to a single system axis."
+  value       = var.platform_system
+}
+
+output "abac_enforced" {
+  description = "True when the module is enabled and at least one resource class (S3/KMS/Secrets) is granted — every such grant carries the ADR-0028 ABAC tag-match condition. Used by the *.tftest.hcl and the evidence matrix to assert ABAC is wired."
+  value       = var.enabled && (length(var.artifact_bucket_arns) > 0 || length(var.kms_key_arns) > 0 || length(var.secret_arns) > 0)
+}
+
+output "platform_tags" {
+  description = "Effective ADR-0028 taxonomy tags applied to the role/policy (base defaults merged with var.tags overrides)."
+  value       = local.effective_tags
+}

--- a/terraform/modules/aws-ml-abac-iam/variables.tf
+++ b/terraform/modules/aws-ml-abac-iam/variables.tf
@@ -1,0 +1,70 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Variables — aws-ml-abac-iam
+# ---------------------------------------------------------------------------------------------------------------------
+# WS-E IAM least-privilege + ABAC role for ML workloads on the greenfield EKS GPU
+# cluster. Provides an EKS Pod Identity role (ADR-0018) whose permission policy is
+# scoped to the ml-platform $system axis by the ADR-0028 ABAC condition
+#   aws:PrincipalTag/platform:system == aws:ResourceTag/platform:system
+# so a pod can only touch S3/KMS/Secrets resources tagged with its own system.
+# apply-gated / default-OFF: gated by `enabled` so plan/validate creates no IAM.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "enabled" {
+  description = "Master gate. When false (DEFAULT), the module creates NO IAM role / policy / Pod Identity association — apply-gated so plan/validate is inert. Set true only behind an explicit human apply (IAM is identity-critical)."
+  type        = bool
+  default     = false
+}
+
+variable "name" {
+  description = "Base name for the IAM role and policy (e.g. 'ml-platform-workload'). The role is named '<name>-role'; the policy '<name>-policy'."
+  type        = string
+  default     = "ml-platform-workload"
+}
+
+variable "platform_system" {
+  description = "The ADR-0028 platform:system value this role is scoped to (e.g. 'ml-platform', 'ml-pipeline'). Stamped as a principal tag on the role and used as the ABAC match key — the role may only access resources whose platform:system ResourceTag equals this principal tag."
+  type        = string
+  default     = "ml-platform"
+}
+
+variable "artifact_bucket_arns" {
+  description = "List of S3 bucket ARNs (e.g. the MLflow artifact store from aws-ml-artifact-store, ADR-0048 D2) the role may access. Object-level access is still gated by the ABAC platform:system tag-match condition — listing these ARNs scopes the resource, ABAC scopes the ownership."
+  type        = list(string)
+  default     = []
+}
+
+variable "kms_key_arns" {
+  description = "List of KMS key ARNs used for SSE-KMS on the ML artifact store / Secrets. Decrypt/GenerateDataKey is granted only under the ABAC tag-match condition. Empty by default."
+  type        = list(string)
+  default     = []
+}
+
+variable "secret_arns" {
+  description = "List of Secrets Manager secret ARNs (e.g. MLflow RDS creds via ESO, ADR-0008/0031) the role may read. GetSecretValue is gated by the ABAC tag-match condition. Empty by default."
+  type        = list(string)
+  default     = []
+}
+
+variable "eks_cluster_name" {
+  description = "Name of the EKS cluster to create the Pod Identity association against (ADR-0018). When empty, no association is created (the role can still be assumed by other means once enabled)."
+  type        = string
+  default     = ""
+}
+
+variable "service_account_namespace" {
+  description = "Kubernetes namespace of the workload ServiceAccount for the Pod Identity association. Used only when eks_cluster_name is set."
+  type        = string
+  default     = "ml-platform"
+}
+
+variable "service_account_name" {
+  description = "Name of the workload ServiceAccount bound to this role via Pod Identity. Used only when eks_cluster_name is set."
+  type        = string
+  default     = "ml-platform-workload"
+}
+
+variable "tags" {
+  description = "ADR-0028 platform taxonomy tags applied to the IAM role/policy. Defaults set platform:system from var.platform_system, platform:component=ml-iam, platform:owner=team-ml-platform. The role's principal tag platform:system (used for ABAC) is derived from var.platform_system, not from this map."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/aws-ml-abac-iam/versions.tf
+++ b/terraform/modules/aws-ml-abac-iam/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/modules/aws-ml-scp-parity/README.md
+++ b/terraform/modules/aws-ml-scp-parity/README.md
@@ -1,0 +1,55 @@
+# Module: `aws-ml-scp-parity`
+
+> **ADRs:** [0044](../../../docs/adrs/0044-aws-eks-gpu-ml-foundation-multiregion.md)
+> (greenfield AWS EKS GPU ML foundation), [0048](../../../docs/adrs/0048-aws-ml-cicd-registry-drift.md)
+> (AWS-native ML backends). Mirrors the GCP org-policy deny-list plane in
+> [0040](../../../docs/adrs/0040-soc-posture-and-oncall.md) D1 onto AWS Service Control
+> Policies, scoped to the GPU/ML OU. Taxonomy per
+> [0028](../../../docs/adrs/0028-unified-platform-tagging-and-labeling-taxonomy.md).
+
+WS-E SCP-parity plane for the **greenfield AWS GPU/ML account**. The org-wide
+`terraform/modules/scps` already enforces broad root-level controls (deny public S3,
+require EBS encryption, restrict regions, deny CloudTrail/GuardDuty changes). This
+module **narrows further for the net-new ML estate**, attaching ML-OU-scoped SCPs that
+the broad module does not cover, so the greenfield `aws-eks-gpu-*` / `aws-ml-*` workloads
+inherit the same preventive guardrails as the rest of the org.
+
+## Apply-gated / default-OFF
+
+**With default inputs, `terraform plan` creates ZERO resources.** Every SCP and every
+attachment is gated by `var.enabled` (master, default `false`) **and** a per-policy
+toggle. SCPs are organization-wide and high-blast-radius; enabling requires an explicit
+human apply + blast-radius review (project `critical-decisions` / `terraform` rules).
+Attachments target `var.ml_target_ou_ids` (the GPU/ML OU) **only** — never the org root.
+
+## SCPs (each AWS analog of a GCP org-policy constraint, ADR-0040 D1)
+
+| SCP | AWS deny | GCP analog (ADR-0040) | SOC2 | Toggle |
+|---|---|---|---|---|
+| `require_imdsv2` | `ec2:RunInstances` unless IMDSv2 (`HttpTokens=required`) | (GPU-node SSRF hardening) | CC6.1 | `require_imdsv2` |
+| `require_ebs_encryption` | `ec2:CreateVolume` with `Encrypted=false` | `gcp.restrictNonCmekServices` | CC6.1 | `require_ebs_encryption` |
+| `deny_access_keys` | `iam:CreateAccessKey` (force Pod Identity / STS) | `iam.disableServiceAccountKeyCreation` | CC6.1 / CC6.3 | `deny_long_lived_access_keys` |
+| `restrict_regions` | resource creation outside `allowed_gpu_regions` (Terraform role exempt) | `gcp.resourceLocations` | C1.1 | `restrict_gpu_regions` |
+
+## ABAC / least-privilege note
+
+The region-restriction SCP exempts the Terraform execution role
+(`var.terraform_role_name_pattern`) via an `ArnNotLike` condition so it can reach global
+services (IAM/STS/Route53) during ML-stack provisioning — the same exemption philosophy
+as `terraform/modules/scps`. Workload-level least-privilege + the ABAC
+`aws:PrincipalTag/platform:system == aws:ResourceTag/platform:system` condition live in
+the companion `aws-ml-abac-iam` module.
+
+## ADR-0028 taxonomy
+
+`aws_organizations_policy` is taggable; every SCP carries `var.tags` (defaults
+`platform:system=security`, `platform:component=scp-parity`, `platform:owner=team-sec`,
+`platform:managed-by=terragrunt`). The `platform_tags` output surfaces them for
+provenance and the SOC2 evidence matrix.
+
+## Validation (plan/validate-only)
+
+`terraform fmt`, `terraform init -backend=false`, `terraform validate`, and
+`terraform test` (mocked `aws` provider, **4/4 pass**). **No `terraform apply`, no SCP
+created or attached** at plan/validate time. `terraform plan` against real AWS needs org
+credentials and is run only from CI on `main` after merge, behind the apply gate.

--- a/terraform/modules/aws-ml-scp-parity/aws-ml-scp-parity.tftest.hcl
+++ b/terraform/modules/aws-ml-scp-parity/aws-ml-scp-parity.tftest.hcl
@@ -1,0 +1,125 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests — aws-ml-scp-parity (mocked AWS provider; plan-only, no apply, no real org policy)
+# ---------------------------------------------------------------------------------------------------------------------
+# Verifies the apply-gated / default-OFF contract and the ADR-0028 taxonomy + ABAC-style
+# exemption wiring. ADR-0040 (GCP etalon) / ADR-0044 / ADR-0048.
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "aws" {}
+
+# --- 1. DEFAULT OFF: with no inputs, the module must create ZERO SCPs -------------------------------------------------
+run "default_is_apply_gated_off" {
+  command = plan
+
+  assert {
+    condition     = var.enabled == false
+    error_message = "Module must default to apply-gated OFF (enabled=false)."
+  }
+
+  assert {
+    condition     = length(aws_organizations_policy.require_imdsv2) == 0
+    error_message = "Default (gated off) must create no IMDSv2 SCP."
+  }
+
+  assert {
+    condition     = length(aws_organizations_policy.require_ebs_encryption) == 0
+    error_message = "Default (gated off) must create no EBS-encryption SCP."
+  }
+
+  assert {
+    condition     = length(aws_organizations_policy.deny_access_keys) == 0
+    error_message = "Default (gated off) must create no access-key SCP."
+  }
+
+  assert {
+    condition     = length(aws_organizations_policy.restrict_regions) == 0
+    error_message = "Default (gated off) must create no region-restriction SCP."
+  }
+
+  assert {
+    condition     = length(output.attached_ou_ids) == 0
+    error_message = "No OU attachments may be reported when gated off."
+  }
+}
+
+# --- 2. ENABLED but no target OU: policies materialise, attachments do not --------------------------------------------
+run "enabled_no_target_ou_creates_policies_not_attachments" {
+  command = plan
+
+  variables {
+    enabled          = true
+    ml_target_ou_ids = []
+  }
+
+  assert {
+    condition     = length(aws_organizations_policy.require_imdsv2) == 1
+    error_message = "Enabling the gate must create the IMDSv2 SCP."
+  }
+
+  assert {
+    condition     = length(aws_organizations_policy_attachment.require_imdsv2) == 0
+    error_message = "With no target OU, no attachment may be created (blast-radius bound)."
+  }
+}
+
+# --- 3. ENABLED with target OU: all four SCPs + taxonomy + naming ------------------------------------------------------
+run "enabled_with_target_full_estate" {
+  command = plan
+
+  variables {
+    enabled          = true
+    project          = "platform-design"
+    ml_target_ou_ids = ["ou-test-mlgpu01"]
+  }
+
+  assert {
+    condition     = aws_organizations_policy.require_imdsv2[0].name == "platform-design-ml-RequireIMDSv2"
+    error_message = "IMDSv2 SCP name must be prefixed project-ml-."
+  }
+
+  assert {
+    condition     = aws_organizations_policy.require_imdsv2[0].tags["platform:system"] == "security"
+    error_message = "ADR-0028 platform:system tag must be 'security' on every SCP."
+  }
+
+  assert {
+    condition     = aws_organizations_policy.require_imdsv2[0].tags["platform:component"] == "scp-parity"
+    error_message = "ADR-0028 platform:component tag must be 'scp-parity'."
+  }
+
+  assert {
+    condition     = aws_organizations_policy.require_imdsv2[0].tags["platform:owner"] == "team-sec"
+    error_message = "ADR-0028 platform:owner tag must be 'team-sec'."
+  }
+
+  assert {
+    condition     = length(aws_organizations_policy_attachment.restrict_regions) == 1
+    error_message = "Region-restriction SCP must attach to the single supplied ML OU."
+  }
+
+  assert {
+    condition     = length(output.attached_ou_ids) == 1 && output.attached_ou_ids[0] == "ou-test-mlgpu01"
+    error_message = "attached_ou_ids output must reflect the supplied ML OU."
+  }
+}
+
+# --- 4. Per-policy toggle: disabling a single constraint drops only that SCP ------------------------------------------
+run "per_policy_toggle_drops_only_that_scp" {
+  command = plan
+
+  variables {
+    enabled                     = true
+    ml_target_ou_ids            = ["ou-test-mlgpu01"]
+    deny_long_lived_access_keys = false
+  }
+
+  assert {
+    condition     = length(aws_organizations_policy.deny_access_keys) == 0
+    error_message = "Disabling deny_long_lived_access_keys must drop that SCP only."
+  }
+
+  assert {
+    condition     = length(aws_organizations_policy.require_imdsv2) == 1
+    error_message = "Other SCPs must remain when one is toggled off."
+  }
+}

--- a/terraform/modules/aws-ml-scp-parity/main.tf
+++ b/terraform/modules/aws-ml-scp-parity/main.tf
@@ -1,0 +1,198 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# aws-ml-scp-parity — SCP deny-list plane for the greenfield AWS GPU/ML OU
+# ---------------------------------------------------------------------------------------------------------------------
+# ADR-0044 (greenfield AWS EKS GPU ML foundation, A1) + ADR-0048 (AWS-native ML
+# backends: S3 + RDS + ABAC). This module is the AWS analog of the GCP org-policy
+# deny-list plane defined in ADR-0040 D1 — it adds GPU/ML-OU-scoped Service Control
+# Policies that the broad org-wide `terraform/modules/scps` does not cover, so the
+# net-new ML estate inherits the same preventive guardrails as the rest of the org.
+#
+# APPLY-GATED / DEFAULT-OFF: every SCP + attachment is created via `count` gated on
+# `var.enabled` (master, default false) AND a per-policy toggle. With defaults,
+# `terraform plan` produces ZERO resources — nothing is ever created at plan/validate
+# time. SCPs are organization-wide and high-blast-radius; enabling requires an explicit
+# human apply + blast-radius review (project rule: critical-decisions / terraform).
+#
+# Blast-radius bound: attachments target `var.ml_target_ou_ids` (the GPU/ML OU) ONLY,
+# never the org root — the broad root-level SCPs (S3 public, EBS-encryption) already
+# live in `terraform/modules/scps`. This module narrows further for the ML estate.
+#
+# ADR-0028: every policy carries `var.tags` (platform:system=security /
+# component=scp-parity / owner=team-sec). `aws_organizations_policy` IS taggable.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  # A policy is materialised only when the master gate AND its own toggle are on.
+  create_imdsv2  = var.enabled && var.require_imdsv2
+  create_ebs_enc = var.enabled && var.require_ebs_encryption
+  create_no_keys = var.enabled && var.deny_long_lived_access_keys
+  create_region  = var.enabled && var.restrict_gpu_regions
+  name_prefix    = "${var.project}-ml"
+  has_target     = length(var.ml_target_ou_ids) > 0
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# SCP 1 — Require IMDSv2 on EC2 RunInstances (deny metadata-v1 GPU nodes)
+# AWS analog of GPU-node SSRF hardening; SOC2 CC6.1 (logical access).
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_organizations_policy" "require_imdsv2" {
+  count = local.create_imdsv2 ? 1 : 0
+
+  name        = "${local.name_prefix}-RequireIMDSv2"
+  description = "ML OU: deny EC2 RunInstances unless IMDSv2 (HttpTokens=required) — protects GPU node credentials from SSRF"
+  type        = "SERVICE_CONTROL_POLICY"
+
+  content = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "DenyImdsV1"
+        Effect   = "Deny"
+        Action   = "ec2:RunInstances"
+        Resource = "arn:aws:ec2:*:*:instance/*"
+        Condition = {
+          StringNotEquals = {
+            "ec2:MetadataHttpTokens" = "required"
+          }
+        }
+      },
+    ]
+  })
+
+  tags = var.tags
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# SCP 2 — Require EBS encryption (deny unencrypted volumes on GPU nodes)
+# AWS analog of GCP gcp.restrictNonCmekServices (ADR-0040 D1); SOC2 CC6.1 (encryption).
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_organizations_policy" "require_ebs_encryption" {
+  count = local.create_ebs_enc ? 1 : 0
+
+  name        = "${local.name_prefix}-RequireEbsEncryption"
+  description = "ML OU: deny creation of unencrypted EBS volumes — GPU node disks must be KMS-encrypted at rest"
+  type        = "SERVICE_CONTROL_POLICY"
+
+  content = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "DenyUnencryptedEbs"
+        Effect   = "Deny"
+        Action   = "ec2:CreateVolume"
+        Resource = "*"
+        Condition = {
+          Bool = {
+            "ec2:Encrypted" = "false"
+          }
+        }
+      },
+    ]
+  })
+
+  tags = var.tags
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# SCP 3 — Deny long-lived IAM access keys (force Pod Identity / role assumption)
+# AWS analog of GCP iam.disableServiceAccountKeyCreation (ADR-0040 D1/D2); the forcing
+# function for keyless identity (ADR-0018). SOC2 CC6.1/CC6.3.
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_organizations_policy" "deny_access_keys" {
+  count = local.create_no_keys ? 1 : 0
+
+  name        = "${local.name_prefix}-DenyLongLivedAccessKeys"
+  description = "ML OU: deny iam:CreateAccessKey — workloads must use EKS Pod Identity / STS, never static keys (ADR-0018)"
+  type        = "SERVICE_CONTROL_POLICY"
+
+  content = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "DenyCreateAccessKey"
+        Effect   = "Deny"
+        Action   = "iam:CreateAccessKey"
+        Resource = "*"
+      },
+    ]
+  })
+
+  tags = var.tags
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# SCP 4 — Restrict GPU/ML resources to allowed regions (data residency)
+# AWS analog of GCP gcp.resourceLocations (ADR-0040 D1); SOC2 C1.1. The Terraform
+# execution role is exempt so it can reach global services (IAM/STS/Route53).
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_organizations_policy" "restrict_regions" {
+  count = local.create_region ? 1 : 0
+
+  name        = "${local.name_prefix}-RestrictGpuRegions"
+  description = "ML OU: deny resource creation outside allowed GPU regions; Terraform role exempt for global services"
+  type        = "SERVICE_CONTROL_POLICY"
+
+  content = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DenyOutsideAllowedRegions"
+        Effect = "Deny"
+        NotAction = [
+          "iam:*",
+          "sts:*",
+          "route53:*",
+          "cloudfront:*",
+          "organizations:*",
+          "support:*",
+          "budgets:*",
+          "ce:*",
+        ]
+        Resource = "*"
+        Condition = {
+          StringNotEquals = {
+            "aws:RequestedRegion" = var.allowed_gpu_regions
+          }
+          # Exempt the Terraform execution role from the region restriction.
+          ArnNotLike = {
+            "aws:PrincipalArn" = "arn:aws:iam::*:role/${var.terraform_role_name_pattern}"
+          }
+        }
+      },
+    ]
+  })
+
+  tags = var.tags
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Attachments — each SCP attaches to every ML target OU (gated by the same toggles).
+# No attachment is created when there is no target OU or the gate is off.
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_organizations_policy_attachment" "require_imdsv2" {
+  for_each = local.create_imdsv2 && local.has_target ? toset(var.ml_target_ou_ids) : toset([])
+
+  policy_id = aws_organizations_policy.require_imdsv2[0].id
+  target_id = each.value
+}
+
+resource "aws_organizations_policy_attachment" "require_ebs_encryption" {
+  for_each = local.create_ebs_enc && local.has_target ? toset(var.ml_target_ou_ids) : toset([])
+
+  policy_id = aws_organizations_policy.require_ebs_encryption[0].id
+  target_id = each.value
+}
+
+resource "aws_organizations_policy_attachment" "deny_access_keys" {
+  for_each = local.create_no_keys && local.has_target ? toset(var.ml_target_ou_ids) : toset([])
+
+  policy_id = aws_organizations_policy.deny_access_keys[0].id
+  target_id = each.value
+}
+
+resource "aws_organizations_policy_attachment" "restrict_regions" {
+  for_each = local.create_region && local.has_target ? toset(var.ml_target_ou_ids) : toset([])
+
+  policy_id = aws_organizations_policy.restrict_regions[0].id
+  target_id = each.value
+}

--- a/terraform/modules/aws-ml-scp-parity/outputs.tf
+++ b/terraform/modules/aws-ml-scp-parity/outputs.tf
@@ -1,0 +1,28 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Outputs — aws-ml-scp-parity
+# ---------------------------------------------------------------------------------------------------------------------
+
+output "policy_ids" {
+  description = "Map of created ML SCP logical names to their AWS Organizations policy IDs. Empty when the module is gated off (var.enabled=false) — used by the catalog stack and the SOC2 evidence matrix for provenance."
+  value = {
+    require_imdsv2         = try(aws_organizations_policy.require_imdsv2[0].id, null)
+    require_ebs_encryption = try(aws_organizations_policy.require_ebs_encryption[0].id, null)
+    deny_access_keys       = try(aws_organizations_policy.deny_access_keys[0].id, null)
+    restrict_regions       = try(aws_organizations_policy.restrict_regions[0].id, null)
+  }
+}
+
+output "enabled" {
+  description = "Echoes the master gate so a consuming stack / test can assert the module is apply-gated off by default."
+  value       = var.enabled
+}
+
+output "platform_tags" {
+  description = "The ADR-0028 taxonomy tags applied to every SCP in this module, surfaced for provenance so a reviewer / *.tftest.hcl can assert the taxonomy is present even though SCP resources are policy bindings."
+  value       = var.tags
+}
+
+output "attached_ou_ids" {
+  description = "The list of ML OU IDs the SCPs are attached to. Empty when gated off or no target supplied — confirms blast radius is bounded to the ML estate, never the org root."
+  value       = var.enabled ? var.ml_target_ou_ids : []
+}

--- a/terraform/modules/aws-ml-scp-parity/variables.tf
+++ b/terraform/modules/aws-ml-scp-parity/variables.tf
@@ -1,0 +1,78 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Variables — aws-ml-scp-parity
+# ---------------------------------------------------------------------------------------------------------------------
+# WS-E SCP-parity plane for the greenfield AWS GPU/ML account (ADR-0044 §A1 greenfield,
+# ADR-0048 backends). Mirrors the GCP org-policy deny-list plane from ADR-0040 D1 onto
+# AWS Service Control Policies, scoped to the ML/GPU OU. apply-gated and default-OFF:
+# every SCP attachment is behind `enabled` + a per-policy toggle so plan/validate never
+# creates a real org policy.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "enabled" {
+  description = "Master gate. When false (DEFAULT), the module creates and attaches NO Service Control Policies — apply-gated so plan/validate is inert. Set true only behind an explicit human apply + blast-radius review (SCPs are org-wide)."
+  type        = bool
+  default     = false
+}
+
+variable "project" {
+  description = "Project name used in SCP policy naming (e.g. 'platform-design'). Net-new ML SCPs are prefixed with this and 'ml-'."
+  type        = string
+  default     = "platform-design"
+}
+
+variable "ml_target_ou_ids" {
+  description = "List of AWS Organizations OU IDs that host the GPU/ML account(s). The ML deny-list SCPs are attached to these targets only — never to the org root, to bound blast radius to the ML estate (ADR-0040 staged-rollout posture)."
+  type        = list(string)
+  default     = []
+}
+
+variable "allowed_gpu_regions" {
+  description = "Regions where GPU/ML resources may be created. Mirrors the GCP `gcp.resourceLocations` data-residency constraint (ADR-0040 D1 -> SOC2 C1.1). Used by the region-restriction SCP for the ML OU."
+  type        = list(string)
+  default = [
+    "eu-west-1",
+    "us-east-1",
+    "us-west-2",
+  ]
+}
+
+variable "terraform_role_name_pattern" {
+  description = "IAM role-name pattern (wildcard) for the Terraform/Terragrunt execution role that is EXEMPT from the region-restriction SCP so it can call global services (IAM, STS, Route53) during ML stack provisioning. Mirrors the scps module exemption philosophy."
+  type        = string
+  default     = "platform-design-terraform-*"
+}
+
+variable "require_imdsv2" {
+  description = "When true, attach an SCP denying EC2 RunInstances unless IMDSv2 is required (HttpTokens=required). Hardens GPU nodes against SSRF credential theft (CIS / SOC2 CC6.1). Gated by `enabled`."
+  type        = bool
+  default     = true
+}
+
+variable "require_ebs_encryption" {
+  description = "When true, attach an SCP denying creation of unencrypted EBS volumes / RunInstances without encrypted block devices. AWS analog of the GCP `gcp.restrictNonCmekServices` constraint (ADR-0040 D1 -> SOC2 CC6.1). Gated by `enabled`."
+  type        = bool
+  default     = true
+}
+
+variable "deny_long_lived_access_keys" {
+  description = "When true, attach an SCP denying `iam:CreateAccessKey` in the ML OU, forcing EKS Pod Identity / role assumption (ADR-0018) instead of static keys. AWS analog of GCP `iam.disableServiceAccountKeyCreation` (ADR-0040 D1/D2 -> SOC2 CC6.1/CC6.3). Gated by `enabled`."
+  type        = bool
+  default     = true
+}
+
+variable "restrict_gpu_regions" {
+  description = "When true, attach a region-restriction SCP limiting the ML OU to `allowed_gpu_regions` (the Terraform role is exempt for global services). AWS analog of GCP `gcp.resourceLocations` (ADR-0040 D1 -> SOC2 C1.1). Gated by `enabled`."
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "ADR-0028 platform taxonomy tags applied to every SCP resource. Defaults set platform:system=security, platform:component=scp-parity, platform:owner=team-sec. Caller may override platform:env / platform:managed-by."
+  type        = map(string)
+  default = {
+    "platform:system"     = "security"
+    "platform:component"  = "scp-parity"
+    "platform:owner"      = "team-sec"
+    "platform:managed-by" = "terragrunt"
+  }
+}

--- a/terraform/modules/aws-ml-scp-parity/versions.tf
+++ b/terraform/modules/aws-ml-scp-parity/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/tests/opa/platform_tags_ml.rego
+++ b/tests/opa/platform_tags_ml.rego
@@ -1,0 +1,161 @@
+package terraform.platform_tags_ml
+
+import rego.v1
+
+# ---------------------------------------------------------------------------
+# Policy: ADR-0028 taxonomy + ABAC coverage for the NET-NEW AWS ML estate
+#
+# WS-E (AWS ML platform plan, §7 decision #13 / §3 coverage caveat). The existing
+# tests/opa/platform_tags.rego enforces the platform taxonomy on *existing* AWS
+# resource types but has NO rules for the net-new `aws-eks-gpu-*` / `aws-ml-*` /
+# `aws-eks-efa-fabric` / `aws-eks-inference-gateway` estate introduced by ADRs
+# 0044–0048 — so taxonomy enforcement on those modules was NOT automatic. This file
+# closes that gap WITHOUT editing platform_tags.rego (kept separate so the two
+# policies evolve independently and the WS-E PR stays file-disjoint).
+#
+# Two enforcement layers:
+#
+#   1. TAGGED-TYPE FLOOR — the net-new ML resource types listed in
+#      `_ml_taggable_types` MUST carry the three required platform tags
+#      (platform:system / platform:component / platform:owner), non-empty. Unlike the
+#      generic policy's exempt-list approach, these types are an explicit ALLOW-LIST:
+#      a net-new ML resource that ships without the taxonomy fails the plan, and it
+#      cannot be silently dropped by adding it to an exempt set.
+#
+#   2. ABAC FLOOR — IAM policy documents created for the ML estate
+#      (`aws_iam_policy` whose taxonomy marks it part of an `ml-*` system) that grant
+#      access to S3 / KMS / Secrets MUST carry the ADR-0028 ABAC tag-match condition
+#      `aws:ResourceTag/platform:system == ${aws:PrincipalTag/platform:system}`, so a
+#      least-privilege grant is also ownership-scoped (the `aws-ml-abac-iam` contract).
+#
+# Evaluated by Conftest against the Terraform plan JSON, same harness as the other
+# tests/opa/*.rego (see .github/workflows/conftest-opa.yml). Plan/validate-only —
+# this is a policy gate, it applies nothing.
+# ---------------------------------------------------------------------------
+
+_required_platform_tags := {"platform:system", "platform:component", "platform:owner"}
+
+# Net-new ML/GPU resource types that MUST carry the platform taxonomy. This is the
+# explicit allow-list that closes the coverage gap: terraform-engineer supplies the
+# per-module resource-type list, WS-E (security) curates it here.
+#
+# Covers the resource types the ADR-0044–0048 modules emit:
+#   - aws-eks-gpu / aws-eks-gpu-vpc / aws-eks-gpu-operator / -dcgm / -scheduling
+#   - aws-eks-gpu-nodepools / -managed-nodegroup / aws-eks-efa-fabric
+#   - aws-ml-artifact-store (S3) / aws-ml-abac-iam (IAM) / aws-ml-scp-parity (SCP)
+#   - aws-eks-inference-gateway (serving front, ADR-0047)
+_ml_taggable_types := {
+  # EKS cluster + GPU compute
+  "aws_eks_cluster",
+  "aws_eks_node_group",
+  "aws_eks_addon",
+  "aws_launch_template",
+  "aws_autoscaling_group",
+  # GPU VPC + EFA fabric
+  "aws_vpc",
+  "aws_subnet",
+  "aws_security_group",
+  "aws_placement_group",
+  # ML artifact store + encryption
+  "aws_s3_bucket",
+  "aws_kms_key",
+  "aws_db_instance",
+  # ML identity / policy
+  "aws_iam_role",
+  "aws_iam_policy",
+  "aws_eks_pod_identity_association",
+  "aws_organizations_policy",
+  # Serving front (inference gateway, ADR-0047) + WAF wiring
+  "aws_wafv2_web_acl",
+  "aws_lb",
+  "aws_lb_target_group",
+}
+
+# A resource is "ML estate" when its taxonomy marks it part of an ml-* / gpu-* /
+# security system OR it is one of the SCP/IAM types this WS introduces. We key off
+# the platform:system tag value so the rule does not over-reach into the existing
+# (already-covered) estate.
+_ml_system_prefixes := {"ml-", "gpu-"}
+_ml_system_exact := {"ml-platform", "ml-pipeline", "ml-monitoring", "security"}
+
+_is_managed(actions) if {
+  some a in actions
+  a in {"create", "update"}
+}
+
+_tags_of(rc) := object.get(rc.change.after, "tags", {})
+
+_is_ml_estate(rc) if {
+  tags := _tags_of(rc)
+  sys := object.get(tags, "platform:system", "")
+  sys in _ml_system_exact
+}
+
+_is_ml_estate(rc) if {
+  tags := _tags_of(rc)
+  sys := object.get(tags, "platform:system", "")
+  some p in _ml_system_prefixes
+  startswith(sys, p)
+}
+
+# ---------------------------------------------------------------------------
+# Layer 1 — TAGGED-TYPE FLOOR: net-new ML resource types must carry every required tag
+# ---------------------------------------------------------------------------
+deny contains msg if {
+  some addr, rc in input.resource_changes
+  rc.type in _ml_taggable_types
+  _is_managed(rc.change.actions)
+  tags := _tags_of(rc)
+  some required_tag in _required_platform_tags
+  not tags[required_tag]
+  msg := sprintf(
+    "POLICY VIOLATION [platform-tags-ml]: net-new ML resource %q (type: %s) is missing required platform tag %q — ADR-0028 taxonomy is mandatory on the aws-eks-gpu-* / aws-ml-* estate (WS-E gap closure, plan §7 #13)",
+    [addr, rc.type, required_tag],
+  )
+}
+
+# Empty values are also a violation (mirrors the generic policy).
+deny contains msg if {
+  some addr, rc in input.resource_changes
+  rc.type in _ml_taggable_types
+  _is_managed(rc.change.actions)
+  tags := _tags_of(rc)
+  some required_tag in _required_platform_tags
+  tags[required_tag] == ""
+  msg := sprintf(
+    "POLICY VIOLATION [platform-tags-ml]: net-new ML resource %q (type: %s) has EMPTY value for required platform tag %q (WS-E gap closure)",
+    [addr, rc.type, required_tag],
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Layer 2 — ABAC FLOOR: ML-estate IAM policies touching S3/KMS/Secrets must carry the
+# ADR-0028 ABAC tag-match condition. We inspect the rendered policy JSON string on
+# aws_iam_policy.after.policy for the ABAC condition key + the principal-tag match.
+# ---------------------------------------------------------------------------
+_abac_resource_actions := {"s3:", "kms:", "secretsmanager:"}
+
+_policy_grants_data(policy_json) if {
+  some action_prefix in _abac_resource_actions
+  contains(policy_json, action_prefix)
+}
+
+_has_abac_condition(policy_json) if {
+  contains(policy_json, "aws:ResourceTag/platform:system")
+  contains(policy_json, "aws:PrincipalTag/platform:system")
+}
+
+deny contains msg if {
+  some addr, rc in input.resource_changes
+  rc.type == "aws_iam_policy"
+  _is_managed(rc.change.actions)
+  _is_ml_estate(rc)
+  policy_json := object.get(rc.change.after, "policy", "")
+  policy_json != ""
+  _policy_grants_data(policy_json)
+  not _has_abac_condition(policy_json)
+  msg := sprintf(
+    "POLICY VIOLATION [platform-abac-ml]: ML-estate IAM policy %q grants S3/KMS/Secrets access without the ADR-0028 ABAC tag-match condition (aws:ResourceTag/platform:system == aws:PrincipalTag/platform:system) — least-privilege ML grants must be ownership-scoped (aws-ml-abac-iam contract)",
+    [addr],
+  )
+}

--- a/tests/opa/platform_tags_ml_test.rego
+++ b/tests/opa/platform_tags_ml_test.rego
@@ -1,0 +1,147 @@
+package terraform.platform_tags_ml
+
+import rego.v1
+
+# ---------------------------------------------------------------------------
+# Unit tests for the WS-E net-new ML taxonomy + ABAC OPA policy.
+# Run: opa test tests/opa/platform_tags_ml.rego tests/opa/platform_tags_ml_test.rego
+# (or via conftest in CI). Fixtures are synthetic plan-JSON fragments — no real data.
+# ---------------------------------------------------------------------------
+
+# A compliant net-new ML resource (all three tags present) -> no denial.
+test_compliant_ml_resource_passes if {
+  result := deny with input as {"resource_changes": [{
+    "address": "module.gpu.aws_eks_cluster.this",
+    "type": "aws_eks_cluster",
+    "change": {
+      "actions": ["create"],
+      "after": {"tags": {
+        "platform:system": "ml-platform",
+        "platform:component": "gpu-compute",
+        "platform:owner": "team-ml-platform",
+      }},
+    },
+  }]}
+  count(result) == 0
+}
+
+# A net-new ML resource MISSING platform:owner -> exactly one denial.
+test_ml_resource_missing_owner_denied if {
+  result := deny with input as {"resource_changes": [{
+    "address": "module.gpu.aws_eks_node_group.gpu",
+    "type": "aws_eks_node_group",
+    "change": {
+      "actions": ["create"],
+      "after": {"tags": {
+        "platform:system": "ml-platform",
+        "platform:component": "gpu-compute",
+      }},
+    },
+  }]}
+  count(result) == 1
+}
+
+# An EFA/GPU security group with an EMPTY tag value -> denied.
+test_ml_resource_empty_tag_denied if {
+  result := deny with input as {"resource_changes": [{
+    "address": "module.efa.aws_security_group.efa",
+    "type": "aws_security_group",
+    "change": {
+      "actions": ["create"],
+      "after": {"tags": {
+        "platform:system": "gpu-fabric",
+        "platform:component": "",
+        "platform:owner": "team-ml-platform",
+      }},
+    },
+  }]}
+  count(result) >= 1
+}
+
+# A destroy-only change is ignored (not managed) -> no denial.
+test_destroy_only_ignored if {
+  result := deny with input as {"resource_changes": [{
+    "address": "module.gpu.aws_eks_cluster.this",
+    "type": "aws_eks_cluster",
+    "change": {
+      "actions": ["delete"],
+      "after": null,
+    },
+  }]}
+  count(result) == 0
+}
+
+# A non-ML resource type is out of this policy's scope (handled by platform_tags.rego).
+test_non_ml_type_out_of_scope if {
+  result := deny with input as {"resource_changes": [{
+    "address": "aws_cloudwatch_log_group.x",
+    "type": "aws_cloudwatch_log_group",
+    "change": {
+      "actions": ["create"],
+      "after": {"tags": {}},
+    },
+  }]}
+  count(result) == 0
+}
+
+# Layer 2 — an ML IAM policy granting S3 WITH the ABAC condition -> passes.
+test_ml_iam_policy_with_abac_passes if {
+  result := deny with input as {"resource_changes": [{
+    "address": "module.iam.aws_iam_policy.this",
+    "type": "aws_iam_policy",
+    "change": {
+      "actions": ["create"],
+      "after": {
+        "tags": {
+          "platform:system": "ml-platform",
+          "platform:component": "ml-iam",
+          "platform:owner": "team-ml-platform",
+        },
+        "policy": "{\"Statement\":[{\"Action\":[\"s3:GetObject\"],\"Condition\":{\"StringEquals\":{\"aws:ResourceTag/platform:system\":\"${aws:PrincipalTag/platform:system}\"}}}]}",
+      },
+    },
+  }]}
+  count(result) == 0
+}
+
+# Layer 2 — an ML IAM policy granting S3 WITHOUT the ABAC condition -> denied.
+test_ml_iam_policy_without_abac_denied if {
+  result := deny with input as {"resource_changes": [{
+    "address": "module.iam.aws_iam_policy.bad",
+    "type": "aws_iam_policy",
+    "change": {
+      "actions": ["create"],
+      "after": {
+        "tags": {
+          "platform:system": "ml-platform",
+          "platform:component": "ml-iam",
+          "platform:owner": "team-ml-platform",
+        },
+        "policy": "{\"Statement\":[{\"Action\":[\"s3:GetObject\"],\"Resource\":\"arn:aws:s3:::x/*\"}]}",
+      },
+    },
+  }]}
+  count(result) >= 1
+}
+
+# Layer 2 — a non-ML IAM policy (different system) is not subject to the ABAC floor.
+test_non_ml_iam_policy_not_abac_gated if {
+  result := deny with input as {"resource_changes": [{
+    "address": "module.other.aws_iam_policy.x",
+    "type": "aws_iam_policy",
+    "change": {
+      "actions": ["create"],
+      "after": {
+        "tags": {
+          "platform:system": "auth-service",
+          "platform:component": "backend",
+          "platform:owner": "team-auth",
+        },
+        "policy": "{\"Statement\":[{\"Action\":[\"s3:GetObject\"],\"Resource\":\"arn:aws:s3:::x/*\"}]}",
+      },
+    },
+  }]}
+  # aws_iam_policy IS in the taggable allow-list and HAS all tags, so Layer-1 passes;
+  # Layer-2 ABAC floor does not apply (system is not ml-*/gpu-*/security) -> no denial.
+  count(result) == 0
+}


### PR DESCRIPTION
## WS-E — AWS SOC posture + on-call + OPA gap closure

Implements **WS-E** of `docs/aws-ml-platform/IMPLEMENTATION_PLAN.md` for the greenfield AWS EKS GPU ML platform: AWS policy enforcement (Kyverno/Gatekeeper + SCP parity), the flagged **OPA coverage-gap closure**, IAM least-privilege + ABAC, the SOC2 control→evidence matrix, and the ML on-call rotation + incident runbooks.

> **⚠️ DESIGN-MOCK repo — apply-gated; do NOT merge until human review. Base targets the design branch `feature/aws-ml-platform-design` on purpose** (the ADRs 0044/0048 this work cites live there, not on `main`). Every resource is default-OFF / Audit-first — nothing creates real infra.

### What I built

**Terraform modules** (apply-gated, default-OFF):
- `terraform/modules/aws-ml-scp-parity/` — ML-OU-scoped SCP deny-list (require IMDSv2, require EBS encryption, deny `iam:CreateAccessKey`, restrict to GPU regions). AWS analog of the GCP org-policy plane (ADR-0040 D1). `enabled=false` ⇒ 0 resources at plan.
- `terraform/modules/aws-ml-abac-iam/` — least-privilege + ABAC IAM role (EKS Pod Identity, ADR-0018) with the ADR-0028 `aws:PrincipalTag/platform:system == aws:ResourceTag/platform:system` tag-match on S3/KMS/Secrets; no wildcard action/resource.

**OPA (the flagged gap — plan §3 caveat / §7 #13):**
- `tests/opa/platform_tags_ml.rego` (+ `_test.rego`) — explicit allow-list of net-new `aws-eks-gpu-*` / `aws-ml-*` resource types that **must** carry the ADR-0028 taxonomy, plus an ABAC floor on ML IAM policies. New file (does **not** edit `platform_tags.rego` → file-disjoint).

**In-cluster delivery (ArgoCD app):**
- `apps/infra/ml-policy/` — Kyverno ClusterPolicies (require ML taxonomy labels; forbid privileged GPU pods) + a Gatekeeper Constraint **reusing** the existing `K8sBlockPrivileged` ConstraintTemplate. Audit-first.

**Catalog units:** `catalog/units/aws-ml-scp-parity/`, `catalog/units/aws-ml-abac-iam/` (both `enabled=false`).

**Docs:**
- `docs/compliance/soc2-control-matrix-aws-ml.md` — SOC2 TSC→evidence matrix (AWS), honest still-gap list.
- `docs/runbooks/ml-incident-runbook-aws.md` — drift / training / serving decision trees.
- `docs/runbooks/oncall-rotation-escalation-aws.md` — `ml-platform-oncall` rotation, L1→L3, tabletop.

### ADRs cited
0044 (GPU/ML foundation) · 0048 (AWS ML backends) · 0040 (GCP SOC etalon) · 0028 (taxonomy + ABAC) · 0018 (Pod Identity) · 0020 (Kyverno/Gatekeeper) · 0047 (inference front).

### Verification (plan/validate-only — real tools run in-session)

| Gate | Result |
|---|---|
| `terraform fmt` | ✅ clean |
| `terraform validate` | ✅ both modules |
| `terraform test` | ✅ 9/9 (4 scp-parity + 5 abac-iam) |
| `tflint` (AWS ruleset 0.35) | ✅ 0 findings, both modules |
| `checkov` (CIS config) | ✅ 0 failed, both modules |
| `opa test` | ✅ 8/8 (platform_tags_ml) |
| `helm lint` / `helm template` | ✅ clean, 3 manifests render |
| `yamllint` | ✅ clean |
| `terragrunt hcl fmt --check` | ✅ both units |
| `terraform plan` | ⏭️ **SKIPPED — needs cloud creds (unavailable in worktree)** |

**No `terraform apply`, no `helm install`, no `kubectl apply`** was run. SCPs/IAM are `enabled=false`; in-cluster policies ship Audit-first.

### File-disjointness
Only WS-E files. Did **not** touch `catalog/stacks/*.stack.hcl` or `docs/adrs/README.md` (WS-A). New companion rego/docs — did not edit `platform_tags.rego` or the GCP `soc2-control-matrix.md`.

### Test plan (for the human reviewer, post-apply-gate)
- [ ] Enable `aws-ml-scp-parity` with a real ML OU id; confirm a reviewed `plan` shows the 4 SCPs + attachments scoped to that OU only.
- [ ] Enable `aws-ml-abac-iam` wired to the WS-B artifact-store ARNs; IAM policy-sim confirms cross-`platform:system` access is denied.
- [ ] `conftest` the `platform_tags_ml.rego` against a real WS-A GPU-stack plan; confirm an untagged `aws_eks_cluster` fails the gate.
- [ ] Promote `apps/infra/ml-policy` from Audit→Enforce after a clean soak; confirm a privileged GPU pod is denied.
