### PR TITLE
fix(aws-wsA): bound EPP resources + securityContext + Gateway TLS-mode + WAF validation

### DIFF
--- a/apps/infra/aws-eks-inference-gateway/templates/endpoint-picker.yaml
+++ b/apps/infra/aws-eks-inference-gateway/templates/endpoint-picker.yaml
@@ -28,6 +28,10 @@ spec:
         app: {{ .Values.inferencePool.name }}-epp
         {{- include "aws-eks-inference-gateway.labels" . | nindent 8 }}
     spec:
+      # Pod-level hardening (ADR-0047): run as the unprivileged nobody user, never root.
+      securityContext:
+        runAsNonRoot: {{ .Values.endpointPicker.podSecurityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.endpointPicker.podSecurityContext.runAsUser }}
       containers:
         - name: epp
           image: {{ .Values.endpointPicker.image }}
@@ -40,6 +44,18 @@ spec:
           env:
             - name: INFERENCE_CRD_VERSION
               value: {{ .Values.inferenceExtension.crdVersion | quote }}
+          # Bound the ext-proc (no unbounded Deployment): requests so the scheduler can
+          # place it, a hard memory cap so it cannot OOM-pressure the node.
+          resources:
+            {{- toYaml .Values.endpointPicker.resources | nindent 12 }}
+          # Container-level hardening: no privilege escalation, read-only rootfs,
+          # drop every Linux capability.
+          securityContext:
+            allowPrivilegeEscalation: {{ .Values.endpointPicker.containerSecurityContext.allowPrivilegeEscalation }}
+            readOnlyRootFilesystem: {{ .Values.endpointPicker.containerSecurityContext.readOnlyRootFilesystem }}
+            capabilities:
+              drop:
+                {{- toYaml .Values.endpointPicker.containerSecurityContext.capabilities.drop | nindent 16 }}
 ---
 apiVersion: v1
 kind: Service

--- a/apps/infra/aws-eks-inference-gateway/values.yaml
+++ b/apps/infra/aws-eks-inference-gateway/values.yaml
@@ -18,6 +18,9 @@ gateway:
   className: envoy-gateway
   name: vllm-inference-gateway
   listenerPort: 80
+  # TLS terminates at the WAF/ALB in front of Envoy (ADR-0047 D4) — the listener above
+  # stays HTTP on the trusted in-cluster hop. Mirrors the module's var.tls_mode.
+  tlsMode: terminate-at-lb
 
 # ---------------------------------------------------------------------------
 # Gateway API Inference Extension (v1 GA CRDs — pinned, ADR-0047 D1)
@@ -49,6 +52,26 @@ endpointPicker:
   config:
     kvCacheWeight: "1.0"
     queueDepthWeight: "1.0"
+  # Bound the ext-proc: requests so the scheduler can place it, a hard memory cap so it
+  # cannot OOM-pressure the node. CPU is request-only (no limit) to avoid throttling
+  # latency-sensitive routing.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  # Pod-level hardening: run as the unprivileged nobody user, never root.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+  # Container-level hardening: no privilege escalation, read-only rootfs, drop all caps.
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
 
 # ---------------------------------------------------------------------------
 # AWS WAF (ADR-0047 D4) — the reused `waf` module's WebACL, bound to the upstream LB.

--- a/terraform/modules/aws-eks-inference-gateway/aws-eks-inference-gateway.tftest.hcl
+++ b/terraform/modules/aws-eks-inference-gateway/aws-eks-inference-gateway.tftest.hcl
@@ -11,10 +11,18 @@ variables {
     "platform.env"   = "staging"
     "platform.owner" = "team-ml-platform"
   }
+  # When enabled the WAF WebACL ARN is required (ADR-0047 D4 validation). Provided here so
+  # the enabled runs below satisfy the variable validation; the default-OFF run omits it.
+  waf_web_acl_arn = "arn:aws:wafv2:eu-west-1:111122223333:regional/webacl/inference/abc"
 }
 
 run "default_off_creates_nothing" {
   command = plan
+
+  variables {
+    # default-OFF must hold even with no WAF ARN (validation only bites when enabled).
+    waf_web_acl_arn = ""
+  }
 
   assert {
     condition     = length(kubernetes_manifest.gateway) == 0
@@ -60,6 +68,57 @@ run "creates_gateway_pool_route_epp" {
   }
 }
 
+run "epp_is_bound_and_hardened" {
+  command = plan
+
+  variables {
+    enabled = true
+  }
+
+  # HIGH: the EPP Deployment must be bound — requests + a memory limit, no unbounded ext-proc.
+  assert {
+    condition     = kubernetes_deployment.epp[0].spec[0].template[0].spec[0].container[0].resources[0].requests.cpu == "100m"
+    error_message = "EPP must declare a CPU request (default 100m) — no unbounded Deployment."
+  }
+
+  assert {
+    condition     = kubernetes_deployment.epp[0].spec[0].template[0].spec[0].container[0].resources[0].requests.memory == "128Mi"
+    error_message = "EPP must declare a memory request (default 128Mi)."
+  }
+
+  assert {
+    condition     = kubernetes_deployment.epp[0].spec[0].template[0].spec[0].container[0].resources[0].limits.memory == "256Mi"
+    error_message = "EPP must declare a memory limit (default 256Mi) so it cannot OOM-pressure the node."
+  }
+
+  # MED: pod-level securityContext — non-root nobody user.
+  assert {
+    condition     = kubernetes_deployment.epp[0].spec[0].template[0].spec[0].security_context[0].run_as_non_root == true
+    error_message = "EPP pod must run as non-root."
+  }
+
+  assert {
+    condition     = kubernetes_deployment.epp[0].spec[0].template[0].spec[0].security_context[0].run_as_user == "65534"
+    error_message = "EPP pod must run as uid 65534 (nobody)."
+  }
+
+  # MED: container-level securityContext — no escalation, read-only rootfs, drop ALL caps.
+  assert {
+    condition     = kubernetes_deployment.epp[0].spec[0].template[0].spec[0].container[0].security_context[0].allow_privilege_escalation == false
+    error_message = "EPP container must not allow privilege escalation."
+  }
+
+  assert {
+    condition     = kubernetes_deployment.epp[0].spec[0].template[0].spec[0].container[0].security_context[0].read_only_root_filesystem == true
+    error_message = "EPP container must use a read-only root filesystem."
+  }
+
+  assert {
+    condition     = contains(kubernetes_deployment.epp[0].spec[0].template[0].spec[0].container[0].security_context[0].capabilities[0].drop, "ALL")
+    error_message = "EPP container must drop ALL Linux capabilities."
+  }
+}
+
 run "inference_objective_per_entry_v1ga" {
   command = plan
 
@@ -95,6 +154,25 @@ run "waf_annotation_when_provided" {
     condition     = kubernetes_manifest.gateway[0].manifest.metadata.annotations["platform.aws/waf-web-acl-arn"] != ""
     error_message = "WAF WebACL ARN must be surfaced on the Gateway when provided (ADR-0047 D4)."
   }
+
+  # MED: TLS terminates at the WAF/ALB before Envoy (ADR-0047 D4); default tls_mode surfaced.
+  assert {
+    condition     = kubernetes_manifest.gateway[0].manifest.metadata.annotations["platform.aws/tls-mode"] == "terminate-at-lb"
+    error_message = "Gateway must record tls_mode = terminate-at-lb (TLS terminates at the WAF/ALB, ADR-0047 D4)."
+  }
+}
+
+run "waf_required_when_enabled" {
+  command = plan
+
+  variables {
+    enabled         = true
+    waf_web_acl_arn = ""
+  }
+
+  expect_failures = [
+    var.waf_web_acl_arn,
+  ]
 }
 
 run "epp_can_be_disabled" {

--- a/terraform/modules/aws-eks-inference-gateway/main.tf
+++ b/terraform/modules/aws-eks-inference-gateway/main.tf
@@ -10,6 +10,9 @@
 #   * EPP (Deployment+Service) — the Endpoint Picker ext-proc, deployed EXPLICITLY
 #     (the gateway does NOT install it — ADR-0047 D2, named deliverable).
 #
+# TLS terminates at the WAF/ALB in front of Envoy (var.tls_mode = terminate-at-lb,
+# ADR-0047 D4); the Gateway listener stays HTTP on the trusted in-cluster hop.
+#
 # AWS WAF (ADR-0047 D4) is the reused `waf` module's WebACL; its ARN is wired here and
 # associated with the serving LB by the catalog unit. Default-OFF (var.enabled) keeps
 # the vLLM ClusterIP path until the gateway is canary-proven (ADR-0047 D5, revertible).
@@ -31,9 +34,11 @@ locals {
   )
 
   # AWS WAF binds to the upstream LB fronting Envoy (D4); surfaced as a Gateway
-  # annotation so the LBC/association layer can pick it up.
+  # annotation so the LBC/association layer can pick it up. The same LB terminates
+  # TLS (var.tls_mode = terminate-at-lb), so the Gateway listener below stays HTTP.
   gateway_annotations = var.waf_web_acl_arn != "" ? {
     "platform.aws/waf-web-acl-arn" = var.waf_web_acl_arn
+    "platform.aws/tls-mode"        = var.tls_mode
   } : {}
 
   deploy_epp = var.enabled && var.deploy_epp
@@ -206,6 +211,12 @@ resource "kubernetes_deployment" "epp" {
         })
       }
       spec {
+        # Pod-level hardening (MED): run as the unprivileged nobody user, never root.
+        security_context {
+          run_as_non_root = true
+          run_as_user     = 65534
+        }
+
         container {
           name  = "epp"
           image = var.epp_image
@@ -223,6 +234,30 @@ resource "kubernetes_deployment" "epp" {
           env {
             name  = "INFERENCE_CRD_VERSION"
             value = var.inference_crd_version
+          }
+
+          # Bound the ext-proc (HIGH): requests so the scheduler can place it, a hard
+          # memory cap so it cannot OOM-pressure the node. CPU is request-only to
+          # avoid throttling latency-sensitive routing.
+          resources {
+            requests = {
+              cpu    = var.epp_cpu_request
+              memory = var.epp_memory_request
+            }
+            limits = {
+              memory = var.epp_memory_limit
+            }
+          }
+
+          # Container-level hardening (MED): no privilege escalation, read-only rootfs,
+          # drop every Linux capability.
+          security_context {
+            allow_privilege_escalation = false
+            read_only_root_filesystem  = true
+
+            capabilities {
+              drop = ["ALL"]
+            }
           }
         }
       }

--- a/terraform/modules/aws-eks-inference-gateway/variables.tf
+++ b/terraform/modules/aws-eks-inference-gateway/variables.tf
@@ -38,6 +38,17 @@ variable "gateway_name" {
   default     = "vllm-inference-gateway"
 }
 
+variable "tls_mode" {
+  description = "Where TLS terminates for the serving front (ADR-0047 D4). 'terminate-at-lb' (default) means TLS is terminated at the AWS WAF/ALB in front of Envoy — the Gateway listener stays HTTP on the trusted in-cluster hop, and the Gateway does not re-terminate. 'passthrough' carries TLS to the data plane."
+  type        = string
+  default     = "terminate-at-lb"
+
+  validation {
+    condition     = contains(["terminate-at-lb", "passthrough"], var.tls_mode)
+    error_message = "tls_mode must be 'terminate-at-lb' (TLS terminates at the WAF/ALB before Envoy, ADR-0047 D4) or 'passthrough'."
+  }
+}
+
 variable "hostnames" {
   description = "HTTPRoute hostnames. Empty matches all."
   type        = list(string)
@@ -99,6 +110,27 @@ variable "epp_replicas" {
   default     = 2
 }
 
+variable "epp_cpu_request" {
+  description = "EPP container CPU request. The EPP ext-proc must be bound (no unbounded Deployment) so the scheduler can place it and it cannot starve co-tenants."
+  type        = string
+  default     = "100m"
+  nullable    = false
+}
+
+variable "epp_memory_request" {
+  description = "EPP container memory request — the scheduling floor for the bound ext-proc."
+  type        = string
+  default     = "128Mi"
+  nullable    = false
+}
+
+variable "epp_memory_limit" {
+  description = "EPP container memory limit. A hard memory cap prevents the ext-proc from OOM-pressuring the node; CPU is left request-only (no CPU limit) to avoid throttling latency-sensitive routing."
+  type        = string
+  default     = "256Mi"
+  nullable    = false
+}
+
 variable "epp_config" {
   description = "EPP routing weights (KV-cache utilisation, queue depth) — turns model-server metrics into routing decisions (ADR-0047 D1)."
   type        = map(string)
@@ -110,9 +142,14 @@ variable "epp_config" {
 }
 
 variable "waf_web_acl_arn" {
-  description = "AWS WAF WebACL ARN (from the reused `waf` module, ADR-0047 D4) associated with the serving LB. Empty leaves the gateway without WAF (surface a warning in review)."
+  description = "AWS WAF WebACL ARN (from the reused `waf` module, ADR-0047 D4) associated with the serving LB. When the module is enabled this must be non-empty — the serving front is not exposed without a WebACL."
   type        = string
   default     = ""
+
+  validation {
+    condition     = !var.enabled || var.waf_web_acl_arn != ""
+    error_message = "waf_web_acl_arn must be set when enabled = true — the inference-gateway serving front must sit behind a WAF WebACL (ADR-0047 D4)."
+  }
 }
 
 variable "platform_labels" {


### PR DESCRIPTION
## Deferred review fixes — aws-eks-inference-gateway (WS-A, ADR-0047)

Applies the deferred review findings to `terraform/modules/aws-eks-inference-gateway` and its GitOps companion chart `apps/infra/aws-eks-inference-gateway`. **Apply-gated / default-OFF** — `enabled = false`, no apply run.

### Findings addressed
- **HIGH — unbounded EPP Deployment.** The Endpoint Picker (EPP) ext-proc had no resource requests/limits, so the scheduler could not place it and it could starve co-tenants. Added requests (cpu/mem) + a memory limit via new typed vars `epp_cpu_request` (`100m`) / `epp_memory_request` (`128Mi`) / `epp_memory_limit` (`256Mi`), wired into **both** the TF `kubernetes_deployment.epp` (`main.tf`) **and** the helm `templates/endpoint-picker.yaml` (+ `values.yaml` `endpointPicker.resources`). CPU is request-only (no CPU limit) to avoid throttling latency-sensitive routing.
- **MED — EPP securityContext.** Added in both TF + helm: pod `runAsNonRoot=true`, `runAsUser=65534`; container `allowPrivilegeEscalation=false`, `readOnlyRootFilesystem=true`, `capabilities.drop=[ALL]`.
- **MED — Gateway TLS mode.** Added typed var `tls_mode` (default `terminate-at-lb`) documenting per ADR-0047 D4 that TLS terminates at the WAF/ALB in front of Envoy; surfaced as a Gateway annotation + mirrored in `values.yaml` `gateway.tlsMode`.
- **MED/LOW — WAF validation.** `waf_web_acl_arn` now has `condition = !var.enabled || var.waf_web_acl_arn != ""` — the serving front cannot be enabled without a WebACL (ADR-0047 D4).

### Verification
- `terraform fmt -recursive` — clean
- `terraform init -backend=false && terraform validate` — Success, configuration valid
- `terraform test` — **7 passed, 0 failed** (mocked kubernetes provider). Updated `aws-eks-inference-gateway.tftest.hcl`: new enabled runs carry the required WAF ARN, added `epp_is_bound_and_hardened` (resources + pod/container securityContext), `waf_required_when_enabled` (`expect_failures` on the new validation), and a `tls-mode` annotation assertion.
- `checkov -d .` — 25 passed / 5 failed; the targeted checks now pass (read-only fs CKV_K8S_22, no priv-esc CKV_K8S_20, drop caps CKV_K8S_37, pod security context CKV_K8S_29). Remaining 5 are out-of-scope/pre-existing (readiness/liveness probes, image-digest pin, CPU limit — intentionally request-only).
- `helm template --set enabled=true` — renders bounded resources + securityContext correctly.
- `tflint` not installed in this environment.

### Risk / rollback
Default-OFF; plan/validate create nothing. No state mutation. Rollback: revert this branch — the EPP module returns to its prior (unbounded) shape. **Do not merge** (apply-gated mock repo).