### PR TITLE
fix(baremetal): review-nit fixes (rgw output, mock drift, BGP validation)

### DIFF
--- a/catalog/units/baremetal-ml-monitoring/terragrunt.hcl
+++ b/catalog/units/baremetal-ml-monitoring/terragrunt.hcl
@@ -52,9 +52,9 @@ dependency "talos_cluster" {
   config_path = "../talos-cluster"
 
   mock_outputs = {
-    kubeconfig_path  = "/dev/null"
+    # Keys MUST match the real talos-cluster outputs.tf (kubeconfig, cluster_endpoint).
+    kubeconfig       = "mock-kubeconfig"
     cluster_endpoint = "https://mock-talos-endpoint.internal:6443"
-    cluster_ca_cert  = "mock-ca-cert-base64"
   }
 
   mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
@@ -68,7 +68,8 @@ dependency "baremetal_rook_ceph" {
   config_path = "../baremetal-rook-ceph"
 
   mock_outputs = {
-    rgw_s3_endpoint = "http://mock-rook-rgw.rook-ceph.svc.cluster.local:80"
+    # Keys MUST match the real baremetal-rook-ceph outputs.tf (s3_endpoint, rgw_bucket_name).
+    s3_endpoint     = "http://mock-rook-rgw.rook-ceph.svc.cluster.local:80"
     rgw_bucket_name = "ml-reference-data"
   }
 

--- a/terraform/modules/baremetal-cilium-lb/baremetal-cilium-lb.tftest.hcl
+++ b/terraform/modules/baremetal-cilium-lb/baremetal-cilium-lb.tftest.hcl
@@ -94,3 +94,14 @@ run "bgp_off_falls_back_to_lb_only" {
     error_message = "LB-IPAM pool must still exist in the BGP-off fallback path."
   }
 }
+
+run "bgp_hold_timer_floor_enforced" {
+  command = plan
+
+  variables {
+    # Below the 90s floor → must fail (sessions drop under GPU load, cilium-bgp-issues runbook).
+    bgp_hold_time_seconds = 60
+  }
+
+  expect_failures = [var.bgp_hold_time_seconds]
+}

--- a/terraform/modules/baremetal-cilium-lb/variables.tf
+++ b/terraform/modules/baremetal-cilium-lb/variables.tf
@@ -89,6 +89,11 @@ variable "bgp_hold_time_seconds" {
   description = "BGP hold timer. Raised (180s) per cilium-bgp-issues.md so sessions survive CPU pressure on GPU nodes."
   type        = number
   default     = 180
+
+  validation {
+    condition     = var.bgp_hold_time_seconds >= 90
+    error_message = "BGP hold timer must be >= 90s to avoid session drops under GPU load (see cilium-bgp-issues runbook)."
+  }
 }
 
 variable "bgp_keepalive_time_seconds" {

--- a/terraform/modules/baremetal-rook-ceph/baremetal-rook-ceph.tftest.hcl
+++ b/terraform/modules/baremetal-rook-ceph/baremetal-rook-ceph.tftest.hcl
@@ -30,6 +30,11 @@ run "disabled_creates_nothing" {
     condition     = length(kubernetes_manifest.ceph_cluster) == 0
     error_message = "No CephCluster when enabled = false."
   }
+
+  assert {
+    condition     = output.rgw_bucket_name == null
+    error_message = "rgw_bucket_name must be null when the object store is not deployed."
+  }
 }
 
 run "deploys_ceph_block_and_object" {
@@ -54,6 +59,12 @@ run "deploys_ceph_block_and_object" {
   assert {
     condition     = output.s3_endpoint != null
     error_message = "An S3 endpoint must be surfaced when the object store is enabled."
+  }
+
+  # rgw_bucket_name is consumed by baremetal-ml-monitoring (driftExporter.referenceBucketUri, ADR-0038).
+  assert {
+    condition     = output.rgw_bucket_name == var.object_store_name
+    error_message = "rgw_bucket_name must surface the object-store name when the object store is enabled (consumed by ml-monitoring)."
   }
 }
 

--- a/terraform/modules/baremetal-rook-ceph/outputs.tf
+++ b/terraform/modules/baremetal-rook-ceph/outputs.tf
@@ -23,6 +23,11 @@ output "s3_endpoint" {
   value       = local.deploy_object_store ? "http://rook-ceph-rgw-${var.object_store_name}.${var.namespace}.svc:${var.rgw_port}" : null
 }
 
+output "rgw_bucket_name" {
+  description = "Name of the Ceph-RGW object store / bucket (null when the object store is disabled). Consumed by baremetal-ml-monitoring (driftExporter.referenceBucketUri, ADR-0038) and other WS-B/WS-C units."
+  value       = local.deploy_object_store ? var.object_store_name : null
+}
+
 output "block_pool_replicas" {
   description = "Replication factor of the Ceph pools."
   value       = var.block_pool_replicas


### PR DESCRIPTION
## Summary

Second-round review-nit fixes for the bare-metal Talos ML platform. All changes are scoped, apply-gated (default-OFF preserved), and verified with `terraform validate` + native `terraform test`.

## Findings addressed

### 1. HIGH — missing output (would fail a live plan)
`catalog/units/baremetal-ml-monitoring/terragrunt.hcl` (line 114) consumes
`dependency.baremetal_rook_ceph.outputs.rgw_bucket_name` in its LIVE `helm_set_values`
(`driftExporter.referenceBucketUri = "s3://${...rgw_bucket_name}"`), but
`terraform/modules/baremetal-rook-ceph` exposed no such output — only `s3_endpoint`,
with `object_store_name` being a variable. A live (non-mock) plan would have failed to
resolve the reference.

**Fix:** added `output "rgw_bucket_name"` = `local.deploy_object_store ? var.object_store_name : null`
(null when the object store is disabled, consistent with `s3_endpoint`). The unit reference
now resolves against a real output.

### 2. MEDIUM — mock_outputs drift
In the same unit, `mock_outputs` did not match the real upstream output names:
- `talos_cluster`: declared `kubeconfig_path` + `cluster_ca_cert`; the real
  `terraform/modules/talos-cluster` outputs `kubeconfig` and has no `cluster_ca_cert`.
  → renamed `kubeconfig_path` → `kubeconfig`, dropped `cluster_ca_cert`
  (preferred matching mocks to reality over adding an unused real output).
- `baremetal_rook_ceph`: declared `rgw_s3_endpoint`; the real output is `s3_endpoint`.
  → renamed `rgw_s3_endpoint` → `s3_endpoint`.

All mock keys now mirror the real `outputs.tf` of each dependency.

### 3. MEDIUM — BGP hold-timer had no floor
`terraform/modules/baremetal-cilium-lb` `bgp_hold_time_seconds` (default 180) had no
validation. Added `validation { condition = var.bgp_hold_time_seconds >= 90 }` with the
cilium-bgp-issues runbook rationale (sessions drop under GPU load below the floor).

## Tests

- **baremetal-rook-ceph.tftest.hcl** — added two assertions for the new output:
  `rgw_bucket_name == var.object_store_name` (enabled path) and `== null` (disabled path).
- **baremetal-cilium-lb.tftest.hcl** — added `bgp_hold_timer_floor_enforced` run asserting
  a below-floor value (60s) fails the plan via `expect_failures`.

## Verification (apply-gated — no apply / plan-against-real-state run)

`terraform fmt -recursive` clean. Per changed module: `init -backend=false` → `validate` → `test`.

| Module | validate | test |
|--------|----------|------|
| baremetal-rook-ceph | Success | 5 passed, 0 failed |
| baremetal-cilium-lb | Success | 6 passed, 0 failed |
| talos-cluster (mocks aligned to it; module unchanged) | Success | 5 passed, 0 failed |

## Notes

- **Lock-file review finding is MOOT.** `.terraform.lock.hcl` is gitignored repo-wide
  (`.gitignore` line 12 — intentional repo policy), so it cannot and should not be committed.
  This is also the root cause of the pre-existing `hetzner-nodes` CI flake — a repo-policy
  artifact, not a defect introduced here.
- Apply gate preserved: `never_apply = true` on the unit; module `enabled` defaults remain OFF.
  No `terraform apply` / `helm install` / `kubectl apply` was run.

**Do not merge** — Draft for review.
