### PR TITLE
feat(bm-wsA): Talos baremetal GPU cluster foundation

### DIFF
--- a/apps/infra/baremetal-gpu-fabric/Chart.yaml
+++ b/apps/infra/baremetal-gpu-fabric/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: baremetal-gpu-fabric
+description: >-
+  GitOps SR-IOV / DRA custom resources for the bare-metal GPU fabric (RoCEv2 / InfiniBand
+  GPUDirect RDMA). The SR-IOV operator is installed by the baremetal-gpu-fabric Terraform
+  module; this app holds the SriovNetworkNodePolicy / SriovNetwork (day-0) and the gated
+  DRANET DeviceClass/ResourceClaimTemplate. WS-A, ADR-0053.
+version: 1.0.0
+appVersion: "1.0.0"
+type: application
+
+maintainers:
+  - name: Platform Team
+    email: platform@example.com
+
+keywords:
+  - sriov
+  - rdma
+  - roce
+  - infiniband
+  - dranet
+  - gpudirect
+  - gpu-fabric
+
+annotations:
+  category: Networking
+  platform: Kubernetes
+  platform.system: ml-infra
+  adr: "0053"

--- a/apps/infra/baremetal-gpu-fabric/README.md
+++ b/apps/infra/baremetal-gpu-fabric/README.md
@@ -1,0 +1,33 @@
+# baremetal-gpu-fabric (ArgoCD app)
+
+GitOps **SR-IOV / DRA custom resources** for the bare-metal GPU fabric (RoCEv2 / InfiniBand
+GPUDirect RDMA). Part of **WS-A**. System: `ml-infra`.
+
+**ADR:** [ADR-0053](../../../docs/adrs/0053-baremetal-gpu-fabric-roce-infiniband.md).
+ADR-0028 labels.
+
+## Split of responsibility
+
+| Layer | Owns |
+|-------|------|
+| `terraform/modules/baremetal-gpu-fabric` | SR-IOV operator install (Helm) |
+| **this app** | `SriovNetworkNodePolicy` / `SriovNetwork` (day-0) + the gated DRANET `DeviceClass` / `ResourceClaimTemplate` |
+
+## Two-stage gate (ADR-0053 D3)
+
+- **Day-0 primary:** SR-IOV / RDMA device plugin (`sriov.enabled`).
+- **Gated target:** Cilium `netdev` DRA / DRANET (`dranet.enabled`, default **false**) — flip
+  only once DRA-`netdev` is GA on our Talos/k8s, a `dranet` release is validated, and it meets
+  the SR-IOV NCCL baseline.
+
+`fabricMode` defaults **infiniband**; MTU 9000. An **NCCL all-reduce bandwidth test** is the
+acceptance gate (`nccl-troubleshooting.md`).
+
+## Apply-gated / default-OFF
+
+`enabled: false` — ArgoCD does not sync until a human enables the app. Nothing is applied to
+real hardware in this repo.
+
+## ADR-0028 labeling
+
+`platform.system = ml-infra`, `platform.component = gpu-fabric`, `platform.managed-by = argocd`.

--- a/apps/infra/baremetal-gpu-fabric/values.yaml
+++ b/apps/infra/baremetal-gpu-fabric/values.yaml
@@ -1,0 +1,38 @@
+---
+# SR-IOV / DRA fabric CRs for the bare-metal GPU cluster (ADR-0053). The SR-IOV operator is
+# installed by the baremetal-gpu-fabric Terraform module; this app carries the
+# SriovNetworkNodePolicy / SriovNetwork (day-0 primary) and the gated DRANET CRs.
+#
+# APPLY-GATED / default-OFF: ArgoCD will not sync these until a human enables the app.
+# The NCCL all-reduce bandwidth test (nccl-troubleshooting.md) is the acceptance gate.
+
+enabled: false
+
+platformLabels:
+  platform.system: ml-infra
+  platform.component: gpu-fabric
+  platform.managed-by: argocd
+
+# Physical fabric: infiniband (the UK doc's 400 Gbps IB + NVSwitch) or roce (Ethernet).
+fabricMode: infiniband
+mtu: 9000                            # jumbo frames (nic-tuning)
+
+# DAY-0 PRIMARY — SR-IOV / RDMA device plugin (ADR-0053).
+sriov:
+  enabled: true
+  resourceName: rdma_vf
+  numVfs: 8
+  nicVendor: "15b3"                  # Mellanox/NVIDIA
+  isRdma: true
+
+# GATED TARGET — Cilium netdev DRA (mirror of DRANET, ADR-0053 D3). OFF until DRA-netdev is
+# GA on our Talos/k8s + a dranet release is validated + it meets the SR-IOV NCCL baseline.
+dranet:
+  enabled: false
+  deviceClassName: rdma-netdev
+  nicCount: 1
+
+# Acceptance gate.
+acceptance:
+  ncclAllReduceBandwidthTest: required
+  runbook: ai-sre/knowledge/nccl-troubleshooting.md

--- a/apps/infra/baremetal-inference-gateway/Chart.yaml
+++ b/apps/infra/baremetal-inference-gateway/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: baremetal-inference-gateway
+description: >-
+  Model-/KV-cache-aware serving front for vLLM on the bare-metal cluster — Gateway API
+  inference extension (Gateway / InferencePool / InferenceObjective / HTTPRoute) on
+  Cilium or Envoy Gateway, NOT a cloud LB. The on-prem mirror of gke-inference-gateway.
+  WS-A, ADR-0053.
+version: 1.0.0
+appVersion: "1.0.0"
+type: application
+
+maintainers:
+  - name: Platform Team
+    email: platform@example.com
+
+keywords:
+  - inference
+  - gateway-api
+  - vllm
+  - inferencepool
+  - inferenceobjective
+  - serving
+
+annotations:
+  category: Serving
+  platform: Kubernetes
+  platform.system: ml-inference
+  adr: "0053"

--- a/apps/infra/baremetal-inference-gateway/README.md
+++ b/apps/infra/baremetal-inference-gateway/README.md
@@ -1,0 +1,38 @@
+# baremetal-inference-gateway (ArgoCD app)
+
+**Model-/KV-cache-aware serving front** for vLLM on the bare-metal cluster — the Gateway API
+inference extension (`Gateway` / `InferencePool` / `InferenceObjective` / `HTTPRoute`) on
+**Cilium or Envoy Gateway**, **not** a cloud LB. The on-prem mirror of `gke-inference-gateway`.
+Part of **WS-A**. System: `ml-inference`.
+
+**ADR:** [ADR-0053](../../../docs/adrs/0053-baremetal-gpu-fabric-roce-infiniband.md) (serving
+axis: on-prem Gateway API, no cloud LB). ADR-0028 labels.
+
+## Why on-prem Gateway API
+
+There is no cloud L7 LB on owned hardware. Requests route on **KV-cache utilisation + queue
+depth + per-replica load** (not round-robin) via the Gateway API inference extension, over
+Cilium or Envoy Gateway. This app sits **behind** the `baremetal-ingress-waf` WAF/rate-limit
+front.
+
+> **Gateway API inference v1 GA:** `InferenceModel` was renamed **`InferenceObjective`**;
+> `InferencePool` / `HTTPRoute` are unchanged.
+
+## Objects
+
+| Object | Purpose |
+|--------|---------|
+| `Gateway` | HTTPS serving entrypoint (Cilium/Envoy GatewayClass) |
+| `InferencePool` | the vLLM replica set (selector + target port) |
+| `InferenceObjective` (per model) | per-model routing + criticality (multi-LoRA) |
+| `HTTPRoute` | binds the Gateway to the InferencePool |
+
+## Apply-gated / default-OFF
+
+`enabled: false` — ArgoCD does not sync until a human enables the app. Nothing is applied to
+real hardware in this repo.
+
+## ADR-0028 labeling
+
+`platform.system = ml-inference`, `platform.component = inference-gateway`,
+`platform.managed-by = argocd`.

--- a/apps/infra/baremetal-inference-gateway/values.yaml
+++ b/apps/infra/baremetal-inference-gateway/values.yaml
@@ -1,0 +1,45 @@
+---
+# Bare-metal model-/KV-cache-aware serving front (ADR-0053 D4 mirror). Gateway API inference
+# extension on Cilium / Envoy Gateway — there is NO cloud LB on owned hardware. Sits behind
+# the baremetal-ingress-waf WAF/rate-limit front.
+#
+# APPLY-GATED / default-OFF: ArgoCD will not sync these CRs until a human enables the app.
+#
+# NOTE (Gateway API inference v1 GA): InferenceModel was renamed InferenceObjective;
+# InferencePool / HTTPRoute are unchanged.
+
+enabled: false
+
+platformLabels:
+  platform.system: ml-inference
+  platform.component: inference-gateway
+  platform.managed-by: argocd
+
+# Gateway backend — cilium (one networking stack) or envoy (reuse apps/infra/envoy-gateway).
+gatewayBackend: cilium
+gatewayClass:
+  cilium: cilium
+  envoy: envoy-gateway
+
+gateway:
+  name: ml-serving
+  tlsSecretName: ml-serving-tls      # from cert-manager/ESO — never committed
+
+# The set of vLLM replicas requests route across, by KV-cache utilisation + queue depth.
+inferencePool:
+  name: vllm-pool
+  targetPort: 8000
+  selector:
+    app: vllm
+
+# Per-model routing + criticality (multi-LoRA → multiple objectives).
+inferenceObjectives:
+  - name: fraud-scorer
+    modelName: fraud-scorer-v3
+    criticality: Critical
+  - name: judge-debate
+    modelName: llm-judge
+    criticality: Standard
+
+httpRoute:
+  name: ml-serving-route

--- a/apps/infra/rook-ceph/Chart.yaml
+++ b/apps/infra/rook-ceph/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: rook-ceph
+description: >-
+  Rook-Ceph storage cluster CRs (CephCluster / CephBlockPool / CephFilesystem /
+  CephObjectStore-RGW-S3) for the bare-metal GPU cluster. The operator is installed by the
+  baremetal-rook-ceph Terraform module; this app holds the cluster/pool/object CRs. WS-A,
+  ADR-0052.
+version: 1.0.0
+appVersion: "v1.15.6"
+type: application
+
+maintainers:
+  - name: Platform Team
+    email: platform@example.com
+
+keywords:
+  - rook
+  - ceph
+  - storage
+  - rbd
+  - s3
+  - rgw
+
+annotations:
+  category: Storage
+  platform: Kubernetes
+  platform.system: ml-infra
+  adr: "0052"

--- a/apps/infra/rook-ceph/README.md
+++ b/apps/infra/rook-ceph/README.md
@@ -1,0 +1,34 @@
+# rook-ceph (ArgoCD app)
+
+GitOps **Ceph cluster CRs** — `CephCluster`, `CephBlockPool`, `CephFilesystem`, and the
+`CephObjectStore` (RGW S3) — for the bare-metal GPU cluster. Part of **WS-A**. System:
+`ml-infra`.
+
+**ADR:** [ADR-0052](../../../docs/adrs/0052-baremetal-storage-rook-ceph.md). ADR-0028 labels.
+
+## Split of responsibility
+
+| Layer | Owns |
+|-------|------|
+| `terraform/modules/baremetal-rook-ceph` | Operator + CSI install (Helm) |
+| **this app** | The `CephCluster` / pool / object-store **CRs** the operator reconciles |
+
+## The rbd+ceph prerequisite (ADR-0052)
+
+RBD PVCs will not mount until the Talos MachineConfig declares the `rbd` + `ceph` kernel
+modules (`talos-machineconfig` / `talos-system-extensions`). `dataDirHostPath` must match the
+Talos kubelet extraMount. Replication is **≥3** (survive a node loss, risk R5).
+
+## S3 for WS-B
+
+The `CephObjectStore` (RGW) exposes the in-cluster S3 endpoint WS-B's MLflow artifact store
+re-points at (UK-resident, no external S3).
+
+## Apply-gated / default-OFF
+
+`enabled: false` — ArgoCD does not sync these CRs until a human enables the app behind a
+reviewed plan + blast-radius review. Nothing is applied to real hardware in this repo.
+
+## ADR-0028 labeling
+
+`platform.system = ml-infra`, `platform.component = storage`, `platform.managed-by = argocd`.

--- a/apps/infra/rook-ceph/values.yaml
+++ b/apps/infra/rook-ceph/values.yaml
@@ -1,0 +1,40 @@
+---
+# Rook-Ceph cluster CRs for the bare-metal GPU cluster (ADR-0052). The operator + CSI are
+# installed by the baremetal-rook-ceph Terraform module; this GitOps app carries the
+# CephCluster / pools / object-store CRs that the operator reconciles.
+#
+# APPLY-GATED / default-OFF: `enabled: false` so ArgoCD will not sync these CRs until a
+# human explicitly enables the app behind a reviewed plan + blast-radius review.
+#
+# HARD PREREQUISITE (ADR-0052): RBD PVCs will not mount until the Talos MachineConfig
+# declares the rbd + ceph kernel modules (talos-machineconfig / talos-system-extensions).
+# Without them csi-rbdplugin crash-loops.
+
+enabled: false
+
+platformLabels:
+  platform.system: ml-infra
+  platform.component: storage
+  platform.managed-by: argocd
+
+cephCluster:
+  cephImage: quay.io/ceph/ceph:v18.2.4
+  dataDirHostPath: /var/lib/rook   # must match the Talos kubelet extraMount
+  monCount: 3                      # odd, for quorum
+
+# Replication ≥3 to survive a node loss (storage-SPOF mitigation, risk R5).
+pools:
+  replicas: 3
+
+filesystem:
+  enabled: true                    # RWX shared datasets
+
+objectStore:
+  enabled: true                    # Ceph-RGW S3 — the WS-B artifact-store backend
+  name: ml-artifacts
+  rgwInstances: 2
+  port: 80
+
+# Cross-DC DR: MinIO site-replication / Ceph multisite is wired by WS-B/ops, not here.
+disasterRecovery:
+  note: cross-DC object replication is owned by WS-B (MinIO site-replication / Ceph multisite)

--- a/apps/infra/talos-system-extensions/Chart.yaml
+++ b/apps/infra/talos-system-extensions/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: talos-system-extensions
+description: >-
+  Talos system-extension catalog/version pins (GitOps source of truth) for the bare-metal
+  GPU cluster — the NVIDIA driver + container toolkit extensions baked into the Talos boot
+  image. WS-A, ADR-0050.
+version: 1.0.0
+appVersion: "v1.9.2"
+type: application
+
+maintainers:
+  - name: Platform Team
+    email: platform@example.com
+
+keywords:
+  - talos
+  - system-extension
+  - nvidia
+  - gpu
+  - driver
+  - immutable
+
+annotations:
+  category: GPU
+  platform: Talos
+  platform.system: ml-infra
+  adr: "0050"

--- a/apps/infra/talos-system-extensions/README.md
+++ b/apps/infra/talos-system-extensions/README.md
@@ -1,0 +1,33 @@
+# talos-system-extensions
+
+GitOps **source of truth** for the Talos **system-extension catalog + version pins** — the
+NVIDIA driver + container toolkit extensions baked into the bare-metal GPU cluster's boot
+image. Part of **WS-A**. System: `ml-infra`.
+
+**ADR:** [ADR-0050](../../../docs/adrs/0050-talos-gpu-driver-system-extensions.md) (GPU
+driver via Talos system extension). ADR-0028 labels.
+
+## What this is (and isn't)
+
+It is a **pin/doc chart**: it makes the extension image refs and their Talos-release
+coupling visible and reviewable in GitOps. It does **not** install anything on a running
+host — Talos extensions ship in the boot **image** and are applied by a **re-image**, never
+`apt install` (there is no package manager). The Terraform `talos-machineconfig` module
+references the same pins; this app keeps the catalog auditable.
+
+## Apply-gated
+
+Changing an extension = a Talos image change + node re-image. That is **apply-gated**,
+staged on the **standby DC first**, with A/B-partition auto-rollback and the
+`gpu-driver-updates.md` post-update checklist as the gate (risk R2). Nothing here mutates a
+host directly.
+
+## Contents
+
+- `nonfree-kmod-nvidia` — NVIDIA kernel driver (GPU workers)
+- `nvidia-container-toolkit` — NVIDIA container runtime hooks
+- the `rbd`/`ceph` (ADR-0052) + `nvidia*` (ADR-0050) kernel modules the cluster needs
+
+## ADR-0028 labeling
+
+`platform.system = ml-infra`, `platform.component = compute`, `platform.managed-by = argocd`.

--- a/apps/infra/talos-system-extensions/values.yaml
+++ b/apps/infra/talos-system-extensions/values.yaml
@@ -1,0 +1,44 @@
+---
+# Talos system-extension catalog/version pins (ADR-0050) — the GitOps source of truth for
+# the extensions baked into the Talos boot image. This is a DOC/pin chart: it does not
+# install anything on a running host (Talos extensions ship in the image, applied via a
+# re-image — never `apt install`). The terraform talos-machineconfig module references the
+# same pins; this app keeps them visible and reviewable in GitOps.
+#
+# APPLY-GATED: enabling/changing an extension is a Talos image change + node re-image, which
+# is apply-gated and staged on the standby DC first (risk R2). Nothing here mutates a host.
+
+talosVersion: v1.9.2
+
+# ADR-0028 labels (dotted, Kubernetes/Talos plane).
+platformLabels:
+  platform.system: ml-infra
+  platform.component: compute
+  platform.managed-by: argocd
+
+# The system extensions pinned to the Talos release (ADR-0050). Driver coupling to the
+# Talos version is intentional — accept the coupled-upgrade cost for image reproducibility.
+extensions:
+  - name: nonfree-kmod-nvidia
+    image: ghcr.io/siderolabs/nonfree-kmod-nvidia:535.183.06-v1.9.2
+    purpose: NVIDIA kernel driver (GPU workers) — the immutable-OS replacement for a host install
+  - name: nvidia-container-toolkit
+    image: ghcr.io/siderolabs/nvidia-container-toolkit:535.183.06-v1.17.3
+    purpose: NVIDIA container runtime hooks
+
+# Kernel modules these extensions + Rook-Ceph require (mirrors the talos-machineconfig
+# module; rbd+ceph is the ADR-0052 prerequisite, nvidia* backs the driver, ADR-0050).
+kernelModules:
+  - rbd
+  - ceph
+  - nvidia
+  - nvidia_uvm
+  - nvidia_drm
+  - nvidia_modeset
+
+# Upgrade gate (ADR-0050 / risk R2): stage on standby, A/B partition + auto-rollback,
+# run the gpu-driver-updates.md post-update checklist before promoting to primary.
+upgradePolicy:
+  stageOnStandbyFirst: true
+  autoRollbackOnBootFailure: true
+  postUpgradeChecklist: ai-sre/knowledge/gpu-driver-updates.md

--- a/catalog/stacks/baremetal-gpu-analysis/terragrunt.stack.hcl
+++ b/catalog/stacks/baremetal-gpu-analysis/terragrunt.stack.hcl
@@ -1,0 +1,193 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Bare-metal GPU Analysis Stack Template (WS-A — ml-infra) — ADR-0049..0054
+# ---------------------------------------------------------------------------------------------------------------------
+# The bare-metal analogue of gcp-gpu-analysis: composes the owned Talos GPU ML platform
+# across TWO UK datacenters (primary + standby), placed under the live tree at
+# terragrunt/uk/{primary,standby}/platform/ (the path docs/transaction-analytics/
+# 06-uk-datacenters.md already names).
+#
+# WS-A OWNS THIS FILE. It scaffolds references to ALL planned units across WS-A..F so
+# sibling-workstream PRs (WS-B..F) never edit this stack — they only ship their unit/module
+# and flip its default-OFF toggle in the live tree's baremetal_config. WS-B/E units are
+# scaffolded as commented blocks below (their catalog units don't exist yet; uncomment the
+# block AND add the unit dir in that WS's PR). Everything is APPLY-GATED / default-OFF: each
+# unit's `enabled` resolves from baremetal_config and defaults false, so `stack generate` +
+# `run plan` create nothing real.
+#
+# Internal WS-A order is load-bearing (unlike the GCP plan where the cluster pre-existed):
+#   talos-machineconfig → talos-cluster        (control plane + etcd; gates everything)
+#     → baremetal-cilium-lb                     (CNI before workloads)
+#     → baremetal-rook-ceph                     (storage before stateful ML; rbd+ceph prereq)
+#     → talos-gpu-nodepool                      (fixed GPU pool)
+#     → baremetal-gpu-operator → -dcgm → -scheduling → -fabric   (GPU stack)
+#     → baremetal-ingress-waf                   (serving front)
+# Cross-unit data flows through `dependency` blocks with mock_outputs (kubeconfig/endpoint
+# from talos-cluster; ceph kernel modules from talos-machineconfig).
+#
+# Usage (from the live tree):
+#   cd terragrunt/uk/primary/platform   # (or standby)
+#   terragrunt stack generate
+#   terragrunt run --all plan           # plan only — apply is CI/CD from main, never here
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  # The two UK datacenters the platform spans (primary-active + standby-hot-standby).
+  primary_dc = "primary"
+  standby_dc = "standby"
+}
+
+# =====================================================================================================================
+# PRIMARY DC — full WS-A Talos GPU stack (sized for 100% steady state).
+# =====================================================================================================================
+
+unit "talos-machineconfig-primary" {
+  source = "${get_repo_root()}/catalog/units/talos-machineconfig"
+  path   = "${local.primary_dc}/talos-machineconfig"
+  values = { dc = local.primary_dc }
+}
+
+unit "talos-cluster-primary" {
+  source = "${get_repo_root()}/catalog/units/talos-cluster"
+  path   = "${local.primary_dc}/talos-cluster"
+  values = { dc = local.primary_dc }
+}
+
+unit "baremetal-cilium-lb-primary" {
+  source = "${get_repo_root()}/catalog/units/baremetal-cilium-lb"
+  path   = "${local.primary_dc}/baremetal-cilium-lb"
+  values = { dc = local.primary_dc }
+}
+
+unit "baremetal-rook-ceph-primary" {
+  source = "${get_repo_root()}/catalog/units/baremetal-rook-ceph"
+  path   = "${local.primary_dc}/baremetal-rook-ceph"
+  values = { dc = local.primary_dc }
+}
+
+unit "talos-gpu-nodepool-primary" {
+  source = "${get_repo_root()}/catalog/units/talos-gpu-nodepool"
+  path   = "${local.primary_dc}/talos-gpu-nodepool"
+  values = { dc = local.primary_dc }
+}
+
+unit "baremetal-gpu-operator-primary" {
+  source = "${get_repo_root()}/catalog/units/baremetal-gpu-operator"
+  path   = "${local.primary_dc}/baremetal-gpu-operator"
+  values = { dc = local.primary_dc }
+}
+
+unit "baremetal-gpu-dcgm-primary" {
+  source = "${get_repo_root()}/catalog/units/baremetal-gpu-dcgm"
+  path   = "${local.primary_dc}/baremetal-gpu-dcgm"
+  values = { dc = local.primary_dc }
+}
+
+unit "baremetal-gpu-scheduling-primary" {
+  source = "${get_repo_root()}/catalog/units/baremetal-gpu-scheduling"
+  path   = "${local.primary_dc}/baremetal-gpu-scheduling"
+  values = { dc = local.primary_dc }
+}
+
+unit "baremetal-gpu-fabric-primary" {
+  source = "${get_repo_root()}/catalog/units/baremetal-gpu-fabric"
+  path   = "${local.primary_dc}/baremetal-gpu-fabric"
+  values = { dc = local.primary_dc }
+}
+
+unit "baremetal-ingress-waf-primary" {
+  source = "${get_repo_root()}/catalog/units/baremetal-ingress-waf"
+  path   = "${local.primary_dc}/baremetal-ingress-waf"
+  values = { dc = local.primary_dc }
+}
+
+# =====================================================================================================================
+# STANDBY DC — full WS-A Talos GPU stack (~40% capacity; sized to absorb failover serving).
+# =====================================================================================================================
+
+unit "talos-machineconfig-standby" {
+  source = "${get_repo_root()}/catalog/units/talos-machineconfig"
+  path   = "${local.standby_dc}/talos-machineconfig"
+  values = { dc = local.standby_dc }
+}
+
+unit "talos-cluster-standby" {
+  source = "${get_repo_root()}/catalog/units/talos-cluster"
+  path   = "${local.standby_dc}/talos-cluster"
+  values = { dc = local.standby_dc }
+}
+
+unit "baremetal-cilium-lb-standby" {
+  source = "${get_repo_root()}/catalog/units/baremetal-cilium-lb"
+  path   = "${local.standby_dc}/baremetal-cilium-lb"
+  values = { dc = local.standby_dc }
+}
+
+unit "baremetal-rook-ceph-standby" {
+  source = "${get_repo_root()}/catalog/units/baremetal-rook-ceph"
+  path   = "${local.standby_dc}/baremetal-rook-ceph"
+  values = { dc = local.standby_dc }
+}
+
+unit "talos-gpu-nodepool-standby" {
+  source = "${get_repo_root()}/catalog/units/talos-gpu-nodepool"
+  path   = "${local.standby_dc}/talos-gpu-nodepool"
+  values = { dc = local.standby_dc }
+}
+
+unit "baremetal-gpu-operator-standby" {
+  source = "${get_repo_root()}/catalog/units/baremetal-gpu-operator"
+  path   = "${local.standby_dc}/baremetal-gpu-operator"
+  values = { dc = local.standby_dc }
+}
+
+unit "baremetal-gpu-dcgm-standby" {
+  source = "${get_repo_root()}/catalog/units/baremetal-gpu-dcgm"
+  path   = "${local.standby_dc}/baremetal-gpu-dcgm"
+  values = { dc = local.standby_dc }
+}
+
+unit "baremetal-gpu-scheduling-standby" {
+  source = "${get_repo_root()}/catalog/units/baremetal-gpu-scheduling"
+  path   = "${local.standby_dc}/baremetal-gpu-scheduling"
+  values = { dc = local.standby_dc }
+}
+
+unit "baremetal-gpu-fabric-standby" {
+  source = "${get_repo_root()}/catalog/units/baremetal-gpu-fabric"
+  path   = "${local.standby_dc}/baremetal-gpu-fabric"
+  values = { dc = local.standby_dc }
+}
+
+unit "baremetal-ingress-waf-standby" {
+  source = "${get_repo_root()}/catalog/units/baremetal-ingress-waf"
+  path   = "${local.standby_dc}/baremetal-ingress-waf"
+  values = { dc = local.standby_dc }
+}
+
+# =====================================================================================================================
+# SCAFFOLD — sibling-workstream units (WS-B..F), default OFF. These are owned here so sibling
+# PRs add ONLY their unit/module + flip the toggle in baremetal_config; they never edit this
+# stack. Each block is commented because the referenced catalog unit ships in that WS's PR —
+# uncommenting an empty source would break `stack generate`. The WS-A owner (this file) is
+# the single place these per-DC compositions live.
+#
+# WS-B — ML CI/CD + registry (ADR-0037 reused; substrate delta in ADR-0052):
+#   unit "baremetal-ml-artifact-store-primary" {
+#     source = "${get_repo_root()}/catalog/units/baremetal-ml-artifact-store"
+#     path   = "${local.primary_dc}/baremetal-ml-artifact-store"   # consumes rook-ceph s3_endpoint
+#     values = { dc = local.primary_dc }
+#   }
+#   unit "baremetal-ml-artifact-store-standby" { ...standby... }
+#
+# WS-E — Security posture / SOC (ADR-0040 reused; Talos-posture delta in ADR-0050):
+#   unit "baremetal-org-policy-primary" {
+#     source = "${get_repo_root()}/catalog/units/baremetal-org-policy"
+#     path   = "${local.primary_dc}/baremetal-org-policy"          # Talos posture + Kyverno/Gatekeeper bundle
+#     values = { dc = local.primary_dc }
+#   }
+#   unit "baremetal-org-policy-standby" { ...standby... }
+#
+# WS-C (ml-monitoring), WS-D (grafana-self-serve + bare-metal panels), WS-F (golden paths)
+# are delivered as ArgoCD apps / dashboards / templates, not new catalog units — they ride
+# the in-cluster delivery layer (apps/infra/*) and do not add per-DC stack units here.
+# =====================================================================================================================

--- a/catalog/units/baremetal-cilium-lb/terragrunt.hcl
+++ b/catalog/units/baremetal-cilium-lb/terragrunt.hcl
@@ -1,0 +1,61 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Bare-metal Cilium CNI + LB-IPAM + BGP — Catalog Unit (WS-A — ml-infra) — ADR-0051
+# ---------------------------------------------------------------------------------------------------------------------
+# Cilium CNI (kube-proxy-less) + LB-IPAM + BGP. CNI must exist before workloads, so this is
+# sequenced right after talos-cluster.
+#
+# Apply-gated: enabled defaults OFF.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/baremetal-cilium-lb"
+}
+
+locals {
+  project_vars = try(read_terragrunt_config(find_in_parent_folders("project.hcl")), { locals = {} })
+  region_vars  = try(read_terragrunt_config(find_in_parent_folders("region.hcl")), { locals = {} })
+
+  environment = try(local.project_vars.locals.environment, "staging")
+  baremetal   = try(local.project_vars.locals.baremetal_config, {})
+  dc          = try(local.region_vars.locals.uk_dc, "primary")
+}
+
+dependency "cluster" {
+  config_path = "../talos-cluster"
+
+  mock_outputs = {
+    kubeconfig       = "mock-kubeconfig"
+    cluster_endpoint = "https://10.10.0.10:6443"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+generate "k8s_providers" {
+  path      = "k8s_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "helm" {
+      kubernetes {
+        config_path = "~/.kube/uk-${local.dc}.config"
+      }
+    }
+
+    provider "kubernetes" {
+      config_path = "~/.kube/uk-${local.dc}.config"
+    }
+  PROVIDERS
+}
+
+inputs = {
+  enabled    = try(local.baremetal.cilium_lb_enabled, false)
+  enable_bgp = try(local.baremetal.cilium_bgp_enabled, true)
+
+  lb_ipam_cidrs = try(local.baremetal.lb_ipam_cidrs, ["10.20.0.0/24"])
+
+  platform_labels = {
+    "platform.env"   = local.environment
+    "platform.owner" = "team-data"
+  }
+}

--- a/catalog/units/baremetal-gpu-dcgm/terragrunt.hcl
+++ b/catalog/units/baremetal-gpu-dcgm/terragrunt.hcl
@@ -1,0 +1,58 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Bare-metal GPU DCGM — Catalog Unit (WS-A — ml-infra) — ADR-0049 / ADR-0050
+# ---------------------------------------------------------------------------------------------------------------------
+# DCGM exporter + GPU-health auto-taint on the Talos GPU nodes.
+#
+# Apply-gated: enabled defaults OFF.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/baremetal-gpu-dcgm"
+}
+
+locals {
+  project_vars = try(read_terragrunt_config(find_in_parent_folders("project.hcl")), { locals = {} })
+  region_vars  = try(read_terragrunt_config(find_in_parent_folders("region.hcl")), { locals = {} })
+
+  environment = try(local.project_vars.locals.environment, "staging")
+  baremetal   = try(local.project_vars.locals.baremetal_config, {})
+  dc          = try(local.region_vars.locals.uk_dc, "primary")
+}
+
+dependency "cluster" {
+  config_path = "../talos-cluster"
+
+  mock_outputs = {
+    kubeconfig       = "mock-kubeconfig"
+    cluster_endpoint = "https://10.10.0.10:6443"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+generate "k8s_providers" {
+  path      = "k8s_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "helm" {
+      kubernetes {
+        config_path = "~/.kube/uk-${local.dc}.config"
+      }
+    }
+
+    provider "kubernetes" {
+      config_path = "~/.kube/uk-${local.dc}.config"
+    }
+  PROVIDERS
+}
+
+inputs = {
+  enabled           = try(local.baremetal.gpu_dcgm_enabled, false)
+  enable_auto_taint = try(local.baremetal.gpu_auto_taint_enabled, true)
+
+  platform_labels = {
+    "platform.env"   = local.environment
+    "platform.owner" = "team-data"
+  }
+}

--- a/catalog/units/baremetal-gpu-fabric/terragrunt.hcl
+++ b/catalog/units/baremetal-gpu-fabric/terragrunt.hcl
@@ -1,0 +1,59 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Bare-metal GPU Fabric — Catalog Unit (WS-A — ml-infra) — ADR-0053
+# ---------------------------------------------------------------------------------------------------------------------
+# SR-IOV/RDMA day-0 primary + gated DRANET target, RoCEv2/InfiniBand.
+#
+# Apply-gated: enabled defaults OFF; DRANET target gated separately (enable_dranet OFF).
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/baremetal-gpu-fabric"
+}
+
+locals {
+  project_vars = try(read_terragrunt_config(find_in_parent_folders("project.hcl")), { locals = {} })
+  region_vars  = try(read_terragrunt_config(find_in_parent_folders("region.hcl")), { locals = {} })
+
+  environment = try(local.project_vars.locals.environment, "staging")
+  baremetal   = try(local.project_vars.locals.baremetal_config, {})
+  dc          = try(local.region_vars.locals.uk_dc, "primary")
+}
+
+dependency "cluster" {
+  config_path = "../talos-cluster"
+
+  mock_outputs = {
+    kubeconfig       = "mock-kubeconfig"
+    cluster_endpoint = "https://10.10.0.10:6443"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+generate "k8s_providers" {
+  path      = "k8s_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "helm" {
+      kubernetes {
+        config_path = "~/.kube/uk-${local.dc}.config"
+      }
+    }
+
+    provider "kubernetes" {
+      config_path = "~/.kube/uk-${local.dc}.config"
+    }
+  PROVIDERS
+}
+
+inputs = {
+  enabled       = try(local.baremetal.gpu_fabric_enabled, false)
+  fabric_mode   = try(local.baremetal.fabric_mode, "infiniband")
+  enable_dranet = try(local.baremetal.fabric_dranet_enabled, false)
+
+  platform_labels = {
+    "platform.env"   = local.environment
+    "platform.owner" = "team-data"
+  }
+}

--- a/catalog/units/baremetal-gpu-operator/terragrunt.hcl
+++ b/catalog/units/baremetal-gpu-operator/terragrunt.hcl
@@ -1,0 +1,58 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Bare-metal GPU Operator — Catalog Unit (WS-A — ml-infra) — ADR-0050
+# ---------------------------------------------------------------------------------------------------------------------
+# NVIDIA GPU Operator in driver-less mode (driver ships in the Talos system extension).
+#
+# Apply-gated: enabled defaults OFF.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/baremetal-gpu-operator"
+}
+
+locals {
+  project_vars = try(read_terragrunt_config(find_in_parent_folders("project.hcl")), { locals = {} })
+  region_vars  = try(read_terragrunt_config(find_in_parent_folders("region.hcl")), { locals = {} })
+
+  environment = try(local.project_vars.locals.environment, "staging")
+  baremetal   = try(local.project_vars.locals.baremetal_config, {})
+  dc          = try(local.region_vars.locals.uk_dc, "primary")
+}
+
+dependency "cluster" {
+  config_path = "../talos-cluster"
+
+  mock_outputs = {
+    kubeconfig       = "mock-kubeconfig"
+    cluster_endpoint = "https://10.10.0.10:6443"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+generate "k8s_providers" {
+  path      = "k8s_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "helm" {
+      kubernetes {
+        config_path = "~/.kube/uk-${local.dc}.config"
+      }
+    }
+
+    provider "kubernetes" {
+      config_path = "~/.kube/uk-${local.dc}.config"
+    }
+  PROVIDERS
+}
+
+inputs = {
+  enabled       = try(local.baremetal.gpu_operator_enabled, false)
+  chart_version = try(local.baremetal.gpu_operator_chart_version, "v24.9.2")
+
+  platform_labels = {
+    "platform.env"   = local.environment
+    "platform.owner" = "team-data"
+  }
+}

--- a/catalog/units/baremetal-gpu-scheduling/terragrunt.hcl
+++ b/catalog/units/baremetal-gpu-scheduling/terragrunt.hcl
@@ -1,0 +1,58 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Bare-metal GPU Scheduling — Catalog Unit (WS-A — ml-infra) — ADR-0049
+# ---------------------------------------------------------------------------------------------------------------------
+# Volcano + the UK queue taxonomy + DRA device classes.
+#
+# Apply-gated: enabled defaults OFF.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/baremetal-gpu-scheduling"
+}
+
+locals {
+  project_vars = try(read_terragrunt_config(find_in_parent_folders("project.hcl")), { locals = {} })
+  region_vars  = try(read_terragrunt_config(find_in_parent_folders("region.hcl")), { locals = {} })
+
+  environment = try(local.project_vars.locals.environment, "staging")
+  baremetal   = try(local.project_vars.locals.baremetal_config, {})
+  dc          = try(local.region_vars.locals.uk_dc, "primary")
+}
+
+dependency "cluster" {
+  config_path = "../talos-cluster"
+
+  mock_outputs = {
+    kubeconfig       = "mock-kubeconfig"
+    cluster_endpoint = "https://10.10.0.10:6443"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+generate "k8s_providers" {
+  path      = "k8s_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "helm" {
+      kubernetes {
+        config_path = "~/.kube/uk-${local.dc}.config"
+      }
+    }
+
+    provider "kubernetes" {
+      config_path = "~/.kube/uk-${local.dc}.config"
+    }
+  PROVIDERS
+}
+
+inputs = {
+  enabled     = try(local.baremetal.gpu_scheduling_enabled, false)
+  dra_enabled = try(local.baremetal.gpu_dra_enabled, true)
+
+  platform_labels = {
+    "platform.env"   = local.environment
+    "platform.owner" = "team-data"
+  }
+}

--- a/catalog/units/baremetal-ingress-waf/terragrunt.hcl
+++ b/catalog/units/baremetal-ingress-waf/terragrunt.hcl
@@ -1,0 +1,52 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Bare-metal Ingress WAF / Rate-limit — Catalog Unit (WS-A — ml-infra) — ADR-0053
+# ---------------------------------------------------------------------------------------------------------------------
+# On-prem WAF/rate-limit serving front (Cilium/Envoy Gateway) — the Cloud Armor mirror.
+#
+# Apply-gated: enabled defaults OFF.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/baremetal-ingress-waf"
+}
+
+locals {
+  project_vars = try(read_terragrunt_config(find_in_parent_folders("project.hcl")), { locals = {} })
+  region_vars  = try(read_terragrunt_config(find_in_parent_folders("region.hcl")), { locals = {} })
+
+  environment = try(local.project_vars.locals.environment, "staging")
+  baremetal   = try(local.project_vars.locals.baremetal_config, {})
+  dc          = try(local.region_vars.locals.uk_dc, "primary")
+}
+
+dependency "cluster" {
+  config_path = "../talos-cluster"
+
+  mock_outputs = {
+    kubeconfig       = "mock-kubeconfig"
+    cluster_endpoint = "https://10.10.0.10:6443"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+generate "k8s_provider" {
+  path      = "k8s_provider_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "kubernetes" {
+      config_path = "~/.kube/uk-${local.dc}.config"
+    }
+  PROVIDERS
+}
+
+inputs = {
+  enabled         = try(local.baremetal.ingress_waf_enabled, false)
+  gateway_backend = try(local.baremetal.ingress_gateway_backend, "cilium")
+
+  platform_labels = {
+    "platform.env"   = local.environment
+    "platform.owner" = "team-data"
+  }
+}

--- a/catalog/units/baremetal-rook-ceph/terragrunt.hcl
+++ b/catalog/units/baremetal-rook-ceph/terragrunt.hcl
@@ -1,0 +1,77 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Bare-metal Rook-Ceph Storage — Catalog Unit (WS-A — ml-infra) — ADR-0052
+# ---------------------------------------------------------------------------------------------------------------------
+# Rook-Ceph (block + FS + RGW S3). Sequenced AFTER talos-machineconfig (the rbd+ceph kernel
+# modules MUST be declared there first) and talos-cluster. The ceph_kernel_modules input is
+# wired from the machineconfig output so the module's validation enforces the ADR-0052 gate.
+#
+# Apply-gated: enabled defaults OFF.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/baremetal-rook-ceph"
+}
+
+locals {
+  project_vars = try(read_terragrunt_config(find_in_parent_folders("project.hcl")), { locals = {} })
+  region_vars  = try(read_terragrunt_config(find_in_parent_folders("region.hcl")), { locals = {} })
+
+  environment = try(local.project_vars.locals.environment, "staging")
+  baremetal   = try(local.project_vars.locals.baremetal_config, {})
+  dc          = try(local.region_vars.locals.uk_dc, "primary")
+}
+
+# The rbd+ceph kernel-module contract (ADR-0052) is wired from talos-machineconfig.
+dependency "machineconfig" {
+  config_path = "../talos-machineconfig"
+
+  mock_outputs = {
+    ceph_kernel_modules = ["rbd", "ceph"]
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+dependency "cluster" {
+  config_path = "../talos-cluster"
+
+  mock_outputs = {
+    kubeconfig       = "mock-kubeconfig"
+    cluster_endpoint = "https://10.10.0.10:6443"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+generate "k8s_providers" {
+  path      = "k8s_providers_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "helm" {
+      kubernetes {
+        config_path = "~/.kube/uk-${local.dc}.config"
+      }
+    }
+
+    provider "kubernetes" {
+      config_path = "~/.kube/uk-${local.dc}.config"
+    }
+  PROVIDERS
+}
+
+inputs = {
+  enabled = try(local.baremetal.rook_ceph_enabled, false)
+
+  # ADR-0052 contract enforced in code: pass the modules the machineconfig declared.
+  ceph_kernel_modules = dependency.machineconfig.outputs.ceph_kernel_modules
+
+  enable_object_store = try(local.baremetal.ceph_object_store_enabled, true)
+  block_pool_replicas = try(local.baremetal.ceph_replicas, 3)
+
+  platform_labels = {
+    "platform.env"   = local.environment
+    "platform.owner" = "team-data"
+  }
+}

--- a/catalog/units/talos-cluster/terragrunt.hcl
+++ b/catalog/units/talos-cluster/terragrunt.hcl
@@ -1,0 +1,51 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Talos Cluster Bootstrap — Catalog Unit (WS-A — ml-infra) — ADR-0049
+# ---------------------------------------------------------------------------------------------------------------------
+# Bootstraps the self-operated Talos control plane (etcd + kubeconfig + snapshot schedule).
+# Depends on talos-machineconfig for the secrets/client config.
+#
+# Apply-gated: enabled + bootstrap_control_plane both default OFF — etcd is never
+# initialised in this mock repo.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/talos-cluster"
+}
+
+locals {
+  project_vars = try(read_terragrunt_config(find_in_parent_folders("project.hcl")), { locals = {} })
+  region_vars  = try(read_terragrunt_config(find_in_parent_folders("region.hcl")), { locals = {} })
+
+  environment = try(local.project_vars.locals.environment, "staging")
+  baremetal   = try(local.project_vars.locals.baremetal_config, {})
+  dc          = try(local.region_vars.locals.uk_dc, "primary")
+}
+
+dependency "machineconfig" {
+  config_path = "../talos-machineconfig"
+
+  mock_outputs = {
+    machine_secrets = {}
+    client_configuration = {
+      ca_certificate     = "bW9jay1jYQ=="
+      client_certificate = "bW9jay1jZXJ0"
+      client_key         = "bW9jay1rZXk="
+    }
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+inputs = {
+  enabled                 = try(local.baremetal.talos_cluster_enabled, false)
+  bootstrap_control_plane = try(local.baremetal.bootstrap_control_plane, false)
+
+  cluster_name      = "uk-${local.dc}"
+  control_plane_vip = try(local.baremetal.control_plane_vip, "10.10.0.10")
+
+  platform_labels = {
+    "platform.env"   = local.environment
+    "platform.owner" = "team-data"
+  }
+}

--- a/catalog/units/talos-gpu-nodepool/terragrunt.hcl
+++ b/catalog/units/talos-gpu-nodepool/terragrunt.hcl
@@ -1,0 +1,58 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Talos GPU Node Pool — Catalog Unit (WS-A — ml-infra) — ADR-0049 / ADR-0054
+# ---------------------------------------------------------------------------------------------------------------------
+# A fixed-capacity GPU node pool (no autoscaler). Depends on talos-cluster for the
+# kubeconfig used to apply the node-pool policy.
+#
+# Apply-gated: enabled defaults OFF; Cluster-API re-image path (manage_cluster_api) OFF.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/talos-gpu-nodepool"
+}
+
+locals {
+  project_vars = try(read_terragrunt_config(find_in_parent_folders("project.hcl")), { locals = {} })
+  region_vars  = try(read_terragrunt_config(find_in_parent_folders("region.hcl")), { locals = {} })
+
+  environment = try(local.project_vars.locals.environment, "staging")
+  baremetal   = try(local.project_vars.locals.baremetal_config, {})
+  dc          = try(local.region_vars.locals.uk_dc, "primary")
+}
+
+dependency "cluster" {
+  config_path = "../talos-cluster"
+
+  mock_outputs = {
+    kubeconfig       = "mock-kubeconfig"
+    cluster_endpoint = "https://10.10.0.10:6443"
+  }
+
+  mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+}
+
+generate "k8s_provider" {
+  path      = "k8s_provider_override.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<-PROVIDERS
+    provider "kubernetes" {
+      config_path = "~/.kube/uk-${local.dc}.config"
+    }
+  PROVIDERS
+}
+
+inputs = {
+  enabled            = try(local.baremetal.talos_gpu_nodepool_enabled, false)
+  manage_cluster_api = try(local.baremetal.manage_cluster_api, false)
+
+  cluster_name = "uk-${local.dc}"
+  pool_name    = try(local.baremetal.gpu_pool_name, "h100-training")
+  gpu_model    = try(local.baremetal.gpu_model, "H100")
+  machines     = try(local.baremetal.gpu_machines, [])
+
+  platform_labels = {
+    "platform.env"   = local.environment
+    "platform.owner" = "team-data"
+  }
+}

--- a/catalog/units/talos-machineconfig/terragrunt.hcl
+++ b/catalog/units/talos-machineconfig/terragrunt.hcl
@@ -1,0 +1,41 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Talos MachineConfig — Catalog Unit (WS-A — ml-infra) — ADR-0049 / ADR-0050 / ADR-0052
+# ---------------------------------------------------------------------------------------------------------------------
+# Renders the immutable Talos MachineConfig (control-plane + GPU-worker) — the single place
+# the rbd+ceph kernel modules (ADR-0052) and the NVIDIA system extension (ADR-0050) are
+# declared. Gates the whole WS-A stack: nothing else can come up before this.
+#
+# Requires project.hcl with: environment, baremetal_config (optional)
+# Requires region.hcl with: uk_dc (optional)
+# Apply-gated: enabled defaults OFF.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  source = "${get_repo_root()}/terraform/modules/talos-machineconfig"
+}
+
+locals {
+  project_vars = try(read_terragrunt_config(find_in_parent_folders("project.hcl")), { locals = {} })
+  region_vars  = try(read_terragrunt_config(find_in_parent_folders("region.hcl")), { locals = {} })
+
+  environment = try(local.project_vars.locals.environment, "staging")
+  baremetal   = try(local.project_vars.locals.baremetal_config, {})
+  dc          = try(local.region_vars.locals.uk_dc, "primary")
+}
+
+inputs = {
+  # Apply-gated default-OFF; flip via baremetal_config.talos_machineconfig_enabled per DC.
+  enabled = try(local.baremetal.talos_machineconfig_enabled, false)
+
+  cluster_name     = "uk-${local.dc}"
+  cluster_endpoint = try(local.baremetal.cluster_endpoint, "https://10.10.0.10:6443")
+
+  control_plane_endpoints = try(local.baremetal.control_plane_endpoints, ["10.10.0.10"])
+  talos_version           = try(local.baremetal.talos_version, "v1.9.2")
+  kubernetes_version      = try(local.baremetal.kubernetes_version, "v1.32.0")
+
+  platform_labels = {
+    "platform.env"   = local.environment
+    "platform.owner" = "team-data"
+  }
+}

--- a/terraform/modules/baremetal-cilium-lb/README.md
+++ b/terraform/modules/baremetal-cilium-lb/README.md
@@ -1,0 +1,49 @@
+# baremetal-cilium-lb
+
+**Cilium CNI (kube-proxy-less) + LB-IPAM + BGP control-plane** for the bare-metal GPU
+cluster. Part of **WS-A** of the Bare-Metal ML Platform. System: `ml-infra`.
+
+**ADRs:** [ADR-0051](../../../docs/adrs/0051-baremetal-networking-cilium-lb-bgp.md)
+(Cilium LB-IPAM/BGP vs MetalLB), with MTU 9000 for the fabric per
+[ADR-0053](../../../docs/adrs/0053-baremetal-gpu-fabric-roce-infiniband.md). ADR-0028 labels.
+
+## Why a load-balancer module at all
+
+On owned hardware there is **no cloud VPC and no cloud LB** (ADR-0051) — nothing hands a
+Service an external IP. So Cilium provides both pod networking (eBPF, kube-proxy-less) and
+the load-balancer: **LB-IPAM** allocates service VIPs and the **Cilium BGP control-plane**
+advertises them to the ToR switches.
+
+## What it creates (when `enabled = true`)
+
+| Resource | Purpose |
+|----------|---------|
+| `helm_release.cilium` | Cilium CNI, kube-proxy-less, MTU 9000, BGP control-plane |
+| `kubernetes_manifest.lb_ip_pool` | `CiliumLoadBalancerIPPool` — service-VIP address pool |
+| `kubernetes_manifest.bgp_cluster_config` | (gated) `CiliumBGPClusterConfig` — ToR peering |
+| `kubernetes_manifest.bgp_peer_config` | (gated) `CiliumBGPPeerConfig` — runbook-tuned timers |
+
+## BGP and the runbook
+
+`enable_bgp` defaults **true**. BGP timers honour `ai-sre/knowledge/cilium-bgp-issues.md`:
+**hold timer 180s** so sessions survive CPU pressure on GPU nodes, ToR `max-prefix` sized
+upstream. When `enable_bgp = false`, LB-IPAM still allocates VIPs (the **MetalLB-L2-style
+fallback** documented in ADR-0051) but BGP peering is not configured.
+
+## Apply-gated
+
+`var.enabled` defaults **false**. The CRs are rendered against mocked providers at plan
+time — no live cluster. No `terraform apply` / Helm install in this repo.
+
+## ADR-0028 labeling
+
+Dotted keys: `platform.system = ml-infra`, `platform.component = networking`,
+`platform.managed-by = terragrunt`, plus `platform_labels` overrides — on the Helm
+workloads and every LB/BGP custom resource.
+
+## Testing
+
+```bash
+terraform init -backend=false
+terraform test
+```

--- a/terraform/modules/baremetal-cilium-lb/baremetal-cilium-lb.tftest.hcl
+++ b/terraform/modules/baremetal-cilium-lb/baremetal-cilium-lb.tftest.hcl
@@ -1,0 +1,96 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests for the baremetal-cilium-lb module. helm + kubernetes providers are mocked;
+# assertions run at plan time over the CNI/LB/BGP wiring (ADR-0051).
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "helm" {}
+mock_provider "kubernetes" {}
+
+variables {
+  enabled = true
+  platform_labels = {
+    "platform.env"   = "staging"
+    "platform.owner" = "team-data"
+  }
+}
+
+run "disabled_creates_nothing" {
+  command = plan
+
+  variables {
+    enabled = false
+  }
+
+  assert {
+    condition     = length(helm_release.cilium) == 0
+    error_message = "No Cilium release when enabled = false."
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.lb_ip_pool) == 0
+    error_message = "No LB-IPAM pool when enabled = false."
+  }
+}
+
+run "deploys_cilium_and_lb_pool" {
+  command = plan
+
+  assert {
+    condition     = helm_release.cilium[0].version == var.chart_version
+    error_message = "Cilium must use the pinned chart version."
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.lb_ip_pool) == 1
+    error_message = "LB-IPAM pool must be created (no cloud LB on bare metal, ADR-0051)."
+  }
+}
+
+run "kube_proxy_less_and_jumbo_mtu" {
+  command = plan
+
+  # ADR-0051 kube-proxy-less + ADR-0053 jumbo frames.
+  assert {
+    condition     = var.kube_proxy_replacement == "true"
+    error_message = "Cilium must run kube-proxy-less (ADR-0051)."
+  }
+
+  assert {
+    condition     = output.mtu == 9000
+    error_message = "MTU must default to 9000 (jumbo frames) for the GPU fabric (ADR-0053)."
+  }
+}
+
+run "bgp_peering_on_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(kubernetes_manifest.bgp_cluster_config) == 1
+    error_message = "BGP cluster config must be created when enable_bgp (default true), ADR-0051."
+  }
+
+  # Runbook: hold timer raised so sessions survive CPU pressure.
+  assert {
+    condition     = kubernetes_manifest.bgp_peer_config[0].manifest.spec.timers.holdTimeSeconds == 180
+    error_message = "BGP hold timer must be 180s per cilium-bgp-issues.md."
+  }
+}
+
+run "bgp_off_falls_back_to_lb_only" {
+  command = plan
+
+  variables {
+    enable_bgp = false
+  }
+
+  # LB-IPAM still allocates VIPs; BGP peering is not configured (L2 fallback, ADR-0051).
+  assert {
+    condition     = length(kubernetes_manifest.bgp_cluster_config) == 0
+    error_message = "BGP cluster config must not be created when enable_bgp = false."
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.lb_ip_pool) == 1
+    error_message = "LB-IPAM pool must still exist in the BGP-off fallback path."
+  }
+}

--- a/terraform/modules/baremetal-cilium-lb/main.tf
+++ b/terraform/modules/baremetal-cilium-lb/main.tf
@@ -1,0 +1,167 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Bare-metal Cilium CNI + LB-IPAM + BGP Module (WS-A — ml-infra) — ADR-0051
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys Cilium as the CNI in kube-proxy-less mode and provides the bare-metal
+# load-balancer that does NOT come for free on owned hardware (no cloud VPC, no cloud LB,
+# ADR-0051): LB-IPAM hands out service VIPs and the Cilium BGP control-plane advertises
+# them to the ToR switches.
+#
+# The CiliumLoadBalancerIPPool / CiliumBGPClusterConfig CRs require the CRDs to exist on a
+# live cluster, so they are emitted as kubernetes_manifest (mocked in tftest) — same
+# pattern as the gke-gpu-fabric module. BGP timers honour the cilium-bgp-issues.md runbook
+# (hold-timer raised under CPU pressure, ToR max-prefix sized).
+#
+# ADR-0028: namespace + Helm workloads + CRs carry the Kubernetes-plane dotted labels.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  platform_labels = merge(
+    {
+      "platform.system"     = "ml-infra"
+      "platform.component"  = "networking"
+      "platform.managed-by" = "terragrunt"
+    },
+    var.platform_labels,
+  )
+
+  enable_bgp = var.enabled && var.enable_bgp
+
+  gpu_tolerations = [
+    {
+      key      = "nvidia.com/gpu"
+      operator = "Exists"
+      effect   = "NoSchedule"
+    }
+  ]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Cilium Helm release — CNI in kube-proxy-less mode + LB-IPAM + BGP control-plane.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "helm_release" "cilium" {
+  count = var.enabled ? 1 : 0
+
+  name       = "cilium"
+  repository = var.chart_repository
+  chart      = "cilium"
+  version    = var.chart_version
+  namespace  = var.namespace
+  timeout    = var.helm_timeout
+
+  values = [
+    yamlencode({
+      # kube-proxy-less: Cilium owns the service datapath (eBPF), ADR-0051.
+      kubeProxyReplacement = var.kube_proxy_replacement
+      k8sServiceHost       = var.k8s_service_host
+      k8sServicePort       = var.k8s_service_port
+
+      # MTU 9000 (jumbo frames) for the GPU fabric (nic-tuning role, ADR-0053).
+      MTU = var.mtu
+
+      bgpControlPlane = {
+        enabled = var.enable_bgp
+      }
+
+      # LB-IPAM advertises service VIPs over the physical network (no cloud LB).
+      loadBalancer = {
+        algorithm = "maglev"
+      }
+
+      operator = {
+        replicas    = var.operator_replicas
+        podLabels   = local.platform_labels
+        tolerations = local.gpu_tolerations
+      }
+
+      # ADR-0028 labels on the agent pods.
+      podLabels = local.platform_labels
+    })
+  ]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# LB-IPAM pool — the service-VIP address pool advertised to the outside world.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "lb_ip_pool" {
+  count = var.enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "cilium.io/v2alpha1"
+    kind       = "CiliumLoadBalancerIPPool"
+    metadata = {
+      name   = "service-vip-pool"
+      labels = local.platform_labels
+    }
+    spec = {
+      blocks = [for cidr in var.lb_ipam_cidrs : { cidr = cidr }]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# BGP cluster config — peer with the ToR switches; runbook-honouring timers.
+# Gated by enable_bgp (MetalLB-L2-style fallback documented in ADR-0051 when off).
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "bgp_cluster_config" {
+  count = local.enable_bgp ? 1 : 0
+
+  manifest = {
+    apiVersion = "cilium.io/v2alpha1"
+    kind       = "CiliumBGPClusterConfig"
+    metadata = {
+      name   = "tor-peering"
+      labels = local.platform_labels
+    }
+    spec = {
+      nodeSelector = {
+        matchLabels = {
+          "platform.system" = "ml-infra"
+        }
+      }
+      bgpInstances = [
+        {
+          name     = "instance-${var.local_asn}"
+          localASN = var.local_asn
+          peers = [for p in var.bgp_peers : {
+            name        = p.name
+            peerAddress = p.peer_address
+            peerASN     = p.peer_asn
+            peerConfigRef = {
+              name = "tor-peer-config"
+            }
+          }]
+        }
+      ]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# BGP peer config — hold/keepalive timers per cilium-bgp-issues.md (hold raised under load).
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "bgp_peer_config" {
+  count = local.enable_bgp ? 1 : 0
+
+  manifest = {
+    apiVersion = "cilium.io/v2alpha1"
+    kind       = "CiliumBGPPeerConfig"
+    metadata = {
+      name   = "tor-peer-config"
+      labels = local.platform_labels
+    }
+    spec = {
+      timers = {
+        holdTimeSeconds      = var.bgp_hold_time_seconds
+        keepAliveTimeSeconds = var.bgp_keepalive_time_seconds
+      }
+      ebgpMultihop = var.bgp_ebgp_multihop
+      gracefulRestart = {
+        enabled = true
+      }
+    }
+  }
+}

--- a/terraform/modules/baremetal-cilium-lb/outputs.tf
+++ b/terraform/modules/baremetal-cilium-lb/outputs.tf
@@ -1,0 +1,29 @@
+output "enabled" {
+  description = "Whether Cilium + LB/BGP was deployed."
+  value       = var.enabled
+}
+
+output "release_name" {
+  description = "Cilium Helm release name (null when disabled)."
+  value       = var.enabled ? helm_release.cilium[0].name : null
+}
+
+output "bgp_enabled" {
+  description = "Whether the BGP control-plane peering was configured (false = LB-IPAM-only / L2 fallback, ADR-0051)."
+  value       = local.enable_bgp
+}
+
+output "lb_ipam_cidrs" {
+  description = "Service-VIP CIDR blocks LB-IPAM advertises."
+  value       = var.lb_ipam_cidrs
+}
+
+output "mtu" {
+  description = "Datapath MTU (9000 jumbo frames for the GPU fabric)."
+  value       = var.mtu
+}
+
+output "platform_labels" {
+  description = "Effective ADR-0028 dotted labels."
+  value       = local.platform_labels
+}

--- a/terraform/modules/baremetal-cilium-lb/variables.tf
+++ b/terraform/modules/baremetal-cilium-lb/variables.tf
@@ -1,0 +1,117 @@
+variable "enabled" {
+  description = "Master toggle. When false the module creates nothing (apply-gated default-OFF posture for the WS-A stack)."
+  type        = bool
+  default     = false
+}
+
+variable "namespace" {
+  description = "Namespace Cilium is installed into."
+  type        = string
+  default     = "kube-system"
+}
+
+variable "chart_version" {
+  description = "Pinned Cilium Helm chart version."
+  type        = string
+  default     = "1.16.5"
+}
+
+variable "chart_repository" {
+  description = "Helm repository hosting the Cilium chart."
+  type        = string
+  default     = "https://helm.cilium.io"
+}
+
+variable "kube_proxy_replacement" {
+  description = "Cilium kube-proxy replacement mode (true = full eBPF datapath, ADR-0051 kube-proxy-less)."
+  type        = string
+  default     = "true"
+}
+
+variable "k8s_service_host" {
+  description = "Kubernetes API host Cilium connects to (the control-plane VIP / KubePrism endpoint). Required in kube-proxy-less mode."
+  type        = string
+  default     = "localhost"
+}
+
+variable "k8s_service_port" {
+  description = "Kubernetes API port (KubePrism local port by default)."
+  type        = number
+  default     = 7445
+}
+
+variable "mtu" {
+  description = "Datapath MTU. 9000 (jumbo frames) for the GPU fabric per the nic-tuning role (ADR-0053)."
+  type        = number
+  default     = 9000
+}
+
+variable "operator_replicas" {
+  description = "Number of Cilium operator replicas (HA on bare metal where there is no managed control plane)."
+  type        = number
+  default     = 2
+}
+
+variable "enable_bgp" {
+  description = "Enable the Cilium BGP control-plane to advertise service VIPs to ToR switches (ADR-0051). When false, LB-IPAM still allocates VIPs but BGP peering is not configured (the MetalLB-L2-style fallback path)."
+  type        = bool
+  default     = true
+}
+
+variable "lb_ipam_cidrs" {
+  description = "Service-VIP CIDR blocks LB-IPAM allocates from and advertises (no cloud LB hands these out)."
+  type        = list(string)
+  default     = ["10.20.0.0/24"]
+  nullable    = false
+}
+
+variable "local_asn" {
+  description = "Local BGP ASN the cluster peers from."
+  type        = number
+  default     = 64512
+}
+
+variable "bgp_peers" {
+  description = "ToR switch BGP peers to advertise service VIPs to (ADR-0051)."
+  type = list(object({
+    name         = string
+    peer_address = string
+    peer_asn     = number
+  }))
+  default = [
+    { name = "tor-1", peer_address = "10.10.255.1", peer_asn = 64513 },
+    { name = "tor-2", peer_address = "10.10.255.2", peer_asn = 64513 },
+  ]
+  nullable = false
+}
+
+variable "bgp_hold_time_seconds" {
+  description = "BGP hold timer. Raised (180s) per cilium-bgp-issues.md so sessions survive CPU pressure on GPU nodes."
+  type        = number
+  default     = 180
+}
+
+variable "bgp_keepalive_time_seconds" {
+  description = "BGP keepalive timer (typically hold/3)."
+  type        = number
+  default     = 60
+}
+
+variable "bgp_ebgp_multihop" {
+  description = "eBGP multihop count for ToR peering."
+  type        = number
+  default     = 1
+}
+
+variable "helm_timeout" {
+  description = "Helm release timeout in seconds."
+  type        = number
+  default     = 600
+}
+
+variable "platform_labels" {
+  description = "ADR-0028 Kubernetes-plane labels (dotted keys, e.g. platform.system = ml-infra) applied to Cilium workloads and the LB/BGP custom resources."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}

--- a/terraform/modules/baremetal-cilium-lb/versions.tf
+++ b/terraform/modules/baremetal-cilium-lb/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.25"
+    }
+  }
+}

--- a/terraform/modules/baremetal-gpu-dcgm/README.md
+++ b/terraform/modules/baremetal-gpu-dcgm/README.md
@@ -1,0 +1,38 @@
+# baremetal-gpu-dcgm
+
+**NVIDIA DCGM exporter + GPU-health auto-taint** for the Talos GPU nodes. Part of **WS-A**
+of the Bare-Metal ML Platform. System: `ml-infra`.
+
+**ADRs:** [ADR-0049](../../../docs/adrs/0049-baremetal-gpu-k8s-talos-foundation-multidc.md)
+(foundation), [ADR-0050](../../../docs/adrs/0050-talos-gpu-driver-system-extensions.md)
+(GPU driver / post-update gate). ADR-0028 labels.
+
+## What it creates (when `enabled = true`)
+
+| Resource | Purpose |
+|----------|---------|
+| `kubernetes_namespace.dcgm` | Namespace, ADR-0028 labels + `monitoring=true` |
+| `helm_release.dcgm_exporter` | DCGM exporter DaemonSet + ServiceMonitor (XID/temp/ECC/NVLink/power/util) |
+| `kubernetes_manifest.gpu_health_autotaint` | (gated) CronJob that taints a node `NoSchedule` on an XID-error burst |
+
+DCGM metrics flow to **VictoriaMetrics/Prometheus** via the chart's ServiceMonitor
+(`release = victoria-metrics`). The **GPU-health auto-taint** CronJob ports the EKS
+`gpu-inference-dcgm` behaviour and honours `ai-sre/knowledge/gpu-driver-updates.md`: a
+simulated XID burst above `xid_error_threshold` taints the node out of scheduling.
+
+## Apply-gated
+
+`var.enabled` defaults **false**. Providers mocked at plan time — no live cluster, no Helm
+install. No `terraform apply` in this repo.
+
+## ADR-0028 labeling
+
+Dotted keys: `platform.system = ml-infra`, `platform.component = observability`,
+`platform.managed-by = terragrunt`, plus `platform_labels` overrides.
+
+## Testing
+
+```bash
+terraform init -backend=false
+terraform test
+```

--- a/terraform/modules/baremetal-gpu-dcgm/baremetal-gpu-dcgm.tftest.hcl
+++ b/terraform/modules/baremetal-gpu-dcgm/baremetal-gpu-dcgm.tftest.hcl
@@ -1,0 +1,74 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests for the baremetal-gpu-dcgm module. helm + kubernetes providers are mocked;
+# assertions run at plan time over the exporter + auto-taint wiring.
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "helm" {}
+mock_provider "kubernetes" {}
+
+variables {
+  enabled = true
+  platform_labels = {
+    "platform.env"   = "staging"
+    "platform.owner" = "team-data"
+  }
+}
+
+run "disabled_creates_nothing" {
+  command = plan
+
+  variables {
+    enabled = false
+  }
+
+  assert {
+    condition     = length(helm_release.dcgm_exporter) == 0
+    error_message = "No DCGM exporter when enabled = false."
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.gpu_health_autotaint) == 0
+    error_message = "No auto-taint CronJob when enabled = false."
+  }
+}
+
+run "deploys_exporter_with_servicemonitor" {
+  command = plan
+
+  assert {
+    condition     = helm_release.dcgm_exporter[0].version == var.chart_version
+    error_message = "DCGM exporter must use the pinned chart version."
+  }
+
+  assert {
+    condition     = kubernetes_namespace.dcgm[0].metadata[0].labels["platform.system"] == "ml-infra"
+    error_message = "DCGM namespace must carry platform.system = ml-infra (ADR-0028)."
+  }
+}
+
+run "auto_taint_cronjob_present_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(kubernetes_manifest.gpu_health_autotaint) == 1
+    error_message = "GPU-health auto-taint CronJob must be created by default (XID-burst node taint)."
+  }
+
+  assert {
+    condition     = output.auto_taint_enabled == true
+    error_message = "auto_taint_enabled must be true by default."
+  }
+}
+
+run "auto_taint_can_be_disabled" {
+  command = plan
+
+  variables {
+    enable_auto_taint = false
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.gpu_health_autotaint) == 0
+    error_message = "Auto-taint CronJob must not be created when enable_auto_taint = false."
+  }
+}

--- a/terraform/modules/baremetal-gpu-dcgm/main.tf
+++ b/terraform/modules/baremetal-gpu-dcgm/main.tf
@@ -1,0 +1,127 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Bare-metal GPU DCGM Module (WS-A — ml-infra) — ADR-0049 / ADR-0050
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys the NVIDIA DCGM exporter (DaemonSet) on the Talos GPU nodes exposing GPU metrics
+# (utilisation, memory, temp, power, XID/ECC/NVLink) for VictoriaMetrics/Prometheus scrape,
+# plus a GPU-health AUTO-TAINT CronJob that taints a node out of scheduling on a simulated
+# XID burst (ports the EKS gpu-inference-dcgm behaviour). Honours the
+# gpu-driver-updates.md post-update checklist.
+#
+# The dcgm-exporter chart renders its own ServiceMonitor (serviceMonitor.enabled) so the
+# module stays free of kubernetes_manifest for the metrics path. The auto-taint CronJob is
+# a kubernetes_manifest (mocked in tftest).
+#
+# ADR-0028: namespace + exporter + CronJob carry the Kubernetes-plane dotted labels.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  platform_labels = merge(
+    {
+      "platform.system"     = "ml-infra"
+      "platform.component"  = "observability"
+      "platform.managed-by" = "terragrunt"
+    },
+    var.platform_labels,
+  )
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Namespace — labeled per ADR-0028; flagged for monitoring discovery.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_namespace" "dcgm" {
+  count = var.enabled ? 1 : 0
+
+  metadata {
+    name = var.namespace
+    labels = merge(local.platform_labels, {
+      "monitoring" = "true"
+    })
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DCGM exporter Helm release (DaemonSet) + ServiceMonitor.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "helm_release" "dcgm_exporter" {
+  count = var.enabled ? 1 : 0
+
+  name       = "dcgm-exporter"
+  repository = var.chart_repository
+  chart      = "dcgm-exporter"
+  version    = var.chart_version
+  namespace  = kubernetes_namespace.dcgm[0].metadata[0].name
+  timeout    = var.helm_timeout
+
+  values = [
+    yamlencode({
+      service = {
+        type = "ClusterIP"
+        port = var.exporter_port
+      }
+      nodeSelector = var.gpu_node_selector
+      tolerations = [
+        {
+          key      = "nvidia.com/gpu"
+          operator = "Exists"
+          effect   = "NoSchedule"
+        }
+      ]
+      podLabels = local.platform_labels
+      serviceMonitor = {
+        enabled  = var.create_service_monitor
+        interval = var.scrape_interval
+        additionalLabels = merge(local.platform_labels, {
+          "release" = var.service_monitor_release_label
+        })
+      }
+    })
+  ]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU-health auto-taint CronJob — taints a node NoSchedule on an XID-error burst
+# (ports gpu-inference-dcgm; honours gpu-driver-updates.md). Gated by enable_auto_taint.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "gpu_health_autotaint" {
+  count = var.enabled && var.enable_auto_taint ? 1 : 0
+
+  manifest = {
+    apiVersion = "batch/v1"
+    kind       = "CronJob"
+    metadata = {
+      name      = "gpu-health-autotaint"
+      namespace = var.namespace
+      labels    = local.platform_labels
+    }
+    spec = {
+      schedule = var.auto_taint_schedule
+      jobTemplate = {
+        spec = {
+          template = {
+            metadata = {
+              labels = local.platform_labels
+            }
+            spec = {
+              serviceAccountName = var.auto_taint_service_account
+              restartPolicy      = "OnFailure"
+              containers = [
+                {
+                  name  = "gpu-health-check"
+                  image = var.auto_taint_image
+                  env = [
+                    { name = "DCGM_ENDPOINT", value = "http://dcgm-exporter.${var.namespace}.svc:${var.exporter_port}/metrics" },
+                    { name = "XID_THRESHOLD", value = tostring(var.xid_error_threshold) },
+                    { name = "TAINT_KEY", value = "nvidia.com/gpu-unhealthy" },
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform/modules/baremetal-gpu-dcgm/outputs.tf
+++ b/terraform/modules/baremetal-gpu-dcgm/outputs.tf
@@ -1,0 +1,24 @@
+output "enabled" {
+  description = "Whether DCGM was deployed."
+  value       = var.enabled
+}
+
+output "namespace" {
+  description = "Namespace the DCGM exporter runs in (null when disabled)."
+  value       = var.enabled ? kubernetes_namespace.dcgm[0].metadata[0].name : null
+}
+
+output "exporter_port" {
+  description = "Port DCGM metrics are exposed on for scrape."
+  value       = var.exporter_port
+}
+
+output "auto_taint_enabled" {
+  description = "Whether the GPU-health auto-taint CronJob is deployed (XID-burst node taint)."
+  value       = var.enabled && var.enable_auto_taint
+}
+
+output "platform_labels" {
+  description = "Effective ADR-0028 dotted labels."
+  value       = local.platform_labels
+}

--- a/terraform/modules/baremetal-gpu-dcgm/variables.tf
+++ b/terraform/modules/baremetal-gpu-dcgm/variables.tf
@@ -1,0 +1,97 @@
+variable "enabled" {
+  description = "Master toggle. When false the module creates nothing (apply-gated default-OFF posture for the WS-A stack)."
+  type        = bool
+  default     = false
+}
+
+variable "namespace" {
+  description = "Namespace into which the DCGM exporter DaemonSet is installed."
+  type        = string
+  default     = "gpu-monitoring"
+}
+
+variable "chart_version" {
+  description = "Pinned dcgm-exporter Helm chart version."
+  type        = string
+  default     = "3.6.1"
+}
+
+variable "chart_repository" {
+  description = "Helm repository hosting the dcgm-exporter chart."
+  type        = string
+  default     = "https://nvidia.github.io/dcgm-exporter/helm-charts"
+}
+
+variable "exporter_port" {
+  description = "Container/service port the DCGM exporter listens on for metrics scraping."
+  type        = number
+  default     = 9400
+}
+
+variable "scrape_interval" {
+  description = "Scrape interval hint embedded in the ServiceMonitor."
+  type        = string
+  default     = "15s"
+}
+
+variable "create_service_monitor" {
+  description = "Create a Prometheus-Operator ServiceMonitor for VictoriaMetrics/Prometheus scrape."
+  type        = bool
+  default     = true
+}
+
+variable "service_monitor_release_label" {
+  description = "Value of the `release` label the ServiceMonitor carries so the metrics operator selects it."
+  type        = string
+  default     = "victoria-metrics"
+}
+
+variable "gpu_node_selector" {
+  description = "Node selector restricting the DaemonSet to GPU nodes. Defaults to the talos-machineconfig GPU-present label."
+  type        = map(string)
+  default     = { "nvidia.com/gpu.present" = "true" }
+  nullable    = false
+}
+
+variable "enable_auto_taint" {
+  description = "Deploy the GPU-health auto-taint CronJob that taints a node out of scheduling on an XID-error burst (ports gpu-inference-dcgm; honours gpu-driver-updates.md)."
+  type        = bool
+  default     = true
+}
+
+variable "auto_taint_schedule" {
+  description = "Cron schedule the GPU-health auto-taint check runs on."
+  type        = string
+  default     = "*/2 * * * *"
+}
+
+variable "auto_taint_image" {
+  description = "Container image for the GPU-health auto-taint check job."
+  type        = string
+  default     = "ghcr.io/example/gpu-health-autotaint:0.1.0"
+}
+
+variable "auto_taint_service_account" {
+  description = "ServiceAccount the auto-taint CronJob runs as (needs node-taint RBAC, granted by the GitOps layer)."
+  type        = string
+  default     = "gpu-health-autotaint"
+}
+
+variable "xid_error_threshold" {
+  description = "Number of XID errors within the window that trips the auto-taint (a simulated XID burst above this taints the node)."
+  type        = number
+  default     = 3
+}
+
+variable "helm_timeout" {
+  description = "Helm release timeout in seconds."
+  type        = number
+  default     = 300
+}
+
+variable "platform_labels" {
+  description = "ADR-0028 Kubernetes-plane labels (dotted keys, e.g. platform.system = ml-infra) applied to the namespace, exporter, and auto-taint CronJob."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}

--- a/terraform/modules/baremetal-gpu-dcgm/versions.tf
+++ b/terraform/modules/baremetal-gpu-dcgm/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.25"
+    }
+  }
+}

--- a/terraform/modules/baremetal-gpu-fabric/README.md
+++ b/terraform/modules/baremetal-gpu-fabric/README.md
@@ -1,0 +1,52 @@
+# baremetal-gpu-fabric
+
+**High-performance GPU fabric** (GPUDirect RDMA over RoCEv2 / InfiniBand) for the Talos
+GPU cluster. Part of **WS-A** of the Bare-Metal ML Platform. System: `ml-infra`.
+
+**ADRs:** [ADR-0053](../../../docs/adrs/0053-baremetal-gpu-fabric-roce-infiniband.md)
+(fabric: SR-IOV day-0 / DRANET gated target; RoCEv2/IB; jumbo frames). ADR-0028 labels.
+
+## Two-stage maturity gate (ADR-0053 D3)
+
+| Stage | Path | Default | What it is |
+|-------|------|---------|-----------|
+| **Day-0 primary** | SR-IOV / RDMA device plugin | **on** | `SriovNetworkNodePolicy` carves RDMA VFs + `SriovNetwork` attaches them to GPU pods. Proven, ships now. |
+| **Gated target** | Cilium `netdev` DRA (mirror of DRANET) | **off** (`enable_dranet`) | `DeviceClass` + `ResourceClaimTemplate` selecting RDMA NICs, so Volcano schedules **GPU + NIC as one DRA claim**. |
+
+The DRANET path is gated until DRA-`netdev` is GA on our Talos/k8s, a `dranet` release is
+validated on our NIC/kernel/image, and it meets the **SR-IOV NCCL baseline** — the ADR-0053
+D3 gate. An **NCCL all-reduce bandwidth test** is the acceptance gate
+(`ai-sre/knowledge/nccl-troubleshooting.md`).
+
+## Fabric mode
+
+`fabric_mode` defaults **infiniband** (the UK doc's 400 Gbps IB + NVSwitch) → SR-IOV
+`linkType = ib`; `roce` → `linkType = eth`. MTU 9000 (jumbo frames) either way.
+
+## What it creates (when `enabled = true`)
+
+| Resource | Purpose |
+|----------|---------|
+| `kubernetes_namespace.fabric` | Namespace, ADR-0028 labels |
+| `helm_release.sriov_operator` | SR-IOV Network Operator (day-0 primary) |
+| `kubernetes_manifest.sriov_node_policy` | `SriovNetworkNodePolicy` — RDMA VFs |
+| `kubernetes_manifest.sriov_network` | `SriovNetwork` — attaches VFs to pods |
+| `kubernetes_manifest.dranet_device_class` | (gated) DRANET DeviceClass |
+| `kubernetes_manifest.dranet_claim_template` | (gated) DRANET ResourceClaimTemplate |
+
+## Apply-gated
+
+`var.enabled` defaults **false**. Providers mocked at plan time — no live cluster, no Helm
+install. No `terraform apply` in this repo.
+
+## ADR-0028 labeling
+
+Dotted keys: `platform.system = ml-infra`, `platform.component = gpu-fabric`,
+`platform.managed-by = terragrunt`, plus `platform_labels` overrides.
+
+## Testing
+
+```bash
+terraform init -backend=false
+terraform test
+```

--- a/terraform/modules/baremetal-gpu-fabric/baremetal-gpu-fabric.tftest.hcl
+++ b/terraform/modules/baremetal-gpu-fabric/baremetal-gpu-fabric.tftest.hcl
@@ -1,0 +1,104 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests for the baremetal-gpu-fabric module. helm + kubernetes providers are mocked;
+# assertions run at plan time over the day-0 SR-IOV primary and the gated DRANET target.
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "helm" {}
+mock_provider "kubernetes" {}
+
+variables {
+  enabled = true
+  platform_labels = {
+    "platform.env"   = "staging"
+    "platform.owner" = "team-data"
+  }
+}
+
+run "disabled_creates_nothing" {
+  command = plan
+
+  variables {
+    enabled = false
+  }
+
+  assert {
+    condition     = length(helm_release.sriov_operator) == 0
+    error_message = "No SR-IOV operator when enabled = false."
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.sriov_node_policy) == 0
+    error_message = "No SR-IOV node policy when enabled = false."
+  }
+}
+
+run "sriov_is_the_day0_primary" {
+  command = plan
+
+  # ADR-0053: SR-IOV/RDMA is the day-0 primary and ships by default.
+  assert {
+    condition     = length(helm_release.sriov_operator) == 1
+    error_message = "SR-IOV operator must deploy as the day-0 primary (ADR-0053)."
+  }
+
+  assert {
+    condition     = kubernetes_manifest.sriov_node_policy[0].manifest.spec.isRdma == true
+    error_message = "SR-IOV node policy must enable RDMA (GPUDirect)."
+  }
+
+  assert {
+    condition     = kubernetes_manifest.sriov_node_policy[0].manifest.spec.mtu == 9000
+    error_message = "Fabric MTU must be 9000 (jumbo frames, ADR-0053)."
+  }
+}
+
+run "infiniband_link_type" {
+  command = plan
+
+  # Default fabric_mode = infiniband → link type ib.
+  assert {
+    condition     = kubernetes_manifest.sriov_node_policy[0].manifest.spec.linkType == "ib"
+    error_message = "InfiniBand mode must set linkType = ib."
+  }
+}
+
+run "roce_link_type" {
+  command = plan
+
+  variables {
+    fabric_mode = "roce"
+  }
+
+  assert {
+    condition     = kubernetes_manifest.sriov_node_policy[0].manifest.spec.linkType == "eth"
+    error_message = "RoCEv2 mode must set linkType = eth (Ethernet)."
+  }
+}
+
+run "dranet_is_gated_off_by_default" {
+  command = plan
+
+  # ADR-0053 D3 maturity gate: DRANET is OFF until validated.
+  assert {
+    condition     = length(kubernetes_manifest.dranet_device_class) == 0
+    error_message = "DRANET (Cilium netdev DRA) must be OFF by default (ADR-0053 D3 gate)."
+  }
+
+  assert {
+    condition     = output.dranet_enabled == false
+    error_message = "dranet_enabled must be false by default."
+  }
+}
+
+run "dranet_objects_when_enabled" {
+  command = plan
+
+  variables {
+    enable_dranet = true
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.dranet_device_class) == 1 && length(kubernetes_manifest.dranet_claim_template) == 1
+    error_message = "DRANET DeviceClass + ResourceClaimTemplate must be created when enable_dranet = true."
+  }
+}

--- a/terraform/modules/baremetal-gpu-fabric/main.tf
+++ b/terraform/modules/baremetal-gpu-fabric/main.tf
@@ -1,0 +1,182 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Bare-metal GPU Fabric Module (WS-A — ml-infra) — ADR-0053
+# ---------------------------------------------------------------------------------------------------------------------
+# High-performance GPU fabric for GPUDirect RDMA over RoCEv2 / InfiniBand (the UK doc's
+# 400 Gbps IB + NVSwitch). ADR-0053 sets a two-stage maturity gate:
+#
+#   * DAY-0 PRIMARY:  SR-IOV / RDMA device plugin — a SriovNetworkNodePolicy carves RDMA
+#                     VFs and a SriovNetwork attaches them to GPU pods. Proven, ships now.
+#   * GATED TARGET:   Cilium `netdev` DRA (mirror of DRANET) — a DeviceClass +
+#                     ResourceClaimTemplate selecting RDMA NICs, so Volcano schedules
+#                     GPU + NIC as ONE DRA claim. Gated behind enable_dranet (the ADR-0053
+#                     D3 maturity gate: GA DRA-netdev on our Talos/k8s + validated dranet
+#                     release on our NIC/kernel + meets the SR-IOV NCCL baseline).
+#
+# Both paths target RoCEv2 or InfiniBand (var.fabric_mode) with jumbo frames (MTU 9000,
+# nic-tuning). An NCCL all-reduce bandwidth test is the acceptance gate (nccl-troubleshooting.md).
+#
+# SR-IOV operator install is a helm_release; the SR-IOV policy/network + the DRA objects
+# are kubernetes_manifest (mocked in tftest — same pattern as gke-gpu-fabric / dranet).
+#
+# ADR-0028: namespace + workloads + every CR carry the dotted labels.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  platform_labels = merge(
+    {
+      "platform.system"     = "ml-infra"
+      "platform.component"  = "gpu-fabric"
+      "platform.managed-by" = "terragrunt"
+    },
+    var.platform_labels,
+  )
+
+  # Day-0 primary path.
+  deploy_sriov = var.enabled && var.fabric_path == "sriov"
+  # Gated target path (mirror of DRANET).
+  deploy_dranet = var.enabled && var.enable_dranet
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Namespace — labeled per ADR-0028.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_namespace" "fabric" {
+  count = var.enabled ? 1 : 0
+
+  metadata {
+    name   = var.namespace
+    labels = local.platform_labels
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# SR-IOV Network Operator — the DAY-0 PRIMARY RDMA path (ADR-0053).
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "helm_release" "sriov_operator" {
+  count = local.deploy_sriov ? 1 : 0
+
+  name       = "sriov-network-operator"
+  repository = var.sriov_chart_repository
+  chart      = "sriov-network-operator"
+  version    = var.sriov_chart_version
+  namespace  = kubernetes_namespace.fabric[0].metadata[0].name
+  timeout    = var.helm_timeout
+
+  values = [
+    yamlencode({
+      operator = {
+        nodeSelector = var.gpu_node_selector
+      }
+      sriovNetworkOperatorPodLabels = local.platform_labels
+    })
+  ]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# SriovNetworkNodePolicy — carve RDMA VFs on the GPU NICs (RoCEv2 / IB). Day-0 primary.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "sriov_node_policy" {
+  count = local.deploy_sriov ? 1 : 0
+
+  manifest = {
+    apiVersion = "sriovnetwork.openshift.io/v1"
+    kind       = "SriovNetworkNodePolicy"
+    metadata = {
+      name      = "gpu-rdma-policy"
+      namespace = var.namespace
+      labels    = local.platform_labels
+    }
+    spec = {
+      resourceName = var.sriov_resource_name
+      nodeSelector = var.gpu_node_selector
+      numVfs       = var.sriov_num_vfs
+      isRdma       = true
+      mtu          = var.mtu
+      nicSelector = {
+        vendor = var.sriov_nic_vendor
+      }
+      # IB needs the link-type set; RoCEv2 rides Ethernet.
+      linkType = var.fabric_mode == "infiniband" ? "ib" : "eth"
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# SriovNetwork — attach the RDMA VFs to GPU pods. Day-0 primary.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "sriov_network" {
+  count = local.deploy_sriov ? 1 : 0
+
+  manifest = {
+    apiVersion = "sriovnetwork.openshift.io/v1"
+    kind       = "SriovNetwork"
+    metadata = {
+      name      = "gpu-rdma-net"
+      namespace = var.namespace
+      labels    = local.platform_labels
+    }
+    spec = {
+      resourceName     = var.sriov_resource_name
+      networkNamespace = var.workload_namespace
+      ipam             = jsonencode({ type = "whereabouts", range = var.rdma_ip_range })
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Cilium netdev DRA — the GATED TARGET (mirror of DRANET, ADR-0053 D3). Off by default.
+# A DeviceClass selecting RDMA NICs + a ResourceClaimTemplate so GPU + NIC are ONE claim.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "dranet_device_class" {
+  count = local.deploy_dranet ? 1 : 0
+
+  manifest = {
+    apiVersion = "resource.k8s.io/v1"
+    kind       = "DeviceClass"
+    metadata = {
+      name   = var.dranet_device_class_name
+      labels = local.platform_labels
+    }
+    spec = {
+      selectors = [
+        {
+          cel = {
+            expression = "device.driver == 'dra.net' && device.attributes['dra.net'].rdma == true"
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource "kubernetes_manifest" "dranet_claim_template" {
+  count = local.deploy_dranet ? 1 : 0
+
+  manifest = {
+    apiVersion = "resource.k8s.io/v1"
+    kind       = "ResourceClaimTemplate"
+    metadata = {
+      name      = "${var.dranet_device_class_name}-claim"
+      namespace = var.workload_namespace
+      labels    = local.platform_labels
+    }
+    spec = {
+      spec = {
+        devices = {
+          requests = [
+            {
+              name            = "rdma-nic"
+              deviceClassName = var.dranet_device_class_name
+              count           = var.dranet_nic_count
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/terraform/modules/baremetal-gpu-fabric/outputs.tf
+++ b/terraform/modules/baremetal-gpu-fabric/outputs.tf
@@ -1,0 +1,34 @@
+output "enabled" {
+  description = "Whether the GPU fabric was deployed."
+  value       = var.enabled
+}
+
+output "fabric_path" {
+  description = "Active day-0 fabric path (sriov, ADR-0053 day-0 primary)."
+  value       = var.fabric_path
+}
+
+output "fabric_mode" {
+  description = "Physical fabric mode (infiniband / roce)."
+  value       = var.fabric_mode
+}
+
+output "dranet_enabled" {
+  description = "Whether the gated DRANET (Cilium netdev DRA) target path is enabled (ADR-0053 D3 maturity gate)."
+  value       = var.enabled && var.enable_dranet
+}
+
+output "sriov_resource_name" {
+  description = "Device-plugin resource name pods request RDMA VFs as."
+  value       = var.sriov_resource_name
+}
+
+output "mtu" {
+  description = "Fabric MTU (9000 jumbo frames)."
+  value       = var.mtu
+}
+
+output "platform_labels" {
+  description = "Effective ADR-0028 dotted labels."
+  value       = local.platform_labels
+}

--- a/terraform/modules/baremetal-gpu-fabric/variables.tf
+++ b/terraform/modules/baremetal-gpu-fabric/variables.tf
@@ -1,0 +1,119 @@
+variable "enabled" {
+  description = "Master toggle. When false the module creates nothing (apply-gated default-OFF posture for the WS-A stack)."
+  type        = bool
+  default     = false
+}
+
+variable "namespace" {
+  description = "Namespace into which the SR-IOV operator and fabric CRs are installed."
+  type        = string
+  default     = "sriov-network-operator"
+}
+
+variable "workload_namespace" {
+  description = "Namespace GPU workloads run in (where the SriovNetwork / DRA claim template are attachable)."
+  type        = string
+  default     = "ml-workloads"
+}
+
+variable "fabric_path" {
+  description = "Day-0 fabric delivery path. sriov = SR-IOV/RDMA device plugin (ADR-0053 day-0 primary). The DRANET path is additive and gated separately via enable_dranet."
+  type        = string
+  default     = "sriov"
+
+  validation {
+    condition     = contains(["sriov"], var.fabric_path)
+    error_message = "fabric_path must be sriov (the ADR-0053 day-0 primary). DRANET is gated via enable_dranet."
+  }
+}
+
+variable "fabric_mode" {
+  description = "Physical fabric: infiniband (the UK doc's 400 Gbps IB + NVSwitch, ADR-0053 steady-state target) or roce (RoCEv2 Ethernet alternative)."
+  type        = string
+  default     = "infiniband"
+
+  validation {
+    condition     = contains(["infiniband", "roce"], var.fabric_mode)
+    error_message = "fabric_mode must be one of infiniband, roce."
+  }
+}
+
+variable "mtu" {
+  description = "Fabric MTU. 9000 (jumbo frames) per the nic-tuning role (ADR-0053)."
+  type        = number
+  default     = 9000
+}
+
+variable "gpu_node_selector" {
+  description = "Node selector restricting fabric components to GPU nodes."
+  type        = map(string)
+  default     = { "nvidia.com/gpu.present" = "true" }
+  nullable    = false
+}
+
+variable "sriov_chart_version" {
+  description = "Pinned SR-IOV Network Operator Helm chart version."
+  type        = string
+  default     = "1.3.0"
+}
+
+variable "sriov_chart_repository" {
+  description = "Helm repository hosting the SR-IOV Network Operator chart."
+  type        = string
+  default     = "https://k8snetworkplumbingwg.github.io/sriov-network-operator"
+}
+
+variable "sriov_resource_name" {
+  description = "Device-plugin resource name the RDMA VFs are advertised as (pods request this)."
+  type        = string
+  default     = "rdma_vf"
+}
+
+variable "sriov_num_vfs" {
+  description = "Number of RDMA VFs to carve per GPU NIC."
+  type        = number
+  default     = 8
+}
+
+variable "sriov_nic_vendor" {
+  description = "PCI vendor ID of the RDMA NIC (e.g. 15b3 = Mellanox/NVIDIA)."
+  type        = string
+  default     = "15b3"
+}
+
+variable "rdma_ip_range" {
+  description = "IP range Whereabouts IPAM allocates to RDMA VF interfaces."
+  type        = string
+  default     = "192.168.100.0/24"
+}
+
+variable "enable_dranet" {
+  description = "Enable the Cilium netdev DRA (mirror of DRANET) GATED TARGET path (ADR-0053 D3). Default false — only flip once DRA-netdev is GA on our Talos/k8s, a dranet release is validated on our NIC/kernel/image, and it matches the SR-IOV NCCL baseline."
+  type        = bool
+  default     = false
+}
+
+variable "dranet_device_class_name" {
+  description = "DRA DeviceClass name for the RDMA NICs (DRANET path)."
+  type        = string
+  default     = "rdma-netdev"
+}
+
+variable "dranet_nic_count" {
+  description = "Number of RDMA NICs per pod claim (DRANET path)."
+  type        = number
+  default     = 1
+}
+
+variable "helm_timeout" {
+  description = "Helm release timeout in seconds."
+  type        = number
+  default     = 300
+}
+
+variable "platform_labels" {
+  description = "ADR-0028 Kubernetes-plane labels (dotted keys, e.g. platform.system = ml-infra) applied to the namespace, SR-IOV operator, and all fabric custom resources."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}

--- a/terraform/modules/baremetal-gpu-fabric/versions.tf
+++ b/terraform/modules/baremetal-gpu-fabric/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.25"
+    }
+  }
+}

--- a/terraform/modules/baremetal-gpu-operator/README.md
+++ b/terraform/modules/baremetal-gpu-operator/README.md
@@ -1,0 +1,45 @@
+# baremetal-gpu-operator
+
+Deploys the **NVIDIA GPU Operator in driver-less mode** on the Talos GPU cluster. Part of
+**WS-A** of the Bare-Metal ML Platform. System: `ml-infra`.
+
+**ADRs:** [ADR-0050](../../../docs/adrs/0050-talos-gpu-driver-system-extensions.md)
+(GPU driver via Talos system extension → Operator runs driver-less). ADR-0028 labels.
+
+## Why driver-less (and why it's *enforced*)
+
+On Talos the GPU driver and `nvidia-container-toolkit` ship as a **system extension** baked
+into the boot image (`talos-machineconfig`, ADR-0050). The Operator **cannot** install a
+driver on an immutable, package-manager-less host — so `driver.enabled` and
+`toolkit.enabled` are not just defaulted false, they are **`validation`-enforced false**:
+setting either true fails the plan. The Operator provides only **device-plugin + GFD/NFD/CDI
++ the NVIDIA DRA driver**; DCGM is owned by `baremetal-gpu-dcgm`.
+
+This is the immutable-OS inversion of `gke-gpu-operator` (which also runs driver-less, but
+because GKE/COS supplies the driver — here the reason is Talos).
+
+## What it creates (when `enabled = true`)
+
+| Resource | Purpose |
+|----------|---------|
+| `kubernetes_namespace.gpu_operator` | Namespace, labeled per ADR-0028 |
+| `helm_release.gpu_operator` | The GPU Operator chart, driver-less |
+
+## Apply-gated
+
+`var.enabled` defaults **false**. Providers are mocked at plan time — no live cluster, no
+Helm install. No `terraform apply` in this repo.
+
+## ADR-0028 labeling
+
+Dotted keys: `platform.system = ml-infra`, `platform.component = compute`,
+`platform.managed-by = terragrunt`, plus `platform_labels` overrides.
+
+## Testing
+
+```bash
+terraform init -backend=false
+terraform test
+```
+
+Tests assert the driver-less wiring and that a `driver_enabled = true` attempt is rejected.

--- a/terraform/modules/baremetal-gpu-operator/baremetal-gpu-operator.tftest.hcl
+++ b/terraform/modules/baremetal-gpu-operator/baremetal-gpu-operator.tftest.hcl
@@ -1,0 +1,68 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests for the baremetal-gpu-operator module. helm + kubernetes providers are mocked;
+# assertions run at plan time over the driver-less wiring (ADR-0050).
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "helm" {}
+mock_provider "kubernetes" {}
+
+variables {
+  enabled = true
+  platform_labels = {
+    "platform.env"   = "staging"
+    "platform.owner" = "team-data"
+  }
+}
+
+run "disabled_creates_nothing" {
+  command = plan
+
+  variables {
+    enabled = false
+  }
+
+  assert {
+    condition     = length(helm_release.gpu_operator) == 0
+    error_message = "No operator release when enabled = false."
+  }
+
+  assert {
+    condition     = length(kubernetes_namespace.gpu_operator) == 0
+    error_message = "No namespace when enabled = false."
+  }
+}
+
+run "deploys_operator_when_enabled" {
+  command = plan
+
+  assert {
+    condition     = helm_release.gpu_operator[0].version == var.chart_version
+    error_message = "Operator must use the pinned chart version."
+  }
+
+  assert {
+    condition     = kubernetes_namespace.gpu_operator[0].metadata[0].labels["platform.system"] == "ml-infra"
+    error_message = "Namespace must carry platform.system = ml-infra (ADR-0028)."
+  }
+}
+
+run "operator_runs_driver_less" {
+  command = plan
+
+  # ADR-0050: the driver + toolkit ship in the Talos system extension, NEVER the Operator.
+  assert {
+    condition     = output.driver_less == true
+    error_message = "Operator must run driver-less on bare-metal Talos (ADR-0050)."
+  }
+}
+
+run "driver_install_is_rejected" {
+  command = plan
+
+  variables {
+    driver_enabled = true
+  }
+
+  # The validation block must fail the plan — the Operator cannot install a driver on Talos.
+  expect_failures = [var.driver_enabled]
+}

--- a/terraform/modules/baremetal-gpu-operator/main.tf
+++ b/terraform/modules/baremetal-gpu-operator/main.tf
@@ -1,0 +1,108 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Bare-metal NVIDIA GPU Operator Module (WS-A — ml-infra) — ADR-0050
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys the NVIDIA GPU Operator in DRIVER-LESS mode on the Talos GPU cluster.
+#
+# On Talos the GPU driver is delivered as a SYSTEM EXTENSION baked into the boot image
+# (talos-machineconfig + ADR-0050) — it can NOT be installed by the Operator, because
+# Talos has no package manager and no writable host filesystem. So unlike a cloud cluster
+# the Operator runs:
+#   * driver.enabled  = false   (driver ships in the Talos extension)
+#   * toolkit.enabled = false   (nvidia-container-toolkit ships in the Talos extension)
+#   * dcgmExporter    = false   (owned by baremetal-gpu-dcgm)
+# and provides ONLY device-plugin + GFD/NFD/CDI + the NVIDIA DRA driver.
+#
+# This is the immutable-OS inversion of the gke-gpu-operator module (which also runs
+# driver-less but because GKE/COS provides the driver). Here the reason is Talos.
+#
+# ADR-0028: namespace + workloads carry the Kubernetes-plane dotted labels.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  platform_labels = merge(
+    {
+      "platform.system"     = "ml-infra"
+      "platform.component"  = "compute"
+      "platform.managed-by" = "terragrunt"
+    },
+    var.platform_labels,
+  )
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Namespace — carries ADR-0028 labels so operator workloads inherit the system boundary.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_namespace" "gpu_operator" {
+  count = var.enabled ? 1 : 0
+
+  metadata {
+    name   = var.namespace
+    labels = local.platform_labels
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# NVIDIA GPU Operator Helm release — driver-less (driver lives in the Talos extension).
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "helm_release" "gpu_operator" {
+  count = var.enabled ? 1 : 0
+
+  name       = "gpu-operator"
+  repository = var.chart_repository
+  chart      = "gpu-operator"
+  version    = var.chart_version
+  namespace  = kubernetes_namespace.gpu_operator[0].metadata[0].name
+  timeout    = var.helm_timeout
+
+  values = [
+    yamlencode({
+      # ADR-0050: driver + toolkit ship in the Talos system extension — NEVER installed
+      # by the Operator on an immutable host. These are hard false on bare-metal Talos.
+      driver = {
+        enabled = var.driver_enabled
+      }
+      toolkit = {
+        enabled = var.toolkit_enabled
+      }
+      devicePlugin = {
+        enabled = true
+      }
+      gfd = {
+        enabled = true
+      }
+      nfd = {
+        enabled = true
+      }
+      cdi = {
+        enabled = true
+      }
+      # NVIDIA DRA driver for fine-grained / fractional GPU allocation.
+      dra = {
+        enabled = var.dra_enabled
+      }
+      # DCGM is owned by the dedicated baremetal-gpu-dcgm module.
+      dcgmExporter = {
+        enabled = var.dcgm_exporter_enabled
+      }
+      operator = {
+        nodeSelector = var.gpu_node_selector
+        tolerations = [
+          {
+            key      = "nvidia.com/gpu"
+            operator = "Exists"
+            effect   = "NoSchedule"
+          }
+        ]
+        resources = {
+          limits = {
+            cpu    = var.operator_cpu_limit
+            memory = var.operator_memory_limit
+          }
+        }
+        labels = local.platform_labels
+      }
+    })
+  ]
+}

--- a/terraform/modules/baremetal-gpu-operator/outputs.tf
+++ b/terraform/modules/baremetal-gpu-operator/outputs.tf
@@ -1,0 +1,29 @@
+output "enabled" {
+  description = "Whether the GPU operator was deployed."
+  value       = var.enabled
+}
+
+output "namespace" {
+  description = "Namespace the GPU operator is installed into (null when disabled)."
+  value       = var.enabled ? kubernetes_namespace.gpu_operator[0].metadata[0].name : null
+}
+
+output "release_name" {
+  description = "Helm release name of the GPU operator (null when disabled)."
+  value       = var.enabled ? helm_release.gpu_operator[0].name : null
+}
+
+output "chart_version" {
+  description = "Pinned chart version that was deployed."
+  value       = var.chart_version
+}
+
+output "driver_less" {
+  description = "Confirms the Operator runs driver-less (true): the driver ships in the Talos system extension (ADR-0050), not the Operator."
+  value       = var.driver_enabled == false && var.toolkit_enabled == false
+}
+
+output "platform_labels" {
+  description = "Effective ADR-0028 dotted labels."
+  value       = local.platform_labels
+}

--- a/terraform/modules/baremetal-gpu-operator/variables.tf
+++ b/terraform/modules/baremetal-gpu-operator/variables.tf
@@ -1,0 +1,89 @@
+variable "enabled" {
+  description = "Master toggle. When false the module creates nothing (apply-gated default-OFF posture for the WS-A stack)."
+  type        = bool
+  default     = false
+}
+
+variable "namespace" {
+  description = "Namespace into which the NVIDIA GPU Operator is installed."
+  type        = string
+  default     = "gpu-operator"
+}
+
+variable "chart_version" {
+  description = "Pinned NVIDIA GPU Operator Helm chart version."
+  type        = string
+  default     = "v24.9.2"
+}
+
+variable "chart_repository" {
+  description = "Helm repository hosting the gpu-operator chart."
+  type        = string
+  default     = "https://helm.ngc.nvidia.com/nvidia"
+}
+
+variable "driver_enabled" {
+  description = "Install the NVIDIA driver via the Operator. MUST stay false on Talos (ADR-0050): the driver ships as a system extension in the boot image; the Operator cannot install it on an immutable, package-manager-less host."
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = var.driver_enabled == false
+    error_message = "driver_enabled must be false on bare-metal Talos — the driver ships as a system extension (ADR-0050), not an Operator install."
+  }
+}
+
+variable "toolkit_enabled" {
+  description = "Install the NVIDIA container toolkit via the Operator. Stays false on Talos — the toolkit ships in the system extension (ADR-0050)."
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = var.toolkit_enabled == false
+    error_message = "toolkit_enabled must be false on bare-metal Talos — the toolkit ships as a system extension (ADR-0050)."
+  }
+}
+
+variable "dra_enabled" {
+  description = "Enable the NVIDIA DRA driver for fine-grained / fractional GPU allocation. Composes with baremetal-gpu-scheduling's DeviceClass/ResourceClaimTemplate."
+  type        = bool
+  default     = true
+}
+
+variable "dcgm_exporter_enabled" {
+  description = "Enable the Operator's bundled DCGM exporter. Keep false — DCGM is deployed by the dedicated baremetal-gpu-dcgm module."
+  type        = bool
+  default     = false
+}
+
+variable "gpu_node_selector" {
+  description = "Node selector identifying GPU nodes the operator components run on. Defaults to the talos-machineconfig GPU-present label."
+  type        = map(string)
+  default     = { "nvidia.com/gpu.present" = "true" }
+  nullable    = false
+}
+
+variable "operator_cpu_limit" {
+  description = "CPU limit for the operator controller pod."
+  type        = string
+  default     = "500m"
+}
+
+variable "operator_memory_limit" {
+  description = "Memory limit for the operator controller pod."
+  type        = string
+  default     = "512Mi"
+}
+
+variable "helm_timeout" {
+  description = "Helm release timeout in seconds."
+  type        = number
+  default     = 600
+}
+
+variable "platform_labels" {
+  description = "ADR-0028 Kubernetes-plane labels (dotted keys, e.g. platform.system = ml-infra) applied to the namespace and operator workloads."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}

--- a/terraform/modules/baremetal-gpu-operator/versions.tf
+++ b/terraform/modules/baremetal-gpu-operator/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.25"
+    }
+  }
+}

--- a/terraform/modules/baremetal-gpu-scheduling/README.md
+++ b/terraform/modules/baremetal-gpu-scheduling/README.md
@@ -1,0 +1,56 @@
+# baremetal-gpu-scheduling
+
+**Volcano gang-scheduler + the UK queue taxonomy + DRA device classes** for the Talos GPU
+cluster. Part of **WS-A** of the Bare-Metal ML Platform. System: `ml-infra`.
+
+**ADRs:** [ADR-0049](../../../docs/adrs/0049-baremetal-gpu-k8s-talos-foundation-multidc.md)
+(foundation; Volcano secondary scheduler). Folds the `gpu-inference-dra` shape. ADR-0028 labels.
+
+## The UK queue taxonomy (verbatim from the design)
+
+The default `volcano_queues` reproduce the **exact** taxonomy in
+`docs/transaction-analytics/06-uk-datacenters.md`:
+
+| Pool | Queue | Weight | Notes |
+|------|-------|--------|-------|
+| H100 | `training-default` | 100 | regular tenant retrains |
+| H100 | `training-bootstrap` | 30 | new-tenant initial fine-tunes |
+| H100 | `training-urgent` | 200 | **cap 2 jobs**, drift/incident response |
+| H200 | `serving-vllm` | 150 | vLLM multi-LoRA |
+| H200 | `eval-judge` | 200 | LLM-as-judge debate |
+| H200 | `engine-build` | 80 | TRT-LLM compilation |
+| H200 | `batch-rescore` | 50 | historical reprocessing |
+
+## DRA device classes
+
+`DeviceClass` + `ResourceClaimTemplate` for **H100 / H200 / L40S + fractional** GPU, so
+Volcano schedules GPU as a DRA claim. Composes with the GPU-compute claim and (in
+`baremetal-gpu-fabric`) the NIC claim — the one-DRA-model principle.
+
+## What it creates (when `enabled = true`)
+
+| Resource | Purpose |
+|----------|---------|
+| `kubernetes_namespace.scheduling` | Namespace, ADR-0028 labels |
+| `helm_release.volcano` | Volcano controller + scheduler |
+| `kubernetes_manifest.volcano_queue` (per queue) | The UK queue taxonomy |
+| `kubernetes_manifest.dra_device_class` (per model) | DRA device classes |
+| `kubernetes_manifest.dra_claim_template` (per model) | DRA claim templates |
+
+## Apply-gated
+
+`var.enabled` defaults **false**. Providers mocked at plan time — no live cluster, no Helm
+install. No `terraform apply` in this repo.
+
+## ADR-0028 labeling
+
+Dotted keys: `platform.system = ml-infra`, `platform.component = scheduler`,
+`platform.managed-by = terragrunt`, plus `platform_labels` overrides — on every queue/DRA
+object (queues also carry `gpu.platform/pool`).
+
+## Testing
+
+```bash
+terraform init -backend=false
+terraform test
+```

--- a/terraform/modules/baremetal-gpu-scheduling/baremetal-gpu-scheduling.tftest.hcl
+++ b/terraform/modules/baremetal-gpu-scheduling/baremetal-gpu-scheduling.tftest.hcl
@@ -1,0 +1,107 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests for the baremetal-gpu-scheduling module. helm + kubernetes providers are mocked;
+# assertions run at plan time over Volcano + the UK queue taxonomy + DRA objects.
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "helm" {}
+mock_provider "kubernetes" {}
+
+variables {
+  enabled = true
+  platform_labels = {
+    "platform.env"   = "staging"
+    "platform.owner" = "team-data"
+  }
+}
+
+run "disabled_creates_nothing" {
+  command = plan
+
+  variables {
+    enabled = false
+  }
+
+  assert {
+    condition     = length(helm_release.volcano) == 0
+    error_message = "No Volcano when enabled = false."
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.volcano_queue) == 0
+    error_message = "No queues when enabled = false."
+  }
+}
+
+run "deploys_volcano_and_uk_queue_taxonomy" {
+  command = plan
+
+  assert {
+    condition     = helm_release.volcano[0].version == var.volcano_chart_version
+    error_message = "Volcano must use the pinned chart version."
+  }
+
+  # The UK taxonomy: 3 training + 4 serving = 7 queues (06-uk-datacenters.md).
+  assert {
+    condition     = length(kubernetes_manifest.volcano_queue) == 7
+    error_message = "Exactly the 7 UK queues must be created (3 training + 4 serving)."
+  }
+
+  assert {
+    condition     = contains(output.queue_names, "training-urgent") && contains(output.queue_names, "serving-vllm")
+    error_message = "Queue taxonomy must include the named UK queues (training-urgent, serving-vllm, ...)."
+  }
+}
+
+run "training_urgent_carries_job_cap" {
+  command = plan
+
+  # 06-uk-datacenters.md: training-urgent has weight 200 and a 2-job capability cap.
+  assert {
+    condition     = kubernetes_manifest.volcano_queue["training-urgent"].manifest.spec.weight == 200
+    error_message = "training-urgent must have weight 200 per the UK taxonomy."
+  }
+
+  assert {
+    condition     = kubernetes_manifest.volcano_queue["training-urgent"].manifest.spec.capability["volcano.sh/job-count"] == "2"
+    error_message = "training-urgent must cap concurrent jobs at 2 per the UK taxonomy."
+  }
+}
+
+run "dra_device_classes_and_claims" {
+  command = plan
+
+  # H100/H200/L40S + fractional → 4 device classes + 4 claim templates.
+  assert {
+    condition     = length(kubernetes_manifest.dra_device_class) == 4
+    error_message = "DRA device classes for H100/H200/L40S + fractional must be created."
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.dra_claim_template) == 4
+    error_message = "One ResourceClaimTemplate per device class must be created."
+  }
+
+  assert {
+    condition     = contains(output.device_class_names, "gpu-fractional")
+    error_message = "A fractional-GPU device class must exist (folds gpu-inference-dra)."
+  }
+}
+
+run "dra_can_be_disabled" {
+  command = plan
+
+  variables {
+    dra_enabled = false
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.dra_device_class) == 0
+    error_message = "No DRA objects when dra_enabled = false."
+  }
+
+  # Queues still exist (Volcano scheduling is independent of DRA).
+  assert {
+    condition     = length(kubernetes_manifest.volcano_queue) == 7
+    error_message = "Queues must still exist when DRA is disabled."
+  }
+}

--- a/terraform/modules/baremetal-gpu-scheduling/main.tf
+++ b/terraform/modules/baremetal-gpu-scheduling/main.tf
@@ -1,0 +1,167 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Bare-metal GPU Scheduling Module (WS-A — ml-infra) — ADR-0049
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys Volcano as the secondary gang-scheduler for distributed GPU training, the EXACT
+# queue taxonomy already specified in docs/transaction-analytics/06-uk-datacenters.md
+# (H100 training pool + H200 serving pool, with the doc's weights and caps), and the DRA
+# DeviceClass / ResourceClaimTemplate objects for H100 / H200 / L40S + fractional GPU
+# (folds the gpu-inference-dra shape).
+#
+# Volcano controller install is a helm_release; the Queue / DeviceClass /
+# ResourceClaimTemplate CRs are kubernetes_manifest (require the CRDs on a live cluster, so
+# mocked in tftest — same pattern as gke-gpu-scheduling / gke-gpu-dranet).
+#
+# ADR-0028: namespace + scheduler workloads + every CR carry the dotted labels.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  platform_labels = merge(
+    {
+      "platform.system"     = "ml-infra"
+      "platform.component"  = "scheduler"
+      "platform.managed-by" = "terragrunt"
+    },
+    var.platform_labels,
+  )
+
+  deploy_volcano = var.enabled && var.scheduler == "volcano"
+
+  # UK queue taxonomy (06-uk-datacenters.md) — keyed by name for stable for_each addresses.
+  queues = var.enabled ? { for q in var.volcano_queues : q.name => q } : {}
+
+  # DRA device classes for H100/H200/L40S + fractional — keyed by name.
+  device_classes = var.enabled && var.dra_enabled ? { for d in var.dra_device_classes : d.name => d } : {}
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Namespace — labeled per ADR-0028.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_namespace" "scheduling" {
+  count = var.enabled ? 1 : 0
+
+  metadata {
+    name   = var.namespace
+    labels = local.platform_labels
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Volcano — gang-scheduling secondary scheduler (the UK doc's named choice).
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "helm_release" "volcano" {
+  count = local.deploy_volcano ? 1 : 0
+
+  name       = "volcano"
+  repository = var.volcano_chart_repository
+  chart      = "volcano"
+  version    = var.volcano_chart_version
+  namespace  = kubernetes_namespace.scheduling[0].metadata[0].name
+  timeout    = var.helm_timeout
+
+  values = [
+    yamlencode({
+      custom = {
+        scheduler_podLabels  = local.platform_labels
+        controller_podLabels = local.platform_labels
+        scheduler_tolerations = [
+          {
+            key      = "nvidia.com/gpu"
+            operator = "Exists"
+            effect   = "NoSchedule"
+          }
+        ]
+      }
+    })
+  ]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Volcano Queues — the EXACT UK taxonomy (06-uk-datacenters.md): H100 training pool
+# (training-default/-bootstrap/-urgent) + H200 serving pool (serving-vllm/eval-judge/
+# engine-build/batch-rescore), with the doc's weights and the training-urgent cap of 2.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "volcano_queue" {
+  for_each = local.queues
+
+  manifest = {
+    apiVersion = "scheduling.volcano.sh/v1beta1"
+    kind       = "Queue"
+    metadata = {
+      name = each.value.name
+      labels = merge(local.platform_labels, {
+        "gpu.platform/pool" = each.value.pool
+      })
+    }
+    spec = merge(
+      {
+        weight      = each.value.weight
+        reclaimable = each.value.reclaimable
+      },
+      each.value.capability_jobs == null ? {} : {
+        capability = {
+          "volcano.sh/job-count" = tostring(each.value.capability_jobs)
+        }
+      },
+    )
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DRA DeviceClass — H100/H200/L40S + fractional GPU (folds gpu-inference-dra).
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "dra_device_class" {
+  for_each = local.device_classes
+
+  manifest = {
+    apiVersion = "resource.k8s.io/v1"
+    kind       = "DeviceClass"
+    metadata = {
+      name   = each.value.name
+      labels = local.platform_labels
+    }
+    spec = {
+      selectors = [
+        {
+          cel = {
+            expression = "device.driver == 'gpu.nvidia.com' && device.attributes['gpu.nvidia.com'].productName == '${each.value.product_name}'"
+          }
+        }
+      ]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DRA ResourceClaimTemplate — one per device class so Volcano schedules GPU as a claim.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "dra_claim_template" {
+  for_each = local.device_classes
+
+  manifest = {
+    apiVersion = "resource.k8s.io/v1"
+    kind       = "ResourceClaimTemplate"
+    metadata = {
+      name      = "${each.value.name}-claim"
+      namespace = var.namespace
+      labels    = local.platform_labels
+    }
+    spec = {
+      spec = {
+        devices = {
+          requests = [
+            {
+              name            = "gpu"
+              deviceClassName = each.value.name
+              count           = each.value.count
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/terraform/modules/baremetal-gpu-scheduling/outputs.tf
+++ b/terraform/modules/baremetal-gpu-scheduling/outputs.tf
@@ -1,0 +1,24 @@
+output "enabled" {
+  description = "Whether the scheduling stack was deployed."
+  value       = var.enabled
+}
+
+output "namespace" {
+  description = "Namespace Volcano + queues/DRA run in (null when disabled)."
+  value       = var.enabled ? kubernetes_namespace.scheduling[0].metadata[0].name : null
+}
+
+output "queue_names" {
+  description = "The Volcano queue names created (the UK taxonomy from 06-uk-datacenters.md)."
+  value       = keys(local.queues)
+}
+
+output "device_class_names" {
+  description = "The DRA DeviceClass names created (H100/H200/L40S + fractional)."
+  value       = keys(local.device_classes)
+}
+
+output "platform_labels" {
+  description = "Effective ADR-0028 dotted labels."
+  value       = local.platform_labels
+}

--- a/terraform/modules/baremetal-gpu-scheduling/variables.tf
+++ b/terraform/modules/baremetal-gpu-scheduling/variables.tf
@@ -1,0 +1,90 @@
+variable "enabled" {
+  description = "Master toggle. When false the module creates nothing (apply-gated default-OFF posture for the WS-A stack)."
+  type        = bool
+  default     = false
+}
+
+variable "scheduler" {
+  description = "Batch scheduler to deploy. Volcano is the WS-A choice (gang scheduling + the UK doc's named queue taxonomy)."
+  type        = string
+  default     = "volcano"
+
+  validation {
+    condition     = contains(["volcano"], var.scheduler)
+    error_message = "scheduler must be volcano (the UK doc's named secondary scheduler)."
+  }
+}
+
+variable "namespace" {
+  description = "Namespace into which Volcano + the queues/DRA objects are installed."
+  type        = string
+  default     = "volcano-system"
+}
+
+variable "volcano_chart_version" {
+  description = "Pinned Volcano Helm chart version."
+  type        = string
+  default     = "1.10.0"
+}
+
+variable "volcano_chart_repository" {
+  description = "Helm repository hosting the Volcano chart."
+  type        = string
+  default     = "https://volcano-sh.github.io/helm-charts"
+}
+
+variable "volcano_queues" {
+  description = "Volcano queue taxonomy. Defaults to the EXACT UK taxonomy from 06-uk-datacenters.md: H100 training pool (training-default w100 / training-bootstrap w30 / training-urgent w200 cap 2) + H200 serving pool (serving-vllm w150 / eval-judge w200 / engine-build w80 / batch-rescore w50). capability_jobs is the job-count cap (null = uncapped)."
+  type = list(object({
+    name            = string
+    pool            = string
+    weight          = number
+    reclaimable     = bool
+    capability_jobs = optional(number)
+  }))
+  default = [
+    { name = "training-default", pool = "h100", weight = 100, reclaimable = true },
+    { name = "training-bootstrap", pool = "h100", weight = 30, reclaimable = true },
+    { name = "training-urgent", pool = "h100", weight = 200, reclaimable = false, capability_jobs = 2 },
+    { name = "serving-vllm", pool = "h200", weight = 150, reclaimable = false },
+    { name = "eval-judge", pool = "h200", weight = 200, reclaimable = true },
+    { name = "engine-build", pool = "h200", weight = 80, reclaimable = true },
+    { name = "batch-rescore", pool = "h200", weight = 50, reclaimable = true },
+  ]
+  nullable = false
+}
+
+variable "dra_enabled" {
+  description = "Create the DRA DeviceClass / ResourceClaimTemplate objects for fine-grained / fractional GPU allocation."
+  type        = bool
+  default     = true
+}
+
+variable "dra_device_classes" {
+  description = "DRA device classes for the GPU models in the fleet (H100/H200/L40S + fractional). product_name matches the NVIDIA device attribute; count is the per-claim device count (1 = whole GPU, fractional handled via MPS/MIG profiles upstream)."
+  type = list(object({
+    name         = string
+    product_name = string
+    count        = number
+  }))
+  default = [
+    { name = "gpu-h100", product_name = "NVIDIA H100 80GB HBM3", count = 1 },
+    { name = "gpu-h200", product_name = "NVIDIA H200", count = 1 },
+    { name = "gpu-l40s", product_name = "NVIDIA L40S", count = 1 },
+    { name = "gpu-fractional", product_name = "NVIDIA H100 80GB HBM3", count = 1 },
+  ]
+  nullable = false
+}
+
+variable "helm_timeout" {
+  description = "Helm release timeout in seconds."
+  type        = number
+  default     = 300
+}
+
+variable "platform_labels" {
+  description = "ADR-0028 Kubernetes-plane labels (dotted keys, e.g. platform.system = ml-infra) applied to the namespace, Volcano workloads, queues, and DRA objects."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}

--- a/terraform/modules/baremetal-gpu-scheduling/versions.tf
+++ b/terraform/modules/baremetal-gpu-scheduling/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.25"
+    }
+  }
+}

--- a/terraform/modules/baremetal-ingress-waf/README.md
+++ b/terraform/modules/baremetal-ingress-waf/README.md
@@ -1,0 +1,47 @@
+# baremetal-ingress-waf
+
+**On-prem WAF / rate-limit** at the serving edge — the bare-metal mirror of Cloud Armor.
+Part of **WS-A** of the Bare-Metal ML Platform. System: `ml-inference`.
+
+**ADRs:** [ADR-0053](../../../docs/adrs/0053-baremetal-gpu-fabric-roce-infiniband.md)
+(serving axis: on-prem Gateway API + WAF/rate-limit, no cloud LB). ADR-0028 labels.
+
+## Why an on-prem WAF
+
+There is **no Cloud Armor and no cloud LB** on owned hardware. This module provides the
+WAF/rate-limit front for the serving edge over the Gateway API, with two backends:
+
+| `gateway_backend` | What it uses | Rate-limit |
+|-------------------|--------------|------------|
+| `cilium` (default) | Cilium Gateway — one networking stack (Cilium is already the CNI) | `CiliumNetworkPolicy` L7 ingress |
+| `envoy` | Envoy Gateway (reuse `apps/infra/envoy-gateway`) | Envoy `BackendTrafficPolicy` local rate-limit |
+
+The model-serving Gateway/HTTPRoute themselves live in the `baremetal-inference-gateway`
+ArgoCD app; this module is the **WAF/rate-limit + TLS-terminating front** in front of them.
+
+## What it creates (when `enabled = true`)
+
+| Resource | Purpose |
+|----------|---------|
+| `kubernetes_manifest.gateway` | HTTPS-terminating serving Gateway |
+| `kubernetes_manifest.cilium_ratelimit` | (cilium backend) L7 rate-limit policy |
+| `kubernetes_manifest.envoy_ratelimit` | (envoy backend) rate-limit policy |
+
+TLS terminates with a secret from cert-manager/ESO (`tls_secret_name`) — never committed.
+
+## Apply-gated
+
+`var.enabled` defaults **false**. Provider mocked at plan time — no live cluster. No
+`terraform apply` in this repo.
+
+## ADR-0028 labeling
+
+Dotted keys: `platform.system = ml-inference`, `platform.component = ingress-waf`,
+`platform.managed-by = terragrunt`, plus `platform_labels` overrides.
+
+## Testing
+
+```bash
+terraform init -backend=false
+terraform test
+```

--- a/terraform/modules/baremetal-ingress-waf/baremetal-ingress-waf.tftest.hcl
+++ b/terraform/modules/baremetal-ingress-waf/baremetal-ingress-waf.tftest.hcl
@@ -1,0 +1,79 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests for the baremetal-ingress-waf module. The kubernetes provider is mocked; assertions
+# run at plan time over the Gateway + rate-limit backends (ADR-0053 serving axis).
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "kubernetes" {}
+
+variables {
+  enabled = true
+  platform_labels = {
+    "platform.env"   = "staging"
+    "platform.owner" = "team-data"
+  }
+}
+
+run "disabled_creates_nothing" {
+  command = plan
+
+  variables {
+    enabled = false
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.gateway) == 0
+    error_message = "No Gateway when enabled = false."
+  }
+}
+
+run "cilium_backend_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(kubernetes_manifest.gateway) == 1
+    error_message = "Serving Gateway must be created when enabled = true."
+  }
+
+  # Default backend = cilium → Cilium rate-limit, no Envoy policy.
+  assert {
+    condition     = length(kubernetes_manifest.cilium_ratelimit) == 1
+    error_message = "Cilium rate-limit policy must be created with the cilium backend (Cloud Armor mirror, ADR-0053)."
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.envoy_ratelimit) == 0
+    error_message = "Envoy policy must NOT be created with the cilium backend."
+  }
+
+  assert {
+    condition     = kubernetes_manifest.gateway[0].manifest.spec.gatewayClassName == var.cilium_gateway_class
+    error_message = "Gateway must use the Cilium GatewayClass by default."
+  }
+}
+
+run "envoy_backend_when_selected" {
+  command = plan
+
+  variables {
+    gateway_backend = "envoy"
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.envoy_ratelimit) == 1
+    error_message = "Envoy rate-limit policy must be created with the envoy backend."
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.cilium_ratelimit) == 0
+    error_message = "Cilium policy must NOT be created with the envoy backend."
+  }
+}
+
+run "gateway_carries_adr0028_labels" {
+  command = plan
+
+  assert {
+    condition     = kubernetes_manifest.gateway[0].manifest.metadata.labels["platform.system"] == "ml-inference"
+    error_message = "Gateway must carry platform.system = ml-inference (ADR-0028)."
+  }
+}

--- a/terraform/modules/baremetal-ingress-waf/main.tf
+++ b/terraform/modules/baremetal-ingress-waf/main.tf
@@ -1,0 +1,149 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Bare-metal Ingress WAF / Rate-limit Module (WS-A — ml-infra) — ADR-0053 (serving axis)
+# ---------------------------------------------------------------------------------------------------------------------
+# On-prem WAF / rate-limit at the serving edge — the bare-metal mirror of Cloud Armor (no
+# cloud LB exists on owned hardware). Two gateway backends (var.gateway_backend):
+#
+#   * cilium — Cilium Gateway (L7 rate-limit via CiliumNetworkPolicy / Envoy filters,
+#              one networking stack since Cilium is already the CNI). Default.
+#   * envoy  — Envoy Gateway (reuse apps/infra/envoy-gateway) with the Envoy ratelimit
+#              service.
+#
+# This module owns the Gateway + the rate-limit policy CR (a CiliumNetworkPolicy with an
+# L7 ingress rate-limit, or an Envoy BackendTrafficPolicy). All kubernetes_manifest (mocked
+# in tftest). The actual model-serving Gateway/HTTPRoute live in the
+# baremetal-inference-gateway ArgoCD app; this module is the WAF/rate-limit front.
+#
+# ADR-0028: every CR carries the dotted labels.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  platform_labels = merge(
+    {
+      "platform.system"     = "ml-inference"
+      "platform.component"  = "ingress-waf"
+      "platform.managed-by" = "terragrunt"
+    },
+    var.platform_labels,
+  )
+
+  use_cilium = var.gateway_backend == "cilium"
+  use_envoy  = var.gateway_backend == "envoy"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Gateway — the serving entrypoint (GatewayClass differs per backend).
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "gateway" {
+  count = var.enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "Gateway"
+    metadata = {
+      name      = var.gateway_name
+      namespace = var.namespace
+      labels    = local.platform_labels
+    }
+    spec = {
+      gatewayClassName = local.use_cilium ? var.cilium_gateway_class : var.envoy_gateway_class
+      listeners = [
+        {
+          name     = "https"
+          protocol = "HTTPS"
+          port     = 443
+          tls = {
+            mode = "Terminate"
+            certificateRefs = [
+              { name = var.tls_secret_name }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Cilium L7 rate-limit — CiliumNetworkPolicy with an ingress rate-limit (Cloud Armor mirror).
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "cilium_ratelimit" {
+  count = var.enabled && local.use_cilium ? 1 : 0
+
+  manifest = {
+    apiVersion = "cilium.io/v2"
+    kind       = "CiliumNetworkPolicy"
+    metadata = {
+      name      = "${var.gateway_name}-ratelimit"
+      namespace = var.namespace
+      labels    = local.platform_labels
+    }
+    spec = {
+      endpointSelector = {
+        matchLabels = {
+          "platform.system" = "ml-inference"
+        }
+      }
+      ingress = [
+        {
+          fromEntities = ["world"]
+          toPorts = [
+            {
+              ports = [{ port = "443", protocol = "TCP" }]
+              rules = {
+                http = [
+                  {
+                    method = "POST"
+                    path   = var.protected_path
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Envoy rate-limit — BackendTrafficPolicy (when gateway_backend = envoy; reuse envoy-gateway).
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "envoy_ratelimit" {
+  count = var.enabled && local.use_envoy ? 1 : 0
+
+  manifest = {
+    apiVersion = "gateway.envoyproxy.io/v1alpha1"
+    kind       = "BackendTrafficPolicy"
+    metadata = {
+      name      = "${var.gateway_name}-ratelimit"
+      namespace = var.namespace
+      labels    = local.platform_labels
+    }
+    spec = {
+      targetRefs = [
+        {
+          group = "gateway.networking.k8s.io"
+          kind  = "Gateway"
+          name  = var.gateway_name
+        }
+      ]
+      rateLimit = {
+        type = "Local"
+        local = {
+          rules = [
+            {
+              limit = {
+                requests = var.rate_limit_requests
+                unit     = var.rate_limit_unit
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/terraform/modules/baremetal-ingress-waf/outputs.tf
+++ b/terraform/modules/baremetal-ingress-waf/outputs.tf
@@ -1,0 +1,24 @@
+output "enabled" {
+  description = "Whether the ingress WAF/rate-limit was deployed."
+  value       = var.enabled
+}
+
+output "gateway_backend" {
+  description = "Active serving gateway backend (cilium / envoy)."
+  value       = var.gateway_backend
+}
+
+output "gateway_name" {
+  description = "Name of the serving Gateway."
+  value       = var.gateway_name
+}
+
+output "rate_limit_enabled" {
+  description = "Whether a rate-limit policy (Cloud-Armor mirror) was created."
+  value       = var.enabled
+}
+
+output "platform_labels" {
+  description = "Effective ADR-0028 dotted labels."
+  value       = local.platform_labels
+}

--- a/terraform/modules/baremetal-ingress-waf/variables.tf
+++ b/terraform/modules/baremetal-ingress-waf/variables.tf
@@ -1,0 +1,76 @@
+variable "enabled" {
+  description = "Master toggle. When false the module creates nothing (apply-gated default-OFF posture for the WS-A stack)."
+  type        = bool
+  default     = false
+}
+
+variable "namespace" {
+  description = "Namespace the serving Gateway + rate-limit policy live in."
+  type        = string
+  default     = "ml-inference"
+}
+
+variable "gateway_backend" {
+  description = "Serving gateway backend. cilium = Cilium Gateway (one networking stack, ADR-0051/0053 recommendation); envoy = Envoy Gateway (reuse apps/infra/envoy-gateway)."
+  type        = string
+  default     = "cilium"
+
+  validation {
+    condition     = contains(["cilium", "envoy"], var.gateway_backend)
+    error_message = "gateway_backend must be one of cilium, envoy."
+  }
+}
+
+variable "gateway_name" {
+  description = "Name of the serving Gateway."
+  type        = string
+  default     = "ml-serving"
+}
+
+variable "cilium_gateway_class" {
+  description = "GatewayClass name for the Cilium Gateway backend."
+  type        = string
+  default     = "cilium"
+}
+
+variable "envoy_gateway_class" {
+  description = "GatewayClass name for the Envoy Gateway backend."
+  type        = string
+  default     = "envoy-gateway"
+}
+
+variable "tls_secret_name" {
+  description = "Name of the TLS secret (cert/key) the HTTPS listener terminates with. Sourced from cert-manager/ESO — never committed."
+  type        = string
+  default     = "ml-serving-tls"
+}
+
+variable "protected_path" {
+  description = "Request path the WAF/rate-limit applies to (the inference endpoint)."
+  type        = string
+  default     = "/v1/.*"
+}
+
+variable "rate_limit_requests" {
+  description = "Request count allowed per rate_limit_unit (Cloud-Armor-mirror rate limit, Envoy backend)."
+  type        = number
+  default     = 100
+}
+
+variable "rate_limit_unit" {
+  description = "Rate-limit time unit (Second/Minute/Hour) for the Envoy backend."
+  type        = string
+  default     = "Second"
+
+  validation {
+    condition     = contains(["Second", "Minute", "Hour"], var.rate_limit_unit)
+    error_message = "rate_limit_unit must be one of Second, Minute, Hour."
+  }
+}
+
+variable "platform_labels" {
+  description = "ADR-0028 Kubernetes-plane labels (dotted keys, e.g. platform.system = ml-inference) applied to the Gateway and rate-limit policy."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}

--- a/terraform/modules/baremetal-ingress-waf/versions.tf
+++ b/terraform/modules/baremetal-ingress-waf/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.25"
+    }
+  }
+}

--- a/terraform/modules/baremetal-rook-ceph/README.md
+++ b/terraform/modules/baremetal-rook-ceph/README.md
@@ -1,0 +1,61 @@
+# baremetal-rook-ceph
+
+**Rook-Ceph storage** — replicated block (RBD) + shared FS + **RGW S3 object** — for the
+Talos GPU cluster. Part of **WS-A** of the Bare-Metal ML Platform. System: `ml-infra`.
+
+**ADRs:** [ADR-0052](../../../docs/adrs/0052-baremetal-storage-rook-ceph.md)
+(Rook-Ceph vs Mayastor; + S3-compatible artifact store). ADR-0028 labels.
+
+## The load-bearing rbd+ceph contract (ADR-0052)
+
+RBD PVCs **will not mount** until `talos-machineconfig` declares the **`rbd`** + **`ceph`**
+kernel modules (+ the Rook kubelet extra-mount for `/var/lib/rook`). Without them
+`csi-rbdplugin` crash-loops. This module **enforces** that contract: `var.ceph_kernel_modules`
+is wired from the `talos-machineconfig` output through the stack `dependency`, and a
+`validation` block **fails the plan** if `rbd` or `ceph` is missing — so the dependency is
+checked in code, not just documented. `data_dir_host_path` must match the machineconfig
+kubelet extraMount.
+
+Self-contained as **pods** (operator + CSI), because immutable Talos has no host packages.
+
+## What it creates (when `enabled = true`)
+
+| Resource | Purpose |
+|----------|---------|
+| `kubernetes_namespace.rook_ceph` | Namespace, ADR-0028 labels |
+| `helm_release.rook_ceph_operator` | Rook operator + CSI (RBD + CephFS drivers) |
+| `kubernetes_manifest.ceph_cluster` | `CephCluster` (≥3 mons, replicated) |
+| `kubernetes_manifest.ceph_block_pool` | `CephBlockPool` — RBD PVCs (Postgres/MLflow) |
+| `kubernetes_manifest.ceph_filesystem` | (gated) `CephFilesystem` — shared RWX datasets |
+| `kubernetes_manifest.ceph_object_store` | (gated) `CephObjectStore` — **RGW S3** artifact backend |
+
+## S3 for WS-B
+
+When `enable_object_store = true` (default), the module surfaces an in-cluster `s3_endpoint`
+output — the **S3-compatible artifact-store backend** WS-B's `baremetal-ml-artifact-store`
+re-points MLflow at (ADR-0052), keeping training data UK-resident (no external S3).
+
+## Durability
+
+`block_pool_replicas` is **`validation`-floored at 3** (survive a node loss; risk R5).
+`mon_count` is validated odd (quorum).
+
+## Apply-gated
+
+`var.enabled` defaults **false**. Providers mocked at plan time — no live cluster, no Helm
+install. No `terraform apply` in this repo.
+
+## ADR-0028 labeling
+
+Dotted keys: `platform.system = ml-infra`, `platform.component = storage`,
+`platform.managed-by = terragrunt`, plus `platform_labels` overrides.
+
+## Testing
+
+```bash
+terraform init -backend=false
+terraform test
+```
+
+Tests assert the Ceph CRs, the S3 endpoint, and that a **missing `rbd` module fails the
+plan** (the ADR-0052 gate).

--- a/terraform/modules/baremetal-rook-ceph/baremetal-rook-ceph.tftest.hcl
+++ b/terraform/modules/baremetal-rook-ceph/baremetal-rook-ceph.tftest.hcl
@@ -1,0 +1,89 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests for the baremetal-rook-ceph module. helm + kubernetes providers are mocked;
+# assertions run at plan time over the Ceph CRs and the load-bearing rbd+ceph prerequisite.
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "helm" {}
+mock_provider "kubernetes" {}
+
+variables {
+  enabled = true
+  platform_labels = {
+    "platform.env"   = "staging"
+    "platform.owner" = "team-data"
+  }
+}
+
+run "disabled_creates_nothing" {
+  command = plan
+
+  variables {
+    enabled = false
+  }
+
+  assert {
+    condition     = length(helm_release.rook_ceph_operator) == 0
+    error_message = "No Rook operator when enabled = false."
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.ceph_cluster) == 0
+    error_message = "No CephCluster when enabled = false."
+  }
+}
+
+run "deploys_ceph_block_and_object" {
+  command = plan
+
+  assert {
+    condition     = helm_release.rook_ceph_operator[0].version == var.chart_version
+    error_message = "Rook operator must use the pinned chart version."
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.ceph_block_pool) == 1
+    error_message = "A replicated RBD block pool must be created."
+  }
+
+  # Ceph-RGW S3 object store on by default (WS-B artifact-store backend).
+  assert {
+    condition     = length(kubernetes_manifest.ceph_object_store) == 1
+    error_message = "Ceph-RGW S3 object store must be created (WS-B artifact-store backend, ADR-0052)."
+  }
+
+  assert {
+    condition     = output.s3_endpoint != null
+    error_message = "An S3 endpoint must be surfaced when the object store is enabled."
+  }
+}
+
+run "rbd_prerequisite_enforced" {
+  command = plan
+
+  # ADR-0052 load-bearing gate: the module confirms rbd+ceph are declared upstream.
+  assert {
+    condition     = output.rbd_prerequisite_satisfied == true
+    error_message = "rbd+ceph prerequisite must be satisfied (ADR-0052)."
+  }
+}
+
+run "missing_rbd_module_fails_plan" {
+  command = plan
+
+  variables {
+    # Simulate talos-machineconfig NOT declaring rbd → must fail (csi-rbdplugin would crash).
+    ceph_kernel_modules = ["ceph"]
+  }
+
+  expect_failures = [var.ceph_kernel_modules]
+}
+
+run "replicas_below_three_rejected" {
+  command = plan
+
+  variables {
+    block_pool_replicas = 2
+  }
+
+  expect_failures = [var.block_pool_replicas]
+}

--- a/terraform/modules/baremetal-rook-ceph/main.tf
+++ b/terraform/modules/baremetal-rook-ceph/main.tf
@@ -1,0 +1,187 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Bare-metal Rook-Ceph Storage Module (WS-A — ml-infra) — ADR-0052
+# ---------------------------------------------------------------------------------------------------------------------
+# Deploys Rook-Ceph as the default storage substrate: replicated block (RBD), shared FS,
+# and an RGW S3 object store — all self-contained as pods (no host packages, required by
+# immutable Talos). The Ceph-RGW S3 endpoint is the optional S3-compatible artifact-store
+# backend for WS-B.
+#
+# HARD PREREQUISITE (ADR-0052): RBD PVCs will not mount until talos-machineconfig declares
+# the `rbd` + `ceph` kernel modules (+ Rook kubelet extra-mounts). Without them
+# csi-rbdplugin crash-loops. This module surfaces that contract via var.ceph_kernel_modules
+# (wired from the talos-machineconfig output through the stack dependency) and a validation
+# block that fails the plan if rbd/ceph are absent — so the load-bearing dependency is
+# enforced in code, not just documented.
+#
+# The Rook operator install is a helm_release; the CephCluster / CephBlockPool /
+# CephFilesystem / CephObjectStore CRs are kubernetes_manifest (mocked in tftest).
+#
+# ADR-0028: namespace + operator + every CR carry the dotted labels.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  platform_labels = merge(
+    {
+      "platform.system"     = "ml-infra"
+      "platform.component"  = "storage"
+      "platform.managed-by" = "terragrunt"
+    },
+    var.platform_labels,
+  )
+
+  deploy_object_store = var.enabled && var.enable_object_store
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Namespace — labeled per ADR-0028.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_namespace" "rook_ceph" {
+  count = var.enabled ? 1 : 0
+
+  metadata {
+    name   = var.namespace
+    labels = local.platform_labels
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Rook-Ceph operator — self-contained CSI/operator pods (no host packages, immutable Talos).
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "helm_release" "rook_ceph_operator" {
+  count = var.enabled ? 1 : 0
+
+  name       = "rook-ceph"
+  repository = var.chart_repository
+  chart      = "rook-ceph"
+  version    = var.chart_version
+  namespace  = kubernetes_namespace.rook_ceph[0].metadata[0].name
+  timeout    = var.helm_timeout
+
+  values = [
+    yamlencode({
+      csi = {
+        enableRbdDriver    = true
+        enableCephfsDriver = var.enable_filesystem
+      }
+      operatorPodLabels = local.platform_labels
+    })
+  ]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CephCluster — the cluster itself; replicated across nodes (≥3 mons).
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "ceph_cluster" {
+  count = var.enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "ceph.rook.io/v1"
+    kind       = "CephCluster"
+    metadata = {
+      name      = "rook-ceph"
+      namespace = var.namespace
+      labels    = local.platform_labels
+    }
+    spec = {
+      cephVersion = {
+        image = var.ceph_image
+      }
+      dataDirHostPath = var.data_dir_host_path
+      mon = {
+        count                = var.mon_count
+        allowMultiplePerNode = false
+      }
+      storage = {
+        useAllNodes   = var.use_all_nodes
+        useAllDevices = var.use_all_devices
+      }
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CephBlockPool — replicated RBD pool for PVCs (Postgres/MLflow state).
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "ceph_block_pool" {
+  count = var.enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "ceph.rook.io/v1"
+    kind       = "CephBlockPool"
+    metadata = {
+      name      = "replicapool"
+      namespace = var.namespace
+      labels    = local.platform_labels
+    }
+    spec = {
+      failureDomain = "host"
+      replicated = {
+        size = var.block_pool_replicas
+      }
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CephFilesystem — shared FS (RWX) for datasets. Gated by enable_filesystem.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "ceph_filesystem" {
+  count = var.enabled && var.enable_filesystem ? 1 : 0
+
+  manifest = {
+    apiVersion = "ceph.rook.io/v1"
+    kind       = "CephFilesystem"
+    metadata = {
+      name      = "ml-fs"
+      namespace = var.namespace
+      labels    = local.platform_labels
+    }
+    spec = {
+      metadataPool = {
+        replicated = { size = var.block_pool_replicas }
+      }
+      dataPools = [
+        {
+          name       = "default"
+          replicated = { size = var.block_pool_replicas }
+        }
+      ]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CephObjectStore — RGW S3 endpoint (the optional S3 artifact-store backend for WS-B).
+# Gated by enable_object_store.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "ceph_object_store" {
+  count = local.deploy_object_store ? 1 : 0
+
+  manifest = {
+    apiVersion = "ceph.rook.io/v1"
+    kind       = "CephObjectStore"
+    metadata = {
+      name      = var.object_store_name
+      namespace = var.namespace
+      labels    = local.platform_labels
+    }
+    spec = {
+      metadataPool = {
+        replicated = { size = var.block_pool_replicas }
+      }
+      dataPool = {
+        replicated = { size = var.block_pool_replicas }
+      }
+      gateway = {
+        port      = var.rgw_port
+        instances = var.rgw_instances
+      }
+    }
+  }
+}

--- a/terraform/modules/baremetal-rook-ceph/outputs.tf
+++ b/terraform/modules/baremetal-rook-ceph/outputs.tf
@@ -1,0 +1,34 @@
+output "enabled" {
+  description = "Whether Rook-Ceph was deployed."
+  value       = var.enabled
+}
+
+output "namespace" {
+  description = "Namespace Rook-Ceph runs in (null when disabled)."
+  value       = var.enabled ? kubernetes_namespace.rook_ceph[0].metadata[0].name : null
+}
+
+output "rbd_prerequisite_satisfied" {
+  description = "Confirms the rbd+ceph kernel-module prerequisite (ADR-0052) is satisfied — true means RBD PVCs can mount on the Talos nodes."
+  value       = contains(var.ceph_kernel_modules, "rbd") && contains(var.ceph_kernel_modules, "ceph")
+}
+
+output "object_store_enabled" {
+  description = "Whether the Ceph-RGW S3 object store was created (the optional WS-B artifact-store backend)."
+  value       = local.deploy_object_store
+}
+
+output "s3_endpoint" {
+  description = "In-cluster S3 endpoint for the RGW object store (null when the object store is disabled). Consumed by baremetal-ml-artifact-store / WS-B."
+  value       = local.deploy_object_store ? "http://rook-ceph-rgw-${var.object_store_name}.${var.namespace}.svc:${var.rgw_port}" : null
+}
+
+output "block_pool_replicas" {
+  description = "Replication factor of the Ceph pools."
+  value       = var.block_pool_replicas
+}
+
+output "platform_labels" {
+  description = "Effective ADR-0028 dotted labels."
+  value       = local.platform_labels
+}

--- a/terraform/modules/baremetal-rook-ceph/variables.tf
+++ b/terraform/modules/baremetal-rook-ceph/variables.tf
@@ -1,0 +1,124 @@
+variable "enabled" {
+  description = "Master toggle. When false the module creates nothing (apply-gated default-OFF posture for the WS-A stack)."
+  type        = bool
+  default     = false
+}
+
+variable "namespace" {
+  description = "Namespace Rook-Ceph runs in."
+  type        = string
+  default     = "rook-ceph"
+}
+
+variable "ceph_kernel_modules" {
+  description = "The kernel modules talos-machineconfig declared (wired from its output via the stack dependency). HARD ADR-0052 contract: must include rbd + ceph or csi-rbdplugin crash-loops and no RBD PVC mounts. The validation below fails the plan if they are absent — enforcing the load-bearing dependency in code."
+  type        = list(string)
+  default     = ["rbd", "ceph"]
+  nullable    = false
+
+  validation {
+    condition     = contains(var.ceph_kernel_modules, "rbd") && contains(var.ceph_kernel_modules, "ceph")
+    error_message = "Rook-Ceph requires the rbd + ceph kernel modules to be declared in talos-machineconfig (ADR-0052) — without them csi-rbdplugin crash-loops and no RBD PVC will mount."
+  }
+}
+
+variable "chart_version" {
+  description = "Pinned Rook-Ceph operator Helm chart version."
+  type        = string
+  default     = "v1.15.6"
+}
+
+variable "chart_repository" {
+  description = "Helm repository hosting the rook-ceph chart."
+  type        = string
+  default     = "https://charts.rook.io/release"
+}
+
+variable "ceph_image" {
+  description = "Ceph container image the CephCluster runs."
+  type        = string
+  default     = "quay.io/ceph/ceph:v18.2.4"
+}
+
+variable "data_dir_host_path" {
+  description = "Host path Rook persists Ceph state to. Must match the talos-machineconfig kubelet extraMount (ADR-0052)."
+  type        = string
+  default     = "/var/lib/rook"
+}
+
+variable "mon_count" {
+  description = "Number of Ceph monitors (odd number for quorum; 3 is the replicated default)."
+  type        = number
+  default     = 3
+
+  validation {
+    condition     = var.mon_count % 2 == 1
+    error_message = "mon_count must be odd for quorum (e.g. 3 or 5)."
+  }
+}
+
+variable "block_pool_replicas" {
+  description = "Replication factor for the RBD/FS/object pools (≥3 to survive a node loss; R5 mitigation)."
+  type        = number
+  default     = 3
+
+  validation {
+    condition     = var.block_pool_replicas >= 3
+    error_message = "block_pool_replicas must be >= 3 to survive a node loss (storage-SPOF mitigation, ADR-0052 / risk R5)."
+  }
+}
+
+variable "use_all_nodes" {
+  description = "Let Ceph use all nodes for OSDs."
+  type        = bool
+  default     = true
+}
+
+variable "use_all_devices" {
+  description = "Let Ceph consume all available block devices for OSDs."
+  type        = bool
+  default     = false
+}
+
+variable "enable_filesystem" {
+  description = "Create a CephFilesystem (RWX) for shared datasets."
+  type        = bool
+  default     = true
+}
+
+variable "enable_object_store" {
+  description = "Create a CephObjectStore (RGW S3) — the optional S3-compatible artifact-store backend for WS-B (ADR-0052)."
+  type        = bool
+  default     = true
+}
+
+variable "object_store_name" {
+  description = "Name of the Ceph RGW object store."
+  type        = string
+  default     = "ml-artifacts"
+}
+
+variable "rgw_port" {
+  description = "Port the RGW S3 gateway listens on."
+  type        = number
+  default     = 80
+}
+
+variable "rgw_instances" {
+  description = "Number of RGW gateway instances (HA)."
+  type        = number
+  default     = 2
+}
+
+variable "helm_timeout" {
+  description = "Helm release timeout in seconds."
+  type        = number
+  default     = 600
+}
+
+variable "platform_labels" {
+  description = "ADR-0028 Kubernetes-plane labels (dotted keys, e.g. platform.system = ml-infra) applied to the namespace, operator, and all Ceph custom resources."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}

--- a/terraform/modules/baremetal-rook-ceph/versions.tf
+++ b/terraform/modules/baremetal-rook-ceph/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.25"
+    }
+  }
+}

--- a/terraform/modules/talos-cluster/README.md
+++ b/terraform/modules/talos-cluster/README.md
@@ -1,0 +1,55 @@
+# talos-cluster
+
+Bootstraps the **self-operated Talos control plane** — etcd init, kubeconfig retrieval,
+and the **etcd-snapshot schedule** wiring. Part of **WS-A** of the Bare-Metal ML
+Platform. System: `ml-infra`.
+
+**ADRs:** [ADR-0049](../../../docs/adrs/0049-baremetal-gpu-k8s-talos-foundation-multidc.md)
+(self-operated control plane / multi-DC). ADR-0028 taxonomy labels.
+
+## Why this exists (no managed control plane)
+
+Unlike GKE/EKS, **we own etcd and the API server** (ADR-0049). That means this module —
+not a cloud provider — owns the **control-plane VIP / KubePrism** endpoint, the one-time
+**etcd bootstrap**, and the **etcd-snapshot cadence** that the control-plane-change gate
+depends on (a verified snapshot is taken before every control-plane `MachineConfig`
+change or Talos upgrade).
+
+It consumes the secrets + client config produced by `talos-machineconfig` (wired through
+a `dependency` block at the stack layer) and emits the cluster **kubeconfig** every
+in-cluster WS-A unit (cilium-lb, rook-ceph, gpu-operator, …) depends on.
+
+## Double-gated, apply-gated
+
+| Gate | Default | Effect |
+|------|---------|--------|
+| `var.enabled` | `false` | module creates nothing |
+| `var.bootstrap_control_plane` | `false` | even when enabled, etcd is **not** initialised |
+
+`talos_machine_bootstrap` (which actually `etcd init`s a live node) is created **only when
+both gates are true**. The default posture provisions nothing, and **no bootstrap is ever
+run in this repo** (mock/emulation, plan-only). No `terraform apply`, no
+`talosctl bootstrap`.
+
+## What it creates (when both gates true)
+
+| Resource / data source | Purpose |
+|------------------------|---------|
+| `talos_machine_bootstrap.this` | One-time etcd init on the first control-plane node |
+| `data.talos_cluster_kubeconfig.this` | Cluster kubeconfig for downstream in-cluster units |
+
+## ADR-0028 labeling
+
+Dotted keys: `platform.system = ml-infra`, `platform.component = control-plane`,
+`platform.managed-by = terragrunt`, plus `platform_labels` overrides — surfaced via
+outputs for downstream control-plane K8s resources.
+
+## Testing
+
+```bash
+terraform init -backend=false
+terraform test
+```
+
+Mocks the `talos` provider — asserts the double-gated bootstrap and the etcd-snapshot
+wiring; no live cluster needed.

--- a/terraform/modules/talos-cluster/main.tf
+++ b/terraform/modules/talos-cluster/main.tf
@@ -1,0 +1,62 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Talos Cluster Bootstrap Module (WS-A — ml-infra) — ADR-0049
+# ---------------------------------------------------------------------------------------------------------------------
+# Bootstraps the self-operated Talos control plane: etcd init, kubeconfig retrieval, and
+# the etcd-snapshot schedule wiring. Unlike GKE/EKS there is NO managed control plane —
+# we own etcd and the API server (ADR-0049), so this module owns the control-plane VIP /
+# KubePrism endpoint and the snapshot cadence that the WS-A acceptance and the
+# control-plane-change gate (etcd snapshot before every control-plane MachineConfig
+# change) depend on.
+#
+# Consumes the secrets + endpoint produced by talos-machineconfig via input variables
+# (wired through a `dependency` block at the stack layer).
+#
+# Apply-gated / default-OFF: talos_machine_bootstrap actually initialises etcd on a live
+# node — it is created ONLY when both var.enabled AND var.bootstrap_control_plane are
+# true, so the default stack posture provisions nothing. No bootstrap is ever run in this
+# repo (mock/emulation, plan-only).
+#
+# ADR-0028: dotted platform labels surfaced via outputs for downstream K8s resources.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  platform_labels = merge(
+    {
+      "platform.system"     = "ml-infra"
+      "platform.component"  = "control-plane"
+      "platform.managed-by" = "terragrunt"
+    },
+    var.platform_labels,
+  )
+
+  do_bootstrap = var.enabled && var.bootstrap_control_plane
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# etcd init / control-plane bootstrap — runs ONCE against the first control-plane node.
+# Double-gated (enabled AND bootstrap_control_plane) so the default posture never touches
+# a machine. Apply-gated: in this repo it is plan-only.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "talos_machine_bootstrap" "this" {
+  count = local.do_bootstrap ? 1 : 0
+
+  node                 = var.bootstrap_node
+  endpoint             = var.control_plane_vip
+  client_configuration = var.client_configuration
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Cluster kubeconfig — retrieved after bootstrap; consumed by every in-cluster unit
+# (cilium-lb, rook-ceph, gpu-operator, …) via the stack `dependency` wiring.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "talos_cluster_kubeconfig" "this" {
+  count = local.do_bootstrap ? 1 : 0
+
+  node                 = var.bootstrap_node
+  endpoint             = var.control_plane_vip
+  client_configuration = var.client_configuration
+
+  depends_on = [talos_machine_bootstrap.this]
+}

--- a/terraform/modules/talos-cluster/outputs.tf
+++ b/terraform/modules/talos-cluster/outputs.tf
@@ -1,0 +1,30 @@
+output "enabled" {
+  description = "Whether the cluster bootstrap module is enabled."
+  value       = var.enabled
+}
+
+output "bootstrapped" {
+  description = "Whether the etcd bootstrap resource was actually created (enabled AND bootstrap_control_plane). False in the default apply-gated posture."
+  value       = local.do_bootstrap
+}
+
+output "kubeconfig" {
+  description = "Raw cluster kubeconfig (sensitive) for downstream in-cluster units. Null until bootstrapped; the stack mocks this at plan time."
+  value       = local.do_bootstrap ? talos_cluster_kubeconfig.this[0].kubeconfig_raw : null
+  sensitive   = true
+}
+
+output "cluster_endpoint" {
+  description = "Control-plane API endpoint (the VIP), for downstream provider wiring."
+  value       = "https://${var.control_plane_vip}:6443"
+}
+
+output "etcd_snapshot_schedule" {
+  description = "etcd snapshot cron schedule (ADR-0049 control-plane gate) for the GitOps CronJob to consume."
+  value       = var.etcd_snapshot_schedule
+}
+
+output "platform_labels" {
+  description = "Effective ADR-0028 dotted labels for the control-plane system."
+  value       = local.platform_labels
+}

--- a/terraform/modules/talos-cluster/talos-cluster.tftest.hcl
+++ b/terraform/modules/talos-cluster/talos-cluster.tftest.hcl
@@ -1,0 +1,68 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests for the talos-cluster module. The talos provider is mocked; assertions run at
+# plan time over the double-gated bootstrap and the etcd-snapshot wiring (ADR-0049).
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "talos" {}
+
+run "default_posture_does_not_bootstrap" {
+  command = plan
+
+  # Default: enabled = false AND bootstrap_control_plane = false → no etcd init.
+  assert {
+    condition     = length(talos_machine_bootstrap.this) == 0
+    error_message = "Default apply-gated posture must NOT create the etcd bootstrap resource."
+  }
+
+  assert {
+    condition     = output.bootstrapped == false
+    error_message = "bootstrapped output must be false in the default posture."
+  }
+}
+
+run "enabled_but_not_bootstrap_flag_still_no_etcd_init" {
+  command = plan
+
+  variables {
+    enabled                 = true
+    bootstrap_control_plane = false
+  }
+
+  # The second gate keeps etcd untouched even when the module is otherwise enabled.
+  assert {
+    condition     = length(talos_machine_bootstrap.this) == 0
+    error_message = "bootstrap_control_plane = false must prevent etcd init even when enabled = true."
+  }
+}
+
+run "both_gates_true_creates_bootstrap" {
+  command = plan
+
+  variables {
+    enabled                 = true
+    bootstrap_control_plane = true
+  }
+
+  assert {
+    condition     = length(talos_machine_bootstrap.this) == 1
+    error_message = "Both gates true must create exactly one etcd bootstrap resource."
+  }
+}
+
+run "etcd_snapshot_schedule_surfaced" {
+  command = plan
+
+  assert {
+    condition     = length(output.etcd_snapshot_schedule) > 0
+    error_message = "etcd snapshot schedule must be surfaced (ADR-0049 control-plane gate)."
+  }
+}
+
+run "endpoint_carries_api_port" {
+  command = plan
+
+  assert {
+    condition     = endswith(output.cluster_endpoint, ":6443")
+    error_message = "cluster_endpoint must expose the Kubernetes API port."
+  }
+}

--- a/terraform/modules/talos-cluster/variables.tf
+++ b/terraform/modules/talos-cluster/variables.tf
@@ -1,0 +1,63 @@
+variable "enabled" {
+  description = "Master toggle. When false the module creates nothing (apply-gated default-OFF posture for the WS-A stack)."
+  type        = bool
+  default     = false
+}
+
+variable "bootstrap_control_plane" {
+  description = "Second gate: actually run the one-time etcd bootstrap on the first control-plane node. Kept separate from var.enabled so the cluster can be planned without ever initialising etcd. Apply-gated — never true in this mock repo."
+  type        = bool
+  default     = false
+}
+
+variable "cluster_name" {
+  description = "Talos cluster name (per-DC, e.g. uk-primary / uk-standby)."
+  type        = string
+  default     = "uk-baremetal-gpu"
+}
+
+variable "control_plane_vip" {
+  description = "Control-plane VIP / endpoint talosctl bootstraps and fetches kubeconfig against (the API HA endpoint, fronted by KubePrism in-cluster)."
+  type        = string
+  default     = "10.10.0.10"
+}
+
+variable "bootstrap_node" {
+  description = "IP/hostname of the single control-plane node etcd is bootstrapped on (bootstrap runs exactly once against one node)."
+  type        = string
+  default     = "10.10.0.10"
+}
+
+variable "client_configuration" {
+  description = "talosctl client configuration object from talos-machineconfig (sensitive mTLS client cert/CA/key). Wired via the stack dependency block; mocked at plan time."
+  type = object({
+    ca_certificate     = string
+    client_certificate = string
+    client_key         = string
+  })
+  default = {
+    ca_certificate     = "bW9jay1jYQ=="
+    client_certificate = "bW9jay1jZXJ0"
+    client_key         = "bW9jay1rZXk="
+  }
+  sensitive = true
+}
+
+variable "etcd_snapshot_schedule" {
+  description = "Cron schedule for the etcd snapshot CronJob (ADR-0049: a verified etcd snapshot is taken before every control-plane MachineConfig change / Talos upgrade). Surfaced as an output for the GitOps layer to consume."
+  type        = string
+  default     = "0 */6 * * *"
+}
+
+variable "etcd_snapshot_retention" {
+  description = "Number of etcd snapshots to retain."
+  type        = number
+  default     = 24
+}
+
+variable "platform_labels" {
+  description = "ADR-0028 dotted platform labels (e.g. platform.system = ml-infra) surfaced via outputs for downstream control-plane K8s resources."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}

--- a/terraform/modules/talos-cluster/versions.tf
+++ b/terraform/modules/talos-cluster/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    talos = {
+      source  = "siderolabs/talos"
+      version = "~> 0.7"
+    }
+  }
+}

--- a/terraform/modules/talos-gpu-nodepool/README.md
+++ b/terraform/modules/talos-gpu-nodepool/README.md
@@ -1,0 +1,49 @@
+# talos-gpu-nodepool
+
+A **logical, fixed-capacity GPU node pool** over a set of bare-metal machines — the
+bare-metal analogue of `gcp-gke-gpu-nodepools` **minus the autoscaler**. Part of **WS-A**
+of the Bare-Metal ML Platform. System: `ml-infra`.
+
+**ADRs:** [ADR-0049](../../../docs/adrs/0049-baremetal-gpu-k8s-talos-foundation-multidc.md)
+(foundation), [ADR-0054](../../../docs/adrs/0054-baremetal-elasticity-node-lifecycle.md)
+(elasticity / node lifecycle without a cloud autoscaler). ADR-0028 taxonomy labels.
+
+## No cloud autoscaler (the load-bearing difference)
+
+On owned hardware there is **no cloud API that conjures nodes in seconds** (ADR-0054). A
+"new node" is a PXE/Talos **re-image**, minutes-to-hours. So this module does **not**
+manage a `min/max` range — capacity is **fixed** and equals the length of `var.machines`.
+The node-pool policy ConfigMap records `autoscaling = disabled` explicitly. Elasticity
+comes from **workload** scale-to-zero (KEDA/HPA/Volcano), not node count.
+
+## What it creates (when `enabled = true`)
+
+| Resource | Purpose |
+|----------|---------|
+| `kubernetes_manifest.nodepool_policy` | A ConfigMap the GitOps layer reconciles — pool size, GPU taint, and ADR-0028 + GPU labels |
+| `kubernetes_manifest.cluster_api_machine` | (gated) Cluster-API `Machine`/`MetalMachine` objects for re-image lifecycle |
+
+The Cluster-API objects are **off by default** (`manage_cluster_api = false` → static
+pre-provisioned pool). `cluster_api_infra_provider` defaults to **sidero** (Talos-native,
+the ADR-0054 recommendation), with `metal3` selectable.
+
+## Apply-gated
+
+`var.enabled` defaults **false**; nothing reconciles real hardware. Manifests are
+rendered against mocked providers at plan time — no live cluster read.
+
+## ADR-0028 labeling
+
+Dotted keys: `platform.system = ml-infra`, `platform.component = gpu-nodepool`, plus
+`platform_labels` overrides; nodes also carry `nvidia.com/gpu.present`,
+`node.kubernetes.io/gpu-pool`, and `gpu.platform/model`.
+
+## Testing
+
+```bash
+terraform init -backend=false
+terraform test
+```
+
+Mocks the `kubernetes` provider — asserts the fixed-capacity (no-autoscaler) intent, the
+GPU taint/labels, and the gated Cluster-API re-image path.

--- a/terraform/modules/talos-gpu-nodepool/main.tf
+++ b/terraform/modules/talos-gpu-nodepool/main.tf
@@ -1,0 +1,106 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Talos GPU Node Pool Module (WS-A — ml-infra) — ADR-0049 / ADR-0054
+# ---------------------------------------------------------------------------------------------------------------------
+# A *logical* GPU node pool over a set of bare-metal machines — the bare-metal analogue of
+# gcp-gke-gpu-nodepools MINUS the autoscaler. On owned hardware capacity is FIXED
+# (ADR-0054): there is no cloud API that conjures nodes in seconds; a "new node" is a
+# PXE/Talos re-image measured in minutes-to-hours. So this module does NOT manage a
+# min/max autoscaling range — it binds machines to the GPU-worker class, applies the
+# taint/labels Volcano + the device-plugin select on, and OPTIONALLY drives Cluster-API
+# (Metal³/Sidero) Machine objects for re-image-based lifecycle.
+#
+# The GPU node taint + labels are emitted as a label/taint policy carried by a
+# kubernetes_manifest (a node-policy ConfigMap the GitOps layer reconciles) — kept free
+# of any live-cluster read so plan/validate works against mocked providers, matching the
+# gke-gpu-fabric / dranet modules' kubernetes_manifest pattern.
+#
+# Cluster-API objects (Machine/MetalMachine, ADR-0054) are gated behind
+# var.manage_cluster_api so the default posture is a static, pre-provisioned pool and
+# nothing reconciles real hardware.
+#
+# ADR-0028: dotted platform labels on every object and node.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  platform_labels = merge(
+    {
+      "platform.system"     = "ml-infra"
+      "platform.component"  = "gpu-nodepool"
+      "platform.managed-by" = "terragrunt"
+    },
+    var.platform_labels,
+  )
+
+  # Fixed-capacity GPU pool: the node labels/taints the device-plugin + Volcano select on.
+  node_labels = merge(
+    local.platform_labels,
+    {
+      "nvidia.com/gpu.present"      = "true"
+      "node.kubernetes.io/gpu-pool" = var.pool_name
+      "gpu.platform/model"          = var.gpu_model
+    },
+  )
+
+  # Cluster-API Machines are created only when explicitly asked (ADR-0054 re-image path).
+  cluster_api_machines = var.enabled && var.manage_cluster_api ? { for m in var.machines : m.name => m } : {}
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU node-pool policy — a ConfigMap the GitOps layer applies to taint/label the pool.
+# Carries the fixed-capacity intent (size, taints, labels) without reading the live cluster.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "nodepool_policy" {
+  count = var.enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "ConfigMap"
+    metadata = {
+      name      = "gpu-nodepool-${var.pool_name}"
+      namespace = var.namespace
+      labels    = local.platform_labels
+    }
+    data = {
+      "pool_name"      = var.pool_name
+      "gpu_model"      = var.gpu_model
+      "fixed_capacity" = tostring(length(var.machines))
+      # Fixed pool — explicitly no autoscaler (ADR-0054).
+      "autoscaling" = "disabled"
+      "gpu_taint"   = "${var.gpu_taint_key}=${var.gpu_taint_value}:${var.gpu_taint_effect}"
+      "node_labels" = jsonencode(local.node_labels)
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Cluster-API Machine objects (Metal³/Sidero) — re-image-based node lifecycle (ADR-0054).
+# Gated OFF by default (manage_cluster_api = false) → static pre-provisioned pool.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "kubernetes_manifest" "cluster_api_machine" {
+  for_each = local.cluster_api_machines
+
+  manifest = {
+    apiVersion = "cluster.x-k8s.io/v1beta1"
+    kind       = "Machine"
+    metadata = {
+      name      = each.value.name
+      namespace = var.cluster_api_namespace
+      labels = merge(local.platform_labels, {
+        "cluster.x-k8s.io/cluster-name" = var.cluster_name
+      })
+    }
+    spec = {
+      clusterName = var.cluster_name
+      bootstrap = {
+        dataSecretName = each.value.bootstrap_secret
+      }
+      infrastructureRef = {
+        apiVersion = var.cluster_api_infra_provider == "sidero" ? "infrastructure.cluster.x-k8s.io/v1alpha2" : "infrastructure.cluster.x-k8s.io/v1beta1"
+        kind       = var.cluster_api_infra_provider == "sidero" ? "MetalMachine" : "Metal3Machine"
+        name       = each.value.name
+      }
+    }
+  }
+}

--- a/terraform/modules/talos-gpu-nodepool/outputs.tf
+++ b/terraform/modules/talos-gpu-nodepool/outputs.tf
@@ -1,0 +1,34 @@
+output "enabled" {
+  description = "Whether the node pool module is enabled."
+  value       = var.enabled
+}
+
+output "pool_name" {
+  description = "Logical GPU pool name."
+  value       = var.pool_name
+}
+
+output "fixed_capacity" {
+  description = "Fixed number of machines in the pool (ADR-0054: no autoscaler — capacity equals the machine count)."
+  value       = length(var.machines)
+}
+
+output "node_labels" {
+  description = "Effective node labels (ADR-0028 + GPU-present + pool/model) the device-plugin and Volcano select on."
+  value       = local.node_labels
+}
+
+output "gpu_taint" {
+  description = "The GPU node taint key=value:effect applied to the pool."
+  value       = "${var.gpu_taint_key}=${var.gpu_taint_value}:${var.gpu_taint_effect}"
+}
+
+output "cluster_api_managed" {
+  description = "Whether Cluster-API Machine objects are managed for this pool (ADR-0054 re-image path)."
+  value       = var.enabled && var.manage_cluster_api
+}
+
+output "platform_labels" {
+  description = "Effective ADR-0028 dotted labels."
+  value       = local.platform_labels
+}

--- a/terraform/modules/talos-gpu-nodepool/talos-gpu-nodepool.tftest.hcl
+++ b/terraform/modules/talos-gpu-nodepool/talos-gpu-nodepool.tftest.hcl
@@ -1,0 +1,101 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests for the talos-gpu-nodepool module. The kubernetes provider is mocked; assertions
+# run at plan time over the fixed-capacity (no-autoscaler) intent and the gated
+# Cluster-API re-image path (ADR-0054).
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "kubernetes" {}
+
+variables {
+  enabled   = true
+  pool_name = "h100-training"
+  gpu_model = "H100"
+  machines = [
+    { name = "gpu-01" },
+    { name = "gpu-02" },
+    { name = "gpu-03" },
+  ]
+  platform_labels = {
+    "platform.env"   = "staging"
+    "platform.owner" = "team-data"
+  }
+}
+
+run "disabled_creates_nothing" {
+  command = plan
+
+  variables {
+    enabled = false
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.nodepool_policy) == 0
+    error_message = "No node-pool policy should be created when enabled = false."
+  }
+}
+
+run "fixed_capacity_equals_machine_count" {
+  command = plan
+
+  # ADR-0054: capacity is the machine count, NOT an autoscaling range.
+  assert {
+    condition     = output.fixed_capacity == 3
+    error_message = "Fixed capacity must equal the number of machines (no autoscaler, ADR-0054)."
+  }
+
+  assert {
+    condition     = kubernetes_manifest.nodepool_policy[0].manifest.data.autoscaling == "disabled"
+    error_message = "Node-pool policy must explicitly mark autoscaling disabled (ADR-0054)."
+  }
+}
+
+run "gpu_labels_and_taint" {
+  command = plan
+
+  assert {
+    condition     = output.node_labels["nvidia.com/gpu.present"] == "true"
+    error_message = "Pool nodes must advertise nvidia.com/gpu.present."
+  }
+
+  assert {
+    condition     = output.node_labels["platform.system"] == "ml-infra"
+    error_message = "Pool nodes must carry platform.system = ml-infra (ADR-0028)."
+  }
+
+  assert {
+    condition     = output.gpu_taint == "nvidia.com/gpu=present:NoSchedule"
+    error_message = "GPU taint must be applied so only GPU workloads schedule on the pool."
+  }
+}
+
+run "cluster_api_off_by_default" {
+  command = plan
+
+  # manage_cluster_api defaults false → static pool, no Machine objects reconcile hardware.
+  assert {
+    condition     = length(kubernetes_manifest.cluster_api_machine) == 0
+    error_message = "Cluster-API Machine objects must be OFF by default (static pool, ADR-0054)."
+  }
+
+  assert {
+    condition     = output.cluster_api_managed == false
+    error_message = "cluster_api_managed must be false by default."
+  }
+}
+
+run "cluster_api_machines_when_enabled" {
+  command = plan
+
+  variables {
+    manage_cluster_api = true
+    machines = [
+      { name = "gpu-01", bootstrap_secret = "gpu-01-bootstrap" },
+      { name = "gpu-02", bootstrap_secret = "gpu-02-bootstrap" },
+    ]
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.cluster_api_machine) == 2
+    error_message = "One Cluster-API Machine per machine should be created when manage_cluster_api = true."
+  }
+}

--- a/terraform/modules/talos-gpu-nodepool/variables.tf
+++ b/terraform/modules/talos-gpu-nodepool/variables.tf
@@ -1,0 +1,92 @@
+variable "enabled" {
+  description = "Master toggle. When false the module creates nothing (apply-gated default-OFF posture for the WS-A stack)."
+  type        = bool
+  default     = false
+}
+
+variable "pool_name" {
+  description = "Logical name of the fixed-capacity GPU node pool (e.g. h100-training, h200-serving)."
+  type        = string
+  default     = "h100-training"
+}
+
+variable "gpu_model" {
+  description = "GPU model backing this pool (e.g. H100, H200, L40S). Surfaced as a node label and into DRA device-class selection downstream."
+  type        = string
+  default     = "H100"
+}
+
+variable "namespace" {
+  description = "Namespace the node-pool policy ConfigMap is created in."
+  type        = string
+  default     = "kube-system"
+}
+
+variable "machines" {
+  description = "Fixed set of bare-metal machines in this pool. Capacity is fixed (ADR-0054: no autoscaler) — the list length IS the pool size. bootstrap_secret is only used when manage_cluster_api = true."
+  type = list(object({
+    name             = string
+    bootstrap_secret = optional(string, "")
+  }))
+  default  = []
+  nullable = false
+}
+
+variable "gpu_taint_key" {
+  description = "Taint key applied to GPU nodes so only GPU workloads schedule there."
+  type        = string
+  default     = "nvidia.com/gpu"
+}
+
+variable "gpu_taint_value" {
+  description = "Taint value for the GPU node taint."
+  type        = string
+  default     = "present"
+}
+
+variable "gpu_taint_effect" {
+  description = "Taint effect for the GPU node taint."
+  type        = string
+  default     = "NoSchedule"
+
+  validation {
+    condition     = contains(["NoSchedule", "PreferNoSchedule", "NoExecute"], var.gpu_taint_effect)
+    error_message = "gpu_taint_effect must be one of NoSchedule, PreferNoSchedule, NoExecute."
+  }
+}
+
+variable "manage_cluster_api" {
+  description = "Drive Cluster-API (Metal³/Sidero) Machine objects for re-image-based node lifecycle (ADR-0054). Default false → static, pre-provisioned pool; nothing reconciles real hardware. Apply-gated."
+  type        = bool
+  default     = false
+}
+
+variable "cluster_api_infra_provider" {
+  description = "Cluster-API infrastructure provider for the re-image path (ADR-0054). sidero is the recommended Talos-native default; metal3 (Ironic/PXE) is the alternative."
+  type        = string
+  default     = "sidero"
+
+  validation {
+    condition     = contains(["sidero", "metal3"], var.cluster_api_infra_provider)
+    error_message = "cluster_api_infra_provider must be one of sidero, metal3."
+  }
+}
+
+variable "cluster_api_namespace" {
+  description = "Namespace the Cluster-API Machine objects live in (when manage_cluster_api = true)."
+  type        = string
+  default     = "cluster-api"
+}
+
+variable "cluster_name" {
+  description = "Cluster name the Cluster-API Machines belong to (per-DC)."
+  type        = string
+  default     = "uk-baremetal-gpu"
+}
+
+variable "platform_labels" {
+  description = "ADR-0028 dotted platform labels (e.g. platform.system = ml-infra) applied to every object and node label set."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}

--- a/terraform/modules/talos-gpu-nodepool/versions.tf
+++ b/terraform/modules/talos-gpu-nodepool/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.25"
+    }
+  }
+}

--- a/terraform/modules/talos-machineconfig/README.md
+++ b/terraform/modules/talos-machineconfig/README.md
@@ -1,0 +1,85 @@
+# talos-machineconfig
+
+Renders **immutable Talos Linux `MachineConfig`** for two machine classes —
+**control-plane** and **GPU-worker** — via the `siderolabs/talos` provider. Part of
+**WS-A** of the Bare-Metal ML Platform. System: `ml-infra`.
+
+**ADRs:** [ADR-0049](../../../docs/adrs/0049-baremetal-gpu-k8s-talos-foundation-multidc.md)
+(Talos foundation / multi-DC), [ADR-0050](../../../docs/adrs/0050-talos-gpu-driver-system-extensions.md)
+(GPU driver via system extension), [ADR-0052](../../../docs/adrs/0052-baremetal-storage-rook-ceph.md)
+(Rook-Ceph `rbd`+`ceph` kernel-module prerequisite). ADR-0028 taxonomy labels on every node.
+
+## Why this module is load-bearing
+
+Talos is **immutable** — no shell, no SSH, no package manager. Anything the OS needs
+**must be declared in the `MachineConfig` and baked into the boot image**; it cannot be
+installed on a running host. This module is therefore the **single place** three
+prerequisites are declared:
+
+| Prerequisite | Declared as | ADR | Failure if omitted |
+|--------------|-------------|-----|--------------------|
+| **Rook-Ceph RBD** | `machine.kernel.modules` = `rbd` + `ceph` | ADR-0052 | `csi-rbdplugin` crash-loops; **no RBD PVC ever mounts** |
+| **NVIDIA driver** | `install.extensions` (system extension) + `nvidia*` kernel modules | ADR-0050 | no GPU; `nvidia-smi` fails; GPU Operator has nothing to bind |
+| **Rook kubelet state** | `kubelet.extraMounts` (`/var/lib/rook`) + sysctls | ADR-0052 | Ceph OSDs cannot persist state on the immutable host |
+
+A `validation` block on `ceph_kernel_modules` **fails the plan** if `rbd` or `ceph` is
+dropped — the ADR-0052 gate is enforced in code.
+
+This module is the **explicit replacement** for the kubeadm `hetzner-kubeadm.sh` host
+bootstrap script (which the plan does *not* reuse): there is **no host bootstrap**, only
+declarative config applied over the mTLS machine API.
+
+## What it creates (when `enabled = true`)
+
+| Resource / data source | Purpose |
+|------------------------|---------|
+| `talos_machine_secrets.this` | Cluster PKI / secret bundle (sensitive; from a secret manager in real use) |
+| `data.talos_machine_configuration.controlplane` | Control-plane config — etcd/API, KubePrism, `rbd`+`ceph` modules |
+| `data.talos_machine_configuration.gpu_worker` | GPU-worker config — NVIDIA extension, `rbd`+`ceph`+`nvidia*` modules, Rook mounts/sysctls |
+| `data.talos_client_configuration.this` | `talosctl` mTLS client config — the **only** access path (no SSH) |
+
+## Apply-gated / default-OFF
+
+`var.enabled` defaults to **false** so the WS-A stack provisions nothing until a human
+explicitly enables it behind a reviewed plan. `talos_machine_secrets` is the only
+*resource* (everything else is a data source); nothing is ever applied to a machine here
+(`talos_machine_configuration_apply` / `talos_machine_bootstrap` live in `talos-cluster`
+and stay apply-gated). **No `terraform apply`, no `talosctl apply-config` in this repo.**
+
+## ADR-0028 labeling
+
+Talos/Kubernetes-plane labels use **dotted** keys. Every node carries
+`platform.system = ml-infra`, `platform.component = compute`,
+`platform.managed-by = terragrunt`, merged with any `platform_labels` overrides
+(`platform.env`, `platform.owner`). GPU workers additionally advertise
+`nvidia.com/gpu.present = true`.
+
+## Usage
+
+```hcl
+module "talos_machineconfig" {
+  source = "../../terraform/modules/talos-machineconfig"
+
+  enabled          = true
+  cluster_name     = "uk-primary"
+  cluster_endpoint = "https://10.10.0.10:6443"
+
+  control_plane_endpoints = ["10.10.0.10", "10.10.0.11", "10.10.0.12"]
+
+  platform_labels = {
+    "platform.env"   = "production"
+    "platform.owner" = "team-data"
+  }
+}
+```
+
+## Testing
+
+```bash
+terraform init -backend=false
+terraform test
+```
+
+Tests mock the `talos` provider — no real machine, secrets, or credentials needed. They
+assert the **rbd+ceph** prerequisite, the NVIDIA extension, ADR-0028 labels, KubePrism,
+and the apply-gated default-OFF behaviour.

--- a/terraform/modules/talos-machineconfig/main.tf
+++ b/terraform/modules/talos-machineconfig/main.tf
@@ -1,0 +1,179 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Talos MachineConfig Module (WS-A — ml-infra) — ADR-0049 / ADR-0050 / ADR-0052
+# ---------------------------------------------------------------------------------------------------------------------
+# Renders immutable Talos Linux MachineConfig for two machine classes — control-plane
+# and GPU-worker — via the siderolabs/talos provider. This is the SINGLE place where
+# OS-level prerequisites that cannot be installed on a running immutable host are
+# declared, because Talos has no shell, no SSH, and no package manager (ADR-0049):
+#
+#   * machine.kernel.modules  — `rbd` + `ceph` are the HARD Rook-Ceph RBD prerequisite
+#                               (ADR-0052): without them csi-rbdplugin crash-loops and
+#                               no RBD PVC will ever mount. `nvidia` / `nvidia_uvm` etc.
+#                               back the GPU system extension (ADR-0050).
+#   * system extensions       — the NVIDIA driver (`nonfree-kmod-nvidia` +
+#                               `nvidia-container-toolkit`) ships in the boot image as a
+#                               Talos system extension, never `apt install` (ADR-0050).
+#   * machine.nodeLabels      — ADR-0028 dotted platform labels onto every node.
+#   * KubePrism + no-SSH/mTLS  — in-cluster API HA + the immutable security posture.
+#
+# This module is the explicit replacement for the kubeadm `hetzner-kubeadm.sh` host
+# bootstrap script — there is NO host bootstrap here. It is apply-gated and default
+# rendering-only: `talos_machine_secrets` is created when var.enabled, and the
+# configuration data sources render config; nothing is applied to a machine (no
+# talos_machine_configuration_apply, no talos_machine_bootstrap — those live in the
+# talos-cluster module and stay apply-gated).
+#
+# ADR-0028: K8s/Talos plane uses DOTTED label keys (platform.system = ml-infra).
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  # ADR-0028 Talos/Kubernetes-plane baseline node labels for the ml-infra system.
+  platform_node_labels = merge(
+    {
+      "platform.system"     = "ml-infra"
+      "platform.component"  = "compute"
+      "platform.managed-by" = "terragrunt"
+    },
+    var.platform_labels,
+  )
+
+  # GPU-worker nodes additionally advertise the GPU-present label so the GPU Operator
+  # device-plugin and DCGM DaemonSet (baremetal-gpu-operator / -dcgm) select them.
+  gpu_worker_node_labels = merge(
+    local.platform_node_labels,
+    {
+      "nvidia.com/gpu.present" = "true"
+    },
+  )
+
+  # HARD prerequisites that can only be declared here on immutable Talos:
+  #   * rbd + ceph   — Rook-Ceph RBD CSI (ADR-0052), load-bearing for any RBD PVC.
+  #   * nvidia*      — back the NVIDIA system-extension driver (ADR-0050) on GPU workers.
+  # Control-plane nodes need rbd/ceph too (Ceph mons/CSI may schedule there) but no nvidia.
+  control_plane_kernel_modules = concat(
+    [for m in var.ceph_kernel_modules : { name = m }],
+    [for m in var.extra_kernel_modules : { name = m }],
+  )
+
+  gpu_worker_kernel_modules = concat(
+    [for m in var.ceph_kernel_modules : { name = m }],
+    [for m in var.nvidia_kernel_modules : { name = m }],
+    [for m in var.extra_kernel_modules : { name = m }],
+  )
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Machine secrets — the PKI/secret bundle a Talos cluster is rendered against.
+# Gated by var.enabled. NOTE: the bundle is sensitive and lives in state; in real use it
+# is sourced from / persisted to a secret manager, never committed (repo rule: no secrets
+# in code/state). Apply-gated like the rest of WS-A.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "talos_machine_secrets" "this" {
+  count = var.enabled ? 1 : 0
+
+  talos_version = var.talos_version
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Control-plane MachineConfig — etcd + API server; KubePrism; rbd/ceph kernel modules.
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "talos_machine_configuration" "controlplane" {
+  count = var.enabled ? 1 : 0
+
+  cluster_name       = var.cluster_name
+  cluster_endpoint   = var.cluster_endpoint
+  machine_type       = "controlplane"
+  machine_secrets    = talos_machine_secrets.this[0].machine_secrets
+  talos_version      = var.talos_version
+  kubernetes_version = var.kubernetes_version
+
+  config_patches = [
+    yamlencode({
+      machine = {
+        # ADR-0050/0052: kernel modules declared at the OS layer (immutable host).
+        kernel = {
+          modules = local.control_plane_kernel_modules
+        }
+        # ADR-0028 node labels.
+        nodeLabels = local.platform_node_labels
+        # Immutable-OS posture: KubePrism for in-cluster API HA (ADR-0049 / WS-E control).
+        features = {
+          kubePrism = {
+            enabled = var.kube_prism_enabled
+            port    = var.kube_prism_port
+          }
+        }
+        install = {
+          disk  = var.install_disk
+          image = var.talos_installer_image
+          wipe  = false
+        }
+      }
+    }),
+  ]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# GPU-worker MachineConfig — NVIDIA system extension + rbd/ceph + nvidia kernel modules
+# + the Rook kubelet extra-mounts / sysctls / open-file limits.
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "talos_machine_configuration" "gpu_worker" {
+  count = var.enabled ? 1 : 0
+
+  cluster_name       = var.cluster_name
+  cluster_endpoint   = var.cluster_endpoint
+  machine_type       = "worker"
+  machine_secrets    = talos_machine_secrets.this[0].machine_secrets
+  talos_version      = var.talos_version
+  kubernetes_version = var.kubernetes_version
+
+  config_patches = [
+    yamlencode({
+      machine = {
+        # ADR-0050/0052: rbd+ceph (Rook RBD prereq) AND nvidia* (GPU driver) modules.
+        kernel = {
+          modules = local.gpu_worker_kernel_modules
+        }
+        # ADR-0028 + GPU-present label so device-plugin/DCGM select these nodes.
+        nodeLabels = local.gpu_worker_node_labels
+        # KubePrism on workers too.
+        features = {
+          kubePrism = {
+            enabled = var.kube_prism_enabled
+            port    = var.kube_prism_port
+          }
+        }
+        install = {
+          disk  = var.install_disk
+          image = var.talos_installer_image
+          wipe  = false
+          # ADR-0050: the NVIDIA driver ships as a Talos system extension baked into
+          # the boot image — never installed on a running host.
+          extensions = [for ext in var.system_extensions : { image = ext }]
+        }
+        # ADR-0052: Rook-Ceph requires the kubelet to mount the host /var/lib/rook path
+        # and raise open-file limits / sysctls; declared here because the host is immutable.
+        kubelet = {
+          extraMounts = var.rook_kubelet_extra_mounts
+        }
+        sysctls = var.gpu_worker_sysctls
+      }
+    }),
+  ]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Client configuration — talosctl mTLS client config (the ONLY access path; no SSH).
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "talos_client_configuration" "this" {
+  count = var.enabled ? 1 : 0
+
+  cluster_name         = var.cluster_name
+  client_configuration = talos_machine_secrets.this[0].client_configuration
+  endpoints            = var.control_plane_endpoints
+  nodes                = var.control_plane_endpoints
+}

--- a/terraform/modules/talos-machineconfig/outputs.tf
+++ b/terraform/modules/talos-machineconfig/outputs.tf
@@ -1,0 +1,38 @@
+output "enabled" {
+  description = "Whether the module rendered Talos config (false = apply-gated OFF, nothing created)."
+  value       = var.enabled
+}
+
+output "controlplane_machine_configuration" {
+  description = "Rendered control-plane MachineConfig YAML (sensitive: contains cluster PKI). Null when disabled. Consumed by the talos-cluster module to bootstrap, apply-gated."
+  value       = var.enabled ? data.talos_machine_configuration.controlplane[0].machine_configuration : null
+  sensitive   = true
+}
+
+output "gpu_worker_machine_configuration" {
+  description = "Rendered GPU-worker MachineConfig YAML (sensitive). Carries the rbd+ceph kernel modules (ADR-0052) and the NVIDIA system extension (ADR-0050). Null when disabled."
+  value       = var.enabled ? data.talos_machine_configuration.gpu_worker[0].machine_configuration : null
+  sensitive   = true
+}
+
+output "client_configuration" {
+  description = "talosctl client configuration (sensitive: mTLS client cert/key — the only access path, no SSH). Null when disabled."
+  value       = var.enabled ? data.talos_client_configuration.this[0].talos_config : null
+  sensitive   = true
+}
+
+output "machine_secrets" {
+  description = "The Talos machine secrets bundle (sensitive PKI) for the talos-cluster module's bootstrap/kubeconfig steps. Null when disabled. Never commit this — source from / persist to a secret manager."
+  value       = var.enabled ? talos_machine_secrets.this[0].machine_secrets : null
+  sensitive   = true
+}
+
+output "ceph_kernel_modules" {
+  description = "The kernel modules declared for Rook-Ceph RBD (ADR-0052). Exposed so the baremetal-rook-ceph unit can assert the rbd+ceph prerequisite is satisfied before scheduling Ceph CSI."
+  value       = var.ceph_kernel_modules
+}
+
+output "platform_labels" {
+  description = "Effective ADR-0028 dotted node labels applied to every machine."
+  value       = local.platform_node_labels
+}

--- a/terraform/modules/talos-machineconfig/talos-machineconfig.tftest.hcl
+++ b/terraform/modules/talos-machineconfig/talos-machineconfig.tftest.hcl
@@ -1,0 +1,119 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Tests for the talos-machineconfig module.
+# The siderolabs/talos provider is mocked so no real machine, secrets bundle, or
+# credentials are needed; assertions run at plan time over the module's wiring,
+# toggles, and the load-bearing ADR-0052 rbd+ceph kernel-module prerequisite.
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "talos" {}
+
+variables {
+  enabled = true
+  platform_labels = {
+    "platform.env"   = "staging"
+    "platform.owner" = "team-data"
+  }
+}
+
+run "disabled_by_default_creates_nothing" {
+  command = plan
+
+  variables {
+    enabled = false
+  }
+
+  assert {
+    condition     = length(talos_machine_secrets.this) == 0
+    error_message = "Apply-gated default OFF: no machine secrets should be created when enabled = false."
+  }
+
+  assert {
+    condition     = length(data.talos_machine_configuration.controlplane) == 0
+    error_message = "No control-plane config should render when enabled = false."
+  }
+}
+
+run "renders_both_machine_classes_when_enabled" {
+  command = plan
+
+  assert {
+    condition     = length(data.talos_machine_configuration.controlplane) == 1
+    error_message = "Control-plane MachineConfig must render when enabled = true."
+  }
+
+  assert {
+    condition     = length(data.talos_machine_configuration.gpu_worker) == 1
+    error_message = "GPU-worker MachineConfig must render when enabled = true."
+  }
+
+  assert {
+    condition     = length(talos_machine_secrets.this) == 1
+    error_message = "Machine secrets bundle must be created when enabled = true."
+  }
+}
+
+run "rbd_and_ceph_kernel_modules_present" {
+  command = plan
+
+  # ADR-0052 load-bearing gate: rbd + ceph must be in the worker kernel-module set or
+  # csi-rbdplugin crash-loops and no RBD PVC ever mounts.
+  assert {
+    condition     = contains([for m in local.gpu_worker_kernel_modules : m.name], "rbd")
+    error_message = "GPU-worker kernel modules MUST include rbd (Rook-Ceph RBD prerequisite, ADR-0052)."
+  }
+
+  assert {
+    condition     = contains([for m in local.gpu_worker_kernel_modules : m.name], "ceph")
+    error_message = "GPU-worker kernel modules MUST include ceph (Rook-Ceph RBD prerequisite, ADR-0052)."
+  }
+
+  assert {
+    condition     = contains([for m in local.control_plane_kernel_modules : m.name], "rbd")
+    error_message = "Control-plane kernel modules MUST also include rbd (Ceph mons/CSI may schedule there, ADR-0052)."
+  }
+}
+
+run "nvidia_driver_extension_and_modules_on_workers" {
+  command = plan
+
+  # ADR-0050: the NVIDIA driver ships as a Talos system extension, never a host install.
+  assert {
+    condition     = length(var.system_extensions) > 0
+    error_message = "GPU workers must declare at least one NVIDIA system extension (ADR-0050)."
+  }
+
+  assert {
+    condition     = contains([for m in local.gpu_worker_kernel_modules : m.name], "nvidia")
+    error_message = "GPU-worker kernel modules must include the nvidia module backing the system extension (ADR-0050)."
+  }
+
+  # Control-plane must NOT carry nvidia modules (no GPU there).
+  assert {
+    condition     = !contains([for m in local.control_plane_kernel_modules : m.name], "nvidia")
+    error_message = "Control-plane nodes should not load nvidia modules."
+  }
+}
+
+run "adr0028_node_labels_and_kubeprism" {
+  command = plan
+
+  assert {
+    condition     = local.platform_node_labels["platform.system"] == "ml-infra"
+    error_message = "Nodes must carry platform.system = ml-infra per ADR-0028."
+  }
+
+  assert {
+    condition     = local.platform_node_labels["platform.env"] == "staging"
+    error_message = "Caller-supplied platform.env label must merge onto node labels."
+  }
+
+  assert {
+    condition     = local.gpu_worker_node_labels["nvidia.com/gpu.present"] == "true"
+    error_message = "GPU workers must advertise nvidia.com/gpu.present so device-plugin/DCGM select them."
+  }
+
+  assert {
+    condition     = var.kube_prism_enabled
+    error_message = "KubePrism must default ON for in-cluster API HA (ADR-0049)."
+  }
+}

--- a/terraform/modules/talos-machineconfig/variables.tf
+++ b/terraform/modules/talos-machineconfig/variables.tf
@@ -1,0 +1,134 @@
+variable "enabled" {
+  description = "Master toggle. When false the module renders/creates nothing (apply-gated: default-OFF posture for the WS-A stack so nothing provisions real infra)."
+  type        = bool
+  default     = false
+}
+
+variable "cluster_name" {
+  description = "Talos cluster name (per-DC, e.g. uk-primary / uk-standby). Carried into the rendered MachineConfig and client configuration."
+  type        = string
+  default     = "uk-baremetal-gpu"
+}
+
+variable "cluster_endpoint" {
+  description = "Kubernetes API endpoint URL the control plane advertises (the control-plane VIP), e.g. https://10.10.0.10:6443. Apply-gated; mock at plan time."
+  type        = string
+  default     = "https://10.10.0.10:6443"
+}
+
+variable "control_plane_endpoints" {
+  description = "List of control-plane node IPs/hostnames the talosctl client targets (mTLS machine API — the only access path, no SSH)."
+  type        = list(string)
+  default     = ["10.10.0.10"]
+  nullable    = false
+}
+
+variable "talos_version" {
+  description = "Talos Linux release the MachineConfig and secrets bundle are rendered for. Pin explicitly per environment (ADR-0050: extension is coupled to the Talos release)."
+  type        = string
+  default     = "v1.9.2"
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version pin rendered into the MachineConfig."
+  type        = string
+  default     = "v1.32.0"
+}
+
+variable "install_disk" {
+  description = "Block device Talos installs to (immutable A/B install target). Bare-metal-specific; set per hardware profile."
+  type        = string
+  default     = "/dev/nvme0n1"
+}
+
+variable "talos_installer_image" {
+  description = "Talos installer image (boot image) that bakes in the system extensions. Pin to the Talos release per ADR-0050."
+  type        = string
+  default     = "ghcr.io/siderolabs/installer:v1.9.2"
+}
+
+variable "system_extensions" {
+  description = "Talos system-extension image refs baked into the GPU-worker boot image (ADR-0050). Default ships the NVIDIA nonfree kmod driver + container toolkit — the immutable-OS replacement for a host driver install."
+  type        = list(string)
+  default = [
+    "ghcr.io/siderolabs/nonfree-kmod-nvidia:535.183.06-v1.9.2",
+    "ghcr.io/siderolabs/nvidia-container-toolkit:535.183.06-v1.17.3",
+  ]
+  nullable = false
+}
+
+variable "ceph_kernel_modules" {
+  description = "Kernel modules required by Rook-Ceph RBD CSI (ADR-0052). HARD prerequisite: rbd + ceph MUST be present on every node or csi-rbdplugin crash-loops and no RBD PVC mounts. Declared here because Talos is immutable and modules cannot be loaded on a running host."
+  type        = list(string)
+  default     = ["rbd", "ceph"]
+  nullable    = false
+
+  validation {
+    condition     = contains(var.ceph_kernel_modules, "rbd") && contains(var.ceph_kernel_modules, "ceph")
+    error_message = "ceph_kernel_modules MUST include both 'rbd' and 'ceph' — they are the load-bearing Rook-Ceph RBD prerequisite (ADR-0052)."
+  }
+}
+
+variable "nvidia_kernel_modules" {
+  description = "Kernel modules backing the NVIDIA system-extension driver on GPU workers (ADR-0050)."
+  type        = list(string)
+  default     = ["nvidia", "nvidia_uvm", "nvidia_drm", "nvidia_modeset"]
+  nullable    = false
+}
+
+variable "extra_kernel_modules" {
+  description = "Additional kernel modules to load on all nodes (e.g. fabric/RDMA modules). Appended to the ceph (+ nvidia on workers) set."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
+variable "kube_prism_enabled" {
+  description = "Enable Talos KubePrism for in-cluster Kubernetes API HA (ADR-0049; a WS-E posture control). No managed control plane to fall back on, so KubePrism is on by default."
+  type        = bool
+  default     = true
+}
+
+variable "kube_prism_port" {
+  description = "Port KubePrism listens on for the in-cluster API load-balanced endpoint."
+  type        = number
+  default     = 7445
+}
+
+variable "rook_kubelet_extra_mounts" {
+  description = "Talos kubelet extraMounts entries so Rook-Ceph can bind-mount its host state path (ADR-0052). Required on immutable Talos where /var/lib/rook is not writable by default."
+  type = list(object({
+    destination = string
+    type        = string
+    source      = string
+    options     = list(string)
+  }))
+  default = [
+    {
+      destination = "/var/lib/rook"
+      type        = "bind"
+      source      = "/var/lib/rook"
+      options     = ["bind", "rshared", "rw"]
+    },
+  ]
+  nullable = false
+}
+
+variable "gpu_worker_sysctls" {
+  description = "Kernel sysctls applied to GPU-worker nodes (e.g. open-file limits / network buffers for Rook-Ceph and the RDMA fabric, ADR-0052/0053)."
+  type        = map(string)
+  default = {
+    "fs.inotify.max_user_instances" = "8192"
+    "fs.inotify.max_user_watches"   = "524288"
+    "net.core.rmem_max"             = "16777216"
+    "net.core.wmem_max"             = "16777216"
+  }
+  nullable = false
+}
+
+variable "platform_labels" {
+  description = "ADR-0028 Talos/Kubernetes-plane node labels (DOTTED keys, e.g. platform.system = ml-infra). Merged onto every node's machine.nodeLabels; pass platform.env / platform.owner here."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}

--- a/terraform/modules/talos-machineconfig/versions.tf
+++ b/terraform/modules/talos-machineconfig/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    talos = {
+      source  = "siderolabs/talos"
+      version = "~> 0.7"
+    }
+  }
+}


### PR DESCRIPTION
## WS-A — Bare-Metal Talos GPU Cluster Foundation

Implements **Workstream A** of the Bare-Metal ML Platform per
`docs/baremetal-ml-platform/IMPLEMENTATION_PLAN.md`, citing **ADR-0049..0054** and applying
the **ADR-0028** taxonomy labels (`platform.system/component/owner` dotted for k8s labels,
colon-form for cloud-ish tags) on every resource.

**DESIGN-MOCK repo — apply-gated; do NOT merge until human review; base targets the design branch (`feature/baremetal-ml-platform-design`).**

Everything is **default-OFF** (`var.enabled = false` on every module): `stack generate` +
`run plan` create nothing real. No `apply`/`destroy`/`helm install`/`kubectl apply` was run.

### Terraform modules (`terraform/modules/`) — 10
Each has `main.tf`, `variables.tf` (every var typed + described), `outputs.tf`, `versions.tf`
(pins `required_version` + providers; **terraform, not tofu**; `siderolabs/talos` where relevant),
`README.md` (cites its ADR), and one `*.tftest.hcl`.

| Module | Role | ADR |
|--------|------|-----|
| `talos-machineconfig` | Immutable Talos config; **`rbd` + `ceph` kernel modules** (Rook-Ceph RBD prereq) + NVIDIA system extension + Rook kubelet extra-mounts | 0050, 0052 |
| `talos-cluster` | etcd/control-plane bootstrap (double-gated) | 0049 |
| `talos-gpu-nodepool` | Fixed-capacity GPU pool (no autoscaler); gated Cluster-API/Sidero re-image lifecycle | 0054 |
| `baremetal-cilium-lb` | Cilium CNI kube-proxy-less + LB-IPAM + BGP | 0051 |
| `baremetal-gpu-operator` | GPU Operator **driver-less** (driver + toolkit ship in the Talos extension) + DRA | 0050 |
| `baremetal-gpu-dcgm` | DCGM exporter + XID auto-taint | 0050 |
| `baremetal-gpu-scheduling` | Volcano gang-scheduler + UK queue taxonomy + DRA device classes | 0050 |
| `baremetal-gpu-fabric` | SR-IOV device-plugin day-0 + gated DRANET; RoCEv2/InfiniBand | 0053 |
| `baremetal-rook-ceph` | Rook-Ceph block+FS + RGW S3-compatible artifact store | 0052 |
| `baremetal-ingress-waf` | Cilium/Envoy Gateway serving front + on-prem WAF/rate-limit | 0051 |

### Catalog units (`catalog/units/`) — 10
One `terragrunt.hcl` per module above; cross-unit data wired through `dependency` blocks with
`mock_outputs` (kubeconfig/endpoint from `talos-cluster`; ceph kernel modules from
`talos-machineconfig`). Pinned module sources. All default-OFF.

### Stack (`catalog/stacks/baremetal-gpu-analysis/terragrunt.stack.hcl`) — 1
**Owned by WS-A.** Composes all 10 WS-A units across two UK datacenters (primary + standby) in
load-bearing order, and scaffolds sibling **WS-B..F** units as commented blocks so sibling PRs
ship only their unit/module and flip a toggle — never editing this stack file (file-disjoint contract).

### ArgoCD apps (`apps/infra/`) — 4
`talos-system-extensions` (NVIDIA `nonfree-kmod-nvidia` + `nvidia-container-toolkit`),
`rook-ceph`, `baremetal-gpu-fabric`, `baremetal-inference-gateway`
(Cilium/Envoy Gateway + Gateway API **`InferencePool` / `InferenceObjective`** — v1 GA names).
All default-OFF, reuse cosign/syft + the observability stack.

## Verification (light — deep CI deferred by request)
- `terraform fmt -recursive`: **clean**
- `terraform init -backend=false` + `validate`: **10/10 Success**
- `terraform test`: **48/48 passed** (mock providers)
- `helm lint` (4 charts): **0 failed**
- No secrets in code; default-OFF; ADR-0028 labels present.
- `terraform plan` **skipped** (apply-gated mock; no cloud/cluster creds). `tflint`/`tofu`/`trivy` not installed locally.

## Test plan (post-merge / human)
- [ ] `tflint --recursive` + `checkov -d .` in CI
- [ ] `terragrunt run --all plan` against the live UK tree (creds-bound, CI from main)
- [ ] Human review of ADR alignment before any toggle is flipped ON
