### PR TITLE
feat(bm-wsC): Talos ML observability / drift

### DIFF
--- a/.github/workflows/ml-monitoring-baremetal-validate.yml
+++ b/.github/workflows/ml-monitoring-baremetal-validate.yml
@@ -1,0 +1,215 @@
+# ML Monitoring Bare-Metal — CI Validation Gate (WS-C)
+#
+# ADR citations: ADR-0038 (drift monitoring), ADR-0049 (bare-metal; UK DC)
+# platform:system = ml-monitoring (ADR-0028)
+#
+# PURPOSE:
+#   Validate all WS-C deliverables on every PR that touches ml-monitoring or
+#   baremetal-ml-monitoring files. Gates:
+#     1. helm lint (base values + baremetal overlay)
+#     2. yamllint on ArgoCD application + alertmanager overlay
+#     3. terragrunt validate (catalog unit)
+#     4. ADR-0028 label check in rendered helm output
+#
+# NO APPLY: this workflow never runs helm install, kubectl apply, or
+# terraform apply. plan/validate-only per the repo's apply-gate posture.
+name: "ML Monitoring Bare-Metal — Validate (WS-C)"
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "feature/**"
+    paths:
+      - "apps/infra/ml-monitoring/values-baremetal.yaml"
+      - "apps/infra/ml-monitoring/argocd-application-baremetal.yaml"
+      - "apps/infra/ml-monitoring/alertmanager-routes-overlay-baremetal.yaml"
+      - "apps/infra/ml-monitoring/values.yaml"
+      - "apps/infra/ml-monitoring/Chart.yaml"
+      - "apps/infra/ml-monitoring/templates/**"
+      - "apps/infra/observability/grafana-dashboards/templates/configmap-ml-drift-baremetal.yaml"
+      - "catalog/units/baremetal-ml-monitoring/**"
+      - "terragrunt/uk/**"
+  workflow_dispatch:
+    inputs:
+      debug:
+        description: "Enable debug logging"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: "ml-monitoring-baremetal-validate-${{ github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  HELM_VERSION: "3.17.0"
+  TF_VERSION: "1.14.8"
+  TG_VERSION: "1.0.8"
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Job 1: Helm lint + template render + ADR-0028 label check
+  # ---------------------------------------------------------------------------
+  helm-lint:
+    name: "Helm lint — ml-monitoring (base + baremetal overlay)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@v4
+
+      - name: Install Helm ${{ env.HELM_VERSION }}
+        uses: azure/setup-helm@v4
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Helm lint (base values only)
+        working-directory: apps/infra/ml-monitoring
+        run: helm lint . --values values.yaml
+
+      - name: Helm lint (base + baremetal overlay)
+        working-directory: apps/infra/ml-monitoring
+        run: |
+          helm lint . \
+            --values values.yaml \
+            --values values-baremetal.yaml
+
+      - name: Helm template (base + baremetal overlay) — render all resources
+        working-directory: apps/infra/ml-monitoring
+        run: |
+          helm template ml-monitoring-baremetal . \
+            --values values.yaml \
+            --values values-baremetal.yaml \
+            --set "modelNamespaces[0].namespace=ml-tenant-test" \
+            --set "modelNamespaces[0].modelName=domain-adapter-test" \
+            --set "modelNamespaces[0].tenant=tenant-test" \
+            --set "modelNamespaces[0].domain=hft" \
+            > /tmp/rendered-baremetal.yaml
+          echo "Rendered resource count:"
+          grep "^kind:" /tmp/rendered-baremetal.yaml | sort | uniq -c
+
+      - name: Verify ADR-0028 labels in rendered output
+        run: |
+          set -euo pipefail
+          MISSING=$(grep -c "platform.system" /tmp/rendered-baremetal.yaml || true)
+          if [ "${MISSING}" -eq 0 ]; then
+            echo "ERROR: No platform.system labels found in rendered output"
+            exit 1
+          fi
+          echo "ADR-0028 platform.system labels found: ${MISSING} occurrences"
+
+  # ---------------------------------------------------------------------------
+  # Job 2: yamllint
+  # ---------------------------------------------------------------------------
+  yamllint:
+    name: "yamllint — ArgoCD app + Alertmanager overlay"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@v4
+
+      - name: Install yamllint
+        run: pip install yamllint==1.35.1
+
+      - name: yamllint — ArgoCD Application
+        run: |
+          yamllint -d relaxed \
+            apps/infra/ml-monitoring/argocd-application-baremetal.yaml
+
+      - name: yamllint — Alertmanager overlay
+        run: |
+          yamllint -d "{extends: relaxed, rules: {line-length: {max: 200}}}" \
+            apps/infra/ml-monitoring/alertmanager-routes-overlay-baremetal.yaml
+
+  # ---------------------------------------------------------------------------
+  # Job 3: Terragrunt validate — catalog unit
+  # ---------------------------------------------------------------------------
+  terragrunt-validate:
+    name: "Terragrunt validate — catalog/units/baremetal-ml-monitoring"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@v4
+
+      - name: Install Terraform ${{ env.TF_VERSION }}
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Install Terragrunt ${{ env.TG_VERSION }}
+        run: |
+          curl -sL \
+            "https://github.com/gruntwork-io/terragrunt/releases/download/v${{ env.TG_VERSION }}/terragrunt_linux_amd64" \
+            -o /usr/local/bin/terragrunt
+          chmod +x /usr/local/bin/terragrunt
+          terragrunt --version
+
+      - name: Terragrunt hcl fmt check
+        working-directory: catalog/units/baremetal-ml-monitoring
+        run: terragrunt hcl fmt --check --diff
+
+      - name: Terragrunt init (backend=false)
+        working-directory: catalog/units/baremetal-ml-monitoring
+        env:
+          TG_NON_INTERACTIVE: "true"
+        run: terragrunt init -backend=false
+
+      - name: Terragrunt validate
+        working-directory: catalog/units/baremetal-ml-monitoring
+        env:
+          TG_NON_INTERACTIVE: "true"
+        run: terragrunt validate
+
+  # ---------------------------------------------------------------------------
+  # Job 4: PR summary comment
+  # ---------------------------------------------------------------------------
+  summary:
+    name: "Validation summary"
+    runs-on: ubuntu-latest
+    needs: [helm-lint, yamllint, terragrunt-validate]
+    if: always() && github.event_name == 'pull_request'
+    steps:
+      - name: Post PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const results = {
+              'helm-lint':           '${{ needs.helm-lint.result }}',
+              'yamllint':            '${{ needs.yamllint.result }}',
+              'terragrunt-validate': '${{ needs.terragrunt-validate.result }}',
+            };
+            const icon = (r) => r === 'success' ? ':white_check_mark:' : r === 'skipped' ? ':white_circle:' : ':x:';
+            const rows = Object.entries(results)
+              .map(([name, result]) => `| ${icon(result)} | \`${name}\` | ${result} |`)
+              .join('\n');
+            const body = [
+              '## WS-C Bare-Metal ML Monitoring — Validation Results',
+              '',
+              '| | Gate | Result |',
+              '|---|---|---|',
+              rows,
+              '',
+              '> ADR-0038 / ADR-0049 / ADR-0028 | plan/validate-only | apply-gated',
+            ].join('\n');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });

--- a/apps/infra/ml-monitoring/alertmanager-routes-overlay-baremetal.yaml
+++ b/apps/infra/ml-monitoring/alertmanager-routes-overlay-baremetal.yaml
@@ -1,0 +1,136 @@
+# Alertmanager Routes Overlay — Bare-Metal (Talos) — ADR-0038 D3, ADR-0049
+#
+# PURPOSE:
+#   Bare-metal-specific Alertmanager route/receiver patch for the in-DC
+#   Prometheus stack (Prometheus/Thanos/Alertmanager deployed by WS-D on the
+#   Talos UK cluster). Extends the base alertmanager-routes-overlay.yaml.
+#
+#   Key differences from the base (cloud/EKS) overlay:
+#     - secretStoreRef: Vault (in-DC, UK-resident) not AWS Secrets Manager
+#     - Alertmanager namespace: 'monitoring' on bare metal (matches in-DC stack)
+#     - cluster matcher added: platform_system=ml-monitoring AND cluster=talos-uk-primary
+#     - Retrain webhook URL: points at in-DC Airflow (WS-B bare-metal)
+#
+#   The routing LOGIC (matchers, continue:true, repeat_interval: 6h,
+#   group_by, group_wait) is IDENTICAL to the base overlay per ADR-0038 D3.
+#   Only substrate references change — demonstrating cluster-agnostic reuse.
+#
+# APPLY GATE:
+#   plan/validate-only. Platform team action required before WS-C go-live.
+#
+# MERGE INSTRUCTIONS (platform team action, same pattern as base overlay):
+#   1. Add the two routes (routes_patch below) into the routes: list in
+#      apps/infra/observability/prometheus-stack/values.yaml BEFORE the
+#      existing severity = critical catch-all routes.
+#   2. Add the two receivers to the receivers: list.
+#   3. Add alertmanager-retrain-token to alertmanagerSpec.secrets.
+#   4. Deploy the cross-namespace ExternalSecret (see CROSS-NAMESPACE NOTE).
+#   5. yamllint and helm lint prometheus-stack before applying.
+#
+# ============================================================================
+# ADD to kube-prometheus-stack.alertmanager.alertmanagerSpec.config.route.routes
+# (insert BEFORE existing severity = critical catch-all routes)
+# ============================================================================
+
+# routes_patch:
+# -----------------------------------------------------------------------
+#   # ML Monitoring (bare-metal): critical drift/accuracy -> PagerDuty
+#   # continue: true so the retrain webhook route also fires
+#   - matchers:
+#     - platform_system = ml-monitoring
+#     - severity = critical
+#     - cluster = talos-uk-primary
+#     receiver: 'ml-drift-pagerduty'
+#     continue: true
+#     group_wait: 10s
+#     group_by: ['model_name', 'tenant', 'domain', 'alertname', 'cluster']
+#
+#   # ML Monitoring (bare-metal): critical drift/accuracy -> retrain webhook
+#   # repeat_interval: 6h prevents retrain storms between drift recovery cycles
+#   - matchers:
+#     - platform_system = ml-monitoring
+#     - severity = critical
+#     - cluster = talos-uk-primary
+#     receiver: 'ml-retrain-webhook-baremetal'
+#     group_wait: 10s
+#     group_by: ['model_name', 'tenant', 'domain', 'alertname']
+#     repeat_interval: 6h
+# -----------------------------------------------------------------------
+
+# ============================================================================
+# ADD to kube-prometheus-stack.alertmanager.alertmanagerSpec.config.receivers
+# ============================================================================
+
+# receivers_patch:
+# -----------------------------------------------------------------------
+#   - name: 'ml-drift-pagerduty'
+#     pagerduty_configs:
+#     - service_key_file: '/etc/alertmanager/secrets/alertmanager-pagerduty-secret/service-key'
+#       description: >-
+#         ML drift (bare-metal): ALERTNAME MODELNAME (TENANT/DOMAIN) cluster=CLUSTER
+#       details:
+#         model_name: '{{ .GroupLabels.model_name }}'
+#         tenant: '{{ .GroupLabels.tenant }}'
+#         domain: '{{ .GroupLabels.domain }}'
+#         severity: '{{ .GroupLabels.severity }}'
+#         platform_system: 'ml-monitoring'
+#         cluster: '{{ .GroupLabels.cluster }}'
+#       send_resolved: true
+#
+#   - name: 'ml-retrain-webhook-baremetal'
+#     webhook_configs:
+#     # ml-retrain-trigger proxy (in-cluster; targets in-DC Airflow; WS-B bare-metal)
+#     # The proxy translates to:
+#     #   POST /api/v1/dags/train_domain_adapter/dagRuns
+#     #   body: { conf: { tenant: "...", domain: "...", trigger: "drift" } }
+#     # Falls back to K8s Job in ml-monitoring namespace if Airflow unreachable.
+#     - url: 'http://ml-retrain-trigger.ml-monitoring.svc.cluster.local:8080/webhook'
+#       send_resolved: false
+#       http_config:
+#         bearer_token_file: '/etc/alertmanager/secrets/alertmanager-retrain-token/token'
+#       max_alerts: 10
+# -----------------------------------------------------------------------
+
+# ============================================================================
+# ADD to kube-prometheus-stack.alertmanager.alertmanagerSpec.secrets
+# ============================================================================
+
+# secrets_patch:
+# -----------------------------------------------------------------------
+#   - alertmanager-retrain-token
+# -----------------------------------------------------------------------
+#
+# CROSS-NAMESPACE NOTE (bare-metal Vault-backed ESO):
+#   The alertmanager-retrain-token ExternalSecret in the ml-monitoring chart
+#   creates the Secret in namespace 'ml-monitoring'. Alertmanager mounts
+#   secrets from its own namespace ('monitoring' on this bare-metal cluster).
+#
+#   Deploy this cross-namespace ExternalSecret (Vault-backed; ADR-0049 D4):
+#
+#     apiVersion: external-secrets.io/v1beta1
+#     kind: ExternalSecret
+#     metadata:
+#       name: alertmanager-retrain-token
+#       namespace: monitoring
+#       labels:
+#         platform.system: ml-monitoring
+#         platform.component: alertmanager
+#         platform.env: production
+#         platform.owner: team-ml-platform
+#         platform.managed-by: argocd
+#     spec:
+#       refreshInterval: 1h
+#       secretStoreRef:
+#         name: vault-cluster-secret-store
+#         kind: ClusterSecretStore
+#       target:
+#         name: alertmanager-retrain-token
+#         creationPolicy: Owner
+#       data:
+#         - secretKey: token
+#           remoteRef:
+#             key: secret/ml-monitoring/alertmanager-retrain-token
+#             property: token
+#
+#   OR deploy a single ClusterExternalSecret covering both namespaces.
+#   See ADR-0038 Implementation Notes and ADR-0049 D4.

--- a/apps/infra/ml-monitoring/argocd-application-baremetal.yaml
+++ b/apps/infra/ml-monitoring/argocd-application-baremetal.yaml
@@ -1,0 +1,93 @@
+---
+# ArgoCD Application — ML Monitoring, Bare-Metal / Talos (WS-C)
+#
+# ADR citations: ADR-0038 (Evidently/whylogs drift monitoring, decision of record),
+#                ADR-0049 (bare-metal foundation, multi-DC scope),
+#                ADR-0028 (platform taxonomy labels on all resources).
+#
+# TOPOLOGY:
+#   - Targets the primary Talos UK cluster (talos-uk-primary).
+#   - A second Application for talos-uk-standby can be added when the standby
+#     cluster comes up (standby serves inference during failover per ADR-0049 D5).
+#   - Sync-wave 20: after prometheus-stack (wave 10) and airflow/WS-B (wave 15)
+#     so Prometheus CRDs and the Airflow retrain endpoint both exist.
+#
+# APPLY GATE:
+#   plan/validate-only. No ArgoCD sync / helm install without explicit human
+#   approval. This mock/emulation repo never applies to real hardware.
+#
+# ADR-0028 mandatory labels are on this Application AND propagated into every
+# in-cluster resource via helm.values (values-baremetal.yaml platformLabels).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ml-monitoring-baremetal
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: ml-monitoring-baremetal
+    app.kubernetes.io/component: ml-observability
+    platform.system: ml-monitoring
+    platform.component: drift-exporter
+    platform.env: production
+    platform.owner: team-ml-platform
+    platform.managed-by: argocd
+    platform.cluster: talos-uk-primary
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+
+spec:
+  project: platform
+
+  source:
+    repoURL: https://github.com/your-org/platform-infrastructure.git
+    targetRevision: main
+    path: apps/infra/ml-monitoring
+
+    helm:
+      # Layer base values then bare-metal overrides.
+      # values-baremetal.yaml re-points artifact store + ESO secretStoreRef
+      # from GCS/AWS Secrets Manager to MinIO/Ceph-RGW + Vault (ADR-0052).
+      valueFiles:
+        - values.yaml
+        - values-baremetal.yaml
+
+  destination:
+    # Bare-metal cluster registered in ArgoCD via its Talos-generated kubeconfig.
+    # KubePrism provides the in-cluster API HA endpoint (ADR-0049 D1).
+    # Registration: argocd cluster add talos-uk-primary --kubeconfig <talos-kube.yaml>
+    server: https://talos-uk-primary.argocd.internal
+    namespace: ml-monitoring
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - RespectIgnoreDifferences=true
+      - ApplyOutOfSyncOnly=true
+
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas
+    - group: "*"
+      kind: "*"
+      managedFieldsManagers:
+        - kube-controller-manager
+
+  revisionHistoryLimit: 3

--- a/apps/infra/ml-monitoring/values-baremetal.yaml
+++ b/apps/infra/ml-monitoring/values-baremetal.yaml
@@ -1,0 +1,157 @@
+# ML Monitoring Helm values — Bare-Metal (Talos) overlay
+# WS-C — ADR-0038 (decision of record), ADR-0049, ADR-0052
+#
+# PURPOSE:
+#   Bare-metal-specific overrides layered on top of values.yaml.
+#   Key substitutions vs the base values:
+#     - referenceBucketUri: GCS  ->  MinIO / Ceph-RGW S3 endpoint  (ADR-0052)
+#     - workloadIdentityAnnotation: GKE-WIF  ->  none (Vault/ESO-issued S3 creds)
+#     - Airflow baseUrl: GKE-Airflow  ->  in-DC Airflow  (WS-B bare-metal)
+#     - ESO secretStoreRef  ->  Vault-backed ClusterSecretStore (in-DC Vault)
+#     - platform.cluster label added for multi-cluster Grafana federation
+#
+# APPLY GATE:
+#   This file is plan/validate-only. No helm install without explicit human
+#   approval. Apply is CI-only from main after merge.
+#
+# ADR-0028 platform taxonomy labels — dot-notation keys in K8s resource metadata.
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# ADR-0028 platform labels (merged with base values.yaml labels at render time)
+# ---------------------------------------------------------------------------
+platformLabels:
+  "platform.system": "ml-monitoring"
+  "platform.component": "drift-exporter"
+  "platform.env": "production"
+  "platform.owner": "team-ml-platform"
+  "platform.managed-by": "argocd"
+  "platform.cluster": "talos-uk-primary"   # override per DC via ArgoCD Application
+
+# ---------------------------------------------------------------------------
+# Namespace (same as base; kept for explicitness)
+# ---------------------------------------------------------------------------
+namespace: ml-monitoring
+
+# ---------------------------------------------------------------------------
+# Evidently drift-exporter — bare-metal substrate overrides
+# ---------------------------------------------------------------------------
+driftExporter:
+  # Reference dataset bucket: MinIO or Ceph-RGW S3 endpoint (ADR-0052).
+  # NOT a GCS URI. S3-compatible API — Evidently uses boto3 endpoint_url.
+  # The actual endpoint hostname is injected via ESO-managed Secret:
+  #   Vault path: secret/ml-monitoring/minio-s3-credentials
+  # Rendered as: s3://<bucket-name>/<path> with env var S3_ENDPOINT_URL
+  # pointing at the MinIO/Ceph-RGW in-cluster service.
+  #
+  # Default: Ceph-RGW in-cluster endpoint (ADR-0052 Rook-Ceph RGW).
+  # Override to MinIO if ADR-0052 sub-decision lands on MinIO-as-primary.
+  referenceBucketUri: "s3://ml-reference-data"
+
+  # Evaluation interval unchanged from base (300s).
+  evaluationIntervalSeconds: 300
+
+  # Thresholds inherited from base values.yaml (ADR-0038 D2).
+  # Do not re-declare here unless overriding specific values.
+
+# ---------------------------------------------------------------------------
+# whylogs distribution profiler — pushgateway URL for in-cluster Prometheus
+# Same hostname as base; bare-metal Prometheus is in the same cluster.
+# ---------------------------------------------------------------------------
+whylogsProfiler:
+  pushgatewayUrl: "http://prometheus-pushgateway.monitoring.svc.cluster.local:9091"
+
+# ---------------------------------------------------------------------------
+# Retrain-trigger webhook proxy
+# Re-pointed at the in-DC Airflow (WS-B bare-metal ArgoCD app).
+# ---------------------------------------------------------------------------
+retrainTrigger:
+  airflow:
+    # In-DC Airflow webserver (WS-B: apps/infra/airflow, bare-metal deploy)
+    baseUrl: "http://airflow-webserver.airflow.svc.cluster.local:8080"
+    dagId: "train_domain_adapter"
+    credentialsSecretName: "airflow-api-credentials"
+
+  # Deduplication: 15 min window per (tenant, domain); unchanged from base.
+  deduplicationWindowSeconds: 900
+
+# ---------------------------------------------------------------------------
+# ExternalSecret — Vault-backed (in-DC Vault, not AWS Secrets Manager)
+# ADR-0049 D4: UK-resident data; Vault KMS in-DC per 06-uk-datacenters.md.
+# The secretStoreRef name must match the ClusterSecretStore deployed by WS-E.
+# ---------------------------------------------------------------------------
+externalSecrets:
+  enabled: true
+  refreshInterval: "1h"
+  secretStoreRef:
+    # In-DC Vault-backed ClusterSecretStore (deployed by WS-E)
+    name: vault-cluster-secret-store
+    kind: ClusterSecretStore
+
+  airflowCredentials:
+    secretName: airflow-api-credentials
+    remoteRef:
+      # Vault KV path: secret/ml-monitoring/airflow-api-credentials
+      key: secret/ml-monitoring/airflow-api-credentials
+
+  alertmanagerRetrainToken:
+    secretName: alertmanager-retrain-token
+    remoteRef:
+      key: secret/ml-monitoring/alertmanager-retrain-token
+
+  # Additional secret: MinIO / Ceph-RGW S3 endpoint + credentials
+  # Injected as env vars into the drift-exporter Deployment.
+  minioS3Credentials:
+    secretName: minio-s3-credentials
+    remoteRef:
+      # Secret keys expected by drift-exporter container:
+      #   S3_ENDPOINT_URL, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+      key: secret/ml-monitoring/minio-s3-credentials
+
+# ---------------------------------------------------------------------------
+# RBAC — no cloud Workload Identity on bare metal.
+# S3 access via ESO-issued Secret (minio-s3-credentials), not a GSA/IRSA.
+# ---------------------------------------------------------------------------
+rbac:
+  create: true
+  serviceAccountName: ml-retrain-trigger
+  # GKE Workload Identity annotation: NOT used on bare metal.
+  workloadIdentityAnnotation: ""
+
+# ---------------------------------------------------------------------------
+# ServiceMonitor — matches in-cluster Prometheus (kube-prometheus-stack)
+# ---------------------------------------------------------------------------
+serviceMonitor:
+  enabled: true
+  prometheusSelector:
+    prometheus: kube-prometheus
+  scrapeInterval: "30s"
+  scrapeTimeout: "10s"
+
+# ---------------------------------------------------------------------------
+# PrometheusRule — unchanged from base (ADR-0038 thresholds)
+# ---------------------------------------------------------------------------
+prometheusRule:
+  enabled: true
+  additionalLabels:
+    prometheus: kube-prometheus
+
+# ---------------------------------------------------------------------------
+# NetworkPolicy — enabled on bare metal (Cilium enforced; ADR-0051).
+# Set to true when WS-A baremetal-cilium-lb is deployed and NetworkPolicy
+# enforcement is active. Start false until Cilium enforce mode confirmed.
+# ---------------------------------------------------------------------------
+networkPolicy:
+  enabled: false   # Flip to true post Cilium enforce gate (WS-A acceptance)
+
+# ---------------------------------------------------------------------------
+# Model namespaces — populated at deploy time per tenant.
+# Namespace-per-tenant matches 06-uk-datacenters.md tenancy model.
+# ---------------------------------------------------------------------------
+modelNamespaces: []
+# Example (uncomment when tenants are onboarded via WS-F golden path):
+# - namespace: ml-tenant-acme-hft
+#   modelName: domain-adapter-hft
+#   tenant: tenant-acme
+#   domain: hft
+#   thresholds: {}

--- a/apps/infra/observability/grafana-dashboards/templates/configmap-ml-drift-baremetal.yaml
+++ b/apps/infra/observability/grafana-dashboards/templates/configmap-ml-drift-baremetal.yaml
@@ -1,0 +1,534 @@
+---
+# Grafana Dashboard ConfigMap: ML Drift & Accuracy — Bare-Metal (Talos)
+# WS-C — ADR-0038 D2, ADR-0049
+#
+# DESIGN NOTE:
+#   Bare-metal mirror of configmap-ml-drift.yaml (cloud/EKS).
+#   ALL PromQL expressions are cluster-agnostic (platform_system="ml-monitoring"
+#   label filter per ADR-0028). The uid is distinct:
+#     cloud/EKS:   ml-drift-accuracy-v1    (configmap-ml-drift.yaml)
+#     bare-metal:  ml-drift-accuracy-bm-v1 (this file)
+#   Both dashboards can coexist in a multi-cluster Grafana instance without
+#   uid collision. Each can be scoped to the right Thanos endpoint.
+#
+# APPLY GATE: plan/validate-only. No helm install without human approval.
+# Label grafana_dashboard=1 causes the Grafana sidecar to auto-import.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-ml-drift-baremetal
+  namespace: {{ .Values.grafanaNamespace }}
+  labels:
+    {{- range $key, $val := .Values.dashboardLabels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+    platform.system: "ml-monitoring"
+    platform.component: "grafana-dashboard"
+    platform.env: "production"
+    platform.owner: "team-ml-platform"
+    platform.managed-by: "argocd"
+    platform.cluster: "talos-uk-primary"
+data:
+  ml-drift-accuracy-baremetal.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "ML model drift detection, feature distribution shift, and accuracy degradation on the Talos bare-metal UK cluster. Per-tenant/domain view. ADR-0038 / ADR-0049.",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [
+        {
+          "asDropdown": true,
+          "icon": "external link",
+          "includeVars": true,
+          "keepTime": true,
+          "tags": ["ml-monitoring"],
+          "title": "ML Monitoring Dashboards",
+          "type": "dashboards"
+        }
+      ],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+          "id": 100,
+          "title": "Overview — Bare-Metal Cluster",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "Number of models currently in critical drift state",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "yellow", "value": 1},
+                  {"color": "red", "value": 3}
+                ]
+              },
+              "unit": "short"
+            }
+          },
+          "gridPos": {"h": 4, "w": 4, "x": 0, "y": 1},
+          "id": 1,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": {"calcs": ["lastNotNull"]}
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "{{ .Values.datasources.prometheus.uid }}"
+              },
+              "expr": "count(ml_monitoring_dataset_drift_score{platform_system=\"ml-monitoring\"} > 0.40) or vector(0)",
+              "legendFormat": "Critical drift models",
+              "refId": "A"
+            }
+          ],
+          "title": "Models in Critical Drift",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "Retrain DAG runs triggered in the last 24 h",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "yellow", "value": 3},
+                  {"color": "red", "value": 10}
+                ]
+              },
+              "unit": "short"
+            }
+          },
+          "gridPos": {"h": 4, "w": 4, "x": 4, "y": 1},
+          "id": 2,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": {"calcs": ["sum"]}
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "{{ .Values.datasources.prometheus.uid }}"
+              },
+              "expr": "increase(ml_monitoring_retrain_triggers_total{platform_system=\"ml-monitoring\"}[24h])",
+              "legendFormat": "Retrain triggers",
+              "refId": "A"
+            }
+          ],
+          "title": "Retrain Triggers (24h)",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "Models with accuracy below warning threshold (< 0.85)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "yellow", "value": 1},
+                  {"color": "red", "value": 3}
+                ]
+              },
+              "unit": "short"
+            }
+          },
+          "gridPos": {"h": 4, "w": 4, "x": 8, "y": 1},
+          "id": 3,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "reduceOptions": {"calcs": ["lastNotNull"]}
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "{{ .Values.datasources.prometheus.uid }}"
+              },
+              "expr": "count(ml_monitoring_model_accuracy{platform_system=\"ml-monitoring\"} < 0.85) or vector(0)",
+              "legendFormat": "Low accuracy models",
+              "refId": "A"
+            }
+          ],
+          "title": "Models Below Accuracy Warning",
+          "type": "stat"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 5},
+          "id": 101,
+          "title": "Dataset Drift",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "Evidently dataset drift score per model/tenant/domain. Warning >= 0.20, Critical >= 0.40 (ADR-0038 D2).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineWidth": 2,
+                "spanNulls": false
+              },
+              "unit": "percentunit",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "yellow", "value": 0.20},
+                  {"color": "red", "value": 0.40}
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 6},
+          "id": 10,
+          "options": {
+            "legend": {"displayMode": "list", "placement": "bottom"}
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "{{ .Values.datasources.prometheus.uid }}"
+              },
+              "expr": "ml_monitoring_dataset_drift_score{platform_system=\"ml-monitoring\", model_name=~\"$model_name\", tenant=~\"$tenant\"}",
+              "legendFormat": "{{ "{{" }}model_name{{ "}}" }}/{{ "{{" }}tenant{{ "}}" }}/{{ "{{" }}domain{{ "}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Dataset Drift Score",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "Feature-level PSI (Population Stability Index). Warning >= 0.10, Critical >= 0.25 (ADR-0038 D2).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineWidth": 2
+              },
+              "unit": "short"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 6},
+          "id": 11,
+          "options": {
+            "legend": {"displayMode": "list", "placement": "bottom"}
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "{{ .Values.datasources.prometheus.uid }}"
+              },
+              "expr": "topk(10, ml_monitoring_feature_psi_score{platform_system=\"ml-monitoring\", model_name=~\"$model_name\", tenant=~\"$tenant\"})",
+              "legendFormat": "{{ "{{" }}feature_name{{ "}}" }} ({{ "{{" }}model_name{{ "}}" }})",
+              "refId": "A"
+            }
+          ],
+          "title": "Top-10 Feature PSI",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 14},
+          "id": 102,
+          "title": "Model Accuracy & F1",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "Model accuracy over time. Warning < 0.85, Critical < 0.75 (ADR-0038 D2).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineWidth": 2
+              },
+              "min": 0,
+              "max": 1,
+              "unit": "percentunit",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "red", "value": null},
+                  {"color": "yellow", "value": 0.75},
+                  {"color": "green", "value": 0.85}
+                ]
+              }
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 15},
+          "id": 20,
+          "options": {
+            "legend": {"displayMode": "list", "placement": "bottom"}
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "{{ .Values.datasources.prometheus.uid }}"
+              },
+              "expr": "ml_monitoring_model_accuracy{platform_system=\"ml-monitoring\", model_name=~\"$model_name\", tenant=~\"$tenant\"}",
+              "legendFormat": "{{ "{{" }}model_name{{ "}}" }}/{{ "{{" }}tenant{{ "}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Model Accuracy",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "F1 score over time. Warning < 0.80, Critical < 0.65 (ADR-0038 D2).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineWidth": 2
+              },
+              "min": 0,
+              "max": 1,
+              "unit": "percentunit"
+            }
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 15},
+          "id": 21,
+          "options": {
+            "legend": {"displayMode": "list", "placement": "bottom"}
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "{{ .Values.datasources.prometheus.uid }}"
+              },
+              "expr": "ml_monitoring_model_f1_score{platform_system=\"ml-monitoring\", model_name=~\"$model_name\", tenant=~\"$tenant\"}",
+              "legendFormat": "{{ "{{" }}model_name{{ "}}" }}/{{ "{{" }}tenant{{ "}}" }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Model F1 Score",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 23},
+          "id": 103,
+          "title": "Serving Latency (OTel/Tempo)",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "p50/p95/p99 inference serving latency via OTel metrics. Tracks serving degradation correlated with drift events.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineWidth": 2
+              },
+              "unit": "ms"
+            }
+          },
+          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 24},
+          "id": 30,
+          "options": {
+            "legend": {"displayMode": "list", "placement": "bottom"}
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "{{ .Values.datasources.prometheus.uid }}"
+              },
+              "expr": "histogram_quantile(0.50, sum(rate(inference_request_duration_milliseconds_bucket{platform_system=\"ml-monitoring\", model_name=~\"$model_name\"}[5m])) by (le, model_name, tenant))",
+              "legendFormat": "p50 {{ "{{" }}model_name{{ "}}" }}/{{ "{{" }}tenant{{ "}}" }}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "{{ .Values.datasources.prometheus.uid }}"
+              },
+              "expr": "histogram_quantile(0.95, sum(rate(inference_request_duration_milliseconds_bucket{platform_system=\"ml-monitoring\", model_name=~\"$model_name\"}[5m])) by (le, model_name, tenant))",
+              "legendFormat": "p95 {{ "{{" }}model_name{{ "}}" }}/{{ "{{" }}tenant{{ "}}" }}",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "{{ .Values.datasources.prometheus.uid }}"
+              },
+              "expr": "histogram_quantile(0.99, sum(rate(inference_request_duration_milliseconds_bucket{platform_system=\"ml-monitoring\", model_name=~\"$model_name\"}[5m])) by (le, model_name, tenant))",
+              "legendFormat": "p99 {{ "{{" }}model_name{{ "}}" }}/{{ "{{" }}tenant{{ "}}" }}",
+              "refId": "C"
+            }
+          ],
+          "title": "Inference Latency (p50/p95/p99)",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 32},
+          "id": 104,
+          "title": "Retrain Trigger History",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "{{ .Values.datasources.prometheus.uid }}"
+          },
+          "description": "Retrain trigger events rate. Each spike = Alertmanager webhook fired to Airflow train_domain_adapter (ADR-0038 D3).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {
+                "drawStyle": "bars",
+                "fillOpacity": 80,
+                "lineWidth": 1
+              },
+              "unit": "reqps"
+            }
+          },
+          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 33},
+          "id": 40,
+          "options": {
+            "legend": {"displayMode": "list", "placement": "bottom"}
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "{{ .Values.datasources.prometheus.uid }}"
+              },
+              "expr": "sum(rate(ml_monitoring_retrain_triggers_total{platform_system=\"ml-monitoring\", model_name=~\"$model_name\", tenant=~\"$tenant\"}[5m])) by (model_name, tenant, trigger_reason)",
+              "legendFormat": "{{ "{{" }}model_name{{ "}}" }}/{{ "{{" }}tenant{{ "}}" }} ({{ "{{" }}trigger_reason{{ "}}" }})",
+              "refId": "A"
+            }
+          ],
+          "title": "Retrain Trigger Rate",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "1m",
+      "schemaVersion": 36,
+      "style": "dark",
+      "tags": ["ml-monitoring", "baremetal", "talos"],
+      "templating": {
+        "list": [
+          {
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{{ .Values.datasources.prometheus.uid }}"
+            },
+            "definition": "label_values(ml_monitoring_dataset_drift_score{platform_system=\"ml-monitoring\"}, model_name)",
+            "hide": 0,
+            "includeAll": true,
+            "multi": true,
+            "name": "model_name",
+            "options": [],
+            "query": "label_values(ml_monitoring_dataset_drift_score{platform_system=\"ml-monitoring\"}, model_name)",
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "type": "query",
+            "label": "Model"
+          },
+          {
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "{{ .Values.datasources.prometheus.uid }}"
+            },
+            "definition": "label_values(ml_monitoring_dataset_drift_score{platform_system=\"ml-monitoring\"}, tenant)",
+            "hide": 0,
+            "includeAll": true,
+            "multi": true,
+            "name": "tenant",
+            "options": [],
+            "query": "label_values(ml_monitoring_dataset_drift_score{platform_system=\"ml-monitoring\"}, tenant)",
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "type": "query",
+            "label": "Tenant"
+          }
+        ]
+      },
+      "time": {"from": "now-6h", "to": "now"},
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "ML Drift & Accuracy — Bare-Metal (Talos UK)",
+      "uid": "ml-drift-accuracy-bm-v1",
+      "version": 1
+    }

--- a/catalog/units/baremetal-ml-monitoring/terragrunt.hcl
+++ b/catalog/units/baremetal-ml-monitoring/terragrunt.hcl
@@ -1,0 +1,114 @@
+# -------------------------------------------------------------------------
+# Catalog Unit: baremetal-ml-monitoring — WS-C (ADR-0038, ADR-0049)
+# -------------------------------------------------------------------------
+#
+# Provisions the ArgoCD Application resources that deploy the ml-monitoring
+# Helm chart onto the Talos UK bare-metal cluster.
+#
+# This unit is cluster-agnostic at the Terraform layer: it creates an ArgoCD
+# Application object (via the kubernetes/kubectl provider targeting the ArgoCD
+# cluster) rather than creating cloud resources. The actual in-cluster
+# Evidently/whylogs Deployments, PrometheusRules, ServiceMonitors, and
+# ExternalSecrets are rendered by Helm and managed by ArgoCD.
+#
+# ADR citations:
+#   ADR-0038 — Evidently/whylogs drift monitoring (decision of record)
+#   ADR-0049 — Bare-metal foundation; multi-DC scope; UK-resident data
+#   ADR-0028 — Platform taxonomy labels (MANDATORY on all resources)
+#
+# APPLY GATE:
+#   never_apply = true (set by CI profile).
+#   plan/validate-only. No terragrunt apply without explicit human approval.
+#   No ArgoCD sync without explicit human approval.
+#
+# DEPENDENCIES (in WS-A sequencing order):
+#   talos-cluster        -> kubeconfig / cluster endpoint
+#   baremetal-rook-ceph  -> MinIO/Ceph-RGW S3 endpoint (ADR-0052)
+#   prometheus-stack     -> Prometheus CRDs (wave 10 before wave 20)
+#   airflow (WS-B)       -> retrain webhook target
+#   ESO ClusterSecretStore (WS-E) -> Vault-backed secret store
+# -------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/argocd-application"
+}
+
+locals {
+  dc_vars  = read_terragrunt_config(find_in_parent_folders("dc.hcl"))
+  env_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+
+  dc           = local.dc_vars.locals.dc_name      # "uk-primary" or "uk-standby"
+  environment  = local.env_vars.locals.environment # "production"
+  cluster_name = "talos-${local.dc}"               # "talos-uk-primary"
+}
+
+# -------------------------------------------------------------------------
+# DEPENDENCY: Talos cluster (WS-A) — provides cluster endpoint
+# -------------------------------------------------------------------------
+dependency "talos_cluster" {
+  config_path = "../talos-cluster"
+
+  mock_outputs = {
+    kubeconfig_path  = "/dev/null"
+    cluster_endpoint = "https://mock-talos-endpoint.internal:6443"
+    cluster_ca_cert  = "mock-ca-cert-base64"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+# -------------------------------------------------------------------------
+# DEPENDENCY: Rook-Ceph (WS-A, ADR-0052) — S3 endpoint for MinIO/RGW
+# -------------------------------------------------------------------------
+dependency "baremetal_rook_ceph" {
+  config_path = "../baremetal-rook-ceph"
+
+  mock_outputs = {
+    rgw_s3_endpoint = "http://mock-rook-rgw.rook-ceph.svc.cluster.local:80"
+    rgw_bucket_name = "ml-reference-data"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+# -------------------------------------------------------------------------
+# MODULE INPUTS
+# -------------------------------------------------------------------------
+inputs = {
+  # ArgoCD Application name — disambiguated from cloud variant
+  app_name         = "ml-monitoring-baremetal"
+  argocd_namespace = "argocd"
+  project          = "platform"
+
+  # Source
+  repo_url         = "https://github.com/your-org/platform-infrastructure.git"
+  target_revision  = "main"
+  chart_path       = "apps/infra/ml-monitoring"
+  helm_value_files = ["values.yaml", "values-baremetal.yaml"]
+
+  # Destination — Talos UK cluster registered in ArgoCD
+  destination_server    = dependency.talos_cluster.outputs.cluster_endpoint
+  destination_namespace = "ml-monitoring"
+
+  # Sync wave: after prometheus-stack (10) and airflow/WS-B (15)
+  sync_wave = 20
+
+  # ADR-0028 labels (underscore form for Terraform resource tags)
+  labels = {
+    platform_system     = "ml-monitoring"
+    platform_component  = "drift-exporter"
+    platform_env        = local.environment
+    platform_owner      = "team-ml-platform"
+    platform_managed_by = "argocd"
+    platform_cluster    = local.cluster_name
+  }
+
+  # Additional Helm values resolved from dependency outputs (substrate-specific)
+  helm_set_values = {
+    "platformLabels.platform\\.cluster"   = local.cluster_name
+    "driftExporter.referenceBucketUri"    = "s3://${dependency.baremetal_rook_ceph.outputs.rgw_bucket_name}"
+    "externalSecrets.secretStoreRef.name" = "vault-cluster-secret-store"
+  }
+}

--- a/catalog/units/baremetal-ml-monitoring/terragrunt.hcl
+++ b/catalog/units/baremetal-ml-monitoring/terragrunt.hcl
@@ -34,12 +34,15 @@ terraform {
 }
 
 locals {
-  dc_vars  = read_terragrunt_config(find_in_parent_folders("dc.hcl"))
-  env_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+  # Guarded reads: the dc.hcl / env.hcl live tree is wired per-datacenter at deploy
+  # time. try() lets the catalog unit also validate standalone (CI) and fall back to
+  # the primary-DC defaults until the live dc/env tree exists.
+  dc_vars  = try(read_terragrunt_config(find_in_parent_folders("dc.hcl")), { locals = {} })
+  env_vars = try(read_terragrunt_config(find_in_parent_folders("env.hcl")), { locals = {} })
 
-  dc           = local.dc_vars.locals.dc_name      # "uk-primary" or "uk-standby"
-  environment  = local.env_vars.locals.environment # "production"
-  cluster_name = "talos-${local.dc}"               # "talos-uk-primary"
+  dc           = try(local.dc_vars.locals.dc_name, "uk-primary")      # "uk-primary" or "uk-standby"
+  environment  = try(local.env_vars.locals.environment, "production") # "production"
+  cluster_name = "talos-${local.dc}"                                  # "talos-uk-primary"
 }
 
 # -------------------------------------------------------------------------

--- a/terragrunt/uk/dc.hcl
+++ b/terragrunt/uk/dc.hcl
@@ -1,0 +1,13 @@
+# dc.hcl — UK bare-metal datacenter hierarchy file (WS-A/C, ADR-0049)
+#
+# Root-level DC config read by all units under terragrunt/uk/.
+# Convention mirrors account.hcl / region.hcl for the AWS live tree.
+# Units under terragrunt/uk/{primary,standby}/ override dc_name via a
+# local dc.hcl in that subdirectory (shadows this file on parent-folder walk).
+#
+# ADR-0028: dc_name feeds platform_cluster label on all resources.
+locals {
+  dc_name     = "uk"
+  dc_location = "uk"
+  environment = "production"
+}

--- a/terragrunt/uk/env.hcl
+++ b/terragrunt/uk/env.hcl
@@ -1,0 +1,5 @@
+# env.hcl — UK bare-metal environment hierarchy file (WS-A/C, ADR-0049)
+# Read by all units under terragrunt/uk/ via find_in_parent_folders("env.hcl").
+locals {
+  environment = "production"
+}

--- a/terragrunt/uk/primary/dc.hcl
+++ b/terragrunt/uk/primary/dc.hcl
@@ -1,0 +1,8 @@
+# dc.hcl — UK primary datacenter (WS-A/C, ADR-0049)
+# Overrides terragrunt/uk/dc.hcl for the primary DC.
+# ADR-0049 D5: primary-active cluster; standby is hot-standby.
+locals {
+  dc_name     = "uk-primary"
+  dc_location = "uk-primary"
+  environment = "production"
+}

--- a/terragrunt/uk/primary/platform/baremetal-ml-monitoring/terragrunt.hcl
+++ b/terragrunt/uk/primary/platform/baremetal-ml-monitoring/terragrunt.hcl
@@ -1,0 +1,16 @@
+# Live tree unit: UK Primary — baremetal-ml-monitoring (WS-C)
+# ADR-0038 (drift monitoring), ADR-0049 (bare-metal foundation)
+#
+# Thin live-tree shim instantiating the catalog unit for the UK primary DC.
+# The catalog unit (catalog/units/baremetal-ml-monitoring/terragrunt.hcl)
+# provides all inputs and dependencies.
+#
+# APPLY GATE: plan/validate-only (never_apply = true in CI profile).
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "${get_repo_root()}/catalog/units/baremetal-ml-monitoring"
+}

--- a/terragrunt/uk/root.hcl
+++ b/terragrunt/uk/root.hcl
@@ -1,0 +1,39 @@
+# root.hcl — UK Bare-Metal Terragrunt Root Configuration (WS-A stub, ADR-0049)
+#
+# STUB root.hcl for the UK bare-metal live tree, created by WS-C to allow
+# the baremetal-ml-monitoring live-tree shim to validate. The full
+# implementation (remote state backend, provider generation, etc.) is owned
+# by WS-A and will replace or extend this stub when WS-A lands.
+#
+# The UK tree uses dc.hcl + env.hcl hierarchy (not account.hcl / region.hcl)
+# because bare-metal has no cloud account or region concept.
+# This mirrors the pattern of terragrunt/gcp-staging/root.hcl (GCP tree root).
+#
+# APPLY GATE: plan/validate-only. No apply without explicit human approval.
+
+locals {
+  dc_vars  = read_terragrunt_config(find_in_parent_folders("dc.hcl"))
+  env_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+
+  dc_name     = local.dc_vars.locals.dc_name
+  environment = local.env_vars.locals.environment
+}
+
+# ---------------------------------------------------------------------------
+# Remote state backend — STUB (WS-A will implement the real backend).
+# In-DC bare-metal: likely Vault-backed or S3-compatible (MinIO/Ceph-RGW).
+# ---------------------------------------------------------------------------
+# remote_state {
+#   backend = "s3"
+#   config = {
+#     bucket  = "tfstate-uk-${local.dc_name}"
+#     key     = "${path_relative_to_include()}/terraform.tfstate"
+#     region  = "us-east-1"  # placeholder; real backend is in-DC (ADR-0049)
+#     use_lockfile = true
+#   }
+# }
+
+# ---------------------------------------------------------------------------
+# Provider generation — STUB (WS-A will inject the kubernetes / talos provider
+# configs, pointing at the Talos cluster endpoint from talos-cluster outputs).
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
## WS-C: Talos ML Observability / Drift — Bare-Metal Platform

> **DESIGN-MOCK repo — apply-gated; do NOT merge until human review; base targets the design branch on purpose.**

---

### What Was Built

Bare-metal WS-C: continuous monitoring of model accuracy + data/concept drift on the Talos UK GPU cluster.  
This is a **cluster-agnostic reuse** of the existing `apps/infra/ml-monitoring` chart (ADR-0038 decision of record), with bare-metal substrate overrides layered via a Helm values overlay.

#### Files Created

| File | Purpose |
|---|---|
| `apps/infra/ml-monitoring/values-baremetal.yaml` | Bare-metal Helm overlay: MinIO/Ceph-RGW S3 ref bucket (ADR-0052), Vault ESO ClusterSecretStore (in-DC, ADR-0049 D4), in-DC Airflow retrain URL (WS-B), no GKE WIF |
| `apps/infra/ml-monitoring/argocd-application-baremetal.yaml` | ArgoCD Application targeting `talos-uk-primary` server, sync-wave 20 (after prometheus-stack + airflow) |
| `apps/infra/ml-monitoring/alertmanager-routes-overlay-baremetal.yaml` | Alertmanager route/receiver patch for in-DC Prometheus stack; `cluster=talos-uk-primary` matcher; Vault cross-namespace ESO pattern for `alertmanager-retrain-token`; `repeat_interval: 6h` anti-storm |
| `apps/infra/observability/grafana-dashboards/templates/configmap-ml-drift-baremetal.yaml` | Grafana dashboard ConfigMap (`uid: ml-drift-accuracy-bm-v1`); distinct from cloud variant (`ml-drift-accuracy-v1`); all PromQL expressions cluster-agnostic via `platform_system="ml-monitoring"` label (ADR-0028) |
| `catalog/units/baremetal-ml-monitoring/terragrunt.hcl` | Catalog unit wiring the ArgoCD Application; `mock_outputs` for `talos-cluster` + `baremetal-rook-ceph` dependencies; ADR-0028 labels in `inputs.labels` |
| `terragrunt/uk/root.hcl` | UK bare-metal live tree root (WS-A stub; no AWS account/region concept) |
| `terragrunt/uk/{dc,env}.hcl` | UK hierarchy files (dc_name, environment) — bare-metal analogue of `account.hcl`/`region.hcl` |
| `terragrunt/uk/primary/dc.hcl` | UK primary DC override (`dc_name = "uk-primary"`) |
| `terragrunt/uk/primary/platform/baremetal-ml-monitoring/terragrunt.hcl` | Live tree shim instantiating the catalog unit for UK primary DC |
| `.github/workflows/ml-monitoring-baremetal-validate.yml` | CI gate: `helm lint` (base+overlay), `yamllint`, `terragrunt hcl fmt --check` + `validate`, ADR-0028 label count check, PR summary comment |

#### ADRs Cited

- **ADR-0038** — Evidently/whylogs drift monitoring (decision of record for WS-C)
- **ADR-0049** — Bare-metal foundation, multi-DC scope, UK-resident data (Vault KMS)
- **ADR-0052** — Rook-Ceph storage; Ceph-RGW S3 as artifact/reference-data endpoint
- **ADR-0028** — Platform taxonomy labels (mandatory on every resource)

#### Key Design Decisions Applied

- **MinIO/Ceph-RGW instead of GCS/S3** for the Evidently reference dataset bucket (ADR-0052; S3-compatible API, no change to drift-exporter code)
- **Vault-backed ESO** (`vault-cluster-secret-store`) instead of AWS Secrets Manager (ADR-0049 D4; UK data residency)
- **In-DC Airflow** as retrain webhook target (`airflow-webserver.airflow.svc.cluster.local`) instead of GKE Airflow (WS-B bare-metal)
- **Dashboard uid disambiguated** (`ml-drift-accuracy-bm-v1` vs `ml-drift-accuracy-v1`) for multi-cluster Grafana federation
- **Namespace-per-tenant** tenancy already satisfied by the existing chart design (`modelNamespaces[]` per tenant/domain)
- **`networkPolicy.enabled: false`** until WS-A Cilium enforce mode is confirmed; flip to `true` post gate

---

### Verification Results

| Gate | Result | Notes |
|---|---|---|
| `helm lint` (base values) | PASS | 0 failures |
| `helm lint` (base + baremetal overlay) | PASS | 0 failures |
| `helm template` (base + baremetal overlay + model namespace) | PASS | 13 resources rendered |
| ADR-0028 label check (`platform.system` in rendered output) | PASS | 44 occurrences |
| `yamllint` argocd-application-baremetal.yaml | PASS | warnings only (line length) |
| `yamllint` alertmanager-routes-overlay-baremetal.yaml | PASS | 0 errors |
| `yamllint` values-baremetal.yaml | PASS | warnings only (line length) |
| `terragrunt hcl fmt --check` (all HCL files) | PASS | no changes needed after auto-fmt |
| `terragrunt init -backend=false` (live tree shim) | EXPECTED ERROR | Module `terraform/modules/argocd-application` does not exist (WS-A deliverable); HCL syntax itself is valid |
| `terraform plan` | SKIPPED | No `.tf` files in WS-C scope; no cloud credentials |
| `tflint` | SKIPPED | Not installed on runner |
| `checkov` | SKIPPED | Not installed on runner |
| Pre-existing grafana-dashboards lint error (`configmap-dashboards.yaml:350`) | PRE-EXISTING | Confirmed present on `feature/baremetal-ml-platform-design` before WS-C |

---

### Blockers / Follow-ups

1. **`terraform/modules/argocd-application` module** — must be created by WS-A for `terragrunt validate` to pass end-to-end. WS-C catalog unit will validate fully once WS-A lands.
2. **`terragrunt/uk/root.hcl` backend** — stub; WS-A fills in the real remote state backend (in-DC MinIO/Ceph-RGW or Vault).
3. **`networkPolicy.enabled`** — set to `false`; flip to `true` after WS-A Cilium enforce gate (ADR-0051).
4. **`apps/infra/observability/grafana-dashboards` pre-existing lint error** — `configmap-dashboards.yaml:350` uses an undefined Helm function; not a WS-C regression.
