### PR TITLE
feat(bm-wsE): Talos SOC posture + on-call + OPA

### DIFF
--- a/apps/infra/baremetal-org-policy/Chart.yaml
+++ b/apps/infra/baremetal-org-policy/Chart.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+name: baremetal-org-policy
+description: >-
+  Talos bare-metal security-policy bundle (WS-E). Delivers the UK-DC
+  tenant-isolation Kyverno ClusterPolicies (require tenant={id} label, deny
+  cross-namespace ServiceAccount refs) to the Talos cluster as the in-cluster
+  GitOps counterpart of terraform/modules/baremetal-org-policy. Observe-first
+  (Audit) by default; promote to Enforce after a clean soak window. Reuses the
+  existing apps/infra/kyverno engine — does NOT reinstall Kyverno.
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+
+keywords:
+  - kyverno
+  - gatekeeper
+  - policy
+  - tenant-isolation
+  - soc2
+  - bare-metal
+  - talos
+  - security
+
+maintainers:
+  - name: Platform Security
+    email: platform-sec@example.com
+
+annotations:
+  category: Security & Compliance
+  platform: Kubernetes (Talos bare metal)
+  adr: "0028,0040,0049,0050"

--- a/apps/infra/baremetal-org-policy/README.md
+++ b/apps/infra/baremetal-org-policy/README.md
@@ -1,0 +1,44 @@
+# baremetal-org-policy (ArgoCD app)
+
+> **WS-E — Security posture & SOC compliance** (Bare-Metal ML Platform).
+> In-cluster GitOps delivery of the Talos tenant-isolation Kyverno policy bundle —
+> the counterpart of [`terraform/modules/baremetal-org-policy`](../../../terraform/modules/baremetal-org-policy/).
+>
+> **ADRs cited:** [ADR-0040](../../../docs/adrs/0040-soc-posture-and-oncall.md) (SOC
+> posture, reused), [ADR-0049](../../../docs/adrs/0049-baremetal-gpu-k8s-talos-foundation-multidc.md)
+> (foundation/tenant model), [ADR-0050](../../../docs/adrs/0050-talos-gpu-driver-system-extensions.md)
+> (immutable-OS posture), [ADR-0028](../../../docs/adrs/0028-unified-platform-tagging-and-labeling-taxonomy.md)
+> (taxonomy), [ADR-0020](../../../docs/adrs/0020-kyverno-and-vap-policy-engine.md)
+> (Kyverno engine — reused, **not** reinstalled).
+
+## What it ships
+
+Two `ClusterPolicy` CRs (the UK-DC Gatekeeper tenant constraints ported to Kyverno):
+
+| Policy | Effect | SOC2 |
+|---|---|---|
+| `bm-require-tenant-label` | reject Pods without a `tenant={id}` label | CC6.1 |
+| `bm-deny-cross-ns-sa` | reject Pods projecting a foreign-namespace SA token | CC6.3 |
+
+Every CR carries the ADR-0028 dotted taxonomy (`platform.system=security` …) via
+`_helpers.tpl`, so SOC2 evidence is attributable on the Grafana `$system` axis.
+
+## Apply-gating (observe-first)
+
+- The ArgoCD `Application` uses **manual sync** (no `automated:` block): the bundle
+  is **not auto-delivered**. A human applies it after blast-radius review.
+- The policies ship in **Audit** mode (`values.enforcementMode`) — violations are
+  recorded in PolicyReports, admission is not blocked. Promote to `Enforce` after a
+  clean soak window (record below).
+- Reuses the existing `apps/infra/kyverno` controller (sync wave 6, after wave 5).
+
+## Enforcement history
+
+| Date | Policy | Mode | Note |
+|---|---|---|---|
+| (design) | both | Audit | initial WS-E delivery; observe-first |
+
+## Validation
+
+`helm lint` clean; `helm template | kubeconform -ignore-missing-schemas` (CRDs
+skipped — Kyverno `ClusterPolicy` is a CRD, validated by the in-cluster controller).

--- a/apps/infra/baremetal-org-policy/argocd-application.yaml
+++ b/apps/infra/baremetal-org-policy/argocd-application.yaml
@@ -1,0 +1,59 @@
+---
+# ArgoCD Application — baremetal-org-policy (WS-E, Talos bare metal)
+#
+# Delivers the UK-DC tenant-isolation Kyverno ClusterPolicy bundle to the Talos
+# cluster. The in-cluster GitOps counterpart of terraform/modules/baremetal-org-policy.
+#
+# APPLY-GATED: syncPolicy is MANUAL (no `automated:` block) — this app does NOT
+# auto-sync. A cluster-wide admission-policy change must be applied by a human after
+# blast-radius review (ADR-0040, plan §6 control-plane gates). Observe-first: the
+# bundle ships in Audit mode (values.enforcementMode) until promoted.
+#
+# Reuses the existing apps/infra/kyverno engine (ADR-0020) — ships ONLY ClusterPolicy
+# CRs, not the Kyverno controller. Sync wave 6: after kyverno (wave 5) is ready.
+#
+# ADR-0028 / ADR-0040 / ADR-0049 / ADR-0050.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: baremetal-org-policy
+  namespace: argocd
+  labels:
+    platform.system: security
+    platform.component: org-policy
+    platform.owner: team-sec
+    platform.managed-by: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "6"
+    adr: ADR-0040
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+
+  source:
+    repoURL: https://github.com/100rd/platform-design.git
+    targetRevision: HEAD
+    path: apps/infra/baremetal-org-policy
+    helm:
+      valueFiles:
+        - values.yaml
+
+  destination:
+    # Talos UK primary DC cluster registered in ArgoCD (name matches the cluster
+    # secret). Per-DC app instances point at talos-uk-primary / talos-uk-standby.
+    name: talos-uk-primary
+    # ClusterPolicy is cluster-scoped; namespace is the app's bookkeeping namespace.
+    namespace: kyverno
+
+  # MANUAL sync only — apply-gated. No `automated:` block on purpose.
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=false
+      - ServerSideApply=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/apps/infra/baremetal-org-policy/templates/_helpers.tpl
+++ b/apps/infra/baremetal-org-policy/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{/*
+ADR-0028 platform taxonomy labels (dotted form) for the bare-metal policy bundle.
+Applied to every CR so the SOC2 evidence is attributable on the Grafana $system axis.
+*/}}
+{{- define "baremetal-org-policy.labels" -}}
+platform.system: {{ .Values.platform.system | quote }}
+platform.component: {{ .Values.platform.component | quote }}
+platform.owner: {{ .Values.platform.owner | quote }}
+platform.env: {{ .Values.platform.env | quote }}
+platform.managed-by: {{ .Values.platform.managedBy | quote }}
+app.kubernetes.io/name: baremetal-org-policy
+app.kubernetes.io/component: policy-bundle
+{{- end -}}
+
+{{/*
+Common annotations carrying ADR provenance + DC attribution + enforcement mode.
+*/}}
+{{- define "baremetal-org-policy.annotations" -}}
+adr: "ADR-0028,ADR-0040,ADR-0049,ADR-0050"
+platform-design.io/dc: {{ .Values.dc | quote }}
+platform-design.io/cluster: {{ .Values.clusterName | quote }}
+platform-design.io/enforcement-mode: {{ .Values.enforcementMode | quote }}
+{{- end -}}

--- a/apps/infra/baremetal-org-policy/templates/deny-cross-ns-sa.yaml
+++ b/apps/infra/baremetal-org-policy/templates/deny-cross-ns-sa.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.policies.denyCrossNamespaceSA.enabled }}
+---
+# Kyverno ClusterPolicy — deny cross-namespace ServiceAccount references.
+#
+# The UK-DC Gatekeeper second tenant constraint ("reject cross-namespace SA refs",
+# 06-uk-datacenters.md), ported to Kyverno. A pod's serviceAccountName resolves
+# within its OWN namespace; this policy blocks any attempt to mount a foreign-namespace
+# SA token by direct projected-volume reference. WS-E (bare metal). SOC2 CC6.3 —
+# least privilege / tenant isolation. ADR-0028 / ADR-0040 / ADR-0049 / ADR-0050.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bm-deny-cross-ns-sa
+  labels:
+    {{- include "baremetal-org-policy.labels" . | nindent 4 }}
+  annotations:
+    {{- include "baremetal-org-policy.annotations" . | nindent 4 }}
+    policies.kyverno.io/title: Deny cross-namespace ServiceAccount refs (bare-metal)
+    policies.kyverno.io/category: Multi-Tenancy
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+spec:
+  validationFailureAction: {{ .Values.enforcementMode }}
+  failurePolicy: {{ if eq .Values.enforcementMode "Enforce" }}Fail{{ else }}Ignore{{ end }}
+  background: false
+  rules:
+    - name: deny-foreign-sa-projected-token
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range .Values.excludedNamespaces }}
+                - {{ . }}
+                {{- end }}
+      validate:
+        message: >-
+          Pod may not project a ServiceAccount token from another namespace
+          (cross-namespace SA refs are denied; SOC2 CC6.3 least privilege).
+        foreach:
+          - list: "request.object.spec.volumes[?projected != null][]"
+            deny:
+              conditions:
+                any:
+                  - key: "{{`{{ element.projected.sources[?serviceAccountToken != null] | length(@) }}`}}"
+                    operator: GreaterThan
+                    value: 0
+                  # A same-namespace projected SA token is fine; a foreign one is the
+                  # case the cluster's RBAC + namespace boundary already blocks, so
+                  # this policy is the belt-and-braces admission check the UK doc names.
+{{- end }}

--- a/apps/infra/baremetal-org-policy/templates/require-tenant-label.yaml
+++ b/apps/infra/baremetal-org-policy/templates/require-tenant-label.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.policies.requireTenantLabel.enabled }}
+---
+# Kyverno ClusterPolicy — require tenant={id} label on workload pods.
+#
+# The UK-DC Gatekeeper tenant constraint ("reject pods without tenant={id}",
+# 06-uk-datacenters.md), ported to Kyverno to run on the existing apps/infra/kyverno
+# engine. WS-E (bare metal). SOC2 CC6.1 — tenant isolation. ADR-0028 / ADR-0040 /
+# ADR-0049 / ADR-0050.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bm-require-tenant-label
+  labels:
+    {{- include "baremetal-org-policy.labels" . | nindent 4 }}
+  annotations:
+    {{- include "baremetal-org-policy.annotations" . | nindent 4 }}
+    policies.kyverno.io/title: Require tenant label (bare-metal)
+    policies.kyverno.io/category: Multi-Tenancy
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+spec:
+  # Observe-first; promote to Enforce after a clean Audit soak window.
+  validationFailureAction: {{ .Values.enforcementMode }}
+  # Fail-open in Audit; tighten to Fail when promoting to Enforce.
+  failurePolicy: {{ if eq .Values.enforcementMode "Enforce" }}Fail{{ else }}Ignore{{ end }}
+  background: true
+  rules:
+    - name: require-tenant-on-pods
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      exclude:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              namespaces:
+                {{- range .Values.excludedNamespaces }}
+                - {{ . }}
+                {{- end }}
+      validate:
+        message: >-
+          Pod is missing the required tenant={id} label (bare-metal tenant
+          isolation; UK-DC Gatekeeper constraint ported to Kyverno; SOC2 CC6.1).
+        pattern:
+          metadata:
+            labels:
+              tenant: "?*"
+{{- end }}

--- a/apps/infra/baremetal-org-policy/values.yaml
+++ b/apps/infra/baremetal-org-policy/values.yaml
@@ -1,0 +1,48 @@
+# baremetal-org-policy — values (WS-E)
+#
+# The in-cluster Kyverno tenant-isolation policy bundle for the Talos bare-metal
+# estate. Observe-first: enforcementMode defaults to Audit. Reuses the existing
+# apps/infra/kyverno engine (ADR-0020) — this chart ships ONLY ClusterPolicy CRs,
+# not the Kyverno controller.
+#
+# ADR-0028 / ADR-0040 / ADR-0049 / ADR-0050.
+
+# ADR-0028 platform taxonomy (dotted form on the K8s plane). Applied to every CR.
+platform:
+  system: security
+  component: org-policy
+  owner: team-sec
+  env: prod
+  managedBy: argocd
+
+# Admission mode for the bundle: Audit (record only) or Enforce (block).
+# Promote to Enforce only after a clean Audit soak window (see README enforcement
+# history). Mirrors the terraform module's policy_enforcement_mode default.
+enforcementMode: Audit
+
+# Per-DC scoping — used only in CR names/annotations for attribution.
+dc: uk-primary
+clusterName: talos-uk-primary
+
+policies:
+  # Reject pods without a tenant={id} label (the UK-DC Gatekeeper tenant constraint,
+  # ported to Kyverno). SOC2 CC6.1.
+  requireTenantLabel:
+    enabled: true
+  # Reject pods referencing a ServiceAccount in another namespace. SOC2 CC6.3.
+  denyCrossNamespaceSA:
+    enabled: true
+
+# Namespaces excluded from the tenant-label requirement (system/infra namespaces
+# that legitimately have no tenant). Mirrors apps/infra/kyverno's exclusion set.
+excludedNamespaces:
+  - kube-system
+  - kube-public
+  - kube-node-lease
+  - kyverno
+  - gatekeeper-system
+  - external-secrets
+  - argocd
+  - monitoring
+  - rook-ceph
+  - cilium

--- a/catalog/units/baremetal-org-policy/terragrunt.hcl
+++ b/catalog/units/baremetal-org-policy/terragrunt.hcl
@@ -1,0 +1,129 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# baremetal-org-policy — Catalog Unit (WS-E — security / compliance, bare metal)
+# ---------------------------------------------------------------------------------------------------------------------
+# Binds the Talos OS security-posture assertions (immutable OS, no SSH, mTLS machine
+# API, KubePrism, no package manager) + the Kyverno/Gatekeeper tenant-isolation policy
+# bundle to a per-DC Talos cluster. Bare-metal analogue of catalog/units/gcp-org-policy.
+#
+# Two planes, both plan-safe:
+#   - Posture assertions read the OBSERVED posture from the WS-A talos-machineconfig
+#     unit (dependency, mock at plan time) and emit posture_violations.
+#   - The policy bundle is APPLY-GATED (deploy_policy_bundle = false by default): a
+#     plan creates ZERO kubectl_manifest resources. Flip to true only in CI on main
+#     after human go + blast-radius review (cluster-wide admission control).
+#
+# Dependencies (in the WS-A baremetal-gpu-analysis stack):
+#   - talos-cluster        (kubeconfig / endpoint / CA — for the kubectl provider)
+#   - talos-machineconfig  (the observed OS posture this module asserts against)
+#
+# Requires site.hcl with: dc_name, environment (mirrors the WS-B sibling unit).
+#
+# ADR-0028: Terraform-plane labels use underscore keys (platform_system); rendered
+# policy CRs carry the dotted form. ADR-0040 (SOC posture, reused) + ADR-0049
+# (foundation/posture) + ADR-0050 (immutable-OS rationale).
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/baremetal-org-policy"
+}
+
+locals {
+  site_vars = read_terragrunt_config(find_in_parent_folders("site.hcl"))
+
+  dc_name     = local.site_vars.locals.dc_name     # "uk-primary" | "uk-standby"
+  environment = local.site_vars.locals.environment # e.g. "prod"
+
+  security_config = try(local.site_vars.locals.security_config, {})
+
+  cluster_name = try(local.security_config.cluster_name, "talos-${local.dc_name}")
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPENDENCY: Talos cluster (kubeconfig + endpoint from WS-A talos-cluster unit).
+# Used to configure the kubectl provider for the (apply-gated) policy bundle.
+# ---------------------------------------------------------------------------------------------------------------------
+
+dependency "talos_cluster" {
+  config_path = "../talos-cluster"
+
+  mock_outputs = {
+    kubeconfig_raw = "apiVersion: v1\nclusters: []\ncontexts: []\nkind: Config\nusers: []"
+    endpoint       = "https://10.0.0.1:6443"
+    ca_certificate = "bW9jay1jYS1jZXJ0"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPENDENCY: Talos machine config (the OBSERVED OS posture WS-A renders). Each
+# observed_* input below is read from this unit's outputs so the posture assertion
+# compares the asserted posture against what talos-machineconfig actually produced.
+# Compliant mock defaults keep the unit green at plan time; a drifted real cluster
+# surfaces posture_violations.
+# ---------------------------------------------------------------------------------------------------------------------
+
+dependency "talos_machineconfig" {
+  config_path = "../talos-machineconfig"
+
+  mock_outputs = {
+    ssh_enabled             = false
+    machine_api_mtls        = true
+    kubeprism_enabled       = true
+    install_immutable       = true
+    package_manager_present = false
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# PROVIDERS: kubectl authenticated via the Talos cluster endpoint + CA. No static
+# credentials — the in-cluster kubeconfig is materialised by talos-cluster. In
+# plan-only/mock mode the provider is exercised against mock outputs and (because the
+# bundle is apply-gated) creates nothing.
+# ---------------------------------------------------------------------------------------------------------------------
+
+generate "baremetal_providers" {
+  path      = "baremetal_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "kubectl" {
+      host                   = "${dependency.talos_cluster.outputs.endpoint}"
+      cluster_ca_certificate = base64decode("${dependency.talos_cluster.outputs.ca_certificate}")
+      load_config_file       = false
+    }
+  PROVIDERS
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE INPUTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+inputs = {
+  cluster_name = local.cluster_name
+  dc_name      = local.dc_name
+
+  # APPLY-GATED: the Kyverno/Gatekeeper bundle is NOT delivered by default. A plan
+  # against this unit creates zero kubectl_manifest resources. Flip via site.hcl
+  # (security_config.deploy_policy_bundle = true) only in CI on main after human go.
+  deploy_policy_bundle    = try(local.security_config.deploy_policy_bundle, false)
+  policy_enforcement_mode = try(local.security_config.policy_enforcement_mode, "Audit")
+  enforce_tenant_label    = try(local.security_config.enforce_tenant_label, true)
+  enforce_no_cross_ns_sa  = try(local.security_config.enforce_no_cross_ns_sa, true)
+
+  # OBSERVED posture wired from the WS-A talos-machineconfig unit.
+  observed_ssh_enabled             = dependency.talos_machineconfig.outputs.ssh_enabled
+  observed_machine_api_mtls        = dependency.talos_machineconfig.outputs.machine_api_mtls
+  observed_kubeprism_enabled       = dependency.talos_machineconfig.outputs.kubeprism_enabled
+  observed_install_immutable       = dependency.talos_machineconfig.outputs.install_immutable
+  observed_package_manager_present = dependency.talos_machineconfig.outputs.package_manager_present
+
+  # ADR-0028 taxonomy (underscore keys on the Terraform plane).
+  labels = {
+    platform_env   = local.environment
+    platform_owner = try(local.security_config.owner, "team-sec")
+  }
+}

--- a/docs/compliance/soc2-control-matrix-baremetal.md
+++ b/docs/compliance/soc2-control-matrix-baremetal.md
@@ -1,0 +1,128 @@
+# SOC2 Control-to-Evidence Matrix — Bare-Metal (Talos) Estate
+
+> **Status:** Design-target (WS-E of the **Bare-Metal ML Platform** plan,
+> `docs/baremetal-ml-platform/IMPLEMENTATION_PLAN.md`). This is the bare-metal/Talos
+> companion to [`soc2-control-matrix.md`](soc2-control-matrix.md) (AWS + GCP). It maps
+> the SOC2 **Trust Services Criteria (2017 / CC-series)** to the controls on the
+> **owned UK-DC Talos estate** — specifically the **immutable-OS posture** the cloud
+> estates cannot offer.
+>
+> **ADRs:** [ADR-0040](../adrs/0040-soc-posture-and-oncall.md) (SOC posture + on-call,
+> reused as decision of record), [ADR-0049](../adrs/0049-baremetal-gpu-k8s-talos-foundation-multidc.md)
+> (Talos foundation / multi-DC), [ADR-0050](../adrs/0050-talos-gpu-driver-system-extensions.md)
+> (immutable-OS rationale), [ADR-0028](../adrs/0028-unified-platform-tagging-and-labeling-taxonomy.md)
+> (taxonomy). **plan/validate-only — apply-gated.**
+>
+> Nothing here is applied to real hardware (MOCK repo). The matrix describes the
+> **intended control surface**; the **Talos posture controls are evidenced as concrete
+> Terraform assertions** in [`terraform/modules/baremetal-org-policy`](../../terraform/modules/baremetal-org-policy/)
+> (`output.posture_compliant` / `output.posture_violations`), which is the WS-E
+> acceptance criterion: "the matrix references concrete Talos-config assertions."
+
+## How to read this
+
+- **Plane** — `Talos` (immutable-OS posture, asserted in `baremetal-org-policy`),
+  `K8s` (ArgoCD/Helm/Kyverno admission plane), `Storage` (Rook-Ceph/MinIO/ESO-Vault),
+  or `CI` (GitHub Actions supply chain, reused).
+- **Status** — `evidenced` (control exists in-repo and produces an auditable signal),
+  `partial`, `gap`, or `reused` (the AWS/GCP-estate control already covers it).
+- **Evidence** — a repo artifact + the runtime signal it produces (a posture
+  assertion result, an admission deny, a PolicyReport, a fired alert, a signed
+  attestation).
+- Every control carries the [ADR-0028](../adrs/0028-unified-platform-tagging-and-labeling-taxonomy.md)
+  `platform.system` taxonomy so evidence is attributable on the Grafana `$system` axis,
+  cross-estate.
+
+---
+
+## CC1 — Control Environment
+
+| Criterion | Control (repo artifact) | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC1.1 Org structure / accountability | ADR-0049/0050 ratification trail; ADR-0028 `platform.owner` on every Talos/K8s resource | — | ADR status footer; owner label per resource | evidenced |
+| CC1.3 Authority & responsibility | `platform.owner=team-sec` on the posture/policy bundle; ML co-owned with `team-ml-platform` | Talos+K8s | owner label; on-call rotation | evidenced (WS-E) |
+| CC1.4 Competence / on-call readiness | [oncall-rotation-escalation.md](../runbooks/oncall-rotation-escalation.md) + [bare-metal ML-incident runbook](../runbooks/ml-incident-runbook-baremetal.md) + [DC-failover runbook](../runbooks/uk-dc-failover.md) | — | PagerDuty schedule; tabletop record | evidenced (WS-E) |
+
+## CC5 — Control Activities (policy enforcement)
+
+| Criterion | Control | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC5.1 Control selection (admission) | Kyverno tenant-isolation bundle (`apps/infra/baremetal-org-policy` + `terraform/modules/baremetal-org-policy`) — require `tenant={id}`, deny cross-ns SA | K8s | PolicyReport / admission deny | evidenced (WS-E) |
+| CC5.2 Technology controls | Reuse `apps/infra/kyverno` + `apps/infra/gatekeeper` + `apps/infra/tetragon` on the Talos cluster | K8s | admission webhook + runtime events | partial (delivery apply-gated) |
+| CC5.3 Policy-as-code deployment | Bundle delivered via GitOps (ArgoCD, manual-sync) + Terraform `kubectl_manifest` (apply-gated) | K8s | ArgoCD app sync status; plan diff | evidenced (WS-E) |
+
+## CC6 — Logical & Physical Access
+
+| Criterion | Control | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC6.1 Access security / least privilege | **Talos no-SSH + mTLS machine API** posture assertion (`assert_no_ssh`, `assert_mtls_machine_api`); tenant-label policy | Talos+K8s | `posture_compliant` assertion; admission deny | evidenced (WS-E) |
+| CC6.2 Credential issuance | mTLS client certs for `talosctl` (no static creds); ESO/Vault for app secrets | Talos+Storage | cert-gated API; ESO ExternalSecret | reused + evidenced |
+| CC6.3 Least-privilege roles | `bm-deny-cross-ns-sa` policy; namespace-per-tenant | K8s | admission deny | evidenced (WS-E) |
+| CC6.6 Boundary protection / attack surface | **Talos minimal OS** — no shell, no sshd, no package manager (`assert_no_ssh`, `assert_no_package_manager`) | Talos | posture assertion result | evidenced (WS-E) |
+| CC6.7 Transmission protection | machine API mTLS-only (`assert_mtls_machine_api`); Cilium mTLS/WireGuard (ADR-0051) | Talos+K8s | posture assertion; CiliumNetworkPolicy | evidenced (WS-E) |
+| CC6.8 Unauthorized-software prevention | **No package manager / writable `/usr`** (`assert_no_package_manager`); GPU driver as a **signed Talos system extension** (ADR-0050) | Talos | posture assertion; image-factory manifest | evidenced (WS-E) |
+
+## CC7 — System Operations
+
+| Criterion | Control | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC7.2 Monitoring for anomalies | Reuse Prometheus/Thanos/Grafana + `talos-log-shipper`→Loki; DCGM/NCCL/BGP alerts (WS-D) | K8s | fired alert | reused |
+| CC7.3 Incident evaluation | [bare-metal ML-incident runbook](../runbooks/ml-incident-runbook-baremetal.md) (drift storm, training-queue starvation) | — | PagerDuty incident + runbook | evidenced (WS-E) |
+| CC7.4 Incident response | On-call rotation + escalation; [DC-failover runbook](../runbooks/uk-dc-failover.md) (`failover-controller`/`dns-monitor`) | — | failover event; tabletop record | evidenced (WS-E) |
+| CC7.5 Recovery / availability | **KubePrism** in-cluster API HA (`assert_kubeprism_enabled`); standby DC; etcd snapshots | Talos | posture assertion; snapshot verify | evidenced (WS-E) |
+
+## CC8 — Change Management
+
+| Criterion | Control | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| CC8.1 Change authorization & atomicity | **Talos A/B-partition immutable install + auto-rollback** (`assert_immutable_install`); apply-gated PRs; etcd snapshot before control-plane change | Talos+CI | posture assertion; PR + plan; snapshot | evidenced (WS-E) |
+
+## A1 — Availability
+
+| Criterion | Control | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| A1.1 Capacity | Fixed GPU pools + workload scale-to-zero + Volcano queues (ADR-0054); risk R1 | K8s | KEDA/HPA + queue metrics | reused |
+| A1.2 Backup & recovery | etcd snapshots; Rook-Ceph replicated pools + MinIO site-replication; CloudNativePG streaming; Velero | Talos+Storage | snapshot/restore; DR drill | partial |
+| A1.3 Recovery testing | Quarterly DR drill per [uk-dc-failover.md](../runbooks/uk-dc-failover.md) + tabletop (the UK doc states the drill runs per SOC2 CC-series) | — | drill record | evidenced (WS-E) |
+
+## C1 — Confidentiality
+
+| Criterion | Control | Plane | Evidence signal | Status |
+|---|---|---|---|---|
+| C1.1 Confidential-data identification & residency | UK-resident data stays in-DC (ADR-0049 fully-isolated ML control plane); only metrics/log aggregates cross to AWS | Storage | data-flow boundary; ESO/Vault scope | evidenced (WS-E) |
+| C1.2 Confidential-data disposal | Rook-Ceph pool deletion + Velero retention; Vault KV rotation | Storage | retention policy | partial |
+
+---
+
+## Coverage summary — what bare-metal WS-E changes
+
+The cloud matrix had strong AWS/GCP-plane controls but **no immutable-OS posture
+plane** — managed K8s hides the node OS. Bare-metal WS-E adds it:
+
+| SOC2 area | Bare-metal gap closed | New artifact |
+|---|---|---|
+| CC6.1 / CC6.6 / CC6.8 | No OS-level attack-surface control (cloud nodes are mutable) | **Talos posture assertions** in `terraform/modules/baremetal-org-policy` (no-SSH, no-pkg-mgr, mTLS API) |
+| CC5.1 / CC6.3 | No bare-metal tenant-isolation admission bundle | `apps/infra/baremetal-org-policy` (Kyverno tenant-label + cross-ns-SA deny) |
+| CC8.1 | No atomic/immutable change-management control | Talos A/B-partition immutable-install assertion |
+| CC7.5 / A1.2 | Self-operated control-plane HA + etcd backup not previously owned | KubePrism assertion + etcd-snapshot gate (plan §6) |
+| CC1.4 / CC7.3 / CC7.4 | No bare-metal ML-incident / DC-failover on-call posture | [ml-incident-runbook-baremetal.md](../runbooks/ml-incident-runbook-baremetal.md) + reused [uk-dc-failover.md](../runbooks/uk-dc-failover.md) |
+| ADR-0028 enforcement | AWS-shaped OPA rego did not gate `talos_*`/manifest resources | [`tests/opa/platform_tags_baremetal.rego`](../../tests/opa/platform_tags_baremetal.rego) (+ `_test.rego`) |
+| (all) | No bare-metal auditor-facing control map | **this matrix** |
+
+### Still-gap (tracked, not closed by WS-E)
+
+- **CC4.1** — no continuous Talos-posture drift-detection daemon yet; posture is
+  asserted at plan time, not continuously re-evaluated in-cluster (a follow-up;
+  Tetragon covers runtime, not config drift).
+- **A1.2 / C1.2** — Rook-Ceph + MinIO site-replication and Velero exist by design but
+  a tested cross-DC restore + confidential-data-disposal procedure is partial.
+- **CC5.2** — the Kyverno/Gatekeeper bundle delivery is apply-gated (manual sync), so
+  in-cluster enforcement is design-target until applied.
+
+> **Evidence-collection approach (ADR-0040 D3, reused):** evidence is pull-based and
+> repo-anchored. An auditor request resolves to: (1) the ADR, (2) the Terraform module
+> / ArgoCD app / OPA policy implementing it, (3) the `*.tftest.hcl` / `opa test` /
+> `helm template` proving it behaves, and (4) the runtime signal (posture assertion
+> result, admission deny, PolicyReport, fired alert). The Talos posture plane's
+> distinctive evidence is the **`posture_compliant` boolean + `posture_violations`
+> list** from `baremetal-org-policy`, citable per SOC2 family via `posture_soc2_map`.

--- a/docs/runbooks/ml-incident-runbook-baremetal.md
+++ b/docs/runbooks/ml-incident-runbook-baremetal.md
@@ -1,0 +1,144 @@
+# Runbook: ML-Platform Incident Response — Bare-Metal (Talos UK DC)
+
+> **Scope (WS-E):** ML-specific incidents on the **owned bare-metal Talos GPU cluster**
+> in the UK DCs — model drift, **training-queue starvation** (Volcano fair-share),
+> GPU/NCCL fabric degradation, and the control-plane-owned failure modes the managed-K8s
+> ML runbook never had (etcd quorum, KubePrism). This **extends** the cloud
+> [ML-incident runbook](ml-incident-runbook.md) and
+> [on-call rotation & escalation](oncall-rotation-escalation.md); follow those for
+> generic triage, PagerDuty ACK, and comms. Here we cover only the bare-metal ML
+> decision trees.
+>
+> **System / owner (ADR-0028):** `platform.system = ml-monitoring` / `ml-pipeline`;
+> `platform.owner = team-ml-platform`, co-owned with `team-sec` for the posture plane.
+> All alerts carry `platform_system` and route on the Grafana `$system` axis.
+>
+> **Substrate references (not re-authored here):**
+> [`ai-sre/knowledge/gpu-driver-updates.md`](../../ai-sre/knowledge/gpu-driver-updates.md),
+> [`nccl-troubleshooting.md`](../../ai-sre/knowledge/nccl-troubleshooting.md),
+> [`cilium-bgp-issues.md`](../../ai-sre/knowledge/cilium-bgp-issues.md), and the
+> [DC-failover runbook](uk-dc-failover-baremetal.md). SOC2 evidence: CC7.3 / CC7.4 in
+> the [bare-metal SOC2 matrix](../compliance/soc2-control-matrix-baremetal.md).
+>
+> **ADRs:** ADR-0040 (on-call, reused), ADR-0049 (foundation), ADR-0050 (immutable-OS),
+> ADR-0053 (GPU fabric), ADR-0054 (elasticity / fixed pools).
+
+## Severity definitions (bare-metal ML)
+
+| Severity | Definition | PagerDuty | ACK SLA |
+|---|---|---|---|
+| **SEV1** | Production serving down on the DC; or GPU fabric collapse halting all training; or etcd quorum loss | Page ML + platform on-call immediately | 5 min |
+| **SEV2** | Drift/accuracy breach on a prod model; or `training-default` queue starved > 1 h blocking a scheduled retrain | Page ML on-call | 15 min |
+| **SEV3** | Drift warning trend; single GPU XID-tainted with capacity headroom; BGP session flap with VIP still reachable | Notify Slack `#ml-incidents` | 1 h |
+
+---
+
+## Scenario 1 — Model drift / accuracy regression
+
+Identical decision tree to the [cloud runbook Scenario 1](ml-incident-runbook.md)
+(Evidently/whylogs, ADR-0038, reused unchanged) **except the retrain trigger lands on
+the in-DC Airflow**, not a cloud-hosted one (ADR-0049 isolation). The retrain webhook
+posts to the **in-DC Airflow REST** `POST /api/v1/dags/train_domain_adapter/dagRuns`.
+
+**Bare-metal-specific check:** confirm the retrain job can actually be *scheduled* —
+on fixed GPU pools a retrain competes for the same H100s as production training. Check
+the Volcano queue before assuming the retrain is stuck on data (see Scenario 2).
+
+---
+
+## Scenario 2 — Training-queue starvation (Volcano fair-share)
+
+**Symptoms / alerts:** `VolcanoQueuePending`, `MLTrainJobStarved`, a scheduled retrain
+DAG run stuck in `Pending`; `training-default` jobs not admitted.
+
+> This failure mode **does not exist on a cloud autoscaler** — there, a pending job
+> triggers a node scale-up. On bare metal capacity is **fixed** (ADR-0054), so a
+> starved queue is a *fair-share* / *prioritization* problem, not a capacity-add one.
+
+### Triage
+
+1. **Acknowledge** in PagerDuty.
+2. **Inspect the Volcano queues** (taxonomy from `06-uk-datacenters.md`):
+   ```bash
+   # Which queue is starved, and who holds the GPUs?
+   kubectl get queues.scheduling.volcano.sh -o wide
+   kubectl get podgroups -A \
+     -l platform.system=ml-pipeline \
+     -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,STATUS:.status.phase,QUEUE:.spec.queue
+   ```
+3. **Find the GPU holder** — a long-running `training-bootstrap` or a runaway
+   `eval-judge` job can monopolize the H100 pool.
+
+### Decision tree
+
+| Finding | Action |
+|---|---|
+| A **bootstrap/eval job overran** its expected runtime | Confirm with the owning team; if abandoned, `kubectl delete podgroup` to free GPUs. Record in postmortem; consider a Volcano `maxAllocated` cap on that queue. |
+| Genuine **contention** — all GPUs busy with legitimate prod training | Escalate to capacity decision: (a) let the retrain wait, (b) preempt a lower-priority `batch-rescore` job (Volcano preemption), or (c) pin the retrain to the standby DC's headroom (~40%, UK doc). **Never** migrate a gang-scheduled in-flight job (ADR-0054 — re-queue, don't relocate). |
+| **`training-urgent` needed** for an incident retrain | Submit to `training-urgent` (cap 2 — reserved for incidents); it preempts. Document the preemption. |
+| Queue weights themselves are wrong | Tune the queue `weight` in `baremetal-gpu-scheduling` via PR (apply-gated); do not hand-edit live queues without a change record (SOC2 CC8.1). |
+
+### Free a starved queue safely
+
+```bash
+# Preempt a reclaimable batch job to admit an urgent retrain (Volcano honours
+# queue weights + reclaimable=true). Confirm the batch job is checkpoint-safe first.
+kubectl label podgroup -n batch <pg-name> volcano.sh/preemptable=true --overwrite
+```
+
+---
+
+## Scenario 3 — GPU / NCCL fabric degradation
+
+**Symptoms / alerts:** `DCGMXidError`, `NCCLAllReduceBelowFloor`, `NVLinkError`,
+training throughput collapse, collectives silently falling back to TCP.
+
+### Triage
+
+1. **Acknowledge**; classify single-GPU vs fabric-wide.
+2. **DCGM first** (the auto-taint CronJob from `baremetal-gpu-dcgm` may have already
+   tainted a node on an XID burst):
+   ```bash
+   kubectl get nodes -l nvidia.com/gpu.present=true \
+     -o custom-columns=NODE:.metadata.name,TAINTS:.spec.taints
+   ```
+3. **NCCL / fabric** — follow
+   [`nccl-troubleshooting.md`](../../ai-sre/knowledge/nccl-troubleshooting.md): check
+   the all-reduce bandwidth test (the ADR-0053 acceptance gate), jumbo-frame MTU 9000,
+   and RoCE/IB topology.
+
+### Decision tree
+
+| Finding | Action |
+|---|---|
+| Single GPU **XID-tainted**, pool has headroom | Let the auto-taint hold; jobs reschedule onto healthy GPUs. Open a hardware ticket; follow `gpu-driver-updates.md` if driver-related. |
+| **Fabric-wide** NCCL collapse (all-reduce below floor) | SEV1. Likely RoCE/IB misconfig or a ToR/subnet-manager fault. Pause new training admissions (Volcano), engage network on-call, run the NCCL pre-flight. Do **not** let jobs limp on a TCP fallback — fail fast. |
+| Driver/extension skew after a Talos upgrade (risk R2) | Roll back the Talos A/B partition (auto-rollback should have fired); stage the fix on the **standby DC first**. The driver is a **system extension** — there is no `apt` rollback; it is an image revert (ADR-0050). |
+| **Cilium BGP flap** dropping a serving VIP | Follow [`cilium-bgp-issues.md`](../../ai-sre/knowledge/cilium-bgp-issues.md) (hold-timer 180 s, ToR max-prefix); MetalLB L2 is the documented fallback (ADR-0051). |
+
+---
+
+## Scenario 4 — Control-plane / etcd (self-operated — new vs managed K8s)
+
+**Symptoms / alerts:** `EtcdQuorumLost`, `KubeAPIUnreachable`, control-plane node
+NotReady. **Managed K8s hid this; on bare metal we own it (ADR-0049, risk R3).**
+
+### Triage & decision tree
+
+| Finding | Action |
+|---|---|
+| One control-plane node down, **quorum intact** | KubePrism keeps the in-cluster API serving (`assert_kubeprism_enabled`). Re-image the node via Cluster-API/Sidero (ADR-0054); do not panic-drain. |
+| **Quorum lost** (≥2 of 3 CP nodes down) | SEV1. Restore from the **verified etcd snapshot** (taken before every CP change per plan §6). Follow the etcd restore procedure; if unrecoverable in-DC, fail over to the standby DC ([DC-failover runbook](uk-dc-failover-baremetal.md)). |
+| About to change a control-plane `MachineConfig` | **Take + verify an etcd snapshot first** (plan §6 gate); check quorum before draining a CP node. This is the CC8.1 evidence. |
+
+---
+
+## Cross-references
+
+- Drift mechanics + retrain-storm suppression: [cloud ML runbook](ml-incident-runbook.md)
+  (reused — Evidently/whylogs are cluster-agnostic).
+- On-call rotation / escalation / tabletop: [oncall-rotation-escalation.md](oncall-rotation-escalation.md).
+- DC-level failover (lose the whole primary DC): [uk-dc-failover-baremetal.md](uk-dc-failover-baremetal.md)
+  and the existing [uk-dc-failover.md](uk-dc-failover.md).
+- SOC2 evidence anchor: CC7.3 / CC7.4 in
+  [soc2-control-matrix-baremetal.md](../compliance/soc2-control-matrix-baremetal.md).

--- a/docs/runbooks/uk-dc-failover-baremetal.md
+++ b/docs/runbooks/uk-dc-failover-baremetal.md
@@ -1,0 +1,83 @@
+# Runbook: ML-Platform DC Failover — Bare-Metal (Talos UK DCs)
+
+> **Scope (WS-E):** the **ML-platform view** of a UK-DC failover on the owned Talos
+> estate — what happens to **GPU serving**, **in-flight training**, **MLflow/registry
+> state**, and the **Talos control plane** when the primary DC is lost. This is a thin
+> companion to the authoritative trading-platform
+> [DC-failover runbook](uk-dc-failover.md) (data tiers, RPO/RTO, QuestDB/PG/Iceberg) —
+> **follow that for the data-plane failover**; this doc covers only the ML-platform
+> and Talos-cluster decisions layered on top.
+>
+> **Reuse, don't reinvent:** failover is driven by the existing
+> [`failover-controller/`](../../failover-controller/) (Go, raft, anti-split-brain) +
+> [`dns-monitor/`](../../dns-monitor/) — WS-E adds **no new failover machinery**
+> (ADR-0049 §7 decision 8: independent per-DC clusters + DNS/health failover, NOT a
+> stretched ClusterMesh).
+>
+> **Targets (from the trading runbook):** RPO < 60 s; RTO < 15 min planned / < 30 min
+> unplanned. **SOC2 evidence:** CC7.4 / A1.2 / A1.3 in the
+> [bare-metal SOC2 matrix](../compliance/soc2-control-matrix-baremetal.md); the
+> quarterly DR drill runs per the SOC2 CC-series (UK doc).
+>
+> **ADRs:** ADR-0049 (multi-DC foundation), ADR-0052 (Rook-Ceph/MinIO replication),
+> ADR-0054 (elasticity — training is DC-pinned), ADR-0040 (on-call, reused).
+
+## 1. The load-bearing rule
+
+| Workload class | Failover behaviour |
+|---|---|
+| **GPU serving** (vLLM / inference) | **Fails over.** `failover-controller` promotes the standby DC; `dns-monitor` repoints the serving VIP. Standby is sized ~40% (UK doc) to absorb the serving load, not to co-work. |
+| **In-flight training / eval** (gang-scheduled GPU jobs) | **NOT migrated.** Gang-scheduled jobs are not safely relocatable (ADR-0054, same rule as ADR-0036 D5). They are **DC-pinned and re-queued** on recovery — checkpoint-resume from the last MLflow/MinIO checkpoint, not live-migrated. |
+| **MLflow / registry state** | Reads fail over (Postgres streaming replica + MinIO site-replication / Ceph-RGW). Writes resume on the promoted DC. |
+| **Talos control plane** | Each DC runs its **own** control plane + etcd (independent clusters). No cross-DC quorum to lose; the standby cluster is already up. |
+
+## 2. Pre-failover verification (ML-platform additions)
+
+Do the [trading runbook §3 data checks](uk-dc-failover.md#3-replication--site-replication-verification) first, then:
+
+```bash
+# MinIO site-replication / Ceph-RGW object lag for the MLflow artifact bucket.
+mc admin replicate status uk-primary/ uk-standby/ --json | jq '.maxLag'
+
+# Standby Talos cluster + GPU pool ready to absorb serving?
+kubectl --context talos-uk-standby get nodes -l nvidia.com/gpu.present=true \
+  -o custom-columns=NODE:.metadata.name,READY:.status.conditions[-1].type
+
+# Standby KubePrism / API reachable (the standby cluster must already be healthy).
+kubectl --context talos-uk-standby get --raw='/readyz?verbose'
+```
+
+*Criteria:* artifact replication lag < 60 s; standby GPU pool Ready; standby API `ok`.
+
+## 3. Failover (ML-platform steps)
+
+> The `failover-controller` performs the promotion + DNS cutover. These are the
+> **ML-platform-specific** actions around it — none are `apply` against this mock; in
+> a real incident they run under the on-call's authority.
+
+1. **Acknowledge** the PagerDuty incident (`platform-oncall` + `ml-pipeline`).
+2. Let `failover-controller` promote standby + `dns-monitor` repoint serving VIPs
+   (do **not** hand-edit DNS — anti-split-brain raft owns it).
+3. **Drain the dead DC's training queue intent:** mark the primary's in-flight
+   `training-*` PodGroups as re-queue-on-recovery (they are lost, not migrated). Record
+   which jobs to resume.
+4. **Point the in-DC Airflow + MLflow** at the standby Postgres replica (now primary)
+   and the standby MinIO/Ceph-RGW endpoint. Serving + registry reads resume.
+5. **Verify serving** on the standby DC (a canary inference request returns); confirm
+   `platform.system=ml-pipeline` dashboards are green on the standby.
+
+## 4. Failback
+
+1. Restore the primary DC's Talos cluster (re-image via Cluster-API/Sidero if needed).
+2. Reverse MinIO/Ceph + Postgres replication direction; verify lag < 60 s.
+3. **Re-queue the training jobs** captured in step 3 above onto the primary's
+   `training-default` queue (checkpoint-resume from MLflow/MinIO).
+4. Cut serving back via `failover-controller` (planned failback, RTO < 15 min).
+
+## 5. DR drill (SOC2 A1.3 evidence)
+
+Run quarterly per the SOC2 CC-series (UK doc). The drill exercises: replication-lag
+verification, a controlled `failover-controller` promotion to standby, a canary
+serving request on standby, a training-job re-queue, and failback. Record the drill in
+the [on-call runbook](oncall-rotation-escalation.md) tabletop log — this is the CC7.4 /
+A1.3 evidence cited in the [SOC2 matrix](../compliance/soc2-control-matrix-baremetal.md).

--- a/terraform/modules/baremetal-org-policy/README.md
+++ b/terraform/modules/baremetal-org-policy/README.md
@@ -1,0 +1,77 @@
+# baremetal-org-policy
+
+> **WS-E — Security posture & SOC compliance** (Bare-Metal ML Platform).
+> Bare-metal/Talos analogue of [`gcp-org-policy`](../gcp-org-policy/) and the AWS
+> `iam-baseline` + `scps` guardrails.
+>
+> **ADRs cited:** [ADR-0040](../../../docs/adrs/0040-soc-posture-and-oncall.md)
+> (SOC posture + on-call, reused as decision of record),
+> [ADR-0049](../../../docs/adrs/0049-baremetal-gpu-k8s-talos-foundation-multidc.md)
+> (Talos foundation / multi-DC — the posture IS a WS-A property this module asserts),
+> [ADR-0050](../../../docs/adrs/0050-talos-gpu-driver-system-extensions.md)
+> (immutable-OS security rationale: no package manager, system-extension driver),
+> [ADR-0028](../../../docs/adrs/0028-unified-platform-tagging-and-labeling-taxonomy.md)
+> (platform taxonomy).
+>
+> **plan/validate-only — apply-gated.** This is a MOCK/emulation repo. Nothing here
+> is applied to a real Talos cluster. The policy bundle is **default-OFF**
+> (`deploy_policy_bundle = false`): a plan creates **zero** resources.
+
+## What it does
+
+The Talos estate has no cloud org-policy API. This module delivers guardrail parity
+on two **plan-safe** planes:
+
+### 1. Talos OS posture assertions (immutable-OS controls)
+
+Compares the **expected** Talos security posture (the `assert_*` toggles) against the
+**observed** posture (the `observed_*` inputs, wired from WS-A's `talos-machineconfig`
+through a `dependency` block) and emits `posture_violations` + a `posture_compliant`
+boolean — pure computation, never touches a cluster. Each assertion maps to a SOC2
+control family, so the [SOC2 control-to-evidence matrix](../../../docs/compliance/soc2-control-matrix-baremetal.md)
+can cite a concrete Terraform assertion (the WS-E acceptance criterion).
+
+| Assertion | Talos posture | SOC2 |
+|---|---|---|
+| `no_ssh` | no shell, no sshd, no shell-opening kernel args | CC6.1 / CC6.6 |
+| `mtls_machine_api` | machine API mTLS-only, strict client-cert auth | CC6.1 / CC6.7 |
+| `kubeprism` | `machine.features.kubePrism` enabled (in-cluster API HA) | A1.2 / CC7.5 |
+| `immutable_install` | immutable install disk; A/B atomic upgrade + auto-rollback | CC8.1 |
+| `no_package_manager` | no package manager / writable `/usr` (driver via system extension) | CC6.8 |
+
+### 2. Kyverno/Gatekeeper admission policy bundle (as code)
+
+Renders the UK-DC tenant-isolation constraints (the `06-uk-datacenters.md` Gatekeeper
+constraints, ported to Kyverno `ClusterPolicy`): **require `tenant={id}` label** and
+**deny cross-namespace ServiceAccount references**. The bundle is **rendered into
+outputs for plan review even when not deployed**; it is only materialised as
+`kubectl_manifest` resources when `deploy_policy_bundle = true` (CI on `main`, after
+human go + blast-radius review).
+
+## Apply-gating
+
+| Plane | Default | Creates infra? |
+|---|---|---|
+| Posture assertions (locals/outputs) | always evaluated | no — pure computation |
+| Policy bundle (`kubectl_manifest.policy`) | `deploy_policy_bundle = false` | **no** — `for_each` is empty |
+
+## ADR-0028 taxonomy
+
+`platform_system = security`, `platform_component = org-policy` on the Terraform plane
+(underscore form, recorded for provenance — neither posture assertions nor CR bindings
+are labelable Terraform resources). Rendered CRs carry the **dotted** form
+(`platform.system`, `platform.managed-by`) in `metadata.labels`.
+
+## Usage (via the catalog unit)
+
+Wired in [`catalog/units/baremetal-org-policy`](../../../catalog/units/baremetal-org-policy/)
+with the Talos kubeconfig from the `talos-cluster` dependency (mocked at plan time)
+and the observed posture from `talos-machineconfig`. See the unit for the provider
+generation pattern (no static credentials).
+
+## Tests
+
+`terraform test` (`baremetal-org-policy.tftest.hcl`, mocked providers): 12 runs —
+posture compliance, per-assertion drift detection + SOC2 mapping, staged carve-outs,
+bundle rendering, the **default-OFF apply gate** (`length(kubectl_manifest.policy) == 0`),
+dotted-label re-keying, enforce-mode threading, and input validation.

--- a/terraform/modules/baremetal-org-policy/baremetal-org-policy.tftest.hcl
+++ b/terraform/modules/baremetal-org-policy/baremetal-org-policy.tftest.hcl
@@ -1,0 +1,260 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests for the baremetal-org-policy module (WS-E — security / compliance).
+# Mocked talos + kubectl providers — no real Talos cluster / credentials required.
+# These are plan-time assertions over the module's posture-evaluation and
+# policy-bundle-rendering logic. No policy CR is ever applied (deploy_policy_bundle
+# defaults false, so the kubectl_manifest for_each is empty).
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "talos" {}
+mock_provider "kubectl" {}
+
+variables {
+  cluster_name = "talos-uk-primary"
+  dc_name      = "uk-primary"
+
+  labels = {
+    platform_env   = "production"
+    platform_owner = "team-sec"
+  }
+}
+
+# -------------------------------------------------------------------------------------------------------------------
+# Default posture: all five assertions ON, observed posture compliant => no violations.
+# -------------------------------------------------------------------------------------------------------------------
+run "compliant_posture_has_no_violations" {
+  command = plan
+
+  assert {
+    condition     = output.posture_compliant == true
+    error_message = "With a compliant observed posture and all assertions on, posture_compliant must be true."
+  }
+
+  assert {
+    condition     = length(output.posture_violations) == 0
+    error_message = "A compliant posture must yield zero posture_violations."
+  }
+
+  assert {
+    condition     = length(output.active_assertions) == 5
+    error_message = "All five Talos posture assertions (no-ssh, mtls, kubeprism, immutable, no-pkg-mgr) must be active by default."
+  }
+}
+
+# -------------------------------------------------------------------------------------------------------------------
+# A drifted node (SSH enabled) must surface a no_ssh violation mapped to its SOC2 family.
+# -------------------------------------------------------------------------------------------------------------------
+run "ssh_enabled_drift_is_flagged" {
+  command = plan
+
+  variables {
+    observed_ssh_enabled = true
+  }
+
+  assert {
+    condition     = output.posture_compliant == false
+    error_message = "An SSH-enabled node must make the posture non-compliant."
+  }
+
+  assert {
+    condition     = length(output.posture_violations) == 1
+    error_message = "Exactly one violation (no_ssh) must be reported when SSH is the only drift."
+  }
+
+  assert {
+    condition     = output.posture_violations[0].assertion == "no_ssh"
+    error_message = "The flagged violation must be the no_ssh assertion."
+  }
+
+  assert {
+    condition     = output.posture_violations[0].soc2 == "CC6.1/CC6.6"
+    error_message = "The no_ssh violation must carry its SOC2 control family CC6.1/CC6.6."
+  }
+}
+
+# -------------------------------------------------------------------------------------------------------------------
+# KubePrism disabled + plaintext machine API => two violations.
+# -------------------------------------------------------------------------------------------------------------------
+run "multiple_drift_reports_each_violation" {
+  command = plan
+
+  variables {
+    observed_kubeprism_enabled = false
+    observed_machine_api_mtls  = false
+  }
+
+  assert {
+    condition     = length(output.posture_violations) == 2
+    error_message = "Two simultaneous drifts (kubeprism off, mtls off) must produce two violations."
+  }
+}
+
+# -------------------------------------------------------------------------------------------------------------------
+# Turning an assertion OFF (staged carve-out) removes it from active_assertions and
+# means its drift is NOT flagged.
+# -------------------------------------------------------------------------------------------------------------------
+run "disabling_assertion_silences_its_drift" {
+  command = plan
+
+  variables {
+    assert_no_ssh        = false
+    observed_ssh_enabled = true
+  }
+
+  assert {
+    condition     = length(output.active_assertions) == 4
+    error_message = "Disabling assert_no_ssh must drop active assertions to four."
+  }
+
+  assert {
+    condition     = output.posture_compliant == true
+    error_message = "With the no_ssh assertion disabled, an SSH drift must not break compliance."
+  }
+}
+
+# -------------------------------------------------------------------------------------------------------------------
+# Posture -> SOC2 map is populated for every active assertion.
+# -------------------------------------------------------------------------------------------------------------------
+run "soc2_map_covers_every_assertion" {
+  command = plan
+
+  assert {
+    condition     = output.posture_soc2_map["kubeprism"] == "A1.2/CC7.5"
+    error_message = "kubeprism must map to SOC2 A1.2/CC7.5."
+  }
+
+  assert {
+    condition     = output.posture_soc2_map["no_package_manager"] == "CC6.8"
+    error_message = "no_package_manager must map to SOC2 CC6.8 (unauthorized software)."
+  }
+}
+
+# -------------------------------------------------------------------------------------------------------------------
+# Policy bundle: built-ins rendered, named per cluster, DEFAULT-OFF (not deployed).
+# -------------------------------------------------------------------------------------------------------------------
+run "default_renders_two_builtin_policies_not_deployed" {
+  command = plan
+
+  assert {
+    condition     = length(output.policy_bundle_names) == 2
+    error_message = "By default both built-in tenant policies (require-tenant-label, deny-cross-ns-sa) must render."
+  }
+
+  assert {
+    condition     = contains(output.policy_bundle_names, "require-tenant-label")
+    error_message = "The require-tenant-label built-in must be in the bundle."
+  }
+
+  assert {
+    condition     = output.policy_bundle_deployed == false
+    error_message = "deploy_policy_bundle defaults false — the bundle must NOT be delivered in plan-only mode."
+  }
+
+  assert {
+    condition     = length(kubectl_manifest.policy) == 0
+    error_message = "With deploy_policy_bundle = false, zero kubectl_manifest resources must be planned (apply-gated)."
+  }
+}
+
+# -------------------------------------------------------------------------------------------------------------------
+# Rendered CR carries the cluster-scoped name + the dotted ADR-0028 labels.
+# -------------------------------------------------------------------------------------------------------------------
+run "rendered_policy_carries_taxonomy_and_name" {
+  command = plan
+
+  assert {
+    condition     = strcontains(output.policy_bundle_yaml["require-tenant-label"], "bm-talos-uk-primary-require-tenant-label")
+    error_message = "The tenant-label policy must be named bm-<cluster>-require-tenant-label."
+  }
+
+  assert {
+    condition     = strcontains(output.policy_bundle_yaml["require-tenant-label"], "\"platform.system\": \"security\"")
+    error_message = "The rendered CR must carry the dotted ADR-0028 platform.system label."
+  }
+
+  assert {
+    condition     = strcontains(output.policy_bundle_yaml["require-tenant-label"], "\"platform.owner\": \"team-sec\"")
+    error_message = "Caller label override (platform_owner = team-sec) must be re-keyed to dotted form in the CR."
+  }
+}
+
+# -------------------------------------------------------------------------------------------------------------------
+# Disabling a built-in policy removes it from the bundle.
+# -------------------------------------------------------------------------------------------------------------------
+run "disabling_builtin_removes_it" {
+  command = plan
+
+  variables {
+    enforce_no_cross_ns_sa = false
+  }
+
+  assert {
+    condition     = length(output.policy_bundle_names) == 1
+    error_message = "Disabling enforce_no_cross_ns_sa must leave only the tenant-label policy."
+  }
+
+  assert {
+    condition     = !contains(output.policy_bundle_names, "deny-cross-ns-sa")
+    error_message = "deny-cross-ns-sa must be absent when its toggle is false."
+  }
+}
+
+# -------------------------------------------------------------------------------------------------------------------
+# Enforcement mode flows into the rendered CR.
+# -------------------------------------------------------------------------------------------------------------------
+run "enforce_mode_threads_into_cr" {
+  command = plan
+
+  variables {
+    policy_enforcement_mode = "Enforce"
+  }
+
+  assert {
+    condition     = strcontains(output.policy_bundle_yaml["require-tenant-label"], "\"validationFailureAction\": \"Enforce\"")
+    error_message = "policy_enforcement_mode = Enforce must set validationFailureAction: Enforce in the CR."
+  }
+}
+
+# -------------------------------------------------------------------------------------------------------------------
+# platform_labels default to the security system with the caller override merged.
+# -------------------------------------------------------------------------------------------------------------------
+run "platform_labels_default_security_system" {
+  command = plan
+
+  assert {
+    condition     = output.platform_labels["platform_system"] == "security"
+    error_message = "platform_system must default to security for this module."
+  }
+
+  assert {
+    condition     = output.platform_labels["platform_owner"] == "team-sec"
+    error_message = "Caller label override (platform_owner = team-sec) must be merged in."
+  }
+}
+
+# -------------------------------------------------------------------------------------------------------------------
+# Validation: reject a non-UK dc_name and a malformed cluster_name.
+# -------------------------------------------------------------------------------------------------------------------
+run "rejects_invalid_dc_name" {
+  command = plan
+
+  variables {
+    dc_name = "us-east-1"
+  }
+
+  expect_failures = [
+    var.dc_name,
+  ]
+}
+
+run "rejects_malformed_cluster_name" {
+  command = plan
+
+  variables {
+    cluster_name = "Talos_UK_Primary"
+  }
+
+  expect_failures = [
+    var.cluster_name,
+  ]
+}

--- a/terraform/modules/baremetal-org-policy/main.tf
+++ b/terraform/modules/baremetal-org-policy/main.tf
@@ -1,0 +1,209 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# baremetal-org-policy — Talos OS security-posture assertions + Kyverno/Gatekeeper
+# policy bundle as code (WS-E — security / compliance).
+# ---------------------------------------------------------------------------------------------------------------------
+# This module is the bare-metal analogue of terraform/modules/gcp-org-policy. The
+# Talos estate has no cloud org-policy API, so guardrail parity is delivered as:
+#
+#   AWS/GCP control (in-repo)                     Bare-metal/Talos parity (this module)
+#   ------------------------------------------    -------------------------------------------------
+#   iam-baseline MFA / no static creds            Talos mTLS machine API, no SSH/shell (posture assertion)
+#   gcp.requireOsLogin / no project SSH keys      Talos no-SSH posture assertion (no shell path at all)
+#   scps deny_public + S3 PAB                     Kyverno default-deny + tenant-isolation policy bundle
+#   iam-baseline immutable/atomic change          Talos A/B-partition immutable install assertion
+#   gcp.restrictNonCmekServices                   (handled by ESO/Vault + Rook-Ceph at-rest, out of scope here)
+#
+# Two planes, both PLAN-SAFE:
+#   1. Posture assertions (locals) — compares the EXPECTED Talos posture (assert_*)
+#      against the OBSERVED posture (observed_*, wired from WS-A talos-machineconfig)
+#      and emits posture_violations. Pure computation; never touches a cluster. This
+#      is the artifact the SOC2 matrix cites for the immutable-OS controls.
+#   2. Policy bundle (kubectl_manifest) — Kyverno/Gatekeeper CRs delivered as code,
+#      DEFAULT-OFF (deploy_policy_bundle = false => for_each is empty => zero
+#      resources). Plan-only renders the bundle into outputs for review.
+#
+# ADR-0028: rendered CR labels carry the dotted taxonomy (platform.system); the
+# Terraform plane records the underscore form for provenance (see local below).
+# ADR-0040 (SOC posture, reused) + ADR-0049 (foundation) + ADR-0050 (immutable-OS).
+#
+# plan/validate-only — apply is gated behind explicit human approval + blast-radius
+# review. A policy-bundle change is cluster-wide admission control and must never
+# auto-apply.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  # ADR-0028 baseline taxonomy for this system, merged with caller overrides.
+  # Underscore form on the Terraform plane (recorded for provenance).
+  platform_labels = merge(
+    {
+      platform_system     = "security"
+      platform_component  = "org-policy"
+      platform_managed_by = "terragrunt"
+    },
+    var.labels,
+  )
+
+  # Dotted form for the K8s/CR plane (ADR-0028). Re-key the leading "platform_"
+  # prefix to "platform." and any remaining underscore to a hyphen, so
+  # platform_managed_by -> platform.managed-by (NOT platform.managed.by), matching
+  # the established dotted taxonomy keys (platform.system / .component / .owner /
+  # .env / .managed-by) used across apps/infra/kyverno.
+  cr_labels = {
+    for k, v in local.platform_labels :
+    replace(replace(k, "platform_", "platform."), "_", "-") => v
+  }
+
+  # -------------------------------------------------------------------------------------------------------------------
+  # Posture assertions. Each entry: { asserted, observed_ok, soc2 }. observed_ok is
+  # the boolean "the observed posture satisfies the assertion". A violation is an
+  # assertion that is asserted = true but observed_ok = false.
+  # -------------------------------------------------------------------------------------------------------------------
+  posture = {
+    no_ssh = {
+      asserted    = var.assert_no_ssh
+      observed_ok = var.observed_ssh_enabled == false
+      soc2        = "CC6.1/CC6.6"
+      desc        = "Talos exposes no SSH/shell path (no sshd, no extra kernel args opening a shell)"
+    }
+    mtls_machine_api = {
+      asserted    = var.assert_mtls_machine_api
+      observed_ok = var.observed_machine_api_mtls == true
+      soc2        = "CC6.1/CC6.7"
+      desc        = "Talos machine API is mTLS-only with strict client-cert auth (no plaintext)"
+    }
+    kubeprism = {
+      asserted    = var.assert_kubeprism_enabled
+      observed_ok = var.observed_kubeprism_enabled == true
+      soc2        = "A1.2/CC7.5"
+      desc        = "machine.features.kubePrism enabled (in-cluster API HA, no API VIP SPOF)"
+    }
+    immutable_install = {
+      asserted    = var.assert_immutable_install
+      observed_ok = var.observed_install_immutable == true
+      soc2        = "CC8.1"
+      desc        = "Immutable install disk; A/B-partition atomic upgrade with auto-rollback"
+    }
+    no_package_manager = {
+      asserted    = var.assert_no_package_manager
+      observed_ok = var.observed_package_manager_present == false
+      soc2        = "CC6.8"
+      desc        = "No package manager / writable /usr (GPU driver via Talos system extension, ADR-0050)"
+    }
+  }
+
+  # The set of assertions that are turned ON.
+  active_assertions = {
+    for k, v in local.posture : k => v if v.asserted
+  }
+
+  # Violations: asserted but observed posture does not satisfy it.
+  posture_violations = [
+    for k, v in local.active_assertions : {
+      assertion = k
+      soc2      = v.soc2
+      detail    = v.desc
+    } if v.observed_ok == false
+  ]
+
+  posture_compliant = length(local.posture_violations) == 0
+
+  # -------------------------------------------------------------------------------------------------------------------
+  # Built-in Kyverno tenant-isolation policy bundle (the UK doc's Gatekeeper tenant
+  # constraints, ported to Kyverno ClusterPolicy). Rendered as YAML strings; only
+  # materialised as kubectl_manifest when deploy_policy_bundle = true.
+  # -------------------------------------------------------------------------------------------------------------------
+  builtin_policies = merge(
+    var.enforce_tenant_label ? {
+      "require-tenant-label" = yamlencode({
+        apiVersion = "kyverno.io/v1"
+        kind       = "ClusterPolicy"
+        metadata = {
+          name   = "bm-${var.cluster_name}-require-tenant-label"
+          labels = local.cr_labels
+          annotations = {
+            adr                                   = "ADR-0028,ADR-0040,ADR-0049"
+            "policies.kyverno.io/title"           = "Require tenant label (bare-metal)"
+            "policies.kyverno.io/category"        = "Multi-Tenancy"
+            "platform-design.io/dc"               = var.dc_name
+            "platform-design.io/enforcement-mode" = var.policy_enforcement_mode
+          }
+        }
+        spec = {
+          validationFailureAction = var.policy_enforcement_mode
+          background              = true
+          rules = [{
+            name  = "require-tenant-on-pods"
+            match = { any = [{ resources = { kinds = ["Pod"] } }] }
+            exclude = { any = [{ resources = { namespaces = [
+              "kube-system", "kube-public", "kube-node-lease", "kyverno",
+              "gatekeeper-system", "external-secrets", "argocd", "monitoring",
+            ] } }] }
+            validate = {
+              message = "Pod is missing the required tenant={id} label (bare-metal tenant isolation, ADR-0049 / UK-DC Gatekeeper constraint)."
+              pattern = { metadata = { labels = { tenant = "?*" } } }
+            }
+          }]
+        }
+      })
+    } : {},
+    var.enforce_no_cross_ns_sa ? {
+      "deny-cross-ns-sa" = yamlencode({
+        apiVersion = "kyverno.io/v1"
+        kind       = "ClusterPolicy"
+        metadata = {
+          name   = "bm-${var.cluster_name}-deny-cross-ns-sa"
+          labels = local.cr_labels
+          annotations = {
+            adr                                   = "ADR-0028,ADR-0040,ADR-0049"
+            "policies.kyverno.io/title"           = "Deny cross-namespace ServiceAccount refs (bare-metal)"
+            "policies.kyverno.io/category"        = "Multi-Tenancy"
+            "platform-design.io/dc"               = var.dc_name
+            "platform-design.io/enforcement-mode" = var.policy_enforcement_mode
+          }
+        }
+        spec = {
+          validationFailureAction = var.policy_enforcement_mode
+          background              = false
+          rules = [{
+            name  = "deny-foreign-sa"
+            match = { any = [{ resources = { kinds = ["Pod"] } }] }
+            validate = {
+              message = "Pod may not reference a ServiceAccount in another namespace (cross-namespace SA refs are denied; SOC2 CC6.3 least privilege)."
+              deny = {
+                conditions = {
+                  any = [{
+                    key      = "{{ request.object.spec.serviceAccountName || '' }}"
+                    operator = "AnyIn"
+                    value    = ["system:serviceaccount:*"]
+                  }]
+                }
+              }
+            }
+          }]
+        }
+      })
+    } : {},
+  )
+
+  # Full bundle = built-ins + caller-supplied extras.
+  policy_bundle = merge(local.builtin_policies, var.policy_bundle_manifests)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Policy bundle delivery — APPLY-GATED / DEFAULT-OFF.
+# When deploy_policy_bundle = false (default) the for_each collapses to an empty map
+# and NO kubectl_manifest resource is created: a plan against this module creates
+# zero infra. When explicitly enabled (CI on main, after human go), each bundle entry
+# becomes one CR. The kubectl provider is configured at the catalog-unit layer from
+# the talos-cluster kubeconfig (mock at plan time) — no static credentials here.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubectl_manifest" "policy" {
+  for_each = var.deploy_policy_bundle ? local.policy_bundle : {}
+
+  yaml_body = each.value
+
+  # Server-side apply so CRDs (Kyverno/Gatekeeper) are validated by the API server.
+  server_side_apply = true
+  wait              = false
+}

--- a/terraform/modules/baremetal-org-policy/outputs.tf
+++ b/terraform/modules/baremetal-org-policy/outputs.tf
@@ -1,0 +1,50 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Outputs for the baremetal-org-policy module (WS-E — security / compliance).
+# ---------------------------------------------------------------------------------------------------------------------
+
+output "cluster_name" {
+  description = "The Talos cluster this posture/policy bundle binds to."
+  value       = var.cluster_name
+}
+
+output "active_assertions" {
+  description = "Talos OS posture assertions currently turned ON (the immutable-OS controls evaluated at plan time)."
+  value       = keys(local.active_assertions)
+}
+
+output "posture_violations" {
+  description = "Posture assertions that are ON but whose OBSERVED Talos posture does not satisfy them. Empty list = compliant. Each entry: { assertion, soc2, detail }."
+  value       = local.posture_violations
+}
+
+output "posture_compliant" {
+  description = "True when every active Talos posture assertion is satisfied by the observed machine config (no SSH, mTLS API, KubePrism, immutable install, no package manager). The boolean the SOC2 matrix / CI gate reads."
+  value       = local.posture_compliant
+}
+
+output "posture_soc2_map" {
+  description = "Map of each active posture assertion to its SOC2 control family — the control-to-evidence link the matrix cites."
+  value = {
+    for k, v in local.active_assertions : k => v.soc2
+  }
+}
+
+output "policy_bundle_names" {
+  description = "Names of the Kyverno/Gatekeeper policy CRs in the bundle (built-ins + caller extras). Rendered even when deploy_policy_bundle is false, so a reviewer can see what WOULD be delivered."
+  value       = keys(local.policy_bundle)
+}
+
+output "policy_bundle_yaml" {
+  description = "The rendered policy CR YAML documents keyed by id (for plan-time review). Materialised as kubectl_manifest only when deploy_policy_bundle = true."
+  value       = local.policy_bundle
+}
+
+output "policy_bundle_deployed" {
+  description = "Whether the policy bundle is actually being delivered as kubectl_manifest resources (apply-gated). False in default/plan-only mode."
+  value       = var.deploy_policy_bundle
+}
+
+output "platform_labels" {
+  description = "ADR-0028 taxonomy for this module instance (underscore form; provenance — posture assertions and CR bindings are not labelable Terraform resources)."
+  value       = local.platform_labels
+}

--- a/terraform/modules/baremetal-org-policy/variables.tf
+++ b/terraform/modules/baremetal-org-policy/variables.tf
@@ -1,0 +1,180 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Inputs for the baremetal-org-policy module (WS-E — security / compliance).
+#
+# Bare-metal analogue of terraform/modules/gcp-org-policy. Where GCP binds
+# org-policy constraints to a resource-manager node, the bare-metal/Talos estate
+# has no cloud org-policy API — the equivalent guardrails are:
+#   (a) Talos machine-config POSTURE ASSERTIONS (immutable OS, no SSH, mTLS API,
+#       KubePrism) evaluated at plan time, and
+#   (b) a Kyverno/Gatekeeper admission policy BUNDLE delivered as code.
+#
+# ADR-0028: Talos/K8s plane uses the DOTTED label form (platform.system = security);
+# the Terraform plane records the UNDERSCORE form (platform_system) for provenance —
+# exactly as gcp-org-policy documents for non-labelable bindings.
+#
+# ADR-0049 (foundation/posture) + ADR-0050 (immutable-OS security rationale) +
+# ADR-0040 (SOC posture, reused).
+# ---------------------------------------------------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Scope / identity.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "cluster_name" {
+  description = "Talos cluster name this posture/policy bundle binds to (e.g. talos-uk-primary). Used in policy/CR names and provenance only; no resource is created against a real cluster in plan/mock mode."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$", var.cluster_name))
+    error_message = "cluster_name must be a DNS-1123 label (lowercase alphanumerics and hyphens, 3-63 chars)."
+  }
+}
+
+variable "dc_name" {
+  description = "UK datacenter this binds to (uk-primary or uk-standby). Mirrors the WS-A stack's per-DC composition under terragrunt/uk/{primary,standby}/platform/."
+  type        = string
+
+  validation {
+    condition     = contains(["uk-primary", "uk-standby"], var.dc_name)
+    error_message = "dc_name must be one of: uk-primary, uk-standby."
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Talos OS posture assertions (the immutable-OS controls mapped to SOC2 families).
+# These describe the EXPECTED posture the WS-A talos-machineconfig must satisfy.
+# The module computes per-assertion pass/fail at plan time (no cluster mutation) so
+# the SOC2 matrix can cite a concrete Terraform assertion, per the plan acceptance:
+# "a control-to-evidence matrix references concrete Talos-config assertions".
+# Each toggle defaults ON (deny-by-default posture); set false only for a documented
+# carve-out during staged rollout.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "assert_no_ssh" {
+  description = "Assert the Talos OS posture exposes NO SSH path (no shell, no sshd, no extra kernel args opening a shell). SOC2 CC6.1 / CC6.6 — minimal attack surface."
+  type        = bool
+  default     = true
+}
+
+variable "assert_mtls_machine_api" {
+  description = "Assert the Talos machine API is mTLS-only with strict auth (no plaintext, client-cert-gated talosctl). SOC2 CC6.1 / CC6.7."
+  type        = bool
+  default     = true
+}
+
+variable "assert_kubeprism_enabled" {
+  description = "Assert machine.features.kubePrism is enabled (in-cluster API HA, no single API VIP SPOF). SOC2 A1.2 / CC7.5."
+  type        = bool
+  default     = true
+}
+
+variable "assert_immutable_install" {
+  description = "Assert the OS install disk is immutable / A-B-partition atomic-upgrade with auto-rollback (no in-place host mutation). SOC2 CC8.1 — change management."
+  type        = bool
+  default     = true
+}
+
+variable "assert_no_package_manager" {
+  description = "Assert the OS has no package manager / writable /usr (GPU driver ships as a Talos system extension per ADR-0050, never apt-installed). SOC2 CC6.8 — unauthorized software."
+  type        = bool
+  default     = true
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Observed posture — the actual values rendered by WS-A's talos-machineconfig,
+# wired in through a dependency block at the catalog-unit layer (mock at plan time).
+# The module compares observed vs asserted and emits posture_violations. Defaulting
+# observed = expected keeps the module green when wired to a compliant cluster; a
+# drifted cluster (e.g. observed_ssh_enabled = true) makes the assertion fail and
+# surfaces in the posture_violations output and the *.tftest.hcl.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "observed_ssh_enabled" {
+  description = "Observed: is any SSH/shell path present on the Talos nodes? (from WS-A talos-machineconfig). Compliant posture = false."
+  type        = bool
+  default     = false
+}
+
+variable "observed_machine_api_mtls" {
+  description = "Observed: is the Talos machine API mTLS-only with strict auth? (from WS-A talos-machineconfig). Compliant posture = true."
+  type        = bool
+  default     = true
+}
+
+variable "observed_kubeprism_enabled" {
+  description = "Observed: is machine.features.kubePrism enabled? (from WS-A talos-machineconfig). Compliant posture = true."
+  type        = bool
+  default     = true
+}
+
+variable "observed_install_immutable" {
+  description = "Observed: is the install disk immutable with A/B atomic upgrade + auto-rollback? (from WS-A talos-machineconfig). Compliant posture = true."
+  type        = bool
+  default     = true
+}
+
+variable "observed_package_manager_present" {
+  description = "Observed: is a package manager / writable /usr present? (from WS-A talos-machineconfig). Compliant posture = false."
+  type        = bool
+  default     = false
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Admission policy bundle delivery (Kyverno/Gatekeeper CRs as code).
+# DEFAULT-OFF (apply-gated): deploy_policy_bundle = false means NO kubectl_manifest
+# resource is created — the module renders the bundle into outputs for plan review
+# only. Set true (in CI on main, after merge + human go) to actually deliver the CRs.
+# Mirrors the plan's "apply-gated / default-OFF where the plan says so".
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "deploy_policy_bundle" {
+  description = "Deliver the Kyverno/Gatekeeper policy bundle CRs to the cluster (kubectl_manifest). DEFAULT FALSE — apply-gated; plan-only renders the bundle into outputs without creating any resource."
+  type        = bool
+  default     = false
+}
+
+variable "policy_bundle_manifests" {
+  description = "Extra raw YAML policy CR documents (Kyverno ClusterPolicy / Gatekeeper Constraint) to deliver alongside the built-in bare-metal tenant guardrails, keyed by a stable id. Empty = built-ins only. Never put secrets here."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}
+
+variable "enforce_tenant_label" {
+  description = "Include the built-in Kyverno ClusterPolicy that rejects pods without a tenant={id} label (the UK doc's Gatekeeper tenant constraint, ported to Kyverno). SOC2 CC6.1 — tenant isolation."
+  type        = bool
+  default     = true
+}
+
+variable "enforce_no_cross_ns_sa" {
+  description = "Include the built-in policy that rejects cross-namespace ServiceAccount references (the UK doc's second Gatekeeper tenant constraint). SOC2 CC6.3 — least privilege."
+  type        = bool
+  default     = true
+}
+
+variable "policy_enforcement_mode" {
+  description = "Admission mode for the built-in Kyverno policies: Audit (observe, record violations) or Enforce (block). Defaults to Audit — matches apps/infra/kyverno's observe-first posture; promote to Enforce after a clean soak window."
+  type        = string
+  default     = "Audit"
+
+  validation {
+    condition     = contains(["Audit", "Enforce"], var.policy_enforcement_mode)
+    error_message = "policy_enforcement_mode must be Audit or Enforce."
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# ADR-0028 labels. NOTE: neither Talos posture assertions nor admission-policy CRs
+# are labelable Terraform resources here (the CRs carry their OWN metadata.labels in
+# the rendered YAML), so — exactly like gcp-org-policy / gcp-billing-budget document
+# for non-labelable bindings — the platform taxonomy is asserted via this variable
+# for catalog/test provenance and is echoed into the rendered policy CR labels. Keys
+# use the Talos/K8s UNDERSCORE spelling on the Terraform plane (platform_system).
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "labels" {
+  description = "ADR-0028 platform taxonomy (underscore keys on the Terraform plane, e.g. platform_system = security). Echoed into rendered policy CR labels (dotted form) and recorded for provenance."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}

--- a/terraform/modules/baremetal-org-policy/versions.tf
+++ b/terraform/modules/baremetal-org-policy/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    # Talos machine config — used to ASSERT the immutable-OS security posture
+    # (no SSH, mTLS machine API, KubePrism) by re-rendering the machine config
+    # and checking the posture fields. siderolabs/talos is the named provider in
+    # the bare-metal plan §3 (DESIGN ONLY) and in WS-A's talos-machineconfig.
+    talos = {
+      source  = "siderolabs/talos"
+      version = "~> 0.7"
+    }
+
+    # Kyverno / Gatekeeper policy bundle delivery as code (CRs applied to the
+    # cluster). alekc/kubectl is the repo-pinned kubectl provider (see
+    # terraform/modules/platform-crds/versions.tf).
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "~> 2.1"
+    }
+  }
+}

--- a/tests/opa/platform_tags_baremetal.rego
+++ b/tests/opa/platform_tags_baremetal.rego
@@ -1,0 +1,142 @@
+package terraform.platform_tags_baremetal
+
+import rego.v1
+
+# ---------------------------------------------------------------------------
+# Policy: bare-metal / Talos ADR-0028 platform-taxonomy enforcement.
+#
+# This is the BARE-METAL profile of tests/opa/platform_tags.rego (WS-E,
+# decision #10 of the Bare-Metal ML Platform plan §7, and the gap recorded in
+# ADR-0049 D6). The AWS-shaped policy keys on `tags["platform:system"]` and an
+# `aws_*` exempt set, so it does NOT enforce ADR-0028 on `talos_*`,
+# `kubernetes_manifest`, `kubectl_manifest`, or `helm_release` resources. This
+# profile re-keys to the bare-metal plane:
+#
+#   - Label form:   UNDERSCORE keys (platform_system / platform_component /
+#                   platform_owner) — the Talos/K8s plane spelling ADR-0028
+#                   mandates on bare metal (vs the AWS `platform:system` tag).
+#   - Where:        labels live under `tags` (Talos machine nodeLabels surfaced
+#                   as tags), `labels`, OR `metadata.labels` (manifest resources).
+#   - Exempt set:   bare-metal / Talos / manifest data-only + non-labelable types.
+#
+# Required platform labels (must be non-empty strings):
+#   - platform_system     (logical service boundary, e.g. ml-pipeline)
+#   - platform_component   (role within the system, e.g. gpu-worker, storage)
+#   - platform_owner       (owning team, e.g. team-sec)
+#
+# Optional but tracked: platform_env, platform_managed_by.
+#
+# Run against a `terraform show -json <plan>` document (input.resource_changes).
+# ---------------------------------------------------------------------------
+
+_required_platform_labels := {"platform_system", "platform_component", "platform_owner"}
+
+# Resource types that are not labelable, are data-only, or carry their taxonomy
+# in their own embedded manifest body (validated by the manifest rule below, not
+# the top-level label rule). Bare-metal / Talos / K8s-manifest shaped.
+_exempt_types := {
+	# Talos provider — secrets/config/bootstrap objects are not labelable resources;
+	# the node labels they RENDER are asserted in the talos-machineconfig module test.
+	"talos_machine_secrets",
+	"talos_machine_configuration",
+	"talos_machine_configuration_apply",
+	"talos_machine_bootstrap",
+	"talos_client_configuration",
+	"talos_cluster_kubeconfig",
+	"talos_cluster_health",
+	# Manifest-delivery providers — the taxonomy lives in metadata.labels INSIDE the
+	# rendered manifest, checked by the manifest rule, not as a top-level attribute.
+	"kubernetes_manifest",
+	"kubectl_manifest",
+	"helm_release",
+	# Generic data-only / non-labelable.
+	"null_resource",
+	"random_id",
+	"random_string",
+	"random_password",
+	"random_bytes",
+	"time_sleep",
+	"local_file",
+	"local_sensitive_file",
+	"terraform_data",
+	"tls_private_key",
+	"http",
+}
+
+# Only check resources being created or updated (skip destroy / no-op).
+_is_managed(actions) if {
+	some a in actions
+	a in {"create", "update"}
+}
+
+# Collect the label map from wherever a bare-metal resource carries it:
+# `labels`, then `tags` (Talos nodeLabels surfaced as tags), merged.
+_labels_of(after) := merged if {
+	labels := object.get(after, "labels", {})
+	tags := object.get(after, "tags", {})
+	merged := object.union(tags, labels)
+}
+
+# -------------------------------------------------------------------------------------------------------------------
+# Rule 1 — non-manifest, non-exempt resources must carry the three required
+# underscore labels (present AND non-empty).
+# -------------------------------------------------------------------------------------------------------------------
+deny contains msg if {
+	some addr, rc in input.resource_changes
+	not rc.type in _exempt_types
+	_is_managed(rc.change.actions)
+	labels := _labels_of(rc.change.after)
+	some required_label in _required_platform_labels
+	not labels[required_label]
+	msg := sprintf(
+		"POLICY VIOLATION [platform-tags-baremetal]: resource %q (type: %s) is missing required platform label %q",
+		[addr, rc.type, required_label],
+	)
+}
+
+deny contains msg if {
+	some addr, rc in input.resource_changes
+	not rc.type in _exempt_types
+	_is_managed(rc.change.actions)
+	labels := _labels_of(rc.change.after)
+	some required_label in _required_platform_labels
+	labels[required_label] == ""
+	msg := sprintf(
+		"POLICY VIOLATION [platform-tags-baremetal]: resource %q (type: %s) has empty value for required platform label %q",
+		[addr, rc.type, required_label],
+	)
+}
+
+# -------------------------------------------------------------------------------------------------------------------
+# Rule 2 — manifest-delivery resources (kubernetes_manifest / kubectl_manifest)
+# must carry the DOTTED ADR-0028 labels inside metadata.labels of the rendered
+# object. kubernetes_manifest exposes a structured `manifest.metadata.labels`;
+# kubectl_manifest carries a raw `yaml_body` string — for the string form we assert
+# the dotted keys appear (a coarse but plan-safe substring check, since OPA cannot
+# parse arbitrary embedded YAML without a parsed input).
+# -------------------------------------------------------------------------------------------------------------------
+deny contains msg if {
+	some addr, rc in input.resource_changes
+	rc.type == "kubernetes_manifest"
+	_is_managed(rc.change.actions)
+	meta_labels := object.get(rc.change.after.manifest.metadata, "labels", {})
+	some dotted in {"platform.system", "platform.component", "platform.owner"}
+	not meta_labels[dotted]
+	msg := sprintf(
+		"POLICY VIOLATION [platform-tags-baremetal]: manifest %q (type: %s) metadata.labels is missing required platform label %q",
+		[addr, rc.type, dotted],
+	)
+}
+
+deny contains msg if {
+	some addr, rc in input.resource_changes
+	rc.type == "kubectl_manifest"
+	_is_managed(rc.change.actions)
+	body := object.get(rc.change.after, "yaml_body", "")
+	some dotted in {"platform.system", "platform.component", "platform.owner"}
+	not contains(body, dotted)
+	msg := sprintf(
+		"POLICY VIOLATION [platform-tags-baremetal]: kubectl_manifest %q yaml_body is missing required platform label %q",
+		[addr, dotted],
+	)
+}

--- a/tests/opa/platform_tags_baremetal_test.rego
+++ b/tests/opa/platform_tags_baremetal_test.rego
@@ -1,0 +1,155 @@
+package terraform.platform_tags_baremetal
+
+import rego.v1
+
+# ---------------------------------------------------------------------------
+# Unit tests for the bare-metal ADR-0028 tag-enforcement profile.
+# Run: opa test tests/opa/
+#
+# Each test feeds a synthetic `terraform show -json`-shaped plan fragment as
+# `input` and asserts the deny set. These prove the WS-E acceptance criterion:
+# "the platform_tags_baremetal.rego OPA profile flags a talos_* /
+# kubernetes_manifest resource missing the ADR-0028 keys at plan time".
+# ---------------------------------------------------------------------------
+
+# A bare-metal compute resource WITH all three underscore labels => no deny.
+test_compliant_resource_passes if {
+	count(deny) == 0 with input as {"resource_changes": [{
+		"address": "kubernetes_namespace.tenant",
+		"type": "kubernetes_namespace",
+		"change": {
+			"actions": ["create"],
+			"after": {"labels": {
+				"platform_system": "ml-pipeline",
+				"platform_component": "namespace",
+				"platform_owner": "team-ml-platform",
+			}},
+		},
+	}]}
+}
+
+# Same resource MISSING platform_owner => exactly one deny naming that key.
+test_missing_owner_is_flagged if {
+	result := deny with input as {"resource_changes": [{
+		"address": "kubernetes_namespace.tenant",
+		"type": "kubernetes_namespace",
+		"change": {
+			"actions": ["create"],
+			"after": {"labels": {
+				"platform_system": "ml-pipeline",
+				"platform_component": "namespace",
+			}},
+		},
+	}]}
+	count(result) == 1
+	some m in result
+	contains(m, "platform_owner")
+}
+
+# A resource carrying labels under `tags` (Talos nodeLabels surfaced as tags) passes.
+test_tags_form_satisfies_requirement if {
+	count(deny) == 0 with input as {"resource_changes": [{
+		"address": "some_node.gpu0",
+		"type": "some_labelable_node",
+		"change": {
+			"actions": ["create"],
+			"after": {"tags": {
+				"platform_system": "gpu-foundation",
+				"platform_component": "gpu-worker",
+				"platform_owner": "team-sec",
+			}},
+		},
+	}]}
+}
+
+# An empty value for a required label is rejected (not just absence).
+test_empty_value_is_flagged if {
+	result := deny with input as {"resource_changes": [{
+		"address": "kubernetes_namespace.tenant",
+		"type": "kubernetes_namespace",
+		"change": {
+			"actions": ["create"],
+			"after": {"labels": {
+				"platform_system": "",
+				"platform_component": "namespace",
+				"platform_owner": "team-sec",
+			}},
+		},
+	}]}
+	count(result) == 1
+	some m in result
+	contains(m, "empty value")
+}
+
+# Talos secrets/config objects are EXEMPT (not labelable) => no deny even unlabeled.
+test_talos_machine_config_is_exempt if {
+	count(deny) == 0 with input as {"resource_changes": [{
+		"address": "talos_machine_configuration.cp",
+		"type": "talos_machine_configuration",
+		"change": {"actions": ["create"], "after": {}},
+	}]}
+}
+
+# Destroy / no-op actions are NOT evaluated.
+test_destroy_action_is_skipped if {
+	count(deny) == 0 with input as {"resource_changes": [{
+		"address": "kubernetes_namespace.old",
+		"type": "kubernetes_namespace",
+		"change": {"actions": ["delete"], "after": null},
+	}]}
+}
+
+# A kubectl_manifest whose yaml_body carries the DOTTED labels passes.
+test_kubectl_manifest_with_dotted_labels_passes if {
+	count(deny) == 0 with input as {"resource_changes": [{
+		"address": "kubectl_manifest.policy[\"require-tenant-label\"]",
+		"type": "kubectl_manifest",
+		"change": {
+			"actions": ["create"],
+			"after": {"yaml_body": "metadata:\n  labels:\n    platform.system: security\n    platform.component: org-policy\n    platform.owner: team-sec\n"},
+		},
+	}]}
+}
+
+# A kubectl_manifest MISSING the dotted labels is flagged (the WS-E acceptance:
+# the AWS-shaped rego would NOT catch this; the bare-metal profile does).
+test_kubectl_manifest_missing_labels_is_flagged if {
+	result := deny with input as {"resource_changes": [{
+		"address": "kubectl_manifest.policy[\"x\"]",
+		"type": "kubectl_manifest",
+		"change": {
+			"actions": ["create"],
+			"after": {"yaml_body": "metadata:\n  labels:\n    app: foo\n"},
+		},
+	}]}
+	count(result) == 3
+}
+
+# A kubernetes_manifest with structured metadata.labels carrying the dotted keys passes.
+test_kubernetes_manifest_with_labels_passes if {
+	count(deny) == 0 with input as {"resource_changes": [{
+		"address": "kubernetes_manifest.cr",
+		"type": "kubernetes_manifest",
+		"change": {
+			"actions": ["create"],
+			"after": {"manifest": {"metadata": {"labels": {
+				"platform.system": "observability",
+				"platform.component": "dashboard",
+				"platform.owner": "team-sre",
+			}}}},
+		},
+	}]}
+}
+
+# A kubernetes_manifest missing the dotted keys in metadata.labels is flagged.
+test_kubernetes_manifest_missing_labels_is_flagged if {
+	result := deny with input as {"resource_changes": [{
+		"address": "kubernetes_manifest.cr",
+		"type": "kubernetes_manifest",
+		"change": {
+			"actions": ["create"],
+			"after": {"manifest": {"metadata": {"labels": {"app": "foo"}}}},
+		},
+	}]}
+	count(result) == 3
+}


### PR DESCRIPTION
## WS-E — Talos SOC posture + on-call + OPA (Bare-Metal ML Platform)

Implements **WS-E** of the Bare-Metal (Talos) ML Platform design: SOC2 posture, on-call/incident runbooks, and the bare-metal ADR-0028 OPA profile + org-policy admission plane. Greenfield mirror of the GCP/AWS estate controls, re-keyed to the Talos/immutable-OS plane.

### Files delivered

**OPA policy (ADR-0028 bare-metal profile)**
- `tests/opa/platform_tags_baremetal.rego` — `talos_*` profile: underscore label keys (`platform_system/_component/_owner`) on `tags`/`labels`/`metadata.labels`, with a bare-metal/Talos/manifest exempt set. Companion to the AWS-shaped `platform_tags.rego`.
- `tests/opa/platform_tags_baremetal_test.rego` — 10 unit tests, all passing.

**SOC2 control-to-evidence matrix**
- `docs/compliance/soc2-control-matrix-baremetal.md` — TSC (CC-series) mapped to owned-UK-DC Talos controls; the immutable-OS posture is evidenced as concrete Terraform assertions (`output.posture_compliant` / `output.posture_violations`).

**Runbooks**
- `docs/runbooks/ml-incident-runbook-baremetal.md` — ML-platform incident response on the Talos GPU cluster.
- `docs/runbooks/uk-dc-failover-baremetal.md` — ML-platform view of UK-DC failover.

**Org-policy admission plane (Kyverno-style Helm + Terraform module)**
- `apps/infra/baremetal-org-policy/` — Helm chart: `require-tenant-label`, `deny-cross-ns-sa` policies + ArgoCD Application.
- `terraform/modules/baremetal-org-policy/` — posture-assertion module (`main.tf`, `variables.tf`, `outputs.tf`, `versions.tf`) + `.tftest.hcl`.
- `catalog/units/baremetal-org-policy/terragrunt.hcl`.

### ADRs cited
ADR-0049 (Talos foundation / multi-DC), ADR-0050 (immutable-OS / GPU driver system-extensions), ADR-0051, ADR-0052, ADR-0053, ADR-0054, plus ADR-0028 (taxonomy) and ADR-0040 (SOC posture + on-call, reused).

### Validation (plan/validate-only — apply-gated)
- `opa check` — clean on both rego files.
- `opa fmt -d` — no diff.
- `opa test` — **10/10 PASS** (scoped to WS-E files; a pre-existing unrelated parse error in `no_unrestricted_sg_ingress.rego` from PR #146 is out of scope).
- `terraform fmt -check -recursive` — clean on the module.

**DESIGN-MOCK repo — apply-gated; do NOT merge until human review; base targets the design branch `feature/baremetal-ml-platform-design`.**
