### PR TITLE
fix(opa): wire baremetal/ML taxonomy unit tests into CI + fix rego-v1 parse error

### DIFF
--- a/.github/workflows/conftest-opa.yml
+++ b/.github/workflows/conftest-opa.yml
@@ -40,6 +40,7 @@ env:
   TF_VERSION: "1.14.8"
   TG_VERSION: "1.0.8"
   CONFTEST_VERSION: "0.57.0"
+  OPA_VERSION: "1.17.1"
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -73,6 +74,37 @@ jobs:
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
+
+  # ---------------------------------------------------------------------------
+  # OPA UNIT TESTS — compile + run every tests/opa/*_test.rego on every PR.
+  #
+  # This is dependency-free (no AWS creds, no terragrunt plan) so it ALWAYS runs,
+  # unlike the conftest gate below which is skipped when OIDC is not wired. It is
+  # what actually exercises the rego unit tests (platform_tags_ml_test.rego,
+  # platform_tags_baremetal_test.rego, ...) — `conftest test` only evaluates the
+  # deny rules against a plan and never runs `opa test`, so before this job the
+  # *_test.rego files were never executed in CI (dead tests). `opa check` also
+  # catches rego parse/type errors that would otherwise only surface at conftest
+  # runtime (e.g. a malformed policy silently loading zero rules).
+  # ---------------------------------------------------------------------------
+  opa-unit:
+    name: OPA Unit Tests (opa check + opa test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install OPA
+        run: |
+          curl -sSL "https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}/opa_linux_amd64_static" \
+            -o /usr/local/bin/opa
+          chmod +x /usr/local/bin/opa
+          opa version
+
+      - name: opa check (compile all policies + tests, strict)
+        run: opa check --strict tests/opa/
+
+      - name: opa test (run all rego unit tests)
+        run: opa test tests/opa/ -v
 
   # ---------------------------------------------------------------------------
   # OPA policy evaluation — one job per changed Terragrunt unit
@@ -264,12 +296,16 @@ jobs:
   # ---------------------------------------------------------------------------
   opa-status:
     name: OPA Policy Status
-    needs: [detect-changes, opa-check]
+    needs: [detect-changes, opa-unit, opa-check]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check OPA results
         run: |
+          if [ "${{ needs.opa-unit.result }}" = "failure" ]; then
+            echo "OPA unit tests (opa check / opa test) failed"
+            exit 1
+          fi
           if [ "${{ needs.opa-check.result }}" = "failure" ]; then
             echo "OPA policy violations found in one or more modules"
             exit 1

--- a/tests/opa/no_unrestricted_sg_ingress.rego
+++ b/tests/opa/no_unrestricted_sg_ingress.rego
@@ -21,10 +21,12 @@ _is_unrestricted_cidr(cidr_blocks) if {
   c in _open_cidrs
 }
 
-# Skip HTTPS (443) — legitimate for public-facing load balancers
-_is_sensitive_port(from_port, to_port) if {
-  not (from_port <= 443; 443 <= to_port; from_port == to_port)
-  true
+# HTTPS-only carve-out: a rule scoped exactly to port 443 is a legitimate
+# public load-balancer listener and is exempt. Rego v1 forbids multi-expression
+# `not (a; b)`, so the AND lives in this helper and the deny rules negate it.
+_is_https_only(from_port, to_port) if {
+  from_port == 443
+  to_port == 443
 }
 
 # aws_security_group — inline ingress blocks
@@ -38,7 +40,7 @@ deny contains msg if {
   _is_unrestricted_cidr(object.get(rule, "cidr_blocks", []))
   from_port := object.get(rule, "from_port", 0)
   to_port := object.get(rule, "to_port", 65535)
-  not (from_port == 443; to_port == 443)
+  not _is_https_only(from_port, to_port)
   msg := sprintf(
     "POLICY VIOLATION [sg-unrestricted-ingress]: resource %q has unrestricted ingress on ports %d-%d from 0.0.0.0/0 or ::/0",
     [addr, from_port, to_port],
@@ -56,7 +58,7 @@ deny contains msg if {
   _is_unrestricted_cidr(object.get(rule, "ipv6_cidr_blocks", []))
   from_port := object.get(rule, "from_port", 0)
   to_port := object.get(rule, "to_port", 65535)
-  not (from_port == 443; to_port == 443)
+  not _is_https_only(from_port, to_port)
   msg := sprintf(
     "POLICY VIOLATION [sg-unrestricted-ingress-ipv6]: resource %q has unrestricted IPv6 ingress on ports %d-%d",
     [addr, from_port, to_port],
@@ -74,7 +76,7 @@ deny contains msg if {
   _is_unrestricted_cidr(object.get(rc.change.after, "cidr_blocks", []))
   from_port := object.get(rc.change.after, "from_port", 0)
   to_port := object.get(rc.change.after, "to_port", 65535)
-  not (from_port == 443; to_port == 443)
+  not _is_https_only(from_port, to_port)
   msg := sprintf(
     "POLICY VIOLATION [sg-rule-unrestricted-ingress]: resource %q allows unrestricted ingress on ports %d-%d",
     [addr, from_port, to_port],
@@ -92,7 +94,7 @@ deny contains msg if {
   cidr in _open_cidrs
   from_port := object.get(rc.change.after, "from_port", 0)
   to_port := object.get(rc.change.after, "to_port", 65535)
-  not (from_port == 443; to_port == 443)
+  not _is_https_only(from_port, to_port)
   msg := sprintf(
     "POLICY VIOLATION [vpc-sg-unrestricted-ingress]: resource %q allows unrestricted ingress on ports %d-%d",
     [addr, from_port, to_port],


### PR DESCRIPTION
## Summary

Closes OPA / ADR-0028 enforcement gaps. Investigated two questions; one was already covered, two were genuine gaps.

### (a) AWS GPU/ML coverage — ALREADY CLOSED (no extension needed)
`tests/opa/platform_tags_ml.rego` (+ `platform_tags_ml_test.rego`, 7 tests) already enforces the `platform:system/component/owner` taxonomy on the net-new `aws-eks-gpu-*` / `aws-ml-*` / `aws-eks-efa-fabric` / `aws-eks-inference-gateway` estate via an explicit ALLOW-LIST of resource types, plus an ABAC floor on ML-estate IAM policies (ADR-0028 `aws:ResourceTag/platform:system == aws:PrincipalTag/platform:system`). No taxonomy gap remained for those types.

### (b) GAP 1 — the rego unit tests were DEAD in CI
`conftest-opa.yml` only ran `conftest test` against a Terraform plan (and that step is **skipped** whenever OIDC / `TERRAFORM_PLAN_ROLE_ARN` is not wired). No workflow ever ran `opa test`. So the unit tests — `platform_tags_ml_test.rego` **and** `platform_tags_baremetal_test.rego` (the `talos_*` profile authored by bm-wsE) — were never executed. The baremetal `deny` rules were only loaded opportunistically by conftest; the tests proving they work ran nowhere.

**Fix:** added a dependency-free `opa-unit` job (no AWS creds, no plan) that runs `opa check --strict tests/opa/` + `opa test tests/opa/ -v` on every PR touching `tests/opa/**`, and gated `opa-status` on it.

### GAP 2 — `tests/opa/` did not compile under OPA 1.x
`no_unrestricted_sg_ingress.rego` had an unused `_is_sensitive_port` helper and four `not (a; b)` multi-expression negations — all invalid in Rego v1 (`import rego.v1` / OPA 1.x). `opa check tests/opa/` failed to load the entire policy set on the first parse error. Replaced with a negated `_is_https_only` helper; the port-443 carve-out semantics are unchanged.

## Verification
- `opa check --strict tests/opa/` — clean
- `opa test tests/opa/` — **18/18 PASS** (7 ML + 11 baremetal)
- `yamllint .github/workflows/conftest-opa.yml` — exit 0 (repo config)

## Apply-gated / mock
No infra applied. CI-only change (workflow + policy). Draft PR, base `main`, not merged.