### PR TITLE
feat(bm-wsF): bare-metal golden paths

### DIFF
--- a/docs/contracts/bm-model-api-contract-addendum.md
+++ b/docs/contracts/bm-model-api-contract-addendum.md
@@ -1,0 +1,193 @@
+# Bare-Metal Model API Contract Addendum
+
+**Version:** 1.0.0
+**Status:** Ratified -- supplement to `docs/contracts/model-api-contract.md` for bare-metal deployments.
+**Scope:** UK DC bare-metal Talos GPU cluster (ADR-0049..0054).
+**Owners:** ML Engineering (spec author), Backend (consumer), Platform/SRE (infra alignment).
+
+This document is a **supplement** to `docs/contracts/model-api-contract.md`. It
+does not change the base model request/response schema or the versioning policy.
+It adds bare-metal-specific fields, constraints, and operational notes that apply
+to models deployed on the UK DC bare-metal cluster.
+
+All four personas must sign off on a bare-metal model's contract instance before
+staging promotion, and this addendum must be referenced in the instance YAML (ss5).
+
+---
+
+## 1. Changes to the base contract
+
+### 1.1 Artifact store endpoint
+
+On GCP/AWS paths, artifact URIs use GCS (`gs://`) or external S3. On the
+bare-metal path, artifact URIs use the **in-DC MinIO or Ceph-RGW S3 endpoint**
+(`s3://`). External AWS S3 is NOT permitted for UK-resident training artifacts
+(ADR-0052, UK data residency).
+
+```yaml
+# In the model contract instance YAML:
+artifactStore:
+  scheme: "s3"
+  # In-DC endpoint only. Value must match the ESO ExternalSecret for the tenant.
+  endpoint: "<in-DC MinIO or Ceph-RGW endpoint>"
+  bucket: "ml-artifacts-<tenant-id>"
+  # Credentials from Vault/ESO -- never hardcoded in the contract instance.
+  credentialsRef: "minio-creds-<tenant-id>"
+```
+
+### 1.2 GPU queue field (new, bare-metal only)
+
+Every model requiring GPU training or inference must declare the target Volcano
+queue from the UK DC taxonomy (`06-uk-datacenters.md`, ADR-0054).
+
+```yaml
+# In the model contract instance YAML:
+volcanoQueue:
+  training: "training-default"    # or training-bootstrap | training-urgent
+  inference: "serving-vllm"       # or eval-judge | engine-build | batch-rescore
+```
+
+Valid values:
+
+| Queue | Pool | Weight | Cap | Use case |
+|-------|------|--------|-----|----------|
+| `training-default` | H100 | 100 | - | Regular tenant retrains |
+| `training-bootstrap` | H100 | 30 | - | New-tenant initial fine-tunes |
+| `training-urgent` | H100 | 200 | 2 jobs | Drift-triggered or incident-response |
+| `serving-vllm` | H200 | 150 | - | vLLM multi-LoRA for internal/batch |
+| `eval-judge` | H200 | 200 | - | LLM-as-judge debate |
+| `engine-build` | H200 | 80 | - | TRT-LLM compilation jobs |
+| `batch-rescore` | H200 | 50 | - | Reprocessing historical data |
+
+**Constraint:** H100 queues are for training only; H200 queues are for inference only.
+Enforced by Volcano scheduling and Talos node labels (ADR-0049/0050).
+
+### 1.3 IB fabric requirements (new, bare-metal only)
+
+Models using multi-node all-reduce (NCCL) must declare their InfiniBand bandwidth
+floor. Used as the NCCL pre-flight acceptance gate (`ai-sre/knowledge/nccl-troubleshooting.md`).
+
+```yaml
+# In the model contract instance YAML:
+gpuFabric:
+  # Minimum NCCL all-reduce bandwidth (GB/s) acceptable for this model.
+  # H100 NVSwitch + 400 Gbps IB target >= 300 GB/s; floor 200 GB/s.
+  nccAllReduceMinBandwidthGbs: 200
+  # Primary: infiniband. Fallback: roce. Baseline: tcp.
+  fabricType: "infiniband"
+```
+
+### 1.4 Tenant KMS key requirement (new, bare-metal only)
+
+All UK-resident artifacts encrypted at rest must reference the per-tenant Vault
+KMS key (ADR-0040). The contract instance must confirm:
+
+```yaml
+# In the model contract instance YAML:
+dataResidency:
+  jurisdiction: "UK"
+  kmsKeyRef: "tenants/<tenant-id>/kms"   # Vault path (provisioned by bm-new-tenant)
+  externalS3Permitted: false             # training data must not leave the DC
+```
+
+---
+
+## 2. SLO additions (bare-metal specific)
+
+| SLO | Target | Rationale |
+|-----|--------|-----------|
+| **NCCL all-reduce bandwidth floor** | >= 200 GB/s (hard gate) | IB fabric health; training must not start below this floor |
+| **GPU health auto-taint response** | < 5 min | DCGM XID burst triggers auto-taint; model must handle rescheduling gracefully |
+
+These SLOs are monitored by `apps/infra/ml-monitoring/` (WS-C) and `baremetal-gpu-dcgm` (WS-A).
+
+---
+
+## 3. Observability alignment
+
+Bare-metal WS-C drift metrics carry an additional label:
+```
+cluster_substrate="baremetal-uk"
+```
+PromQL queries for bare-metal models must include this label:
+
+```promql
+ml_model_accuracy{model_name="fraud-uk", cluster_substrate="baremetal-uk"} < 0.85
+```
+
+Grafana dashboards from the `bm-new-model-service` golden path pre-filter by
+`cluster_substrate="baremetal-uk"`.
+
+---
+
+## 4. Drift monitoring alignment
+
+```yaml
+# In the model contract instance YAML:
+driftMonitoring:
+  # S3-compatible reference dataset path (in-DC -- NOT gs:// or external S3).
+  referenceBucketUri: "s3://ml-artifacts-<tenant-id>/<model-name>/<tenant-id>/<domain>/reference.parquet"
+  s3Endpoint: "<in-DC MinIO/Ceph-RGW endpoint>"
+  s3CredentialsRef: "minio-creds-<tenant-id>"
+```
+
+---
+
+## 5. Contract instance additions
+
+When authoring a contract instance for a bare-metal model, add a top-level
+`baremetal:` section alongside the base contract fields:
+
+```yaml
+# docs/contracts/<your-model>-bm-contract.yaml
+# ... base contract fields (model_name, tenant, domain, etc.) ...
+baremetal:
+  addendumVersion: "1.0.0"
+  artifactStore:
+    scheme: "s3"
+    endpoint: "<in-DC MinIO or Ceph-RGW endpoint>"
+    bucket: "ml-artifacts-<tenant-id>"
+    credentialsRef: "minio-creds-<tenant-id>"
+  volcanoQueue:
+    training: "training-default"
+    inference: "serving-vllm"
+  gpuFabric:
+    nccAllReduceMinBandwidthGbs: 200
+    fabricType: "infiniband"
+  dataResidency:
+    jurisdiction: "UK"
+    kmsKeyRef: "tenants/<tenant-id>/kms"
+    externalS3Permitted: false
+  driftMonitoring:
+    referenceBucketUri: "s3://ml-artifacts-<tenant-id>/<model-name>/<tenant-id>/<domain>/reference.parquet"
+    s3Endpoint: "<in-DC MinIO/Ceph-RGW endpoint>"
+    s3CredentialsRef: "minio-creds-<tenant-id>"
+```
+
+---
+
+## 6. Sign-off requirements
+
+All four personas sign off before bare-metal staging promotion:
+- Data Engineering: reference dataset at `driftMonitoring.referenceBucketUri` is verified
+- ML Engineering: `volcanoQueue.training` matches the model's GPU pool requirement
+- Backend/Frontend: SLO targets (p50/p99/error rate + NCCL floor) are acceptable
+- Platform/SRE: Vault KMS key at `dataResidency.kmsKeyRef` exists and is accessible
+
+See `docs/golden-paths/bm-RACI-and-handoffs.md` Handoff H5 for the gate.
+
+---
+
+## 7. References
+
+- `docs/contracts/model-api-contract.md` (base contract spec -- this is its BM addendum)
+- `docs/adrs/0049-baremetal-gpu-k8s-talos-foundation-multidc.md` (WS-A)
+- `docs/adrs/0052-baremetal-storage-rook-ceph.md` (artifact store substrate)
+- `docs/adrs/0053-baremetal-gpu-fabric-roce-infiniband.md` (IB fabric SLO)
+- `docs/adrs/0054-baremetal-elasticity-node-lifecycle.md` (Volcano queue discipline)
+- `docs/adrs/0040-soc-posture-and-oncall.md` (Vault KMS, UK data residency)
+- `docs/adrs/0041-golden-paths-collaboration.md` (WS-F)
+- `docs/transaction-analytics/06-uk-datacenters.md` (UK DC queue taxonomy)
+- `ai-sre/knowledge/nccl-troubleshooting.md` (NCCL all-reduce acceptance gate)
+- `docs/golden-paths/bm-RACI-and-handoffs.md` (RACI and handoff protocol)
+- `templates/golden-paths/bm-new-model-service/` (model service golden path)

--- a/docs/golden-paths/bm-RACI-and-handoffs.md
+++ b/docs/golden-paths/bm-RACI-and-handoffs.md
@@ -1,0 +1,301 @@
+# RACI and Handoffs: Bare-Metal Production Model Lifecycle
+
+**Document scope:** end-to-end lifecycle for a new ML model (or pipeline, dashboard,
+or tenant) from raw data to monitored production on the **owned bare-metal UK DC
+cluster** (Talos Linux, two DCs, ADR-0049..0054). This is the bare-metal supplement
+to `docs/golden-paths/RACI-and-handoffs.md` — read both. Where they differ, this
+document takes precedence for bare-metal deployments.
+
+**Related ADRs:** ADR-0041 (WS-F golden paths), ADR-0037 (WS-B ML CI/CD + MLflow
+re-targeted at MinIO/Ceph-RGW), ADR-0038 (WS-C drift monitoring, reused), ADR-0039
+(WS-D self-serve observability, reused + BM panels), ADR-0040 (WS-E SOC posture +
+on-call, reused), ADR-0049..0054 (BM foundation).
+
+**MOCK/emulation repo — apply-gated.** Nothing in this document implies a live
+`helm install`, `terraform apply`, `talosctl apply-config`, or cluster mutation
+without explicit human approval and blast-radius review.
+
+---
+
+## 1. Personas
+
+| ID | Persona | Responsibility scope (bare-metal additions in italics) |
+|----|---------|------------------------------------------------------|
+| DE | **Data Engineering** | Feature pipelines, Iceberg snapshot management, data quality, reference dataset curation; UK data residency checks (ADR-0052) |
+| ML | **ML Engineering** | Model training, evaluation, MLflow registry (CloudNativePG + MinIO/Ceph-RGW backend), DAG authorship, VolcanoJob queue selection, adapter packaging |
+| BE | **Backend / Frontend** | API integration, inference client, contract implementation, latency budgets, BM addendum sign-off |
+| PL | **Platform / SRE** | Infrastructure GitOps, observability stack, on-call, incident command, Talos cluster lifecycle, etcd backups, BGP fabric, Ceph health, Vault KMS |
+
+---
+
+## 2. RACI matrix
+
+**Key:** R = Responsible . A = Accountable . C = Consulted . I = Informed
+
+### 2a. Feature pipeline and data
+
+| Activity | DE | ML | BE | PL |
+|----------|----|----|----|-----|
+| A1 Feature pipeline: design schema + Iceberg namespace | R/A | C | C | I |
+| A2 Feature pipeline: implement + deploy snapshot | R/A | C | I | C |
+| A3 Feature pipeline: verify UK data residency (MinIO/Ceph-RGW, no external S3) | R/A | C | I | C |
+| A4 Feature pipeline: validate reference dataset quality | R/A | C | I | I |
+
+### 2b. Model training and registration (BM-specific: VolcanoJob + MinIO backend)
+
+| Activity | DE | ML | BE | PL |
+|----------|----|----|----|-----|
+| B1 Configure Airflow DAG; select Volcano queue (H100/H200 taxonomy) | C | R/A | I | C |
+| B2 Run `ml-pipeline-baremetal.yml` (VolcanoJob on selected queue) | I | R/A | I | C |
+| B3 MLflow registration + cosign sign (artifact_uri s3:// in-DC) | I | R/A | I | C |
+| B4 Author model contract instance (base + BM addendum, ADR-0052/0053) | C | R/A | C | I |
+| B5 Contract sign-off: all four personas before staging promotion | C | A | R (BE) | C (PL) |
+
+### 2c. Drift and accuracy monitoring (WS-C, cluster-agnostic reuse)
+
+| Activity | DE | ML | BE | PL |
+|----------|----|----|----|-----|
+| C1 Configure drift-exporter with in-DC s3Endpoint (MinIO/Ceph-RGW) | I | R | I | A |
+| C2 Set drift alert thresholds (`bm-new-model-service` values) | I | R | I | A |
+| C3 Drift alert fires: acknowledge + classify | I | R | I | A |
+| C4 Drift alert fires: trigger retrain or escalate | I | R/A | I | C |
+
+### 2d. Serving and API
+
+| Activity | DE | ML | BE | PL |
+|----------|----|----|----|-----|
+| D1 Implement inference client (target: Cilium BGP VIP, ADR-0051) | I | C | R/A | I |
+| D2 Integrate request_id / OTel tracing | I | I | R/A | C |
+| D3 Validate SLO targets (p50/p99/error rate + NCCL floor, BM addendum) | I | C | R/A | C |
+
+### 2e. On-call: bare-metal additions (Talos / etcd / fabric / Ceph / BGP)
+
+| Activity | DE | ML | BE | PL |
+|----------|----|----|----|-----|
+| E1 Platform infra alert fires (any: node/etcd/BGP/Ceph/DCGM) | I | I | I | R/A |
+| E2 Model accuracy/drift alert fires | I | R/A | I | C |
+| E3 Incident declared (P0/P1) | I | C | C | R/A |
+| E4 Post-incident review + runbook update | C | C | C | R/A |
+| E5 Talos node lifecycle event (re-image, upgrade, MachineConfig change) | I | I | I | R/A |
+| E6 etcd health check + snapshot before control-plane change | I | I | I | R/A |
+| E7 BGP session flap: hold-timer / max-prefix triage (ADR-0051) | I | I | I | R/A |
+| E8 Ceph HEALTH_WARN/HEALTH_ERR triage + OSD rebalance | I | I | I | R/A |
+| E9 NCCL all-reduce bandwidth drops below contract floor | I | R/A | I | C |
+
+### 2f. Tenant onboarding (bare-metal only, no GCP/AWS equivalent)
+
+| Activity | DE | ML | BE | PL |
+|----------|----|----|----|-----|
+| F1 New tenant: request with metadata (tier, queues, Iceberg prefixes) | C | C | C | R/A |
+| F2 New tenant: `bm-new-tenant` golden path PR (helm-values.yaml) | I | I | I | R/A |
+| F3 New tenant: first `helm upgrade --install charts/tenant-bootstrap/` (apply-gated) | I | I | I | R/A |
+| F4 New tenant: verify Vault KMS key, Gatekeeper constraints, Kafka ACLs | I | I | I | R/A |
+| F5 New tenant: hand over namespace + credentials to requesting team | I | I | I | R/A |
+
+### Gap resolution rules
+
+- **B5 sign-off blocks staging promotion.** The `ml-pipeline-baremetal.yml` `deploy`
+  job environment gate (`environment: staging`) requires the contract sign-off (base +
+  BM addendum) to be documented in the PR description before reviewer approval.
+  Platform/SRE must confirm the Vault KMS key at `dataResidency.kmsKeyRef` exists.
+- **C4 retrain decision.** ML Engineering decides whether to trigger a retrain
+  (`trigger_reason: drift`) or escalate to Platform if the in-DC Airflow is
+  unreachable. Platform/SRE checks the Airflow pod on the CPU pool.
+- **E5 Talos lifecycle gating.** Every control-plane `MachineConfig` change or Talos
+  upgrade requires: (a) etcd snapshot + verify, (b) quorum check, (c) stage on
+  standby DC first. Platform/SRE owns this gate; no other persona may initiate it.
+- **E9 NCCL floor breach.** If the NCCL all-reduce bandwidth test falls below the
+  contract floor (`gpuFabric.nccAllReduceMinBandwidthGbs`), training jobs must NOT
+  be promoted to the `training-urgent` queue. ML Engineering and Platform/SRE
+  co-own the gate per `ai-sre/knowledge/nccl-troubleshooting.md`.
+
+---
+
+## 3. Handoff flow (bare-metal substrate)
+
+Key differences from the GCP/cloud handoff in `RACI-and-handoffs.md`:
+- `ml-pipeline-baremetal.yml` replaces `ml-pipeline.yml`
+- VolcanoJob (H100/H200 queue) replaces KubernetesPodOperator / GKE pod
+- `artifact_uri: s3://` (MinIO/Ceph-RGW in-DC) replaces `gs://`
+- BM contract addendum sign-off is an additional gate at H5
+- Talos lifecycle gates (etcd snapshot, quorum check) added at T1/T2
+
+```
+Data Engineering              ML Engineering             Backend/Frontend      Platform/SRE
+     |                              |                           |                    |
+─── Feature pipeline ──────────────────────────────────────────────────────────────────────
+     |                              |                           |                    |
+[H1] Freeze Iceberg snapshot ──────>|                           |                    |
+     | (train_domain_adapter.py:    |                           |                    |
+     |  freeze_snapshot() +         |                           |                    |
+     |  verify UK residency --      |                           |                    |
+     |  s3:// in-DC only)           |                           |                    |
+─── Tenant provisioned (bm-new-tenant) ─────────────────────────────────────────────────
+     |                              |                           |              [F3] helm install
+     |                              |                           |              charts/tenant-bootstrap/
+     |                              |                           |              (apply-gated; PL only)
+─── Model training -- bare-metal (WS-B) ────────────────────────────────────────────────
+     |                         [H2] ml-pipeline-baremetal.yml  |                    |
+     |                              | POST Airflow              |                    |
+     |                              |  train_domain_adapter/    |                    |
+     |                              |  dagRuns                  |                    |
+     |                              | VolcanoJob on H100 queue  |                    |
+     |                              | (training-default /       |                    |
+     |                              |  training-urgent etc.)    |                    |
+     |                         [H3] eval_adapter_debate VolcanoJob (eval-judge H200) |
+     |                              | win_rate >= 0.55 gate     |                    |
+     |                         [H4] Register in MLflow ──────────────────────────── >|
+     |                              | artifact_uri: s3://       |                    |
+     |                              |  ml-artifacts-<tenant>/   |                    |
+     |                              |  <model>/<git-sha>        |                    |
+     |                              | cosign sign + SBOM        |                    |
+─── Contract sign-off (BM addendum required) ──────────────────────────────────────────
+     |                         [H5] Contract instance PR ──────>| BE sign-off       |
+     |                              | base contract +           |                    | PL sign-off
+     |                              | bm addendum (volcanoQueue |                    | (Vault KMS
+     |                              | gpuFabric, dataResidency) |                    |  confirmed)
+─── Staging promotion ─────────────────────────────────────────────────────────────────
+     |                         [H6] Kargo: dev (auto) ─────────────────────────────>|
+     |                         [H7] Kargo: staging (reviewer gate) ────────────────>|
+─── Production deployment ─────────────────────────────────────────────────────────────
+     |                         [H8] Kargo: prod (manual gate) ─────────────────────>|
+─── Drift monitoring (WS-C/D) ──────────────────────────────────────────────────────────
+     |                              |              WS-C drift-exporter               |
+     |                              |              s3Endpoint: in-DC MinIO/Ceph-RGW  |
+     |                              |              cluster_substrate="baremetal-uk"  |
+─── Retrain trigger (WS-C -> WS-B) ─────────────────────────────────────────────────────
+     |                         [H9] Drift alert fires ──────────────────────────── >|
+     |                              | Alertmanager -> Airflow REST                   |
+     |                              | POST train_domain_adapter/dagRuns              |
+     |                              | conf: {trigger_reason: "drift"}               |
+─── Talos lifecycle gates (bare-metal only) ────────────────────────────────────────────
+     |                              |                           |             [T1] etcd snapshot
+     |                              |                           |             + verify (before
+     |                              |                           |             MachineConfig/upgrade)
+     |                              |                           |             [T2] Stage standby DC
+     |                              |                           |             before primary
+```
+
+### Handoff summary table
+
+| ID | Artifact handed off | From | To | Gate / mechanism |
+|----|--------------------|----|-----|-----------------|
+| H1 | Iceberg snapshot (frozen, UK-resident, s3:// in-DC) | DE | ML | `freeze_snapshot()` task; s3Endpoint validated |
+| H2 | VolcanoJob training run (H100 queue) | ML | ML (eval) | Airflow `TriggerDagRunOperator`; queue per contract |
+| H3 | Eval report (win_rate, p95_distance) | ML (eval) | ML (register) | Quality gate: `win_rate >= 0.55` |
+| H4 | Signed model artifact + SBOM (s3:// in-DC) | ML | BE + PL | MLflow registry (Staging) + cosign; artifact in MinIO/Ceph-RGW |
+| H5 | Contract instance YAML (base + BM addendum) | ML | BE + PL | PR to `docs/contracts/`; BE + PL sign-off; Vault KMS confirmed |
+| H6 | Staged deploy (dev) | ML | PL | Kargo auto-promotion |
+| H7 | Staged deploy (staging) | ML | PL | Kargo reviewer gate |
+| H8 | Staged deploy (prod) | PL | BE/all | Kargo manual gate; PL confirms BM cluster health |
+| H9 | Drift alert (Alertmanager) | PL (infra) | ML | Alertmanager webhook -> Airflow REST; `trigger_reason: drift` |
+| T1 | etcd snapshot + verify | PL | PL | Gate before any control-plane MachineConfig or Talos upgrade |
+| T2 | Standby DC smoke test | PL | PL | Stage on standby before primary; per `uk-dc-failover-baremetal.md` |
+
+---
+
+## 4. On-call and escalation (bare-metal additions)
+
+Supplements `docs/runbooks/ml-incident-runbook-baremetal.md` and
+`docs/runbooks/uk-dc-failover-baremetal.md` (both WS-E deliverables).
+
+### Alert routing table
+
+| Alert | First paged | Ack SLA | First action | Escalate to | Escalate after |
+|-------|------------|---------|--------------|-------------|----------------|
+| `AirflowDagRunFailed` | ML on-call | 15 min | Check Airflow pod (CPU pool) -> retry DAG | PL if pod down | 30 min |
+| `MLModelDriftHigh` (drift > 0.4) | ML on-call | 15 min | Evidently report -> trigger retrain | PL if Airflow down | 30 min |
+| `MLModelAccuracyLow` (< 0.75) | ML on-call | 15 min | MLflow eval metrics -> ArgoCD rollback | PL for Kargo rollback | 30 min |
+| `MLflowTrackingDown` | PL on-call | 5 min | MLflow pod + CloudNativePG -> ArgoCD sync | P1 if pipeline blocked | 15 min |
+| `NcclBandwidthBelowFloor` | PL on-call | 5 min | `nccl-troubleshooting.md` pre-flight; pause training-urgent queue | Incident if all H100 affected | 15 min |
+| `TalosNodeUnhealthy` | PL on-call | 5 min | `talosctl health`; DCGM auto-taint check | Incident if >1 node | 10 min |
+| `EtcdLeaderElection` | PL on-call | 5 min | Check etcd logs; verify quorum; pause control-plane changes | P0 if quorum lost | 5 min |
+| `CiliumBgpSessionDown` | PL on-call | 5 min | `cilium-bgp-issues.md`; hold-timer + ToR peer | Incident if VIPs unreachable | 10 min |
+| `CephHealthWarn` | PL on-call | 10 min | `ceph status`; OSD rebalance watch | Incident if HEALTH_ERR | 15 min |
+| `CephHealthError` | PL on-call | 5 min | OSD repair; Rook-Ceph mgr | P0 if data unavailable | 5 min |
+| `DCPrimaryDown` | PL on-call | 5 min | `uk-dc-failover-baremetal.md`; failover-controller promote standby | P0 (auto if health-check fails) | 5 min |
+
+### Escalation path
+
+```
+BM platform alert fires
+    |
+    v
+Platform / SRE on-call  (PagerDuty: platform-oncall)
+    |  > 15 min unresolved OR customer impact confirmed
+    v
+Incident Commander (Platform lead or on-call manager)
+    |  P0 declared (full outage / data loss / DC failover)
+    v
+Engineering Manager + Comms + (if DC failover) DC operations contact
+
+ML alert fires
+    |
+    v
+ML Engineering on-call  (PagerDuty: ml-platform-oncall)
+    |  > 30 min unresolved OR infra cause confirmed
+    v
+Platform / SRE on-call
+    |  P0 declared
+    v
+Incident Commander
+```
+
+---
+
+## 5. Golden-path selection guide
+
+| Task | Golden path | Key gate |
+|------|------------|---------|
+| Onboard a new tenant (namespace, Vault KMS, Kafka ACLs, MinIO bucket) | `bm-new-tenant` | Platform lead approval (apply-gated F3) |
+| Register a new ML model service (train->eval->register->deploy) | `bm-new-model-service` | B5 contract sign-off (base + BM addendum) |
+| Add a new Airflow DAG / batch pipeline (non-canonical) | `bm-new-ml-pipeline` | B5 contract sign-off if model involved; PL for Volcano quota |
+| Onboard a team to self-serve observability (Grafana folder + alerts) | `bm-new-dashboard` | PL review of PrometheusRule RBAC |
+| Any of the above on GCP or AWS | `templates/golden-paths/new-*` (non-BM paths) | Per `docs/golden-paths/RACI-and-handoffs.md` |
+
+---
+
+## 6. ADR-0034 revisit criteria (Backstage, bare-metal)
+
+Backstage (ADR-0034 deferred) revisit conditions for the bare-metal track:
+
+1. BM ML platform (WS-A..E applied and stable in the primary UK DC).
+2. A dedicated Backstage owner assigned with BM cluster knowledge.
+3. Three or more tenants onboarded via `bm-new-tenant` + at least one via
+   `bm-new-model-service`.
+4. The `bm-RACI-and-handoffs.md` process exercised in at least one tabletop DR
+   drill per ADR-0040 + WS-E quarterly-DR requirement.
+
+Current status: all four conditions pending (BM cluster is plan/validate-only;
+WS-A..E are design-only at this stage).
+
+---
+
+## 7. References
+
+- `docs/golden-paths/RACI-and-handoffs.md` (GCP/cloud base RACI)
+- `docs/adrs/0041-golden-paths-collaboration.md` (WS-F decision of record)
+- `docs/adrs/0049-baremetal-gpu-k8s-talos-foundation-multidc.md` (BM foundation)
+- `docs/adrs/0050-talos-gpu-driver-system-extensions.md` (GPU driver)
+- `docs/adrs/0051-baremetal-networking-cilium-lb-bgp.md` (Cilium BGP LB)
+- `docs/adrs/0052-baremetal-storage-rook-ceph.md` (MinIO/Ceph-RGW)
+- `docs/adrs/0053-baremetal-gpu-fabric-roce-infiniband.md` (IB fabric SLO)
+- `docs/adrs/0054-baremetal-elasticity-node-lifecycle.md` (Volcano queues)
+- `docs/adrs/0037-ml-cicd-pipeline-mlflow.md` (WS-B, re-targeted at BM)
+- `docs/adrs/0038-ml-observability-drift.md` (WS-C, reused)
+- `docs/adrs/0039-self-serve-observability.md` (WS-D, reused + BM panels)
+- `docs/adrs/0040-soc-posture-and-oncall.md` (WS-E, on-call + Vault KMS)
+- `docs/contracts/model-api-contract.md` (base contract spec)
+- `docs/contracts/bm-model-api-contract-addendum.md` (BM addendum)
+- `docs/runbooks/ml-incident-runbook-baremetal.md` (WS-E)
+- `docs/runbooks/uk-dc-failover-baremetal.md` (WS-E)
+- `docs/transaction-analytics/06-uk-datacenters.md` (UK DC design fiction)
+- `ai-sre/knowledge/nccl-troubleshooting.md` (NCCL all-reduce acceptance gate)
+- `ai-sre/knowledge/cilium-bgp-issues.md` (BGP session triage)
+- `ai-sre/knowledge/gpu-driver-updates.md` (GPU driver update checklist)
+- `charts/tenant-bootstrap/` (Helm chart for bm-new-tenant)
+- `templates/golden-paths/bm-new-model-service/` (model service golden path)
+- `templates/golden-paths/bm-new-ml-pipeline/` (Airflow DAG golden path)
+- `templates/golden-paths/bm-new-dashboard/` (team dashboard golden path)
+- `templates/golden-paths/bm-new-tenant/` (tenant onboarding golden path)
+- `.claude/rules/critical-decisions.md` (apply-gated approval gates)

--- a/templates/golden-paths/bm-new-dashboard/README.md
+++ b/templates/golden-paths/bm-new-dashboard/README.md
@@ -1,0 +1,132 @@
+# Golden Path: New Team Dashboard (Bare-Metal / Talos)
+
+**Substrate:** Owned bare-metal GPU cluster on Talos Linux, two UK DCs.
+See `docs/transaction-analytics/06-uk-datacenters.md`.
+
+**ADRs cited:**
+- ADR-0049 -- Talos foundation, immutability, multi-DC
+- ADR-0051 -- Cilium LB-IPAM + BGP (Cilium BGP session panel)
+- ADR-0052 -- Rook-Ceph (Ceph health panel)
+- ADR-0041 -- Golden paths and collaboration (this document)
+- ADR-0028 -- Platform taxonomy labels (mandatory on every resource)
+- ADR-0039 -- Self-serve observability (WS-D, reused + BM panels)
+
+This template onboards a new team into the WS-D (ADR-0039) self-serve
+observability layer on the bare-metal cluster: one Grafana folder + starter
+dashboard + PrometheusRule alert groups, delivered in a single PR.
+
+The BM version adds **bare-metal-specific starter panels** absent from GCP/AWS paths:
+- **Talos node health** (machine API liveness, kubelet ready)
+- **InfiniBand/RoCEv2 fabric** (NCCL all-reduce bandwidth, NVLink counters)
+- **Cilium BGP session state** (ToR peering; per `cilium-bgp-issues.md`)
+- **Ceph cluster health** (HEALTH_OK/HEALTH_WARN, OSD up/in)
+- **etcd control-plane** (latency + quorum -- absent on managed K8s)
+
+**Key differences from the GCP golden path (`templates/golden-paths/new-dashboard/`):**
+
+| Concern | GCP path | This bare-metal path |
+|---------|---------|----------------------|
+| BM-specific panels | None | baremetal.enabled: true in values |
+| etcd panel | Absent (managed K8s) | Required (self-operated control plane, ADR-0049) |
+| BGP panel | Absent (cloud LB) | Cilium BGP session state (ADR-0051) |
+| Ceph panel | Absent (cloud storage) | Rook-Ceph health (ADR-0052) |
+
+Backstage scaffolder mapping: `spec.type: team-dashboard` (future, ADR-0034 deferred)
+
+---
+
+## When to use this template
+
+Use this golden path when:
+- A team is new to the bare-metal cluster and needs a scoped Grafana folder
+- The team does not need ML drift panels (use `bm-new-model-service` for ML)
+- You want to start from the standard RED + saturation + BM-specific alerts dashboard
+
+---
+
+## Prerequisites
+
+- [ ] Tenant namespace `tenant-{{TENANT_ID}}` exists (provisioned by `bm-new-tenant`)
+- [ ] Grafana service account `grafana-sa-{{TEAM_SLUG}}` exists in Grafana
+  (create via Grafana UI or API before ArgoCD sync)
+- [ ] CI service account `{{TEAM_SLUG}}-ci` exists in namespace `{{TEAM_NAMESPACE}}`
+  (for PrometheusRule RBAC; omit `ciServiceAccount` if not needed)
+
+---
+
+## Step 1 -- Substitute placeholders
+
+```bash
+export TEAM_NAME="Checkout UK"        # human-readable
+export TEAM_SLUG="team-checkout-uk"   # lower-kebab
+export TENANT_ID="acme"               # tenant ID (namespace: tenant-acme)
+export TEAM_NAMESPACE="tenant-${TENANT_ID}"
+export TEAM_SYSTEM="checkout"         # ADR-0028 platform.system
+export TEAM_OWNER="team-checkout-uk"  # ADR-0028 platform.owner
+export PLATFORM_ENV="production"      # production | staging | dev | sandbox
+
+mkdir -p out
+for f in values.yaml argocd-application.yaml; do
+  envsubst < "$f" > "out/${f}"
+done
+
+# Verify no raw {{}} remain
+grep -r '{{' out/ && echo "UNSUBSTITUTED PLACEHOLDERS FOUND" || echo "OK"
+```
+
+---
+
+## Step 2 -- Commit the files
+
+Place the substituted files in the PR at:
+```
+apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/values.yaml
+apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/argocd-application.yaml
+```
+
+ArgoCD (wave 30) will pick them up and provision the Grafana folder.
+
+---
+
+## Step 3 -- Verify ADR-0028 labels
+
+The BM OPA profile (`tests/opa/platform_tags_baremetal.rego`) checks all K8s
+resources at plan time. Ensure your committed values carry:
+
+```yaml
+team:
+  system: "{{TEAM_SYSTEM}}"   # ADR-0028 platform.system
+  owner:  "{{TEAM_OWNER}}"    # ADR-0028 platform.owner
+  env:    "{{PLATFORM_ENV}}"  # ADR-0028 platform.env
+```
+
+---
+
+## Step 4 -- Bare-metal panel customization
+
+Enable only the BM panels relevant to your team's scope:
+
+| Panel | Enable when... |
+|-------|---------------|
+| `talosNodeHealth` | Always -- all teams on BM cluster benefit |
+| `gpuFabric` | Team owns GPU workloads (training or inference) |
+| `ciliumBgp` | Platform/SRE teams monitoring ingress / LB VIPs |
+| `cephHealth` | Teams owning persistent storage (MLflow, Postgres, MinIO) |
+| `etcd` | Platform/SRE teams only -- control-plane health |
+
+---
+
+## References
+
+- `docs/adrs/0049-baremetal-gpu-k8s-talos-foundation-multidc.md` (WS-A)
+- `docs/adrs/0051-baremetal-networking-cilium-lb-bgp.md` (BGP panel)
+- `docs/adrs/0052-baremetal-storage-rook-ceph.md` (Ceph panel)
+- `docs/adrs/0039-self-serve-observability.md` (WS-D self-serve)
+- `docs/adrs/0041-golden-paths-collaboration.md` (WS-F)
+- `docs/golden-paths/bm-RACI-and-handoffs.md` (RACI and handoff protocol)
+- `docs/transaction-analytics/06-uk-datacenters.md` (UK DC design)
+- `ai-sre/knowledge/cilium-bgp-issues.md` (BGP troubleshooting)
+- `ai-sre/knowledge/nccl-troubleshooting.md` (NCCL/IB metrics)
+- `apps/infra/grafana-self-serve/` (WS-D self-serve chart)
+- `templates/golden-paths/bm-new-tenant/` (provision tenant namespace first)
+- `templates/golden-paths/bm-new-model-service/` (if you also need ML panels)

--- a/templates/golden-paths/bm-new-dashboard/argocd-application.yaml
+++ b/templates/golden-paths/bm-new-dashboard/argocd-application.yaml
@@ -1,0 +1,70 @@
+---
+# Golden Path: bm-new-dashboard -- ArgoCD Application (grafana-self-serve)
+# WS-D (ADR-0039) chart: apps/infra/grafana-self-serve
+# Substrate: bare-metal Talos (ADR-0049), KubePrism API (ADR-0049 D2)
+#
+# USAGE: substitute all {{PLACEHOLDER}} values, then commit this file at:
+#   apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/argocd-application.yaml
+#
+# Deploys into {{TEAM_NAMESPACE}}. Namespace must pre-exist (provisioned by
+# bm-new-tenant golden path via charts/tenant-bootstrap/).
+# Wave 30 -- after all observability components (wave 10-20).
+#
+# See README.md Step 2 for full instructions.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  # Substitute: grafana-self-serve-bm-{{TEAM_SLUG}}
+  name: "grafana-self-serve-bm-{{TEAM_SLUG}}"
+  namespace: argocd
+  labels:
+    # ADR-0028 platform taxonomy (K8s plane -- dotted form)
+    platform.system: "observability"
+    platform.component: "self-serve"
+    # Substitute: {{PLATFORM_ENV}}
+    platform.env: "{{PLATFORM_ENV}}"
+    # Substitute: {{TEAM_OWNER}}
+    platform.owner: "{{TEAM_OWNER}}"
+    platform.managed-by: "argocd"
+    # Substitute: grafana-self-serve-bm-{{TEAM_SLUG}}
+    app.kubernetes.io/name: "grafana-self-serve-bm-{{TEAM_SLUG}}"
+    app.kubernetes.io/component: "self-serve"
+    app.kubernetes.io/managed-by: "argocd"
+    # Bare-metal cluster identifier.
+    cluster-substrate: "baremetal-uk"
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/your-org/platform-design.git
+    targetRevision: main
+    path: apps/infra/grafana-self-serve
+    helm:
+      valueFiles:
+        - values.yaml
+        # Substitute: example-teams/{{TEAM_SLUG}}/values.yaml
+        - "example-teams/{{TEAM_SLUG}}/values.yaml"
+  destination:
+    # Bare-metal cluster in-cluster API via KubePrism (ADR-0049 D2).
+    server: https://kubernetes.default.svc
+    # Substitute: {{TEAM_NAMESPACE}}
+    namespace: "{{TEAM_NAMESPACE}}"
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=false
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m

--- a/templates/golden-paths/bm-new-dashboard/values.yaml
+++ b/templates/golden-paths/bm-new-dashboard/values.yaml
@@ -1,0 +1,107 @@
+# Golden Path: bm-new-dashboard -- grafana-self-serve values
+# WS-D (ADR-0039) chart: apps/infra/grafana-self-serve
+# Substrate: bare-metal Talos (ADR-0049) -- baremetal panels enabled
+#
+# USAGE: substitute all {{PLACEHOLDER}} values before committing.
+# Place the substituted file at:
+#   apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/values.yaml
+#
+# For ML teams that also need drift + accuracy panels, set ml.enabled: true,
+# or use the bm-new-model-service template instead.
+#
+# See README.md for full instructions and panel selection guidance.
+
+team:
+  # Human-readable team name shown in the Grafana folder title.
+  # Substitute: {{TEAM_NAME}}
+  name: "{{TEAM_NAME}}"
+
+  # Machine-safe slug -- lowercase, hyphens only.
+  # Substitute: {{TEAM_SLUG}}
+  slug: "{{TEAM_SLUG}}"
+
+  # Kubernetes namespace where this team's workloads run.
+  # Must already exist (provisioned by bm-new-tenant golden path).
+  # Substitute: {{TEAM_NAMESPACE}}
+  namespace: "{{TEAM_NAMESPACE}}"
+
+  # platform.system value (ADR-0028 taxonomy).
+  # Substitute: {{TEAM_SYSTEM}}  e.g., checkout, auth, data-pipeline
+  system: "{{TEAM_SYSTEM}}"
+
+  # platform.owner value (ADR-0028 taxonomy).
+  # Substitute: {{TEAM_OWNER}}
+  owner: "{{TEAM_OWNER}}"
+
+  # Deployment environment.
+  # Substitute: {{PLATFORM_ENV}}
+  env: "{{PLATFORM_ENV}}"
+
+  # Grafana service account for folder Editor access.
+  # Create this SA in Grafana before ArgoCD sync.
+  # Substitute: grafana-sa-{{TEAM_SLUG}}
+  grafanaServiceAccount: "grafana-sa-{{TEAM_SLUG}}"
+
+  # CI/CD service account for PrometheusRule RBAC.
+  # Substitute: {{TEAM_SLUG}}-ci
+  ciServiceAccount: "{{TEAM_SLUG}}-ci"
+
+# ML panels -- set enabled: true if this team owns a model service.
+# Otherwise use bm-new-model-service template instead.
+ml:
+  enabled: false
+  modelName: ""
+  tenant: ""
+
+# Bare-metal specific panels (BM cluster only; set enabled: false on GCP/AWS).
+# Enable per-panel based on your team's scope (see README.md Step 4).
+# Metric sources:
+#   talosNodeHealth : talos-log-shipper -> Loki + node_exporter
+#   gpuFabric       : DCGM exporter (baremetal-gpu-dcgm, ADR-0049)
+#                     DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL, ib_port_rcv_data_bytes
+#   ciliumBgp       : cilium_bgp_peer_session_state (ADR-0051)
+#   cephHealth      : ceph_health_status, ceph_osd_up, ceph_osd_in (ADR-0052)
+#   etcd            : etcd_server_leader_changes_seen_total (ADR-0049 D3)
+baremetal:
+  enabled: true
+
+  talosNodeHealth:
+    # Always enable for all teams on the BM cluster.
+    enabled: true
+    # ADR-0028 node label selector (adjust for your pool).
+    nodeSelector: "platform_system=~\"gpu-worker|cpu-pool\""
+
+  gpuFabric:
+    # Enable for teams owning GPU workloads (training or inference).
+    enabled: false
+    # H100 NVSwitch + 400 Gbps IB target. Alert if NCCL all-reduce drops below floor.
+    nccAllReduceBandwidthFloorGbs: 200
+    nccAllReduceBandwidthTargetGbs: 300
+
+  ciliumBgp:
+    # Enable for Platform/SRE teams monitoring LB VIPs (ADR-0051).
+    enabled: false
+    # Expected BGP peers per DC (ToR switches). Alert if count drops.
+    expectedPeerCount: 2
+
+  cephHealth:
+    # Enable for teams owning persistent storage (MLflow, Postgres, MinIO).
+    enabled: false
+    alertWarnThreshold: "10m"
+    alertCritThreshold: "5m"
+
+  etcd:
+    # Enable for Platform/SRE only -- self-operated control plane health.
+    enabled: false
+    # Alert if etcd leader elections > 0 in this window (unexpected re-election).
+    leaderElectionAlertWindow: "10m"
+    # Alert if etcd proposal failure rate > threshold/s.
+    proposalFailureRateThreshold: "0.01"
+
+# Alert thresholds -- adjust for your team SLOs.
+alerts:
+  errorRateThreshold: "0.05"
+  cpuSaturationThreshold: "0.80"
+  memorySaturationThreshold: "0.80"
+  availabilityFor: "5m"
+  saturationFor: "15m"

--- a/templates/golden-paths/bm-new-ml-pipeline/README.md
+++ b/templates/golden-paths/bm-new-ml-pipeline/README.md
@@ -1,0 +1,180 @@
+# Golden Path: New ML Pipeline / Airflow DAG (Bare-Metal / Talos)
+
+**Substrate:** Owned bare-metal GPU cluster on Talos Linux, two UK DCs.
+See `docs/transaction-analytics/06-uk-datacenters.md`.
+
+**ADRs cited:**
+- ADR-0049 -- Talos foundation, immutability, multi-DC
+- ADR-0052 -- Rook-Ceph / MinIO (artifact store, no GCS)
+- ADR-0053 -- InfiniBand/RoCEv2 GPU fabric (VolcanoJob DRA claim)
+- ADR-0054 -- Elasticity: fixed capacity + Volcano queue discipline
+- ADR-0041 -- Golden paths and collaboration (this document)
+- ADR-0028 -- Platform taxonomy labels (mandatory on every resource)
+- ADR-0037 -- ML CI/CD + MLflow registry (WS-B, re-targeted at MinIO/Ceph-RGW)
+- ADR-0038 -- Model observability / drift (WS-C, reused unchanged)
+
+This template creates a new Airflow DAG on the bare-metal cluster, mirroring the
+WS-B (ADR-0037) DAG shape. The DAG:
+- Submits work as a **VolcanoJob** on the appropriate UK DC GPU queue (H100/H200 pool)
+- Registers artifacts in MLflow backed by **MinIO/Ceph-RGW** (not GCS)
+- Emits drift metrics so they are scrapeable by WS-C Evidently + whylogs
+
+**Key differences from the GCP golden path (`templates/golden-paths/new-ml-pipeline/`):**
+
+| Concern | GCP path | This bare-metal path |
+|---------|---------|----------------------|
+| Work submission | KubernetesPodOperator or GKE-native | VolcanoJob on UK DC queue taxonomy |
+| GPU queue | GCP-shaped | H100: training-default/bootstrap/urgent; H200: serving-vllm/eval-judge/engine-build/batch-rescore |
+| Artifact store | GCS (gs://) | MinIO/Ceph-RGW (s3://, in-DC) |
+| Pipeline workflow | ml-pipeline.yml | ml-pipeline-baremetal.yml |
+| GPU+NIC scheduling | cloud-native | DRA ResourceClaimTemplate (ADR-0053) |
+
+Backstage scaffolder mapping: `spec.type: ml-pipeline` (future, ADR-0034 deferred)
+
+---
+
+## When to use this template
+
+Use this golden path when you need a **net-new Airflow DAG** that is:
+- Not one of the four canonical WS-B DAGs (`train_domain_adapter`, `eval_adapter_debate`,
+  `mine_templates`, `promote_to_edge`)
+- Running GPU work on the UK DC bare-metal cluster
+- Processing a new data domain or running a periodic batch ML job
+- Registering its own model artifacts in MLflow (MinIO/Ceph-RGW backend)
+- Expected to emit distribution metrics for WS-C drift monitoring
+
+If you are adding a model that uses the existing canonical DAGs, use the
+`bm-new-model-service` golden path instead.
+
+---
+
+## Prerequisites
+
+- [ ] Tenant namespace `tenant-{{TENANT_ID}}` exists (provisioned by `bm-new-tenant`)
+- [ ] MinIO bucket `ml-artifacts-{{TENANT_ID}}` or Ceph-RGW bucket exists
+  (provisioned by WS-B `terraform/modules/baremetal-ml-artifact-store`)
+- [ ] Airflow is reachable at `$AIRFLOW_BASE_URL` (in-DC CPU pool, WS-B)
+- [ ] MLflow tracking server is reachable at `$MLFLOW_TRACKING_URI` (WS-B)
+- [ ] WS-C `ml-monitoring` namespace and Pushgateway exist (`apps/infra/ml-monitoring/`)
+- [ ] You know which Volcano queue you need (H100 vs H200 pool; default vs urgent)
+- [ ] Your DAG code will live in `apps/infra/airflow/dags/{{DAG_NAME}}.py`
+  (Airflow gitSync picks it up automatically from the repo)
+
+---
+
+## Step 1 -- Substitute placeholders
+
+```bash
+export DAG_NAME="my_custom_bm_pipeline"   # snake_case; Airflow dag_id
+export MODEL_NAME="my-model"              # lower-kebab; MLflow registry name
+export TENANT_ID="acme"                   # tenant ID (namespace: tenant-acme)
+export TENANT="tenant-acme"              # full label (ADR-0038)
+export DOMAIN="hft"                       # hft | solana | insurance | rtb
+export TEAM_OWNER="team-ml-platform"     # ADR-0028 platform.owner
+export PLATFORM_ENV="production"          # production | staging | dev | sandbox
+export MINIO_ENDPOINT="http://minio.minio.svc.cluster.local:9000"
+export MINIO_BUCKET="ml-artifacts-${TENANT_ID}"
+# Choose queue: H100 training pool or H200 inference pool
+export VOLCANO_QUEUE="training-default"   # or training-bootstrap, training-urgent, etc.
+export GPU_REPLICAS="8"                   # gang size (DGX H100: 8 GPUs per node)
+
+mkdir -p out
+for f in argocd-application.yaml; do
+  envsubst < "$f" > "out/${f}"
+done
+
+# DAG file: substitute manually (see Step 2)
+cp dag_template.py apps/infra/airflow/dags/${DAG_NAME}.py
+
+# Verify no raw {{}} remain in YAML output
+grep -r '{{' out/ && echo "UNSUBSTITUTED PLACEHOLDERS FOUND" || echo "OK"
+```
+
+---
+
+## Step 2 -- Implement the DAG tasks
+
+Open `apps/infra/airflow/dags/{{DAG_NAME}}.py` and implement the `# SCAFFOLD`
+task bodies:
+
+| Task | What to implement |
+|------|-------------------|
+| `ingest_data` | Load from MinIO/Ceph-RGW (boto3 with in-DC endpoint), Iceberg snapshot, Kafka, etc. |
+| `submit_volcano_job` | Render VolcanoJob YAML with spec.queue={{VOLCANO_QUEUE}} and submit via k8s API |
+| `register_results` | Write metrics + artifacts to MLflow (s3:// URI, in-DC endpoint) |
+| `emit_drift_metrics` | Push feature distributions to Prometheus Pushgateway |
+
+### VolcanoJob queue selection (UK DC taxonomy)
+
+Pick the queue that matches your workload type:
+
+| Queue | Pool | Weight | Cap | Use case |
+|-------|------|--------|-----|----------|
+| `training-default` | H100 | 100 | - | Regular tenant retrains |
+| `training-bootstrap` | H100 | 30 | - | New-tenant initial fine-tunes |
+| `training-urgent` | H100 | 200 | 2 jobs | Drift-triggered or incident-response |
+| `serving-vllm` | H200 | 150 | - | vLLM multi-LoRA for internal/batch |
+| `eval-judge` | H200 | 200 | - | LLM-as-judge debate |
+| `engine-build` | H200 | 80 | - | TRT-LLM compilation jobs |
+| `batch-rescore` | H200 | 50 | - | Reprocessing historical data |
+
+The VolcanoJob must also include a DRA ResourceClaimTemplate for GPU + IB NIC
+(ADR-0053 one-DRA-model pattern, provisioned by `baremetal-gpu-scheduling` module).
+
+### MinIO/MLflow integration pattern
+
+```python
+import os
+import mlflow
+import boto3
+
+# Credentials from Vault / ESO ExternalSecret -- never hardcoded.
+s3_client = boto3.client(
+    "s3",
+    endpoint_url=os.environ["MINIO_ENDPOINT"],   # in-DC, not external AWS
+    aws_access_key_id=os.environ["MINIO_ACCESS_KEY"],
+    aws_secret_access_key=os.environ["MINIO_SECRET_KEY"],
+)
+
+mlflow.set_tracking_uri(os.environ["MLFLOW_TRACKING_URI"])
+mlflow.set_experiment("{{DAG_NAME}}")
+# artifact_uri uses s3:// with in-DC endpoint -- NOT gs://
+with mlflow.start_run():
+    mlflow.log_param("volcano_queue", os.environ["VOLCANO_QUEUE"])
+    mlflow.log_artifact(local_model_path)
+```
+
+---
+
+## Step 3 -- Verify ADR-0028 labels
+
+Every K8s resource (VolcanoJob, ConfigMap) submitted by your DAG must carry the
+platform taxonomy labels. The BM OPA profile (`tests/opa/platform_tags_baremetal.rego`)
+enforces this at plan time:
+
+```yaml
+metadata:
+  labels:
+    platform.system: "ml-pipeline"
+    platform.component: "airflow"
+    platform.env: "{{PLATFORM_ENV}}"
+    platform.owner: "{{TEAM_OWNER}}"
+    platform.managed-by: "argocd"
+```
+
+---
+
+## References
+
+- `docs/adrs/0049-baremetal-gpu-k8s-talos-foundation-multidc.md` (WS-A)
+- `docs/adrs/0052-baremetal-storage-rook-ceph.md` (MinIO/Ceph-RGW)
+- `docs/adrs/0053-baremetal-gpu-fabric-roce-infiniband.md` (DRA + IB)
+- `docs/adrs/0054-baremetal-elasticity-node-lifecycle.md` (Volcano queue discipline)
+- `docs/adrs/0037-ml-cicd-pipeline-mlflow.md` (WS-B ML pipeline)
+- `docs/adrs/0038-ml-observability-drift.md` (WS-C drift monitoring)
+- `docs/adrs/0041-golden-paths-collaboration.md` (WS-F)
+- `docs/transaction-analytics/06-uk-datacenters.md` (UK DC queue taxonomy)
+- `ai-sre/knowledge/nccl-troubleshooting.md` (NCCL/IB pre-flight)
+- `docs/golden-paths/bm-RACI-and-handoffs.md` (RACI and handoff protocol)
+- `templates/golden-paths/bm-new-tenant/` (provision tenant namespace first)
+- `templates/golden-paths/bm-new-model-service/` (for canonical DAG model services)

--- a/templates/golden-paths/bm-new-ml-pipeline/argocd-application.yaml
+++ b/templates/golden-paths/bm-new-ml-pipeline/argocd-application.yaml
@@ -1,0 +1,73 @@
+---
+# Golden Path: bm-new-ml-pipeline -- ArgoCD Application stub
+# WS-B (ADR-0037): ml-pipeline namespace on bare-metal cluster
+# Substrate: bare-metal Talos (ADR-0049), KubePrism API (ADR-0049 D2)
+#
+# This stub is only needed if your DAG requires dedicated per-pipeline
+# Kubernetes resources (e.g., a dedicated ExternalSecret or ConfigMap).
+# For DAG-only additions (a .py file in apps/infra/airflow/dags/), the
+# existing Airflow ArgoCD Application picks up the new DAG via gitSync
+# automatically -- no separate Application needed.
+#
+# USAGE: substitute all {{PLACEHOLDER}} values, then commit this file
+# alongside your DAG if you need pipeline-specific K8s resources.
+#
+# Wave 25 -- after Airflow (wave 20) + ml-monitoring (wave 20).
+# ADR-0028 platform labels: system=ml-pipeline, component=airflow.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  # Substitute: ml-pipeline-bm-{{DAG_NAME}}
+  name: "ml-pipeline-bm-{{DAG_NAME}}"
+  namespace: argocd
+  labels:
+    # ADR-0028 platform taxonomy (K8s plane -- dotted form)
+    platform.system: "ml-pipeline"
+    platform.component: "airflow"
+    # Substitute: {{PLATFORM_ENV}}
+    platform.env: "{{PLATFORM_ENV}}"
+    # Substitute: {{TEAM_OWNER}}
+    platform.owner: "{{TEAM_OWNER}}"
+    platform.managed-by: "argocd"
+    # Substitute: ml-pipeline-bm-{{DAG_NAME}}
+    app.kubernetes.io/name: "ml-pipeline-bm-{{DAG_NAME}}"
+    app.kubernetes.io/component: "airflow"
+    app.kubernetes.io/managed-by: "argocd"
+    # Bare-metal cluster identifier.
+    cluster-substrate: "baremetal-uk"
+  annotations:
+    argocd.argoproj.io/sync-wave: "25"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/your-org/platform-design.git
+    targetRevision: main
+    # If pipeline-specific K8s resources live under a dedicated path, update below.
+    # For DAG-only additions, remove this Application and rely on the Airflow app.
+    path: apps/infra/airflow
+    helm:
+      valueFiles:
+        - values.yaml
+  destination:
+    # Bare-metal cluster in-cluster API via KubePrism (ADR-0049 D2).
+    server: https://kubernetes.default.svc
+    # Substitute: {{MODEL_NAMESPACE}} or ml-pipeline
+    namespace: "{{MODEL_NAMESPACE}}"
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=false
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m

--- a/templates/golden-paths/bm-new-ml-pipeline/dag_template.py
+++ b/templates/golden-paths/bm-new-ml-pipeline/dag_template.py
@@ -1,0 +1,342 @@
+"""
+{{DAG_NAME}} -- Airflow DAG template (WS-F BM golden path, ADR-0041)
+
+Substrate: bare-metal Talos UK DC cluster (ADR-0049).
+Mirrors the WS-B (ADR-0037) DAG shape re-targeted at MinIO/Ceph-RGW + VolcanoJobs.
+
+Key differences from the GCP DAG template (templates/golden-paths/new-ml-pipeline/):
+  - GPU work submitted as VolcanoJob on UK DC queue taxonomy (ADR-0054),
+    not KubernetesPodOperator with a GKE node pool selector.
+  - Artifact store is MinIO/Ceph-RGW (s3://, in-DC, ADR-0052) not GCS (gs://).
+  - DRA ResourceClaimTemplate for GPU + IB NIC as one unit (ADR-0053).
+  - Node selectors use bare-metal labels (platform_system), not GKE pool names.
+
+Instructions:
+  1. Copy to apps/infra/airflow/dags/{{DAG_NAME}}.py
+  2. Replace all SUBSTITUTE: blocks with real values.
+  3. Implement the four # SCAFFOLD task bodies.
+  4. See README.md for MinIO/MLflow and Pushgateway integration patterns.
+
+Platform labels (ADR-0028):
+  platform.system    = ml-pipeline
+  platform.component = airflow
+  platform.owner     = {{TEAM_OWNER}}
+  platform.env       = {{PLATFORM_ENV}}
+
+UK DC Volcano queue taxonomy (06-uk-datacenters.md, ADR-0054):
+  H100 pool: training-default (w100) | training-bootstrap (w30)
+             | training-urgent (w200, cap 2 jobs)
+  H200 pool: serving-vllm (w150) | eval-judge (w200)
+             | engine-build (w80) | batch-rescore (w50)
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta
+
+from airflow.decorators import dag, task
+from airflow.models.param import Param
+
+# ---------------------------------------------------------------------------
+# Executor config -- CPU task pods on the bare-metal CPU pool (ADR-0049).
+# Bare-metal nodes carry platform_system label, not a GKE pool name.
+# ---------------------------------------------------------------------------
+_CPU_EXECUTOR_CONFIG = {
+    "pod_override": {
+        "spec": {
+            "nodeSelector": {
+                # ADR-0028 bare-metal node label
+                "platform_system": "cpu-pool",
+            },
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# VolcanoJob spec template for GPU tasks (ADR-0053 DRA one-DRA-model pattern).
+# Rendered at runtime by submit_volcano_job task.
+# ADR-0028 labels included on all K8s resources.
+# ---------------------------------------------------------------------------
+_VOLCANO_JOB_TEMPLATE: dict = {
+    "apiVersion": "batch.volcano.sh/v1alpha1",
+    "kind": "Job",
+    "metadata": {
+        "generateName": "{{DAG_NAME}}-",
+        # ADR-0028 platform taxonomy labels (K8s dotted form)
+        "labels": {
+            "platform.system": "ml-pipeline",
+            "platform.component": "airflow",
+            # SUBSTITUTE: {{PLATFORM_ENV}}
+            "platform.env": "{{PLATFORM_ENV}}",
+            # SUBSTITUTE: {{TEAM_OWNER}}
+            "platform.owner": "{{TEAM_OWNER}}",
+            "platform.managed-by": "airflow",
+        },
+    },
+    "spec": {
+        # SUBSTITUTE: {{VOLCANO_QUEUE}}
+        # UK DC taxonomy -- pick one for your pool/priority.
+        "queue": "{{VOLCANO_QUEUE}}",
+        # Gang scheduling: all replicas schedulable before any starts.
+        # SUBSTITUTE: {{GPU_REPLICAS}}  (DGX H100: 8 GPUs per node)
+        "minAvailable": "{{GPU_REPLICAS}}",
+        "tasks": [
+            {
+                "name": "worker",
+                # SUBSTITUTE: {{GPU_REPLICAS}}
+                "replicas": "{{GPU_REPLICAS}}",
+                "template": {
+                    "spec": {
+                        "schedulerName": "volcano",
+                        "nodeSelector": {
+                            "platform_system": "gpu-worker",
+                            "nvidia.com/gpu.present": "true",
+                        },
+                        "tolerations": [
+                            {
+                                "key": "nvidia.com/gpu",
+                                "operator": "Exists",
+                                "effect": "NoSchedule",
+                            }
+                        ],
+                        # ADR-0053: DRA claim for GPU + IB NIC as one scheduling unit.
+                        # ResourceClaimTemplate provisioned by baremetal-gpu-scheduling.
+                        "resourceClaims": [
+                            {
+                                "name": "gpu-ib-claim",
+                                "resourceClaimTemplateName": "gpu-ib-h100-template",
+                            }
+                        ],
+                        "containers": [
+                            {
+                                # SUBSTITUTE: {{TRAINING_IMAGE}}
+                                "image": "{{TRAINING_IMAGE}}",
+                                "name": "worker",
+                                "resources": {
+                                    "limits": {
+                                        "nvidia.com/gpu": "1",
+                                        "resource.k8s.io/gpu-ib-claim": "1",
+                                    }
+                                },
+                                "env": [
+                                    # Credentials from Vault/ESO -- never hardcoded.
+                                    {
+                                        "name": "MINIO_ENDPOINT",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                # SUBSTITUTE: minio-creds-{{TENANT_ID}}
+                                                "name": "minio-creds-{{TENANT_ID}}",
+                                                "key": "endpoint",
+                                            }
+                                        },
+                                    },
+                                    {
+                                        "name": "MINIO_ACCESS_KEY",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "name": "minio-creds-{{TENANT_ID}}",
+                                                "key": "access_key",
+                                            }
+                                        },
+                                    },
+                                    {
+                                        "name": "MINIO_SECRET_KEY",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "name": "minio-creds-{{TENANT_ID}}",
+                                                "key": "secret_key",
+                                            }
+                                        },
+                                    },
+                                    {
+                                        "name": "MLFLOW_TRACKING_URI",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "name": "mlflow-tracking-uri",
+                                                "key": "uri",
+                                            }
+                                        },
+                                    },
+                                ],
+                            }
+                        ],
+                        "restartPolicy": "Never",
+                    }
+                },
+            }
+        ],
+    },
+}
+
+
+@dag(
+    # SUBSTITUTE: replace {{DAG_NAME}} with your snake_case DAG identifier.
+    dag_id="{{DAG_NAME}}",
+    # SUBSTITUTE: update the description.
+    description="Custom BM ML pipeline: {{DAG_NAME}} (WS-F BM golden path, ADR-0041).",
+    schedule=None,
+    start_date=datetime(2026, 1, 1),
+    catchup=False,
+    max_active_runs=1,
+    default_args={
+        "retries": 1,
+        "retry_delay": timedelta(minutes=5),
+        # SUBSTITUTE: replace {{TEAM_OWNER}} with your team slug.
+        "owner": "{{TEAM_OWNER}}",
+    },
+    params={
+        # SUBSTITUTE: replace {{TENANT}} with your full tenant label.
+        "tenant": Param(
+            default="{{TENANT}}", type="string", description="Tenant identifier"
+        ),
+        # SUBSTITUTE: replace {{DOMAIN}} with your ML domain.
+        "domain": Param(
+            default="{{DOMAIN}}",
+            type="string",
+            enum=["hft", "solana", "insurance", "rtb"],
+            description="ML domain",
+        ),
+        # SUBSTITUTE: replace {{VOLCANO_QUEUE}} with the target UK DC queue.
+        "volcano_queue": Param(
+            default="{{VOLCANO_QUEUE}}",
+            type="string",
+            enum=[
+                "training-default",
+                "training-bootstrap",
+                "training-urgent",
+                "serving-vllm",
+                "eval-judge",
+                "engine-build",
+                "batch-rescore",
+            ],
+            description="UK DC Volcano queue (06-uk-datacenters.md)",
+        ),
+        "trigger_reason": Param(
+            default="manual",
+            type="string",
+            enum=["manual", "drift", "scheduled"],
+            description="Trigger reason (manual | drift | scheduled)",
+        ),
+    },
+    tags=["ml-pipeline", "baremetal", "volcano", "{{DOMAIN}}"],
+)
+def {{DAG_NAME}}():
+    """
+    {{DAG_NAME}}: bare-metal ML pipeline DAG (ADR-0041 WS-F BM golden path).
+
+    Platform taxonomy (ADR-0028):
+      platform.system    = ml-pipeline
+      platform.component = airflow
+      platform.owner     = {{TEAM_OWNER}}
+      platform.env       = {{PLATFORM_ENV}}
+    """
+
+    @task(executor_config=_CPU_EXECUTOR_CONFIG)
+    def ingest_data(**context: dict) -> dict:
+        """
+        # SCAFFOLD: ingest data from MinIO/Ceph-RGW (s3://, in-DC, ADR-0052),
+        # Iceberg snapshot, Kafka, or another source.
+        # Return metadata dict for downstream tasks.
+        #
+        # Example (MinIO via boto3 -- credentials from env, not hardcoded):
+        #   import boto3
+        #   s3 = boto3.client("s3",
+        #       endpoint_url=os.environ["MINIO_ENDPOINT"],
+        #       aws_access_key_id=os.environ["MINIO_ACCESS_KEY"],
+        #       aws_secret_access_key=os.environ["MINIO_SECRET_KEY"],
+        #   )
+        #   objs = s3.list_objects_v2(Bucket="{{MINIO_BUCKET}}", Prefix="input/")
+        """
+        params = context["params"]
+        return {
+            "tenant": params["tenant"],
+            "domain": params["domain"],
+            "volcano_queue": params["volcano_queue"],
+            "run_id": context["run_id"],
+        }
+
+    @task(executor_config=_CPU_EXECUTOR_CONFIG)
+    def submit_volcano_job(ingest_meta: dict, **context: dict) -> dict:
+        """
+        # SCAFFOLD: render _VOLCANO_JOB_TEMPLATE with runtime values and submit.
+        #
+        # Steps:
+        #   1. Deep-copy _VOLCANO_JOB_TEMPLATE.
+        #   2. Replace {{VOLCANO_QUEUE}} with ingest_meta["volcano_queue"].
+        #   3. Replace {{GPU_REPLICAS}}, {{TRAINING_IMAGE}}, {{TENANT_ID}}.
+        #   4. Submit via kubernetes.client.CustomObjectsApi (incluster config).
+        #   5. Poll until the VolcanoJob reaches terminal state (Completed/Failed).
+        #
+        # NCCL pre-flight (ai-sre/knowledge/nccl-troubleshooting.md):
+        #   Embed an nccl-tests all-reduce as the first container init step
+        #   to gate that IB fabric is healthy before the real training run.
+        #
+        # Credentials for MinIO/MLflow come from ESO ExternalSecret in the
+        # tenant namespace (charts/tenant-bootstrap/ provisions them).
+        """
+        return {
+            **ingest_meta,
+            "job_name": f"{{DAG_NAME}}-{context['run_id'][:8]}",
+            "artifact_uri": f"s3://{{MINIO_BUCKET}}/{{MODEL_NAME}}/{context['run_id']}",
+        }
+
+    @task(executor_config=_CPU_EXECUTOR_CONFIG)
+    def register_results(job_meta: dict, **context: dict) -> dict:
+        """
+        # SCAFFOLD: write metrics and artifacts to MLflow with in-DC s3:// backend.
+        #
+        # Example:
+        #   import mlflow
+        #   mlflow.set_tracking_uri(os.environ["MLFLOW_TRACKING_URI"])
+        #   mlflow.set_experiment("{{DAG_NAME}}")
+        #   with mlflow.start_run(run_name=job_meta["job_name"]):
+        #       mlflow.log_param("volcano_queue", job_meta["volcano_queue"])
+        #       mlflow.log_param("tenant", job_meta["tenant"])
+        #       mlflow.set_tag("cluster_substrate", "baremetal-uk")
+        #       mlflow.log_artifact(local_model_path)
+        #       mlflow.register_model(
+        #           f"runs:/{mlflow.active_run().info.run_id}/model",
+        #           "{{MODEL_NAME}}",
+        #       )
+        #
+        # artifact_uri uses s3:// (MinIO/Ceph-RGW, in-DC) -- NOT gs://.
+        # s3_endpoint_url injected from ESO ExternalSecret -- not hardcoded.
+        """
+        return {
+            **job_meta,
+            "mlflow_run_id": "placeholder",
+        }
+
+    @task(executor_config=_CPU_EXECUTOR_CONFIG)
+    def emit_drift_metrics(result_meta: dict, **context: dict) -> None:
+        """
+        # SCAFFOLD: push feature distribution metrics to Prometheus Pushgateway
+        # for WS-C (Evidently/whylogs) drift tracking.
+        #
+        # Example:
+        #   from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+        #   registry = CollectorRegistry()
+        #   g = Gauge("{{DAG_NAME}}_feature_mean", "Mean of feature X",
+        #             ["model_name", "tenant", "domain", "cluster_substrate"],
+        #             registry=registry)
+        #   g.labels(
+        #       model_name="{{MODEL_NAME}}",
+        #       tenant=result_meta["tenant"],
+        #       domain=result_meta["domain"],
+        #       cluster_substrate="baremetal-uk",  # distinguishes from GCP/AWS
+        #   ).set(feature_mean_value)
+        #   push_to_gateway(
+        #       "prometheus-pushgateway.ml-monitoring.svc.cluster.local:9091",
+        #       job="{{DAG_NAME}}",
+        #       registry=registry,
+        #   )
+        """
+
+    # DAG wiring
+    ingest_meta = ingest_data()
+    job_meta = submit_volcano_job(ingest_meta)
+    result_meta = register_results(job_meta)
+    emit_drift_metrics(result_meta)
+
+
+{{DAG_NAME}}_dag = {{DAG_NAME}}()

--- a/templates/golden-paths/bm-new-model-service/README.md
+++ b/templates/golden-paths/bm-new-model-service/README.md
@@ -1,0 +1,231 @@
+# Golden Path: New Model Service (Bare-Metal / Talos)
+
+**Substrate:** Owned bare-metal GPU cluster on Talos Linux, two UK DCs
+(primary + standby). See `docs/transaction-analytics/06-uk-datacenters.md`.
+
+**ADRs cited:**
+- ADR-0049 — Talos foundation, immutability, multi-DC
+- ADR-0050 — GPU driver as Talos system extension (driver-less GPU Operator)
+- ADR-0051 — Cilium LB-IPAM + BGP (service VIPs, no cloud LB)
+- ADR-0052 — Rook-Ceph / MinIO (artifact store S3 endpoint, no GCS)
+- ADR-0053 — InfiniBand/RoCEv2 GPU fabric
+- ADR-0054 — Elasticity: fixed capacity + workload scale-to-zero
+- ADR-0041 — Golden paths and collaboration (this document)
+- ADR-0028 — Platform taxonomy labels (mandatory on every resource)
+- ADR-0037 — ML CI/CD + MLflow registry (WS-B, re-targeted at MinIO/Ceph-RGW)
+- ADR-0038 — Model observability / drift (WS-C, reused unchanged)
+- ADR-0039 — Self-serve observability (WS-D, reused + BM panels)
+
+This template wires a new ML model into the full bare-metal platform stack:
+- **WS-B** (ADR-0037): `ml-pipeline-baremetal.yml` train->eval->register->deploy
+  + MLflow registry (Postgres via CloudNativePG, artifacts in MinIO/Ceph-RGW)
+- **WS-C** (ADR-0038): Evidently drift-exporter + whylogs profiler per-model namespace
+- **WS-D** (ADR-0039): `grafana-self-serve` per-team dashboard + alert rules, including
+  bare-metal-specific panels (Talos node health, IB/RoCE fabric, Cilium BGP, Ceph, etcd)
+
+**Key differences from the GCP golden path (`templates/golden-paths/new-model-service/`):**
+
+| Concern | GCP path | This bare-metal path |
+|---------|---------|----------------------|
+| Artifact store | GCS bucket (gs://...) | MinIO S3 endpoint or Ceph-RGW (s3://... at in-DC endpoint) |
+| GPU Operator | driver managed by Operator | driver-less (driver baked into Talos system extension, ADR-0050) |
+| Load balancer | Cloud LB / GKE Gateway | Cilium BGP VIP (ADR-0051) |
+| Volcano queues | GCP-shaped | UK DC taxonomy: H100 -> training-default/bootstrap/urgent; H200 -> serving-vllm/eval-judge/engine-build/batch-rescore |
+| Pipeline trigger | ml-pipeline.yml | ml-pipeline-baremetal.yml |
+
+Backstage scaffolder mapping: `spec.type: model-service` (future, ADR-0034 deferred)
+
+---
+
+## Prerequisites
+
+Before you start, confirm:
+
+- [ ] Tenant namespace `tenant-{{TENANT_ID}}` exists (provisioned by the
+  `bm-new-tenant` golden path, `templates/golden-paths/bm-new-tenant/`)
+- [ ] `charts/tenant-bootstrap/` install has completed for your tenant
+  (namespace, NetworkPolicy, ResourceQuota, Gatekeeper constraints, Kafka ACLs,
+  per-tenant Vault KMS key are all in place)
+- [ ] MinIO bucket `ml-artifacts-{{TENANT_ID}}` or Ceph-RGW bucket exists
+  (provisioned by WS-B `terraform/modules/baremetal-ml-artifact-store`)
+- [ ] MLflow tracking server is reachable at `$MLFLOW_TRACKING_URI`
+  (`apps/infra/mlflow/` re-targeted at CloudNativePG + MinIO/Ceph-RGW)
+- [ ] Airflow is reachable at `$AIRFLOW_BASE_URL`
+  (`apps/infra/airflow/` deployed on the CPU pool of the bare-metal cluster)
+- [ ] Grafana service account `grafana-sa-{{TEAM_SLUG}}` exists in Grafana
+- [ ] Model training code lives under `models/{{MODEL_NAME}}/` or `adapters/{{MODEL_NAME}}/`
+  (triggers `.github/workflows/ml-pipeline-baremetal.yml` on push)
+- [ ] You have read `docs/contracts/model-api-contract.md` and
+  `docs/contracts/bm-model-api-contract-addendum.md` and your model schema matches both
+- [ ] Contract sign-off obtained from Data Eng, Backend, and Frontend leads
+  (see `docs/golden-paths/bm-RACI-and-handoffs.md` -- required before staging promotion)
+- [ ] Your VolcanoJob YAML sets `spec.queue` to one of the UK DC queues:
+  H100 training: `training-default`, `training-bootstrap`, `training-urgent`
+  H200 inference: `serving-vllm`, `eval-judge`, `engine-build`, `batch-rescore`
+
+---
+
+## Step 1 -- Substitute placeholders
+
+Copy this template directory to a working location and substitute all placeholders.
+Use `envsubst` or `sed`:
+
+```bash
+export MODEL_NAME="fraud-uk"              # lower-kebab; used in DAG IDs, MLflow model name
+export MODEL_NAMESPACE="fraud-uk"         # Kubernetes namespace for this model
+export TENANT_ID="acme"                   # tenant ID (namespace is tenant-acme)
+export TENANT="tenant-acme"              # full tenant label (ADR-0038)
+export DOMAIN="hft"                       # one of: hft, solana, insurance, rtb
+export TEAM_NAME="ML Fraud UK"           # human-readable
+export TEAM_SLUG="team-ml-fraud-uk"      # lower-kebab
+export TEAM_OWNER="team-ml-fraud-uk"     # ADR-0028 platform.owner
+export PLATFORM_ENV="production"          # production | staging | dev | sandbox
+export MINIO_ENDPOINT="http://minio.minio.svc.cluster.local:9000"
+export MINIO_BUCKET="ml-artifacts-${TENANT_ID}"
+export VOLCANO_QUEUE="training-default"
+
+mkdir -p out
+for f in argocd-application.yaml values-ml-monitoring.yaml values-grafana-self-serve.yaml ml-pipeline-trigger.yaml volcanjob-training.yaml; do
+  envsubst < "$f" > "out/${f}"
+done
+
+# Verify no raw {{}} remain
+grep -r '{{' out/ && echo "UNSUBSTITUTED PLACEHOLDERS FOUND" || echo "OK"
+```
+
+In the Python DAG / VolcanoJob files, replace `# SUBSTITUTE:` blocks manually.
+
+---
+
+## Step 2 -- Add the model to the ML pipeline trigger
+
+Review `out/ml-pipeline-trigger.yaml` and dispatch the first pipeline run:
+
+```bash
+gh workflow run ml-pipeline-baremetal.yml \
+  --ref main \
+  --field model="${MODEL_NAME}" \
+  --field environment="${PLATFORM_ENV}" \
+  --field tenant="${TENANT_ID}"
+```
+
+The pipeline:
+1. Submits a VolcanoJob on the H100 queue (`spec.queue: {{VOLCANO_QUEUE}}`)
+2. Runs `eval_adapter_debate` on `eval-judge` H200 queue
+3. Quality gate: `win_rate >= 0.55`
+4. Registers signed artifact in MLflow (MinIO/Ceph-RGW S3 backend)
+5. SBOM (syft) + cosign sign (same composites as `.github/actions/sign-image/`)
+6. Kargo promotion: dev (auto) -> staging (reviewer gate) -> prod (manual gate)
+
+---
+
+## Step 3 -- Configure drift monitoring (WS-C)
+
+Add your model to `apps/infra/ml-monitoring/values.yaml` by appending the
+content of `out/values-ml-monitoring.yaml` under `modelNamespaces:`.
+
+The bare-metal drift-exporter reads the reference dataset from the MinIO/Ceph-RGW
+S3 endpoint instead of GCS. Set `s3Endpoint` to the in-DC address (UK data residency):
+
+```yaml
+# apps/infra/ml-monitoring/values.yaml (append under modelNamespaces:)
+- namespace: "{{MODEL_NAMESPACE}}"
+  referenceBucketUri: "s3://{{MINIO_BUCKET}}/{{MODEL_NAME}}/{{TENANT_ID}}/{{DOMAIN}}/reference.parquet"
+  s3Endpoint: "{{MINIO_ENDPOINT}}"   # in-DC S3 endpoint; NOT external AWS
+```
+
+A drift alert routes: Alertmanager -> PagerDuty -> Airflow REST retrain trigger
+(POST .../train_domain_adapter/dagRuns on the in-DC Airflow, same path as GCP).
+
+---
+
+## Step 4 -- Configure self-serve observability (WS-D)
+
+Commit `out/values-grafana-self-serve.yaml` at:
+```
+apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/values.yaml
+```
+
+The bare-metal Grafana values enable the **BM-specific starter panels**
+(`baremetal.*` section in `values-grafana-self-serve.yaml`):
+- Talos node health (machine API liveness, kubelet ready)
+- InfiniBand / RoCEv2 fabric (NCCL all-reduce bandwidth, NVLink counters per
+  `ai-sre/knowledge/nccl-troubleshooting.md`)
+- Cilium BGP session state (ToR peering, per `ai-sre/knowledge/cilium-bgp-issues.md`)
+- Ceph cluster health (HEALTH_OK / HEALTH_WARN, OSD up/in)
+- etcd latency + quorum (control-plane health -- absent on managed-K8s paths)
+
+Then commit `out/argocd-application.yaml` at:
+```
+apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/argocd-application.yaml
+```
+
+---
+
+## Step 5 -- Contract sign-off
+
+Before the Kargo staging promotion gate:
+
+1. Author a contract instance YAML in `docs/contracts/` following
+   `docs/contracts/model-api-contract.md` **and** the BM addendum at
+   `docs/contracts/bm-model-api-contract-addendum.md` (MinIO endpoint, Volcano
+   queue, IB fabric requirements).
+2. Open a PR with the contract YAML.
+3. Obtain sign-off from: Data Engineering + Backend/Frontend + Platform/SRE
+   (see `docs/golden-paths/bm-RACI-and-handoffs.md` Handoff H5 -- required gate).
+
+---
+
+## Step 6 -- Verify ADR-0028 labels
+
+Every resource you commit must carry the platform taxonomy labels.
+Use `tests/opa/platform_tags_baremetal.rego` (WS-E) to check at plan time:
+
+```bash
+# Kubernetes manifests must carry (dotted form):
+#   platform.system / platform.component / platform.env
+#   platform.owner  / platform.managed-by
+#
+# Terraform resources (talos_* / kubernetes_manifest) must carry (underscore form):
+#   platform_system / platform_component / platform_env
+#   platform_owner  / platform_managed_by
+```
+
+The bare-metal OPA profile (`platform_tags_baremetal.rego`) flags missing labels
+on `talos_*` and `kubernetes_manifest` resources at plan time. The AWS-shaped
+policy (`platform_tags.rego`) does NOT cover these resource types.
+
+---
+
+## Backstage future mapping
+
+When ADR-0034 revisit criteria are met (see `docs/golden-paths/bm-RACI-and-handoffs.md` ss5):
+- `spec.type: model-service`
+- `spec.lifecycle: production | staging`
+- `spec.owner: {{TEAM_SLUG}}`
+- `spec.system: ml-platform-baremetal`
+- `spec.dependsOn: [mlflow-baremetal, airflow-baremetal, minio-artifacts, evidently-drift-exporter]`
+
+---
+
+## References
+
+- `docs/adrs/0049-baremetal-gpu-k8s-talos-foundation-multidc.md` (WS-A foundation)
+- `docs/adrs/0050-talos-gpu-driver-system-extensions.md` (GPU driver via Talos extension)
+- `docs/adrs/0051-baremetal-networking-cilium-lb-bgp.md` (Cilium BGP LB)
+- `docs/adrs/0052-baremetal-storage-rook-ceph.md` (storage substrate)
+- `docs/adrs/0053-baremetal-gpu-fabric-roce-infiniband.md` (IB/RoCE fabric)
+- `docs/adrs/0054-baremetal-elasticity-node-lifecycle.md` (fixed capacity model)
+- `docs/adrs/0037-ml-cicd-pipeline-mlflow.md` (WS-B ML pipeline)
+- `docs/adrs/0038-ml-observability-drift.md` (WS-C drift monitoring)
+- `docs/adrs/0039-self-serve-observability.md` (WS-D self-serve)
+- `docs/adrs/0041-golden-paths-collaboration.md` (WS-F, this document)
+- `docs/contracts/model-api-contract.md` (base contract spec)
+- `docs/contracts/bm-model-api-contract-addendum.md` (BM-specific addendum)
+- `docs/golden-paths/bm-RACI-and-handoffs.md` (RACI and handoff protocol)
+- `docs/transaction-analytics/06-uk-datacenters.md` (UK DC design fiction)
+- `ai-sre/knowledge/nccl-troubleshooting.md` (NCCL/IB runbook)
+- `ai-sre/knowledge/cilium-bgp-issues.md` (BGP runbook)
+- `ai-sre/knowledge/gpu-driver-updates.md` (GPU driver checklist)
+- `.github/workflows/ml-pipeline-baremetal.yml` (WS-B BM pipeline)
+- `templates/golden-paths/bm-new-tenant/` (provision tenant namespace first)

--- a/templates/golden-paths/bm-new-model-service/argocd-application.yaml
+++ b/templates/golden-paths/bm-new-model-service/argocd-application.yaml
@@ -1,0 +1,71 @@
+---
+# Golden Path: bm-new-model-service -- ArgoCD Application (grafana-self-serve)
+# WS-D (ADR-0039) chart: apps/infra/grafana-self-serve
+# Substrate: bare-metal Talos (ADR-0049) -- baremetal.enabled: true
+#
+# USAGE: substitute all {{PLACEHOLDER}} values, then commit this file at:
+#   apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/argocd-application.yaml
+#
+# Deploys into {{MODEL_NAMESPACE}}. The namespace must pre-exist (provisioned by
+# bm-new-tenant golden path via charts/tenant-bootstrap/).
+# Wave 30 -- after all observability + ml-monitoring components (wave 10-20).
+#
+# See README.md Step 4 for full instructions.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  # Substitute: grafana-self-serve-{{TEAM_SLUG}}
+  name: "grafana-self-serve-{{TEAM_SLUG}}"
+  namespace: argocd
+  labels:
+    # ADR-0028 platform taxonomy (K8s plane -- dotted form)
+    platform.system: "observability"
+    platform.component: "self-serve"
+    # Substitute: {{PLATFORM_ENV}}
+    platform.env: "{{PLATFORM_ENV}}"
+    # Substitute: {{TEAM_OWNER}}
+    platform.owner: "{{TEAM_OWNER}}"
+    platform.managed-by: "argocd"
+    # Substitute: grafana-self-serve-{{TEAM_SLUG}}
+    app.kubernetes.io/name: "grafana-self-serve-{{TEAM_SLUG}}"
+    app.kubernetes.io/component: "self-serve"
+    app.kubernetes.io/managed-by: "argocd"
+    # Bare-metal cluster identifier (for multi-cluster ArgoCD registration).
+    cluster-substrate: "baremetal-uk"
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/your-org/platform-design.git
+    targetRevision: main
+    path: apps/infra/grafana-self-serve
+    helm:
+      valueFiles:
+        - values.yaml
+        # Substitute: example-teams/{{TEAM_SLUG}}/values.yaml
+        - "example-teams/{{TEAM_SLUG}}/values.yaml"
+  destination:
+    # Bare-metal cluster in-cluster API via KubePrism (ADR-0049 D2).
+    # For the primary UK DC. Use the standby cluster server URL for standby.
+    server: https://kubernetes.default.svc
+    # Substitute: {{MODEL_NAMESPACE}}
+    namespace: "{{MODEL_NAMESPACE}}"
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=false
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m

--- a/templates/golden-paths/bm-new-model-service/ml-pipeline-trigger.yaml
+++ b/templates/golden-paths/bm-new-model-service/ml-pipeline-trigger.yaml
@@ -1,0 +1,87 @@
+# Golden Path: bm-new-model-service -- ml-pipeline-baremetal.yml dispatch payload
+# WS-B (ADR-0037) re-targeted at bare-metal: .github/workflows/ml-pipeline-baremetal.yml
+# Substrate: bare-metal Talos / MinIO/Ceph-RGW (ADR-0052)
+#
+# This is a REFERENCE file, not a deployed Kubernetes manifest.
+# It documents the GitHub workflow_dispatch payload for your model on bare metal.
+#
+# USAGE (after substituting {{PLACEHOLDER}} values):
+#
+#   gh workflow run ml-pipeline-baremetal.yml \
+#     --ref main \
+#     --field model={{MODEL_NAME}} \
+#     --field environment={{PLATFORM_ENV}} \
+#     --field tenant={{TENANT_ID}}
+#
+# The ml-pipeline-baremetal.yml workflow:
+#   1. POST $AIRFLOW_BASE_URL/api/v1/dags/train_domain_adapter/dagRuns
+#      conf: {model_id, tenant, domain, volcano_queue, trigger_reason: "manual"}
+#      DAG submits VolcanoJob on H100 training pool (spec.queue: {{VOLCANO_QUEUE}})
+#   2. Poll eval_adapter_debate dag run (VolcanoJob on eval-judge H200 queue)
+#      until terminal state
+#   3. Quality gate: win_rate >= 0.55
+#   4. Register model version in MLflow:
+#      artifact_uri: s3://{{MINIO_BUCKET}}/{{MODEL_NAME}}/<git-sha>
+#      mlflow_tracking_uri: $MLFLOW_TRACKING_URI (in-DC CloudNativePG backend)
+#   5. SBOM (syft) + cosign sign (.github/actions/sign-image/)
+#   6. Kargo promotion: dev (auto) -> staging (reviewer gate) -> prod (manual gate)
+#
+# Key differences from GCP path (ml-pipeline.yml):
+#   - Workflow: ml-pipeline-baremetal.yml (not ml-pipeline.yml)
+#   - artifact_uri: s3:// (MinIO/Ceph-RGW, in-DC) not gs://
+#   - VolcanoJob queues follow UK DC taxonomy (06-uk-datacenters.md):
+#     H100 training: training-default (w100) / training-bootstrap (w30) /
+#                    training-urgent (w200, cap 2 jobs)
+#     H200 inference: serving-vllm (w150) / eval-judge (w200) /
+#                     engine-build (w80) / batch-rescore (w50)
+
+dispatch:
+  workflow: ml-pipeline-baremetal.yml
+  ref: main
+  inputs:
+    # Substitute: {{MODEL_NAME}}
+    model: "{{MODEL_NAME}}"
+    # Substitute: {{PLATFORM_ENV}}
+    environment: "{{PLATFORM_ENV}}"
+    # Substitute: {{TENANT_ID}}  (short form, e.g. acme)
+    tenant: "{{TENANT_ID}}"
+
+# Airflow DAG conf injected via dagRuns (for reference):
+airflow_dag_conf:
+  model_id: "{{MODEL_NAME}}"
+  # Substitute: {{TENANT}}  (full label, e.g. tenant-acme)
+  tenant: "{{TENANT}}"
+  # Substitute: {{DOMAIN}}  (hft | solana | insurance | rtb)
+  domain: "{{DOMAIN}}"
+  # UK DC Volcano queue on H100 pool.
+  # Substitute: {{VOLCANO_QUEUE}}
+  volcano_queue: "{{VOLCANO_QUEUE}}"
+  # First run is always manual. Drift-triggered retrains use trigger_reason: drift.
+  trigger_reason: "manual"
+
+# MLflow registration (for reference):
+mlflow:
+  # Substitute: {{MODEL_NAME}}
+  model_name: "{{MODEL_NAME}}"
+  # MinIO/Ceph-RGW S3 artifact path (in-DC -- UK data residency, ADR-0052):
+  # Substitute: {{MINIO_BUCKET}}, {{MODEL_NAME}}
+  artifact_uri: "s3://{{MINIO_BUCKET}}/{{MODEL_NAME}}/<git-sha>"
+  # In-DC S3 endpoint injected via ESO ExternalSecret -- not hardcoded here.
+  # Substitute: {{MINIO_ENDPOINT}}
+  s3_endpoint_url: "{{MINIO_ENDPOINT}}"
+
+# VolcanoJob training parameters (for reference -- rendered by the Airflow DAG):
+# ADR-0053: GPU + IB NIC scheduled as one DRA claim (baremetal-gpu-scheduling module).
+volcanoJob:
+  # Substitute: {{VOLCANO_QUEUE}}
+  queue: "{{VOLCANO_QUEUE}}"
+  # H100 SXM5 nodes: 8 GPUs per node.
+  minAvailable: 8
+  tasks:
+    - name: worker
+      replicas: 8
+      resources:
+        limits:
+          "nvidia.com/gpu": "1"
+          # DRA ResourceClaimTemplate for H100 + IB NIC (ADR-0053 one-DRA-model).
+          "resource.k8s.io/gpu-ib-claim": "1"

--- a/templates/golden-paths/bm-new-model-service/values-grafana-self-serve.yaml
+++ b/templates/golden-paths/bm-new-model-service/values-grafana-self-serve.yaml
@@ -1,0 +1,119 @@
+# Golden Path: bm-new-model-service -- grafana-self-serve values
+# WS-D (ADR-0039) chart: apps/infra/grafana-self-serve
+# Substrate: bare-metal Talos (ADR-0049) -- includes BM-specific panels
+#
+# USAGE: substitute all {{PLACEHOLDER}} values before committing.
+# Place the substituted file at:
+#   apps/infra/grafana-self-serve/example-teams/{{TEAM_SLUG}}/values.yaml
+#
+# BM additions vs GCP path (baremetal.enabled: true):
+#   - Talos node health (machine API liveness, kubelet ready)
+#   - InfiniBand/RoCEv2 fabric (NCCL all-reduce bandwidth, NVLink counters)
+#   - Cilium BGP session state (ToR peering; per cilium-bgp-issues.md)
+#   - Ceph cluster health (HEALTH_OK / HEALTH_WARN, OSD up/in)
+#   - etcd latency + quorum (self-operated control plane)
+#
+# See README.md Step 4 for full instructions.
+
+team:
+  # Human-readable team name shown in the Grafana folder title.
+  # Substitute: {{TEAM_NAME}}
+  name: "{{TEAM_NAME}}"
+
+  # Machine-safe slug -- lowercase, hyphens only.
+  # Substitute: {{TEAM_SLUG}}
+  slug: "{{TEAM_SLUG}}"
+
+  # Kubernetes namespace where this team's workloads run.
+  # Must already exist (CreateNamespace=false on the ArgoCD Application).
+  # Substitute: {{MODEL_NAMESPACE}}
+  namespace: "{{MODEL_NAMESPACE}}"
+
+  # platform.system value (ADR-0028). For a model service: ml-pipeline.
+  system: "ml-pipeline"
+
+  # platform.owner value (ADR-0028).
+  # Substitute: {{TEAM_OWNER}}
+  owner: "{{TEAM_OWNER}}"
+
+  # Deployment environment.
+  # Substitute: {{PLATFORM_ENV}}
+  env: "{{PLATFORM_ENV}}"
+
+  # Grafana service account for folder Editor access.
+  # Create this SA in Grafana before ArgoCD sync.
+  # Substitute: grafana-sa-{{TEAM_SLUG}}
+  grafanaServiceAccount: "grafana-sa-{{TEAM_SLUG}}"
+
+  # CI/CD service account in team.namespace for PrometheusRule RBAC.
+  # Substitute: {{TEAM_SLUG}}-ci
+  ciServiceAccount: "{{TEAM_SLUG}}-ci"
+
+# ML panels enabled -- wires ADR-0038 drift + accuracy metrics into the dashboard.
+ml:
+  enabled: true
+
+  # Scope ML panels to this specific model.
+  # Substitute: {{MODEL_NAME}}
+  modelName: "{{MODEL_NAME}}"
+
+  # Scope ML panels to this tenant (ADR-0038 multi-tenant label).
+  # Substitute: {{TENANT}}
+  tenant: "{{TENANT}}"
+
+# Bare-metal specific panels (BM cluster only; set enabled: false on GCP/AWS).
+# Metric sources: talos-log-shipper, DCGM exporter (baremetal-gpu-dcgm),
+#   Rook-Ceph mgr exporter (baremetal-rook-ceph), Cilium BGP metrics (ADR-0051),
+#   etcd metrics from control-plane nodes (ADR-0049 D3).
+baremetal:
+  enabled: true
+
+  # Talos node health panel.
+  # Metric: talos_machine_api_liveness (via talos-log-shipper -> Loki scrape)
+  talosNodeHealth:
+    enabled: true
+    # ADR-0028 label selector for GPU worker nodes.
+    nodeSelector: "platform_system=\"gpu-worker\""
+
+  # InfiniBand / RoCEv2 fabric panel.
+  # Metric: DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL, ib_port_rcv_data_bytes
+  # Acceptance gate: NCCL all-reduce >= floor from nccl-troubleshooting.md
+  gpuFabric:
+    enabled: true
+    # H100 NVSwitch + 400 Gbps IB target. Alert if below floor.
+    nccAllReduceBandwidthFloorGbs: 200
+    nccAllReduceBandwidthTargetGbs: 300
+
+  # Cilium BGP session state panel.
+  # Metric: cilium_bgp_peer_session_state (ADR-0051 Cilium LB-IPAM + BGP)
+  # Per cilium-bgp-issues.md: hold-timer 180 s; alert if not Established.
+  ciliumBgp:
+    enabled: true
+    # Expected BGP peers per DC (ToR switches). Alert if count drops.
+    expectedPeerCount: 2
+
+  # Rook-Ceph cluster health panel.
+  # Metric: ceph_health_status, ceph_osd_up, ceph_osd_in
+  cephHealth:
+    enabled: true
+    alertWarnThreshold: "10m"
+    alertCritThreshold: "5m"
+
+  # etcd control-plane panel (self-operated; absent on managed K8s paths).
+  # Metric: etcd_server_leader_changes_seen_total, etcd_server_proposals_failed_total
+  etcd:
+    enabled: true
+    leaderElectionAlertWindow: "10m"
+    proposalFailureRateThreshold: "0.01"
+
+# Alert thresholds -- adjust for your model SLOs.
+alerts:
+  errorRateThreshold: "0.05"
+  cpuSaturationThreshold: "0.80"
+  memorySaturationThreshold: "0.80"
+  availabilityFor: "5m"
+  saturationFor: "15m"
+  # Drift and accuracy floors from docs/contracts/model-api-contract.md.
+  mlDriftThreshold: "0.2"
+  mlAccuracyThreshold: "0.85"
+  mlAlertFor: "10m"

--- a/templates/golden-paths/bm-new-model-service/values-ml-monitoring.yaml
+++ b/templates/golden-paths/bm-new-model-service/values-ml-monitoring.yaml
@@ -1,0 +1,94 @@
+# Golden Path: bm-new-model-service -- ml-monitoring per-model override
+# WS-C (ADR-0038) chart: apps/infra/ml-monitoring
+# Substrate: bare-metal Talos / MinIO/Ceph-RGW (ADR-0052), NOT GCS
+#
+# USAGE: substitute all {{PLACEHOLDER}} values, then append this block
+# under `modelNamespaces:` in apps/infra/ml-monitoring/values.yaml
+# (or mount as a second values file in a per-model ArgoCD Application).
+#
+# Key difference from GCP path:
+#   referenceBucketUri uses s3:// (MinIO/Ceph-RGW in-DC) instead of gs://
+#   s3Endpoint must be set to the in-DC MinIO/Ceph-RGW address (UK data residency).
+#   Do NOT point at external AWS S3 -- that breaks UK data-residency (ADR-0052).
+#
+# ADR-0028 platform labels (K8s plane):
+#   platform.system     = ml-monitoring
+#   platform.component  = drift-exporter
+#   platform.env        = {{PLATFORM_ENV}}
+#   platform.owner      = {{TEAM_OWNER}}
+#   platform.managed-by = argocd
+
+# Namespace for this model's drift-monitoring components.
+# Substitute: {{MODEL_NAMESPACE}}
+namespace: "{{MODEL_NAMESPACE}}"
+
+driftExporter:
+  enabled: true
+
+  # Per-model reference dataset path in MinIO or Ceph-RGW (S3-compatible, in-DC).
+  # Pattern: <bucket>/<modelName>/<tenantId>/<domain>/reference.parquet
+  # Substitute: {{MINIO_BUCKET}}, {{MODEL_NAME}}, {{TENANT_ID}}, {{DOMAIN}}
+  referenceBucketUri: "s3://{{MINIO_BUCKET}}/{{MODEL_NAME}}/{{TENANT_ID}}/{{DOMAIN}}/reference.parquet"
+
+  # In-DC S3-compatible endpoint (MinIO or Ceph-RGW). NOT external AWS.
+  # Substitute: {{MINIO_ENDPOINT}}
+  # Example: http://minio.minio.svc.cluster.local:9000
+  s3Endpoint: "{{MINIO_ENDPOINT}}"
+
+  # Force path-style S3 addressing (required for MinIO and Ceph-RGW).
+  s3ForcePathStyle: true
+
+  # Credentials sourced from Vault / ESO ExternalSecret -- never hardcoded.
+  # The ExternalSecret is provisioned by charts/tenant-bootstrap/ for the tenant.
+  s3CredentialsSecretRef:
+    # Substitute: minio-creds-{{TENANT_ID}}
+    name: "minio-creds-{{TENANT_ID}}"
+    accessKeyKey: access_key
+    secretKeyKey: secret_key
+
+  # Model-specific drift thresholds.
+  # Adjust to match the contract floors in docs/contracts/model-api-contract.md
+  # and docs/contracts/bm-model-api-contract-addendum.md.
+  defaultThresholds:
+    datasetDriftScore:
+      warning: 0.20
+      critical: 0.40
+    featurePsiScore:
+      warning: 0.10
+      critical: 0.25
+    featureKlDivergence:
+      warning: 0.10
+      critical: 0.30
+    modelAccuracy:
+      warning: 0.85
+      critical: 0.75
+    modelF1Score:
+      warning: 0.80
+      critical: 0.65
+
+whylogsProfiler:
+  enabled: true
+
+  # Pushgateway address -- shared across model namespaces on the BM cluster.
+  pushgatewayAddress: "http://prometheus-pushgateway.ml-monitoring.svc.cluster.local:9091"
+
+  # Labels injected into every whylogs push for multi-tenant PromQL queries.
+  extraLabels:
+    # Substitute: {{MODEL_NAME}}
+    model_name: "{{MODEL_NAME}}"
+    # Substitute: {{TENANT}}  (full tenant label, e.g. tenant-acme)
+    tenant: "{{TENANT}}"
+    # Substitute: {{DOMAIN}}
+    domain: "{{DOMAIN}}"
+    # BM cluster identifier (distinguishes from GCP/AWS metrics in shared Thanos)
+    cluster_substrate: "baremetal-uk"
+
+# ADR-0028 platform labels applied to all K8s resources in this release.
+platformLabels:
+  "platform.system": "ml-monitoring"
+  "platform.component": "drift-exporter"
+  # Substitute: {{PLATFORM_ENV}}
+  "platform.env": "{{PLATFORM_ENV}}"
+  # Substitute: {{TEAM_OWNER}}
+  "platform.owner": "{{TEAM_OWNER}}"
+  "platform.managed-by": "argocd"

--- a/templates/golden-paths/bm-new-model-service/volcanjob-training.yaml
+++ b/templates/golden-paths/bm-new-model-service/volcanjob-training.yaml
@@ -1,0 +1,188 @@
+---
+# Golden Path: bm-new-model-service -- VolcanoJob training scaffold
+# WS-A (ADR-0049) + WS-B (ADR-0037): submitted by Airflow train_domain_adapter DAG
+# Substrate: bare-metal Talos UK DC, H100 GPU pool (ADR-0050 driver-less GPU Operator)
+#
+# USAGE: substitute all {{PLACEHOLDER}} values via envsubst (see README.md Step 1).
+# This file is rendered at runtime by the Airflow DAG task `submit_volcano_job`
+# and submitted via the Kubernetes API. It is NOT applied directly.
+#
+# ADR-0028 platform taxonomy labels (K8s plane -- dotted form):
+#   platform.system     = ml-pipeline
+#   platform.component  = volcano-training
+#   platform.env        = {{PLATFORM_ENV}}
+#   platform.owner      = {{TEAM_OWNER}}
+#   platform.managed-by = airflow
+#
+# ADR-0053 one-DRA-model: GPU + IB NIC scheduled as a single ResourceClaimTemplate.
+# ResourceClaimTemplate "h100-ib-claim" is provisioned by the
+# baremetal-gpu-scheduling module (WS-A) and is available in every GPU namespace.
+#
+# ADR-0054 elasticity: there is no cloud autoscaler. minAvailable must not exceed
+# the fixed H100 pool capacity. training-urgent queue cap is 2 concurrent jobs --
+# use only for drift/incident-response retrains.
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  # Substitute: train-{{MODEL_NAME}}-<git-sha> (unique per pipeline run)
+  name: "train-{{MODEL_NAME}}"
+  # Substitute: tenant-{{TENANT_ID}}
+  namespace: "tenant-{{TENANT_ID}}"
+  labels:
+    # ADR-0028 platform taxonomy (dotted form for K8s resources).
+    platform.system: "ml-pipeline"
+    platform.component: "volcano-training"
+    # Substitute: {{PLATFORM_ENV}}
+    platform.env: "{{PLATFORM_ENV}}"
+    # Substitute: {{TEAM_OWNER}}
+    platform.owner: "{{TEAM_OWNER}}"
+    platform.managed-by: "airflow"
+    # Model and tenant scope for PromQL multi-tenant filtering (ADR-0038).
+    # Substitute: {{MODEL_NAME}}
+    ml.model-name: "{{MODEL_NAME}}"
+    # Substitute: {{TENANT_ID}}
+    tenant: "{{TENANT_ID}}"
+    # BM cluster identifier (distinguishes from GCP/AWS metrics in shared Thanos).
+    cluster-substrate: "baremetal-uk"
+spec:
+  # UK DC Volcano queue (H100 pool -- ADR-0054 queue taxonomy from 06-uk-datacenters.md).
+  # Valid values:
+  #   training-default   (weight 100  -- regular tenant retrains)
+  #   training-bootstrap (weight 30   -- new-tenant initial fine-tunes)
+  #   training-urgent    (weight 200, cap 2 -- drift-triggered / incident-response)
+  # Substitute: {{VOLCANO_QUEUE}}
+  queue: "{{VOLCANO_QUEUE}}"
+
+  # Gang scheduling: all replicas must be co-scheduled before any starts.
+  # H100 SXM5 nodes have 8 GPUs per node. Set minAvailable = replicas for strict gang.
+  minAvailable: 8
+
+  # Maximum retries before the job is marked failed.
+  maxRetry: 3
+
+  # Restart all tasks if any task fails (NCCL all-reduce requires the full gang).
+  policies:
+    - event: PodFailed
+      action: RestartJob
+
+  tasks:
+    - name: worker
+      replicas: 8
+
+      policies:
+        - event: TaskCompleted
+          action: CompleteJob
+
+      template:
+        metadata:
+          labels:
+            # ADR-0028 labels propagated to pods.
+            platform.system: "ml-pipeline"
+            platform.component: "volcano-training"
+            # Substitute: {{PLATFORM_ENV}}
+            platform.env: "{{PLATFORM_ENV}}"
+            # Substitute: {{TEAM_OWNER}}
+            platform.owner: "{{TEAM_OWNER}}"
+            platform.managed-by: "airflow"
+            # Substitute: {{MODEL_NAME}}
+            ml.model-name: "{{MODEL_NAME}}"
+            # Substitute: {{TENANT_ID}}
+            tenant: "{{TENANT_ID}}"
+        spec:
+          # GPU node pool taint (ADR-0049/0050 -- Talos system extension driver).
+          tolerations:
+            - key: "nvidia.com/gpu.present"
+              operator: "Exists"
+              effect: "NoSchedule"
+            - key: "dedicated"
+              value: "gpu-training"
+              effect: "NoSchedule"
+
+          # Pin to H100 GPU worker pool (ADR-0049 node labels set by talos-machineconfig).
+          nodeSelector:
+            platform_system: "gpu-worker"
+            nvidia.com/gpu.product: "NVIDIA-H100-SXM5-80GB"
+
+          # Credentials and endpoints from Vault / ESO ExternalSecrets.
+          # ExternalSecret provisioned by charts/tenant-bootstrap/ (bm-new-tenant golden path).
+          envFrom:
+            - secretRef:
+                # Substitute: minio-creds-{{TENANT_ID}}
+                name: "minio-creds-{{TENANT_ID}}"
+            - secretRef:
+                name: "mlflow-tracking-credentials"
+
+          containers:
+            - name: training
+              # Substitute: your training image (cosign-signed per .github/actions/sign-image/).
+              # Pin by digest in production.
+              image: "ghcr.io/your-org/ml-training-{{MODEL_NAME}}:{{GIT_SHA}}"
+              imagePullPolicy: Always
+
+              resources:
+                requests:
+                  # One GPU per pod (gang of 8 = full H100 node, 8 x GPU).
+                  nvidia.com/gpu: "1"
+                  cpu: "8"
+                  memory: "64Gi"
+                limits:
+                  nvidia.com/gpu: "1"
+                  cpu: "16"
+                  memory: "128Gi"
+
+              # ADR-0053 one-DRA-model: GPU + IB NIC as a single DRA claim.
+              # ResourceClaimTemplate "h100-ib-claim" is cluster-scoped, provisioned
+              # by baremetal-gpu-scheduling (WS-A). This schedules the GPU via the
+              # NVIDIA DRA driver AND the IB NIC via SR-IOV device plugin (day-0) or
+              # Cilium netdev-DRA (gated target, ADR-0053 D3 maturity gate).
+              resourceClaims:
+                - name: gpu-ib
+                  resourceClaimTemplateName: h100-ib-claim
+
+              env:
+                # In-DC MinIO/Ceph-RGW endpoint (UK data residency, ADR-0052).
+                # Do NOT use external AWS S3 for UK-resident training data.
+                # Substitute: {{MINIO_ENDPOINT}}
+                - name: MINIO_ENDPOINT
+                  value: "{{MINIO_ENDPOINT}}"
+                # Substitute: s3://{{MINIO_BUCKET}}/{{MODEL_NAME}}/{{TENANT_ID}}/{{DOMAIN}}
+                - name: ARTIFACT_URI
+                  value: "s3://{{MINIO_BUCKET}}/{{MODEL_NAME}}/{{TENANT_ID}}/{{DOMAIN}}"
+                # Airflow-injected run ID for MLflow lineage tracking.
+                - name: MLFLOW_RUN_ID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.labels['airflow/run-id']
+                # NCCL InfiniBand config (ADR-0053 IB fabric -- 400 Gbps target).
+                # IB_SOCKET_IFNAME must match the IB interface confirmed by the
+                # NCCL pre-flight in ai-sre/knowledge/nccl-troubleshooting.md.
+                - name: NCCL_IB_DISABLE
+                  value: "0"
+                - name: NCCL_IB_SOCKET_IFNAME
+                  value: "ib0"
+                - name: NCCL_DEBUG
+                  value: "INFO"
+                # Volcano rank injection for PyTorch / NCCL distributed init.
+                - name: WORLD_SIZE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['volcano.sh/task-spec-index']
+
+              securityContext:
+                runAsNonRoot: true
+                # IPC_LOCK required for RDMA / GPUDirect RDMA (ADR-0053).
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                readOnlyRootFilesystem: false
+
+          volumes:
+            # Shared memory for NCCL inter-process communication.
+            - name: shm
+              emptyDir:
+                medium: Memory
+                # Sized for NCCL_SHM_DISABLE=0 local transfer on an 8-GPU node.
+                sizeLimit: 16Gi
+
+          # Allow NCCL all-reduce to finish current step before eviction.
+          terminationGracePeriodSeconds: 120

--- a/templates/golden-paths/bm-new-tenant/README.md
+++ b/templates/golden-paths/bm-new-tenant/README.md
@@ -1,0 +1,186 @@
+# Golden Path: New Tenant (Bare-Metal / Talos)
+
+**Substrate:** Owned bare-metal GPU cluster on Talos Linux, two UK DCs.
+See `docs/transaction-analytics/06-uk-datacenters.md`.
+
+**ADRs cited:**
+- ADR-0049 -- Talos foundation, immutability, multi-DC (namespace-per-tenant model)
+- ADR-0052 -- Rook-Ceph / MinIO (per-tenant S3 bucket + scoped credential)
+- ADR-0041 -- Golden paths and collaboration (this document)
+- ADR-0028 -- Platform taxonomy labels (mandatory on every resource)
+- ADR-0040 -- SOC posture: Gatekeeper tenant constraints, Vault per-tenant KMS key
+
+**This golden path is unique to the bare-metal platform.** No GCP or AWS
+equivalent exists because the full bare-metal tenant bundle (Vault KMS key, MinIO
+bucket, Gatekeeper constraints, Kafka ACLs) requires explicit provisioning in the
+UK DC model.
+
+---
+
+## What this golden path provisions
+
+A single PR via this golden path triggers `charts/tenant-bootstrap/` to create
+the full tenant bundle described in `06-uk-datacenters.md`:
+
+| Resource | Provisioned by |
+|----------|---------------|
+| Kubernetes namespace `tenant-{{TENANT_ID}}` | `charts/tenant-bootstrap/` |
+| `NetworkPolicy` default-deny + explicit allows | `charts/tenant-bootstrap/` |
+| `ResourceQuota` + `LimitRange` per contract tier | `charts/tenant-bootstrap/` |
+| Gatekeeper constraints (reject pods without `tenant={{TENANT_ID}}`) | `charts/tenant-bootstrap/` |
+| Kafka ACLs scoped to `tenant-{{TENANT_ID}}.*` topics | `charts/tenant-bootstrap/` |
+| QuestDB database with dedicated role | `charts/tenant-bootstrap/` |
+| Iceberg namespace `tenant_{{TENANT_ID}}.*` + REST catalog perms | `charts/tenant-bootstrap/` |
+| Qdrant collection with scoped API key | `charts/tenant-bootstrap/` |
+| Postgres schema `tenant_{{TENANT_ID}}.*` with dedicated role | `charts/tenant-bootstrap/` |
+| Argilla workspace with tenant-scoped membership | `charts/tenant-bootstrap/` |
+| **Vault per-tenant KMS key** (UK-resident data, ADR-0040) | `charts/tenant-bootstrap/` |
+| MinIO bucket `ml-artifacts-{{TENANT_ID}}` + S3 credential (ESO) | `terraform/modules/baremetal-ml-artifact-store` (WS-B) |
+| Service-account OIDC issuer claim | `charts/tenant-bootstrap/` |
+| ADR-0028 labels on all resources | `charts/tenant-bootstrap/` + this template |
+
+After this golden path completes, all other BM golden paths
+(`bm-new-model-service`, `bm-new-ml-pipeline`, `bm-new-dashboard`) can be used
+for this tenant.
+
+---
+
+## Prerequisites
+
+- [ ] `charts/tenant-bootstrap/` exists in the repo
+- [ ] Vault (in-DC) is running and reachable from the bare-metal cluster
+- [ ] You have the `platform-admin` ClusterRole to install Helm charts
+- [ ] Tenant metadata (contract tier, Kafka topics, Iceberg prefixes) is in the
+  platform Postgres tenant registry
+
+---
+
+## Step 1 -- Substitute placeholders
+
+```bash
+export TENANT_ID="acme"                # short identifier (namespace: tenant-acme)
+export TENANT="tenant-acme"           # full Kubernetes namespace
+export TENANT_DISPLAY_NAME="Acme Corp" # human-readable
+export TEAM_OWNER="team-acme"         # ADR-0028 platform.owner
+export PLATFORM_ENV="production"       # production | staging | dev | sandbox
+# Contract tier controls ResourceQuota/LimitRange.
+# Values: starter (dev/small) | standard (prod default) | gpu (GPU workload)
+export CONTRACT_TIER="standard"
+# GPU queue access (comma-separated; empty for CPU-only tenants).
+# Must match UK DC Volcano queue taxonomy (06-uk-datacenters.md).
+export GPU_QUEUES="training-default,training-bootstrap"
+export MINIO_BUCKET="ml-artifacts-${TENANT_ID}"
+
+mkdir -p out
+for f in argocd-application.yaml helm-values.yaml; do
+  envsubst < "$f" > "out/${f}"
+done
+
+# Verify no raw {{}} remain
+grep -r '{{' out/ && echo "UNSUBSTITUTED PLACEHOLDERS FOUND" || echo "OK"
+```
+
+---
+
+## Step 2 -- Install charts/tenant-bootstrap/
+
+**CRITICAL DECISION** (per `.claude/rules/critical-decisions.md`): this step
+creates a Vault KMS key, Kafka ACLs, and a production Kubernetes namespace.
+It MUST be approved by a platform lead before execution.
+
+```bash
+# First install (manual, apply-gated -- human approval required):
+helm upgrade --install "tenant-${TENANT_ID}" charts/tenant-bootstrap/ \
+  --namespace argocd \
+  --values out/helm-values.yaml \
+  --atomic --timeout 10m
+
+# Verify namespace exists with ADR-0028 labels:
+kubectl get namespace "${TENANT}" -o jsonpath='{.metadata.labels}' | jq .
+# Verify Gatekeeper constraints are active:
+kubectl get constraints -o wide | grep "${TENANT_ID}"
+```
+
+---
+
+## Step 3 -- Commit the ArgoCD Application (for GitOps updates)
+
+After the first install, commit `out/argocd-application.yaml` at:
+```
+apps/infra/tenants/{{TENANT_ID}}/argocd-application.yaml
+```
+
+Future changes (quota adjustments, queue permission changes) are made via PR to
+`helm-values.yaml` and picked up by ArgoCD.
+
+---
+
+## Step 4 -- Verify ADR-0028 labels
+
+All resources provisioned by `charts/tenant-bootstrap/` must carry the platform
+taxonomy labels. The BM OPA profile (`tests/opa/platform_tags_baremetal.rego`)
+checks `kubernetes_manifest` resources at plan time:
+
+```yaml
+metadata:
+  labels:
+    platform.system: "tenant-bootstrap"
+    platform.component: "namespace"
+    platform.env: "{{PLATFORM_ENV}}"
+    platform.owner: "{{TEAM_OWNER}}"
+    platform.managed-by: "helm"
+    tenant: "{{TENANT_ID}}"
+```
+
+---
+
+## Step 5 -- Smoke tests
+
+```bash
+# Namespace exists with correct labels:
+kubectl get namespace "${TENANT}" -o jsonpath='{.metadata.labels}' | jq .
+
+# NetworkPolicy default-deny is in place:
+kubectl get networkpolicy -n "${TENANT}" | grep default-deny
+
+# Gatekeeper rejects pods without tenant label:
+kubectl run test-pod --image=busybox -n "${TENANT}" --restart=Never
+# Expected: admission webhook denied (missing tenant={{TENANT_ID}} label)
+
+# Vault KMS key accessible from the tenant namespace via ESO:
+kubectl get externalsecret -n "${TENANT}" | grep kms
+```
+
+---
+
+## Volcano queue access
+
+If `GPU_QUEUES` is set, `charts/tenant-bootstrap/` creates a Volcano `Queue`
+object and a `ClusterRole` allowing the tenant to submit `VolcanoJob` objects
+to those queues.
+
+UK DC queue taxonomy (`06-uk-datacenters.md`, ADR-0054):
+
+| Queue | Pool | Weight | Cap | Use case |
+|-------|------|--------|-----|----------|
+| `training-default` | H100 | 100 | - | Regular tenant retrains |
+| `training-bootstrap` | H100 | 30 | - | New-tenant initial fine-tunes |
+| `training-urgent` | H100 | 200 | 2 jobs | Drift/incident response |
+| `serving-vllm` | H200 | 150 | - | vLLM multi-LoRA batch |
+| `eval-judge` | H200 | 200 | - | LLM-as-judge debate |
+| `engine-build` | H200 | 80 | - | TRT-LLM compilation |
+| `batch-rescore` | H200 | 50 | - | Historical reprocessing |
+
+---
+
+## References
+
+- `docs/adrs/0049-baremetal-gpu-k8s-talos-foundation-multidc.md` (namespace-per-tenant)
+- `docs/adrs/0052-baremetal-storage-rook-ceph.md` (MinIO per-tenant bucket)
+- `docs/adrs/0040-soc-posture-and-oncall.md` (Vault KMS, Gatekeeper)
+- `docs/adrs/0041-golden-paths-collaboration.md` (WS-F)
+- `docs/transaction-analytics/06-uk-datacenters.md` (tenant-bootstrap design fiction)
+- `charts/tenant-bootstrap/` (Helm chart provisioning the tenant bundle)
+- `terraform/modules/baremetal-ml-artifact-store` (WS-B -- MinIO bucket + ESO)
+- `docs/golden-paths/bm-RACI-and-handoffs.md` (RACI and handoff protocol)
+- `.claude/rules/critical-decisions.md` (approval gates)

--- a/templates/golden-paths/bm-new-tenant/argocd-application.yaml
+++ b/templates/golden-paths/bm-new-tenant/argocd-application.yaml
@@ -1,0 +1,75 @@
+---
+# Golden Path: bm-new-tenant -- ArgoCD Application (tenant-bootstrap GitOps updates)
+# Substrate: bare-metal Talos UK DC cluster (ADR-0049), KubePrism API
+#
+# USAGE: commit this file at:
+#   apps/infra/tenants/{{TENANT_ID}}/argocd-application.yaml
+#
+# This Application manages subsequent GitOps updates to the tenant bundle after
+# the first Helm install (Step 2 in README.md). The first install is manual
+# (apply-gated, requires platform lead approval per .claude/rules/critical-decisions.md).
+#
+# Wave 5 -- before any tenant workload Applications (waves 20-30).
+# ADR-0028 platform labels: system=tenant-bootstrap, component=namespace.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  # Substitute: tenant-{{TENANT_ID}}
+  name: "tenant-{{TENANT_ID}}"
+  namespace: argocd
+  labels:
+    # ADR-0028 platform taxonomy (K8s plane -- dotted form)
+    platform.system: "tenant-bootstrap"
+    platform.component: "namespace"
+    # Substitute: {{PLATFORM_ENV}}
+    platform.env: "{{PLATFORM_ENV}}"
+    # Substitute: {{TEAM_OWNER}}
+    platform.owner: "{{TEAM_OWNER}}"
+    platform.managed-by: "argocd"
+    # Substitute: tenant-{{TENANT_ID}}
+    app.kubernetes.io/name: "tenant-{{TENANT_ID}}"
+    app.kubernetes.io/component: "namespace"
+    app.kubernetes.io/managed-by: "argocd"
+    # Tenant label for multi-tenant filtering.
+    # Substitute: {{TENANT_ID}}
+    tenant: "{{TENANT_ID}}"
+    # Bare-metal cluster identifier.
+    cluster-substrate: "baremetal-uk"
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/your-org/platform-design.git
+    targetRevision: main
+    path: charts/tenant-bootstrap
+    helm:
+      valueFiles:
+        - values.yaml
+        # Substitute: apps/infra/tenants/{{TENANT_ID}}/helm-values.yaml
+        - "apps/infra/tenants/{{TENANT_ID}}/helm-values.yaml"
+  destination:
+    # Bare-metal cluster in-cluster API via KubePrism (ADR-0049 D2).
+    server: https://kubernetes.default.svc
+    # The chart creates the tenant namespace; ArgoCD manages the parent app here.
+    namespace: argocd
+  syncPolicy:
+    automated:
+      # prune: false -- tenant deletion is destructive; require explicit PR + approval.
+      prune: false
+      # selfHeal: false -- prevent unintended auto-revert of manual emergency changes.
+      selfHeal: false
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=false
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - ApplyOutOfSyncOnly=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 2m

--- a/templates/golden-paths/bm-new-tenant/helm-values.yaml
+++ b/templates/golden-paths/bm-new-tenant/helm-values.yaml
@@ -1,0 +1,92 @@
+# Golden Path: bm-new-tenant -- charts/tenant-bootstrap/ Helm values
+# Substrate: bare-metal Talos UK DC cluster (ADR-0049)
+#
+# USAGE: substitute all {{PLACEHOLDER}} values, then install via:
+#   helm upgrade --install "tenant-{{TENANT_ID}}" charts/tenant-bootstrap/ \
+#     --namespace argocd \
+#     --values out/helm-values.yaml \
+#     --atomic --timeout 10m
+#
+# CRITICAL: first install is apply-gated (creates Vault KMS key, Kafka ACLs,
+# production namespace). Requires platform lead approval per
+# .claude/rules/critical-decisions.md.
+#
+# ADR-0028 platform labels applied to all K8s resources created by this chart.
+# ADR-0040: Vault per-tenant KMS key for UK-resident data.
+# ADR-0049: namespace-per-tenant multi-tenancy model.
+
+# Tenant identity
+tenant:
+  # Short identifier -- used in namespace, labels, bucket names.
+  # Substitute: {{TENANT_ID}}
+  id: "{{TENANT_ID}}"
+
+  # Full Kubernetes namespace name.
+  # Substitute: {{TENANT}}
+  namespace: "{{TENANT}}"
+
+  # Human-readable display name.
+  # Substitute: {{TENANT_DISPLAY_NAME}}
+  displayName: "{{TENANT_DISPLAY_NAME}}"
+
+# Contract tier controls ResourceQuota and LimitRange sizes.
+# starter  : dev/small tenants; minimal quotas
+# standard : production default; balanced quotas
+# gpu      : tenants owning GPU workloads; elevated limits + GPU quota
+# Substitute: {{CONTRACT_TIER}}
+contractTier: "{{CONTRACT_TIER}}"
+
+# GPU queue access (subset of the UK DC Volcano queue taxonomy).
+# Leave empty for CPU-only tenants.
+# Substitute: {{GPU_QUEUES}}  (comma-separated)
+# Valid values: training-default, training-bootstrap, training-urgent,
+#               serving-vllm, eval-judge, engine-build, batch-rescore
+gpuQueues: "{{GPU_QUEUES}}"
+
+# MinIO / Ceph-RGW artifact store (ADR-0052).
+# Bucket provisioned by terraform/modules/baremetal-ml-artifact-store (WS-B).
+# Credentials sourced via ESO ExternalSecret from Vault -- never hardcoded here.
+artifactStore:
+  # Substitute: {{MINIO_BUCKET}}
+  bucket: "{{MINIO_BUCKET}}"
+  # In-DC S3 endpoint (UK data residency -- NOT external AWS S3, ADR-0052).
+  endpointRef:
+    secretName: "minio-endpoint-global"
+    key: "endpoint"
+  credentialsSecretRef:
+    # Substitute: minio-creds-{{TENANT_ID}}
+    name: "minio-creds-{{TENANT_ID}}"
+    accessKeyKey: "access_key"
+    secretKeyKey: "secret_key"
+
+# Vault KMS configuration (ADR-0040, UK-resident data).
+# All data-at-rest encryption for this tenant uses this key.
+vault:
+  # KMS key path in Vault.
+  # Substitute: tenants/{{TENANT_ID}}/kms
+  kmsPath: "tenants/{{TENANT_ID}}/kms"
+  # ESO SecretStore for the tenant namespace (provisioned by platform bootstrap).
+  secretStoreName: "vault-backend"
+
+# Kafka ACL scope. Tenant gets access to topics: tenant-{{TENANT_ID}}.*
+kafkaTopicPrefix: "tenant-{{TENANT_ID}}"
+
+# Gatekeeper constraints (ADR-0049 + WS-E):
+#   requireTenantLabel: reject pods without tenant={{TENANT_ID}} label
+#   blockCrossNamespaceSARef: reject pods referencing SAs from other namespaces
+gatekeeperConstraints:
+  requireTenantLabel: true
+  blockCrossNamespaceSARef: true
+
+# ADR-0028 platform taxonomy labels applied to ALL K8s resources by this chart.
+platformLabels:
+  "platform.system": "tenant-bootstrap"
+  "platform.component": "namespace"
+  # Substitute: {{PLATFORM_ENV}}
+  "platform.env": "{{PLATFORM_ENV}}"
+  # Substitute: {{TEAM_OWNER}}
+  "platform.owner": "{{TEAM_OWNER}}"
+  "platform.managed-by": "helm"
+  # Tenant label for Gatekeeper enforcement and PromQL multi-tenant filtering.
+  # Substitute: {{TENANT_ID}}
+  "tenant": "{{TENANT_ID}}"


### PR DESCRIPTION
## Summary

**DESIGN-MOCK repo — apply-gated; do NOT merge until human review; base targets the design branch.**

Completes WS-F (Collaboration / Golden Paths) from `docs/baremetal-ml-platform/IMPLEMENTATION_PLAN.md`, the bare-metal mirror of ADR-0041. Carries ADR-0028 `platform:system/component/owner` labels throughout; wired to WS-B/C/D artifacts (Airflow/MLflow, drift-monitoring, Grafana self-serve) by name per the plan.

**Resumes a prior session** that created the template directories and the contract addendum but hit the session limit before committing.

## Files delivered (17 files, +2541 lines)

### Golden-path templates (`templates/golden-paths/`)

| Template | Files | Purpose |
|----------|-------|---------|
| `bm-new-model-service/` | README.md, argocd-application.yaml, ml-pipeline-trigger.yaml, values-ml-monitoring.yaml, values-grafana-self-serve.yaml, **volcanjob-training.yaml** | Full model service scaffold: WS-B pipeline dispatch, WS-C drift values, WS-D Grafana values, VolcanoJob H100 gang-schedule + DRA IB NIC claim (ADR-0053) |
| `bm-new-ml-pipeline/` | README.md, argocd-application.yaml, dag_template.py | New Airflow DAG on UK DC Volcano queues, MinIO/Ceph-RGW artifact store |
| `bm-new-dashboard/` | README.md, argocd-application.yaml, values.yaml | Team Grafana onboarding with BM-specific panels (Talos node health, IB/RoCE fabric, Cilium BGP, Ceph, etcd) |
| `bm-new-tenant/` | README.md, argocd-application.yaml, helm-values.yaml | `charts/tenant-bootstrap/` install: namespace + NetworkPolicy + ResourceQuota + Gatekeeper + Kafka ACLs + Vault KMS + MinIO bucket (unique to BM; no GCP/AWS equivalent) |

### Contracts and process docs

| File | Purpose |
|------|---------|
| `docs/contracts/bm-model-api-contract-addendum.md` | BM-specific contract addendum: in-DC artifact store (s3://), Volcano queue field, IB fabric SLO, per-tenant Vault KMS field, drift monitoring alignment |
| `docs/golden-paths/bm-RACI-and-handoffs.md` | Full BM RACI matrix (6 activity areas, 4 personas), handoff flow diagram with Talos lifecycle gates (T1/T2 etcd snapshot gates), alert routing table, golden-path selection guide |

### ADRs cited (pre-existing in the design branch)

ADR-0049 (Talos foundation + multi-DC), ADR-0050 (GPU driver via system extension), ADR-0051 (Cilium LB-IPAM + BGP), ADR-0052 (Rook-Ceph / MinIO), ADR-0053 (IB/RoCEv2 fabric + one-DRA-model), ADR-0054 (fixed capacity + Volcano queue discipline), ADR-0041 (golden paths, this WS-F), ADR-0028 (platform taxonomy labels, mandatory on all resources), ADR-0037/0038/0039/0040 (WS-B/C/D/E, reused and referenced by name).

## Key differences from GCP golden paths (`templates/golden-paths/new-*/`)

- Artifact store: `s3://` MinIO/Ceph-RGW in-DC (not `gs://` or external S3)
- GPU submission: VolcanoJob on H100/H200 UK DC queue taxonomy (not KubernetesPodOperator)
- DRA: `h100-ib-claim` ResourceClaimTemplate (GPU + IB NIC as one unit, ADR-0053)
- New golden path: `bm-new-tenant` (no GCP/AWS equivalent — explicit UK-DC tenant bundle)
- BM observability panels: Talos node health, IB fabric, Cilium BGP, Ceph, etcd
- BM contract addendum gate at H5 (Vault KMS confirmation required before staging)
- Talos lifecycle gates T1/T2 in RACI handoff flow

## Verification (light — deep CI deferred)

- No `.tf` files in WS-F deliverables (no `terraform fmt` needed)
- `yamllint -d relaxed` on all 10 YAML files: **0 errors, warnings are line-length only (comments)**
- No secrets hardcoded; all credentials sourced from Vault/ESO ExternalSecrets
- File-disjoint from WS-A stack (`catalog/stacks/*.stack.hcl`) and `docs/adrs/README.md` (WS-A owns those)

## Test plan

- [ ] Human reviewer: confirm templates match the UK DC queue taxonomy in `06-uk-datacenters.md`
- [ ] Human reviewer: confirm BM addendum fields align with WS-B/C/D artifact names
- [ ] Human reviewer: confirm no overlap with WS-A stack files or ADR README
- [ ] Platform lead: walk through `bm-new-tenant` step by step (apply-gated; F3 is a critical decision)
- [ ] Run `yamllint` on all YAML before merge (already passing in this PR)
- [ ] Apply gate: do NOT run `helm install`, `terraform apply`, or any cluster mutation