### PR TITLE
fix(baremetal): add missing argocd-application module (unbreaks main)

### DIFF
--- a/terraform/modules/argocd-application/README.md
+++ b/terraform/modules/argocd-application/README.md
@@ -1,0 +1,132 @@
+# `argocd-application` — generic ArgoCD Application wrapper
+
+Renders a single **ArgoCD `Application`** (`argoproj.io/v1alpha1`) as a `kubernetes_manifest`
+resource via the `hashicorp/kubernetes` provider. The Application points at a Helm chart in a
+Git repository; the actual in-cluster workloads (Deployments, ServiceMonitors, PrometheusRules,
+ExternalSecrets, …) are rendered by Helm and reconciled by ArgoCD — not by Terraform.
+
+This is the **generic, reusable** Application wrapper. It is substrate-agnostic: bare-metal
+(Talos) and cloud (EKS/GKE) catalog units can all source it. It was introduced to satisfy the
+`catalog/units/baremetal-ml-monitoring` unit (WS-C), but the interface is intentionally generic
+so other units can source it too.
+
+## Why this module exists
+
+The `baremetal-ml-monitoring` catalog unit (merged via PR #326) sources
+`${get_repo_root()}/terraform/modules/argocd-application`, but that module directory did not
+exist on `main` — so `terragrunt init/validate` of the unit errored. This module fills that gap
+and conforms to the unit's `inputs` interface.
+
+## Apply gate (mock / `never_apply`)
+
+This is a **mock / emulation** repo. Cluster mutation is gated:
+
+- `enabled` defaults to **`false`**. The Application resource is created with
+  `count = var.enabled ? 1 : 0`, so a default `plan`/`validate` renders **nothing**.
+- `automated_sync` defaults to **`false`** — no ArgoCD auto-sync without explicit human approval.
+- CI/CD flips `enabled` to `true` only on `main` after merge, with human approval. **Never** run
+  `terraform apply` / `argocd sync` from an agent or feature branch.
+
+## ADR citations
+
+- **ADR-0028 — Unified Platform Tagging and Labeling Taxonomy.** The five core taxonomy keys
+  (`platform.system`, `platform.component`, `platform.env`, `platform.owner`,
+  `platform.managed-by`) are applied as **Kubernetes labels** on the Application metadata.
+  Catalog units pass the keys in underscore form (`platform_system`, …) because dotted keys are
+  awkward in HCL map literals; this module normalizes them to the canonical dotted form. The
+  `platform.cluster` extension key is also carried through. Labels propagate to the destination
+  workload through the Helm chart's own templated metadata.
+- **ADR-0038 — ML Observability (Drift Detection, Accuracy Monitoring, Retrain Trigger).** The
+  first consumer is `baremetal-ml-monitoring`, which deploys the `ml-monitoring` Helm chart
+  (Evidently/whylogs drift exporter) onto the Talos UK bare-metal cluster.
+- **ADR-0049 — Bare-metal GPU K8s (Talos) foundation, multi-DC, UK-resident data** — provides
+  the destination cluster context for the first consumer.
+
+## Inputs
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `enabled` | `bool` | `false` | Apply gate. `false` ⇒ no resources rendered (plan/validate create nothing). |
+| `app_name` | `string` | — | Application `metadata.name`. |
+| `argocd_namespace` | `string` | `"argocd"` | Namespace where ArgoCD runs / the Application object lives. |
+| `project` | `string` | `"default"` | ArgoCD AppProject (`spec.project`). |
+| `repo_url` | `string` | — | Git repo URL of the chart/manifests (`spec.source.repoURL`). |
+| `target_revision` | `string` | `"main"` | Git revision to track (`spec.source.targetRevision`). |
+| `chart_path` | `string` | — | Path within the repo to the chart/manifests (`spec.source.path`). |
+| `helm_value_files` | `list(string)` | `[]` | Helm values files (`spec.source.helm.valueFiles`). |
+| `helm_set_values` | `map(string)` | `{}` | Helm parameter overrides (`spec.source.helm.parameters`). No secrets. |
+| `destination_server` | `string` | `"https://kubernetes.default.svc"` | Target cluster API URL (`spec.destination.server`). |
+| `destination_namespace` | `string` | — | Destination namespace (`spec.destination.namespace`). |
+| `sync_wave` | `number` | `0` | Rendered as `argocd.argoproj.io/sync-wave` annotation. |
+| `automated_sync` | `bool` | `false` | Enable `spec.syncPolicy.automated` (gated). |
+| `auto_prune` | `bool` | `false` | Prune on auto-sync. |
+| `self_heal` | `bool` | `false` | Self-heal drift on auto-sync. |
+| `create_namespace` | `bool` | `true` | Add `CreateNamespace=true` to `syncOptions`. |
+| `labels` | `map(string)` | `{}` | ADR-0028 taxonomy labels (underscore keys, normalized to dotted). |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `application_name` | Application `metadata.name`. |
+| `namespace` | ArgoCD namespace (`metadata.namespace`). |
+| `destination_namespace` | Destination namespace in the target cluster. |
+| `labels` | Normalized (dotted-key) taxonomy labels applied to the Application. |
+| `enabled` | Whether the Application was actually rendered. |
+
+Outputs are derived from inputs/locals (not the count-gated resource) so they resolve even when
+`enabled = false`.
+
+## Security
+
+- **No secrets.** `helm_set_values` carries non-sensitive wiring only (e.g. an S3 bucket URI,
+  an ExternalSecrets `secretStoreRef` *name*). Secret material is sourced in-cluster via the
+  referenced secret store (Vault/ESO), never passed through Terraform variables or state.
+
+## Usage (Terragrunt unit)
+
+```hcl
+terraform {
+  source = "${get_repo_root()}/terraform/modules/argocd-application"
+}
+
+inputs = {
+  app_name              = "ml-monitoring-baremetal"
+  argocd_namespace      = "argocd"
+  project               = "platform"
+  repo_url              = "https://github.com/your-org/platform-infrastructure.git"
+  target_revision       = "main"
+  chart_path            = "apps/infra/ml-monitoring"
+  helm_value_files      = ["values.yaml", "values-baremetal.yaml"]
+  destination_server    = dependency.talos_cluster.outputs.cluster_endpoint
+  destination_namespace = "ml-monitoring"
+  sync_wave             = 20
+
+  labels = {
+    platform_system     = "ml-monitoring"
+    platform_component  = "drift-exporter"
+    platform_env        = "production"
+    platform_owner      = "team-ml-platform"
+    platform_managed_by = "argocd"
+    platform_cluster    = "talos-uk-primary"
+  }
+
+  helm_set_values = {
+    "driftExporter.referenceBucketUri"    = "s3://${dependency.baremetal_rook_ceph.outputs.rgw_bucket_name}"
+    "externalSecrets.secretStoreRef.name" = "vault-cluster-secret-store"
+  }
+}
+```
+
+## Testing
+
+`argocd-application.tftest.hcl` is a plan-command test with a mocked `kubernetes` provider. It
+asserts: nothing renders when `enabled = false`; the Application renders as
+`argoproj.io/v1alpha1` with the correct identity/destination/source when `enabled = true`; and
+ADR-0028 labels are normalized to dotted K8s label keys with the sync-wave annotation applied.
+
+```bash
+terraform init -backend=false
+terraform validate
+terraform test
+```

--- a/terraform/modules/argocd-application/argocd-application.tftest.hcl
+++ b/terraform/modules/argocd-application/argocd-application.tftest.hcl
@@ -1,0 +1,116 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Native test — generic ArgoCD Application wrapper
+# ---------------------------------------------------------------------------------------------------------------------
+# Plan-command test with a mocked kubernetes provider (no live cluster). Asserts that:
+#   1. With the default apply gate (enabled = false) NOTHING is rendered.
+#   2. With enabled = true the Application renders as argoproj.io/v1alpha1 Application,
+#      with the destination/source wired and ADR-0028 taxonomy labels normalized to dotted
+#      K8s label keys on the Application metadata.
+# Mirrors the baremetal-ml-monitoring unit's interface.
+# ---------------------------------------------------------------------------------------------------------------------
+
+mock_provider "kubernetes" {}
+
+variables {
+  app_name              = "ml-monitoring-baremetal"
+  argocd_namespace      = "argocd"
+  project               = "platform"
+  repo_url              = "https://github.com/your-org/platform-infrastructure.git"
+  target_revision       = "main"
+  chart_path            = "apps/infra/ml-monitoring"
+  helm_value_files      = ["values.yaml", "values-baremetal.yaml"]
+  destination_server    = "https://mock-talos-endpoint.internal:6443"
+  destination_namespace = "ml-monitoring"
+  sync_wave             = 20
+
+  labels = {
+    platform_system     = "ml-monitoring"
+    platform_component  = "drift-exporter"
+    platform_env        = "production"
+    platform_owner      = "team-ml-platform"
+    platform_managed_by = "argocd"
+    platform_cluster    = "talos-uk-primary"
+  }
+
+  helm_set_values = {
+    "driftExporter.referenceBucketUri"    = "s3://ml-reference-data"
+    "externalSecrets.secretStoreRef.name" = "vault-cluster-secret-store"
+  }
+}
+
+# Apply gate default: no Application created on a plan.
+run "apply_gated_off_by_default" {
+  command = plan
+
+  variables {
+    enabled = false
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.application) == 0
+    error_message = "With enabled = false the module must render zero Application resources (apply gate)."
+  }
+}
+
+# When enabled, the Application renders with the correct kind and identity.
+run "renders_application_when_enabled" {
+  command = plan
+
+  variables {
+    enabled = true
+  }
+
+  assert {
+    condition     = length(kubernetes_manifest.application) == 1
+    error_message = "With enabled = true exactly one ArgoCD Application must be rendered."
+  }
+
+  assert {
+    condition     = kubernetes_manifest.application[0].manifest.apiVersion == "argoproj.io/v1alpha1"
+    error_message = "Application apiVersion must be argoproj.io/v1alpha1."
+  }
+
+  assert {
+    condition     = kubernetes_manifest.application[0].manifest.kind == "Application"
+    error_message = "Rendered manifest kind must be Application."
+  }
+
+  assert {
+    condition     = kubernetes_manifest.application[0].manifest.metadata.name == "ml-monitoring-baremetal"
+    error_message = "Application metadata.name must equal app_name."
+  }
+
+  assert {
+    condition     = kubernetes_manifest.application[0].manifest.spec.destination.namespace == "ml-monitoring"
+    error_message = "spec.destination.namespace must equal destination_namespace."
+  }
+
+  assert {
+    condition     = kubernetes_manifest.application[0].manifest.spec.source.path == "apps/infra/ml-monitoring"
+    error_message = "spec.source.path must equal chart_path."
+  }
+}
+
+# ADR-0028 labels are normalized to dotted K8s label keys on the Application metadata.
+run "adr0028_labels_normalized" {
+  command = plan
+
+  variables {
+    enabled = true
+  }
+
+  assert {
+    condition     = kubernetes_manifest.application[0].manifest.metadata.labels["platform.system"] == "ml-monitoring"
+    error_message = "platform_system must be normalized to the dotted label platform.system."
+  }
+
+  assert {
+    condition     = kubernetes_manifest.application[0].manifest.metadata.labels["platform.managed-by"] == "argocd"
+    error_message = "platform_managed_by must be normalized to platform.managed-by."
+  }
+
+  assert {
+    condition     = kubernetes_manifest.application[0].manifest.metadata.annotations["argocd.argoproj.io/sync-wave"] == "20"
+    error_message = "sync_wave must be rendered as the argocd.argoproj.io/sync-wave annotation."
+  }
+}

--- a/terraform/modules/argocd-application/main.tf
+++ b/terraform/modules/argocd-application/main.tf
@@ -1,0 +1,109 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Generic ArgoCD Application wrapper
+# ---------------------------------------------------------------------------------------------------------------------
+# Renders a single argoproj.io/v1alpha1 Application object via the kubernetes provider's
+# kubernetes_manifest resource. Substrate-agnostic: it creates an ArgoCD Application that
+# points at a Helm chart in a Git repo; the actual in-cluster workloads are rendered by Helm
+# and reconciled by ArgoCD. Any catalog unit can source this module (ADR-0028 taxonomy).
+#
+# Apply gate: the resource is created only when var.enabled = true (default false), via
+# count. A plan/validate with the default creates nothing — satisfies never_apply CI policy.
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  # -------------------------------------------------------------------------------------------------------------------
+  # ADR-0028 label normalization
+  # -------------------------------------------------------------------------------------------------------------------
+  # Catalog units pass labels with underscore keys (platform_system, ...) because dotted keys
+  # are awkward in HCL map literals. ArgoCD/Kubernetes expect the canonical dotted form
+  # (platform.system, ...). Map the five core taxonomy keys (+ the platform_cluster extension)
+  # to their dotted equivalents; pass any other keys through verbatim.
+  taxonomy_key_map = {
+    platform_system     = "platform.system"
+    platform_component  = "platform.component"
+    platform_env        = "platform.env"
+    platform_owner      = "platform.owner"
+    platform_managed_by = "platform.managed-by"
+    platform_cluster    = "platform.cluster"
+  }
+
+  normalized_labels = {
+    for k, v in var.labels :
+    lookup(local.taxonomy_key_map, k, k) => v
+  }
+
+  # -------------------------------------------------------------------------------------------------------------------
+  # Helm source block — only emit valueFiles / parameters when non-empty so the rendered
+  # manifest stays minimal and ArgoCD does not see spurious empty keys.
+  # -------------------------------------------------------------------------------------------------------------------
+  helm_parameters = [
+    for name, value in var.helm_set_values : {
+      name  = name
+      value = value
+    }
+  ]
+
+  helm_block = merge(
+    length(var.helm_value_files) > 0 ? { valueFiles = var.helm_value_files } : {},
+    length(local.helm_parameters) > 0 ? { parameters = local.helm_parameters } : {},
+  )
+
+  source_block = merge(
+    {
+      repoURL        = var.repo_url
+      targetRevision = var.target_revision
+      path           = var.chart_path
+    },
+    length(local.helm_block) > 0 ? { helm = local.helm_block } : {},
+  )
+
+  # -------------------------------------------------------------------------------------------------------------------
+  # syncPolicy — automated sync is opt-in and off by default (apply-gated repo). syncOptions
+  # always include CreateNamespace per create_namespace.
+  # -------------------------------------------------------------------------------------------------------------------
+  sync_options = var.create_namespace ? ["CreateNamespace=true"] : []
+
+  automated_block = var.automated_sync ? {
+    automated = {
+      prune    = var.auto_prune
+      selfHeal = var.self_heal
+    }
+  } : {}
+
+  sync_policy = merge(
+    local.automated_block,
+    length(local.sync_options) > 0 ? { syncOptions = local.sync_options } : {},
+  )
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# The ArgoCD Application. count = enabled ? 1 : 0 — apply gate. Nothing is created on a
+# default plan/validate.
+# ---------------------------------------------------------------------------------------------------------------------
+resource "kubernetes_manifest" "application" {
+  count = var.enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "argoproj.io/v1alpha1"
+    kind       = "Application"
+    metadata = {
+      name      = var.app_name
+      namespace = var.argocd_namespace
+      labels    = local.normalized_labels
+      annotations = {
+        "argocd.argoproj.io/sync-wave" = tostring(var.sync_wave)
+      }
+    }
+    spec = merge(
+      {
+        project = var.project
+        source  = local.source_block
+        destination = {
+          server    = var.destination_server
+          namespace = var.destination_namespace
+        }
+      },
+      length(local.sync_policy) > 0 ? { syncPolicy = local.sync_policy } : {},
+    )
+  }
+}

--- a/terraform/modules/argocd-application/outputs.tf
+++ b/terraform/modules/argocd-application/outputs.tf
@@ -1,0 +1,32 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------------------------------------------------------
+# Derived from inputs/locals (not from the count-gated resource) so they resolve cleanly even
+# when enabled = false and no Application object is created. Consumers (dependency blocks in
+# other units) get stable values during plan/validate.
+# ---------------------------------------------------------------------------------------------------------------------
+
+output "application_name" {
+  description = "Name of the rendered ArgoCD Application (metadata.name)."
+  value       = var.app_name
+}
+
+output "namespace" {
+  description = "Namespace where the ArgoCD Application object is created (metadata.namespace, i.e. the ArgoCD namespace)."
+  value       = var.argocd_namespace
+}
+
+output "destination_namespace" {
+  description = "Destination namespace in the target cluster where the application is deployed."
+  value       = var.destination_namespace
+}
+
+output "labels" {
+  description = "Normalized ADR-0028 taxonomy labels applied to the Application metadata (dotted K8s label keys)."
+  value       = local.normalized_labels
+}
+
+output "enabled" {
+  description = "Whether the Application resource was actually rendered (apply gate). False on a default plan/validate."
+  value       = var.enabled
+}

--- a/terraform/modules/argocd-application/variables.tf
+++ b/terraform/modules/argocd-application/variables.tf
@@ -1,0 +1,118 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Input variables — generic ArgoCD Application wrapper
+# ---------------------------------------------------------------------------------------------------------------------
+# Every variable below is part of the public interface that catalog units (e.g.
+# catalog/units/baremetal-ml-monitoring) wire in via Terragrunt `inputs`. Each has an
+# explicit type and a description per repo Terraform rules. Sensible defaults are provided
+# so the module validates/plans standalone in CI.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# --- Apply gate -------------------------------------------------------------------------------------------------------
+
+variable "enabled" {
+  description = "Apply gate. When false (default), the module renders NO cluster resources — plan/validate create nothing. CI/CD flips this to true only on main after merge, with explicit human approval. Mirrors the unit's never_apply policy."
+  type        = bool
+  default     = false
+}
+
+# --- Identity ---------------------------------------------------------------------------------------------------------
+
+variable "app_name" {
+  description = "Name of the ArgoCD Application object (metadata.name)."
+  type        = string
+}
+
+variable "argocd_namespace" {
+  description = "Namespace where ArgoCD is installed and where the Application object is created (metadata.namespace)."
+  type        = string
+  default     = "argocd"
+}
+
+variable "project" {
+  description = "ArgoCD AppProject the Application belongs to (spec.project)."
+  type        = string
+  default     = "default"
+}
+
+# --- Source (Git repo + Helm chart path) ------------------------------------------------------------------------------
+
+variable "repo_url" {
+  description = "Git repository URL containing the application manifests / Helm chart (spec.source.repoURL)."
+  type        = string
+}
+
+variable "target_revision" {
+  description = "Git revision (branch, tag, or commit) to track (spec.source.targetRevision)."
+  type        = string
+  default     = "main"
+}
+
+variable "chart_path" {
+  description = "Path within the repository to the Helm chart or manifests (spec.source.path)."
+  type        = string
+}
+
+variable "helm_value_files" {
+  description = "Ordered list of Helm values files (relative to chart_path) to apply (spec.source.helm.valueFiles). Empty list omits the valueFiles key."
+  type        = list(string)
+  default     = []
+}
+
+variable "helm_set_values" {
+  description = "Map of Helm parameter overrides rendered as spec.source.helm.parameters (name/value pairs). Use for substrate-specific wiring resolved from dependency outputs (e.g. S3 bucket URI, secret store ref). No secrets — reference a secret manager instead."
+  type        = map(string)
+  default     = {}
+}
+
+# --- Destination ------------------------------------------------------------------------------------------------------
+
+variable "destination_server" {
+  description = "API server URL of the target cluster registered in ArgoCD (spec.destination.server). For the in-cluster ArgoCD target use https://kubernetes.default.svc."
+  type        = string
+  default     = "https://kubernetes.default.svc"
+}
+
+variable "destination_namespace" {
+  description = "Namespace in the destination cluster where the application is deployed (spec.destination.namespace)."
+  type        = string
+}
+
+# --- Sync behaviour ---------------------------------------------------------------------------------------------------
+
+variable "sync_wave" {
+  description = "ArgoCD sync wave for ordering relative to other Applications. Rendered as the argocd.argoproj.io/sync-wave annotation."
+  type        = number
+  default     = 0
+}
+
+variable "automated_sync" {
+  description = "Enable ArgoCD automated sync (spec.syncPolicy.automated). Default false — sync is gated and requires explicit human approval in this mock/apply-gated repo."
+  type        = bool
+  default     = false
+}
+
+variable "auto_prune" {
+  description = "When automated_sync is true, prune resources removed from Git (spec.syncPolicy.automated.prune)."
+  type        = bool
+  default     = false
+}
+
+variable "self_heal" {
+  description = "When automated_sync is true, automatically correct drift (spec.syncPolicy.automated.selfHeal)."
+  type        = bool
+  default     = false
+}
+
+variable "create_namespace" {
+  description = "Add CreateNamespace=true to spec.syncPolicy.syncOptions so ArgoCD creates the destination namespace."
+  type        = bool
+  default     = true
+}
+
+# --- ADR-0028 taxonomy labels -----------------------------------------------------------------------------------------
+
+variable "labels" {
+  description = "Platform taxonomy labels (ADR-0028). Keys use the underscore form the catalog units pass (e.g. platform_system, platform_component, platform_env, platform_owner, platform_managed_by, platform_cluster); the module normalizes them to the canonical dotted K8s label keys (platform.system, ...) on the Application metadata and propagates them to the destination workload via Helm-rendered metadata. Non-taxonomy keys are passed through verbatim."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/argocd-application/versions.tf
+++ b/terraform/modules/argocd-application/versions.tf
@@ -1,0 +1,18 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Provider & version constraints
+# ---------------------------------------------------------------------------------------------------------------------
+# Terraform (NOT OpenTofu). Renders an ArgoCD Application via the kubernetes provider's
+# kubernetes_manifest resource. No helm provider here — the Application object itself is a
+# CRD manifest; Helm rendering happens in-cluster, managed by ArgoCD.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  required_version = "~> 1.11"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.25"
+    }
+  }
+}


### PR DESCRIPTION
## Problem: broken reference on `main`

The `baremetal-ml-monitoring` catalog unit (`catalog/units/baremetal-ml-monitoring/terragrunt.hcl`, merged via **#326**) sources:

```hcl
terraform {
  source = "${get_repo_root()}/terraform/modules/argocd-application"
}
```

…but `terraform/modules/argocd-application/` **did not exist on `main`**, so `terragrunt init/validate` of that unit errored with a missing-module-source failure. This PR creates the module so the source resolves and `main` is unbroken.

## What this adds

A **generic, reusable** `argocd-application` module that renders a single ArgoCD `Application` (`argoproj.io/v1alpha1`) via the `kubernetes_manifest` resource (`hashicorp/kubernetes`). It conforms exactly to the `inputs` the `baremetal-ml-monitoring` unit passes, and is generic enough that other units (cloud or bare-metal) can source it too.

Files:
- `main.tf` — renders the Application; ADR-0028 label normalization; helm source/syncPolicy assembly.
- `variables.tf` — every input typed + described (`app_name`, `argocd_namespace`, `project`, `repo_url`, `target_revision`, `chart_path`, `helm_value_files`, `helm_set_values`, `destination_server`, `destination_namespace`, `sync_wave`, `automated_sync`/`auto_prune`/`self_heal`/`create_namespace`, `labels`, plus the `enabled` apply gate).
- `outputs.tf` — `application_name`, `namespace`, `destination_namespace`, `labels`, `enabled` (derived from inputs/locals so they resolve even when gated off).
- `versions.tf` — `required_version = "~> 1.11"`, `hashicorp/kubernetes ~> 2.25` (Terraform, **not** OpenTofu).
- `README.md` — explains the generic wrapper; cites **ADR-0028** (taxonomy) and **ADR-0038** (ML observability / drift).
- `argocd-application.tftest.hcl` — plan-command test, mock kubernetes provider.

## Apply-gated / mock

This is a mock/emulation repo. Cluster mutation is gated:
- `enabled` defaults to **`false`** → resource created via `count = enabled ? 1 : 0`, so a default `plan`/`validate` renders **nothing**.
- `automated_sync` defaults to **`false`** — no ArgoCD auto-sync without explicit human approval.
- **No apply / no sync** from this branch. CI/CD flips `enabled` to `true` on `main` after merge, with human approval.

## ADR-0028 label handling

Catalog units pass taxonomy labels with **underscore** keys (`platform_system`, …) because dotted keys are awkward in HCL map literals. The module normalizes them to the canonical **dotted** K8s label keys (`platform.system`, `platform.component`, `platform.env`, `platform.owner`, `platform.managed-by`, plus the `platform.cluster` extension) on the Application `metadata.labels`. Non-taxonomy keys pass through verbatim.

## Verification

| Step | Result |
|------|--------|
| `terraform fmt -recursive -check` | PASS (clean) |
| `terraform init -backend=false` | PASS (kubernetes v2.38.0) |
| `terraform validate` | PASS — "configuration is valid" |
| `terraform test` (mock kubernetes provider) | **PASS — 3 passed, 0 failed** (gate-off renders nothing; gate-on renders the Application w/ correct kind/identity/destination/source; ADR-0028 labels normalized to dotted keys; sync-wave annotation applied) |
| `checkov -d .` (v3.3.1, framework terraform) | PASS — 0 failed |
| Plan with the unit's exact inputs, gate **off** | PASS — zero resources, "without changing any real infrastructure" |
| `tflint` | not installed in this environment (noted) |

**Source now resolves:** `terraform/modules/argocd-application/main.tf` exists and `${get_repo_root()}/terraform/modules/argocd-application` resolves under the repo root.

> Note: validating the `baremetal-ml-monitoring` unit fully standalone still errors on **dependency-graph resolution** (`../talos-cluster`, `../baremetal-rook-ceph` are wired in the live dc/env tree, not present as sibling catalog units). That is a **pre-existing** condition unrelated to this PR and documented in the unit's own header — it is *not* the missing-module-source error this PR fixes. The module interface is proven satisfied by a direct `terraform plan` using the unit's exact `inputs`.

## No secrets

`helm_set_values` carries non-sensitive wiring only (S3 bucket URI, ExternalSecrets `secretStoreRef` *name*). Secret material is sourced in-cluster via Vault/ESO.
