### PR TITLE
fix(aws): review-nit hardening (source paths, IAM/S3-TLS, DCGM)

### DIFF
--- a/catalog/units/aws-ml-abac-iam/terragrunt.hcl
+++ b/catalog/units/aws-ml-abac-iam/terragrunt.hcl
@@ -13,7 +13,7 @@
 # ---------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  source = "${get_repo_root()}/project/platform-design/terraform/modules/aws-ml-abac-iam"
+  source = "${get_repo_root()}/terraform/modules/aws-ml-abac-iam"
 }
 
 locals {

--- a/catalog/units/aws-ml-scp-parity/terragrunt.hcl
+++ b/catalog/units/aws-ml-scp-parity/terragrunt.hcl
@@ -11,7 +11,7 @@
 # ---------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  source = "${get_repo_root()}/project/platform-design/terraform/modules/aws-ml-scp-parity"
+  source = "${get_repo_root()}/terraform/modules/aws-ml-scp-parity"
 }
 
 locals {

--- a/project/PROJECT_HISTORY.md
+++ b/project/PROJECT_HISTORY.md
@@ -1,0 +1,28 @@
+# Project History
+
+Auto-generated activity log. Newest entries at the bottom.
+
+
+---
+## [2026-06-15 19:42:33] terraform-engineer: 2nd-round AWS review-nit hardening
+
+**Action**: implementation
+**Category**: infrastructure
+
+### What Was Done
+Applied three independent 2nd-round review findings on the AWS GPU ML platform (branch fix/aws-review-nits, off main): (1) removed an erroneous /project/platform-design/ segment from the terraform source path in the aws-ml-abac-iam and aws-ml-scp-parity catalog units (broke terragrunt init); (2) in aws-ml-artifact-store converted the inline aws_iam_role_policy to a standalone aws_iam_policy + aws_iam_role_policy_attachment (CIS AWS 1.16) and added an aws_s3_bucket_policy with a DenyInsecureTransport statement (CIS AWS 2.1.1), keeping the public-access block; (3) hardened the aws-eks-gpu-dcgm auto-taint CronJob container with a restricted security_context (run_as_non_root, read_only_root_filesystem, no priv-esc, drop ALL caps) plus pod-level non-root/seccomp and var-driven resource requests/limits. Updated both modules' tftest.hcl with assertions for the new resources.
+
+### Reasoning
+Source-path bug was a real terragrunt init breaker (old path absent on disk). IAM/S3-TLS and CronJob hardening close CIS gaps flagged in review. Everything stays apply-gated / default-OFF. Did not touch aws-eks-inference-gateway (separate PR).
+
+### Files Changed
+- Modified: catalog/units/aws-ml-abac-iam/terragrunt.hcl, catalog/units/aws-ml-scp-parity/terragrunt.hcl, terraform/modules/aws-ml-artifact-store/main.tf, terraform/modules/aws-ml-artifact-store/aws-ml-artifact-store.tftest.hcl, terraform/modules/aws-eks-gpu-dcgm/main.tf, terraform/modules/aws-eks-gpu-dcgm/variables.tf, terraform/modules/aws-eks-gpu-dcgm/aws-eks-gpu-dcgm.tftest.hcl
+
+### Outcome
+✅ Completed - fmt clean; artifact-store test 20/20, dcgm test 6/6; checkov dcgm 5/0, artifact-store 10/1 (the 1 = pre-existing CKV2_AWS_62 S3 event-notifications, out of scope); source paths resolve. Draft PR opened, not merged.
+
+### Follow-up
+- [ ] Reviewer merge after CI (tflint runs in CI; not installed locally)
+
+**Tags**: #aws #terraform #cis #iam #s3 #dcgm #review-fixes #apply-gated
+---

--- a/project/project_history.json
+++ b/project/project_history.json
@@ -1,0 +1,48 @@
+{
+  "project": "platform-design",
+  "entries": [
+    {
+      "id": "20260615-194244-terraform_engineer",
+      "timestamp": "2026-06-15T19:42:44Z",
+      "agent": "terraform-engineer",
+      "action": {
+        "type": "implementation",
+        "description": "2nd-round AWS review-nit hardening: unit source paths, artifact-store IAM/S3-TLS, DCGM CronJob hardening"
+      },
+      "context": {
+        "task": "Apply 2nd-round review fixes to AWS GPU ML platform (mock repo 100rd/platform-design)",
+        "category": "infrastructure"
+      },
+      "files": {
+        "created": [],
+        "modified": [
+          "catalog/units/aws-ml-abac-iam/terragrunt.hcl",
+          "catalog/units/aws-ml-scp-parity/terragrunt.hcl",
+          "terraform/modules/aws-ml-artifact-store/main.tf",
+          "terraform/modules/aws-ml-artifact-store/aws-ml-artifact-store.tftest.hcl",
+          "terraform/modules/aws-eks-gpu-dcgm/main.tf",
+          "terraform/modules/aws-eks-gpu-dcgm/variables.tf",
+          "terraform/modules/aws-eks-gpu-dcgm/aws-eks-gpu-dcgm.tftest.hcl"
+        ],
+        "deleted": []
+      },
+      "outcome": {
+        "status": "completed",
+        "summary": "fmt clean; artifact-store 20/20, dcgm 6/6 tests; checkov dcgm 5/0, artifact-store 10/1 (pre-existing CKV2_AWS_62 out of scope); source paths resolve; Draft PR opened not merged"
+      },
+      "follow_up": [
+        "Reviewer merge after CI"
+      ],
+      "tags": [
+        "aws",
+        "terraform",
+        "cis",
+        "iam",
+        "s3",
+        "dcgm",
+        "review-fixes",
+        "apply-gated"
+      ]
+    }
+  ]
+}

--- a/terraform/modules/aws-eks-gpu-dcgm/aws-eks-gpu-dcgm.tftest.hcl
+++ b/terraform/modules/aws-eks-gpu-dcgm/aws-eks-gpu-dcgm.tftest.hcl
@@ -82,3 +82,59 @@ run "namespace_adr0028_labels" {
     error_message = "platform.component must be gpu-dcgm."
   }
 }
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Auto-taint CronJob container hardening (CIS K8s 5.2.x / Pod Security "restricted")
+# Path: spec -> job_template -> spec -> template -> spec -> container[0]
+# ---------------------------------------------------------------------------------------------------------------------
+
+run "auto_taint_container_security_context" {
+  command = plan
+
+  variables {
+    enabled = true
+  }
+
+  assert {
+    condition     = kubernetes_cron_job_v1.taint[0].spec[0].job_template[0].spec[0].template[0].spec[0].container[0].security_context[0].run_as_non_root == true
+    error_message = "Auto-taint container must set run_as_non_root = true."
+  }
+
+  assert {
+    condition     = kubernetes_cron_job_v1.taint[0].spec[0].job_template[0].spec[0].template[0].spec[0].container[0].security_context[0].read_only_root_filesystem == true
+    error_message = "Auto-taint container must set read_only_root_filesystem = true."
+  }
+
+  assert {
+    condition     = kubernetes_cron_job_v1.taint[0].spec[0].job_template[0].spec[0].template[0].spec[0].container[0].security_context[0].allow_privilege_escalation == false
+    error_message = "Auto-taint container must set allow_privilege_escalation = false."
+  }
+
+  assert {
+    condition     = contains(kubernetes_cron_job_v1.taint[0].spec[0].job_template[0].spec[0].template[0].spec[0].container[0].security_context[0].capabilities[0].drop, "ALL")
+    error_message = "Auto-taint container must drop ALL Linux capabilities."
+  }
+}
+
+run "auto_taint_container_resources_bounded" {
+  command = plan
+
+  variables {
+    enabled = true
+  }
+
+  assert {
+    condition     = kubernetes_cron_job_v1.taint[0].spec[0].job_template[0].spec[0].template[0].spec[0].container[0].resources[0].requests["cpu"] == "50m"
+    error_message = "Auto-taint container must declare a CPU request (default 50m)."
+  }
+
+  assert {
+    condition     = kubernetes_cron_job_v1.taint[0].spec[0].job_template[0].spec[0].template[0].spec[0].container[0].resources[0].requests["memory"] == "64Mi"
+    error_message = "Auto-taint container must declare a memory request (default 64Mi)."
+  }
+
+  assert {
+    condition     = kubernetes_cron_job_v1.taint[0].spec[0].job_template[0].spec[0].template[0].spec[0].container[0].resources[0].limits["memory"] == "128Mi"
+    error_message = "Auto-taint container must declare a memory limit (default 128Mi) so a wedged probe cannot starve the node."
+  }
+}

--- a/terraform/modules/aws-eks-gpu-dcgm/main.tf
+++ b/terraform/modules/aws-eks-gpu-dcgm/main.tf
@@ -176,6 +176,44 @@ resource "kubernetes_cron_job_v1" "taint" {
                 name  = "TEMP_THRESHOLD"
                 value = tostring(var.temperature_threshold)
               }
+
+              # Container hardening — the CronJob only runs kubectl patch, so it
+              # needs no root, no extra Linux capabilities, and no writable root
+              # filesystem (CIS K8s 5.2.x / Pod Security "restricted").
+              security_context {
+                run_as_non_root            = true
+                read_only_root_filesystem  = true
+                allow_privilege_escalation = false
+
+                capabilities {
+                  drop = ["ALL"]
+                }
+              }
+
+              # Bounded footprint so a wedged probe cannot starve the node; memory
+              # request == limit (no overcommit). CPU is left burstable (no CPU
+              # limit) to avoid throttling a short-lived patch job.
+              resources {
+                requests = {
+                  cpu    = var.taint_cpu_request
+                  memory = var.taint_memory_request
+                }
+                limits = {
+                  memory = var.taint_memory_limit
+                }
+              }
+            }
+
+            # Pod-level non-root + seccomp so the run_as_non_root contract is
+            # enforced even if a future container omits its own user.
+            security_context {
+              run_as_non_root = true
+              run_as_user     = 65532 # nonroot (distroless) uid
+              run_as_group    = 65532
+
+              seccomp_profile {
+                type = "RuntimeDefault"
+              }
             }
           }
         }

--- a/terraform/modules/aws-eks-gpu-dcgm/variables.tf
+++ b/terraform/modules/aws-eks-gpu-dcgm/variables.tf
@@ -94,6 +94,31 @@ variable "kubectl_image" {
   default     = "bitnami/kubectl:1.34"
 }
 
+# -------------------------------------------------------------------------
+# Auto-taint CronJob container resources (hardening)
+# The CronJob only runs `kubectl patch` on nodes, so the footprint is tiny.
+# memory request == limit (no overcommit); CPU stays burstable (no CPU limit)
+# so a short-lived patch is not throttled. Override per-env if needed.
+# -------------------------------------------------------------------------
+
+variable "taint_cpu_request" {
+  description = "CPU request for the auto-taint CronJob container (Kubernetes quantity, e.g. '50m'). Small by design — the job only runs kubectl patch."
+  type        = string
+  default     = "50m"
+}
+
+variable "taint_memory_request" {
+  description = "Memory request for the auto-taint CronJob container (Kubernetes quantity, e.g. '64Mi')."
+  type        = string
+  default     = "64Mi"
+}
+
+variable "taint_memory_limit" {
+  description = "Memory limit for the auto-taint CronJob container (Kubernetes quantity, e.g. '128Mi'). Caps the container so a wedged probe cannot starve the node."
+  type        = string
+  default     = "128Mi"
+}
+
 variable "gpu_node_selector" {
   description = "Node selector identifying GPU nodes the exporter DaemonSet runs on."
   type        = map(string)

--- a/terraform/modules/aws-ml-artifact-store/aws-ml-artifact-store.tftest.hcl
+++ b/terraform/modules/aws-ml-artifact-store/aws-ml-artifact-store.tftest.hcl
@@ -4,12 +4,12 @@
 # All runs use command = plan (no real S3 bucket or IAM role is created).
 #
 # Note on IAM policy document assertions:
-# The mlflow_s3_abac data source references aws_s3_bucket.mlflow_artifacts[0].arn
-# which is a computed value unknown at plan time. The trust_policy and s3_abac
-# content is verified structurally via the variable and locals layer instead of
-# by parsing the rendered JSON (which is only available post-apply).
-# The mock_provider provides a realistic JSON for the trust policy data source
-# (which has no computed dependencies) so that assertion CAN fire at plan time.
+# The mlflow_s3_abac and mlflow_bucket_policy data sources reference
+# aws_s3_bucket.mlflow_artifacts[0].arn — a computed value unknown at plan time —
+# so their rendered `json` (and any resource attribute fed by it) is also unknown at
+# plan time and cannot be asserted. Those are verified structurally instead: resource
+# existence via count. The trust-policy data source has no computed inputs, so its
+# mock JSON IS available and CAN be regex-asserted.
 # ---------------------------------------------------------------------------------------------------------------------
 
 mock_provider "aws" {
@@ -21,8 +21,10 @@ mock_provider "aws" {
     }
   }
 
-  # aws_iam_policy_document generates JSON. The trust policy data source
-  # has no computed dependencies so mock_provider can provide its json.
+  # aws_iam_policy_document generates JSON. Only the trust-policy data source has no
+  # computed inputs, so this mock JSON is what its `json` attribute returns at plan
+  # time. (The s3_abac and bucket_policy docs depend on the computed bucket ARN, so
+  # their json stays unknown until apply and is asserted structurally instead.)
   mock_data "aws_iam_policy_document" {
     defaults = {
       json = <<-POLICY
@@ -44,6 +46,14 @@ mock_provider "aws" {
     values = {
       arn  = "arn:aws:iam::123456789012:role/mlflow-artifact-store"
       name = "mlflow-artifact-store"
+    }
+  }
+
+  override_resource {
+    target = aws_iam_policy.mlflow_s3_abac[0]
+    values = {
+      arn  = "arn:aws:iam::123456789012:policy/mlflow-artifact-store-s3-abac"
+      name = "mlflow-artifact-store-s3-abac"
     }
   }
 }
@@ -82,6 +92,16 @@ run "no_resources_when_gate_off" {
     condition     = length(aws_iam_role.mlflow_artifact_store) == 0
     error_message = "No IAM role should be planned when create_resources = false (apply gate)."
   }
+
+  assert {
+    condition     = length(aws_s3_bucket_policy.mlflow_artifacts) == 0
+    error_message = "No bucket policy should be planned when create_resources = false (apply gate)."
+  }
+
+  assert {
+    condition     = length(aws_iam_policy.mlflow_s3_abac) == 0
+    error_message = "No standalone IAM policy should be planned when create_resources = false (apply gate)."
+  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -113,6 +133,29 @@ run "bucket_public_access_fully_blocked" {
   assert {
     condition     = aws_s3_bucket_public_access_block.mlflow_artifacts[0].restrict_public_buckets == true
     error_message = "restrict_public_buckets must be true."
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Bucket policy — DenyInsecureTransport (CIS AWS 2.1.1)
+# The bucket-policy document depends on the computed bucket ARN, so its rendered
+# JSON (and the policy resource's read-back attributes) is unknown at plan time.
+# Verified structurally: both the DenyInsecureTransport policy document and the
+# aws_s3_bucket_policy resource are planned exactly once. (JSON content is verified
+# post-apply.)
+# ---------------------------------------------------------------------------------------------------------------------
+
+run "bucket_policy_denies_insecure_transport" {
+  command = plan
+
+  assert {
+    condition     = length(data.aws_iam_policy_document.mlflow_bucket_policy) == 1
+    error_message = "A DenyInsecureTransport policy document must be rendered for the bucket (CIS AWS 2.1.1)."
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket_policy.mlflow_artifacts) == 1
+    error_message = "A bucket policy must be created to deny insecure (non-TLS) transport (CIS AWS 2.1.1)."
   }
 }
 
@@ -273,13 +316,24 @@ run "abac_platform_system_value_is_ml_pipeline" {
   }
 }
 
-# Verify the IAM role policy resource exists (policy content verified post-apply).
-run "iam_role_policy_attached" {
+# CIS AWS 1.16: the S3/ABAC permissions live in a standalone (managed) IAM policy,
+# not an inline aws_iam_role_policy, so they are discoverable/auditable and reusable.
+run "iam_uses_standalone_managed_policy" {
   command = plan
 
   assert {
-    condition     = aws_iam_role_policy.mlflow_s3_abac[0].name == "mlflow-s3-abac"
-    error_message = "IAM role policy 'mlflow-s3-abac' must be created and attached to the MLflow role (ADR-0048 D2)."
+    condition     = length(aws_iam_policy.mlflow_s3_abac) == 1
+    error_message = "S3/ABAC permissions must be a standalone aws_iam_policy (CIS AWS 1.16), not an inline role policy."
+  }
+
+  assert {
+    condition     = aws_iam_policy.mlflow_s3_abac[0].name == "mlflow-artifact-store-s3-abac"
+    error_message = "Standalone policy name must be derived from the role name (<role>-s3-abac)."
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy_attachment.mlflow_s3_abac) == 1
+    error_message = "The standalone policy must be bound to the MLflow role via aws_iam_role_policy_attachment."
   }
 }
 

--- a/terraform/modules/aws-ml-artifact-store/main.tf
+++ b/terraform/modules/aws-ml-artifact-store/main.tf
@@ -8,16 +8,21 @@
 #   - aws_s3_bucket                              (versioning, SSE-KMS, ADR-0028 tags)
 #   - aws_s3_bucket_ownership_controls           (BucketOwnerEnforced — IAM-only, no ACLs)
 #   - aws_s3_bucket_public_access_block          (all-block)
+#   - aws_s3_bucket_policy                       (DenyInsecureTransport — CIS AWS 2.1.1)
 #   - aws_s3_bucket_server_side_encryption_configuration (SSE-KMS or AES256)
 #   - aws_s3_bucket_versioning                   (SOC2 audit chain)
 #   - aws_s3_bucket_lifecycle_configuration      (STANDARD-IA -> Glacier IR -> Expire)
 #   - aws_iam_role                               (Pod Identity trust + ADR-0028 tags)
-#   - aws_iam_role_policy                        (S3 scoped to this bucket + ABAC condition)
+#   - aws_iam_policy                             (S3 scoped to this bucket + ABAC — standalone, CIS 1.16)
+#   - aws_iam_role_policy_attachment             (binds the standalone policy to the role)
 #
 # ADR-0028: AWS resource tags use colon separator (platform:system) — AWS allows ':'.
 # ADR-0018: EKS Pod Identity; trust policy scoped per eks_cluster_name.
 # ADR-0048 D2: ABAC — only a principal tagged platform:system=ml-pipeline may
 #   access a resource tagged the same way. Enforced in the role policy condition.
+# CIS AWS 1.16: prefer managed (standalone) policies over inline role policies so
+#   permissions are discoverable/auditable and reusable.
+# CIS AWS 2.1.1: deny any S3 request not using TLS (aws:SecureTransport = false).
 # ---------------------------------------------------------------------------------------------------------------------
 
 locals {
@@ -78,6 +83,50 @@ resource "aws_s3_bucket_public_access_block" "mlflow_artifacts" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Bucket policy — DenyInsecureTransport (CIS AWS 2.1.1)
+# Deny every S3 action on the bucket and its objects when the request is not over
+# TLS (aws:SecureTransport = false). Complements the public-access block above.
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "mlflow_bucket_policy" {
+  count = var.create_resources ? 1 : 0
+
+  statement {
+    sid    = "DenyInsecureTransport"
+    effect = "Deny"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+
+    resources = [
+      aws_s3_bucket.mlflow_artifacts[0].arn,
+      "${aws_s3_bucket.mlflow_artifacts[0].arn}/*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "mlflow_artifacts" {
+  count = var.create_resources ? 1 : 0
+
+  # Ensure the public-access block is in place before the policy is attached so a
+  # transient policy evaluation can never widen access.
+  depends_on = [aws_s3_bucket_public_access_block.mlflow_artifacts]
+
+  bucket = aws_s3_bucket.mlflow_artifacts[0].id
+  policy = data.aws_iam_policy_document.mlflow_bucket_policy[0].json
 }
 
 # SSE-KMS at rest; falls back to AES256 when no KMS key is provided (ADR-0048 D2).
@@ -271,10 +320,21 @@ data "aws_iam_policy_document" "mlflow_s3_abac" {
   }
 }
 
-resource "aws_iam_role_policy" "mlflow_s3_abac" {
+# Standalone managed policy (CIS AWS 1.16) — discoverable/auditable, reusable, and
+# decoupled from the role lifecycle (vs. an inline aws_iam_role_policy).
+resource "aws_iam_policy" "mlflow_s3_abac" {
   count = var.create_resources ? 1 : 0
 
-  name   = "mlflow-s3-abac"
-  role   = aws_iam_role.mlflow_artifact_store[0].id
-  policy = data.aws_iam_policy_document.mlflow_s3_abac[0].json
+  name        = "${var.mlflow_pod_identity_role_name}-s3-abac"
+  description = "Bucket-scoped S3 (+optional KMS) access for the MLflow artifact store, ABAC-gated on platform:system (ADR-0048 D2 / CIS AWS 1.16)."
+  policy      = data.aws_iam_policy_document.mlflow_s3_abac[0].json
+
+  tags = local.effective_tags
+}
+
+resource "aws_iam_role_policy_attachment" "mlflow_s3_abac" {
+  count = var.create_resources ? 1 : 0
+
+  role       = aws_iam_role.mlflow_artifact_store[0].name
+  policy_arn = aws_iam_policy.mlflow_s3_abac[0].arn
 }


### PR DESCRIPTION
## Summary

Three independent 2nd-round review findings on the AWS GPU ML platform. All changes stay **apply-gated / default-OFF** — plan/validate create nothing without an explicit human apply. Does **not** touch `aws-eks-inference-gateway` (covered by a separate PR).

### 1. Real bug — wrong unit source path (broke `terragrunt init`)
`catalog/units/aws-ml-abac-iam/terragrunt.hcl` and `catalog/units/aws-ml-scp-parity/terragrunt.hcl` had a `source` containing an erroneous `/project/platform-design/` segment. That directory does not exist on disk (verified), so `terragrunt init` would fail. Corrected to `${get_repo_root()}/terraform/modules/...`, matching every sibling AWS unit (e.g. `aws-eks-gpu`).

### 2. `aws-ml-artifact-store` — IAM + S3 TLS (CIS)
- **(a) CIS AWS 1.16** — converted the inline `aws_iam_role_policy` to a standalone `aws_iam_policy` + `aws_iam_role_policy_attachment` so the S3/ABAC permissions are discoverable, auditable, and reusable.
- **(b) CIS AWS 2.1.1** — added an `aws_s3_bucket_policy` with a `DenyInsecureTransport` statement (Deny `s3:*` when `aws:SecureTransport == false`). Existing public-access block retained; the policy `depends_on` it.

### 3. `aws-eks-gpu-dcgm` — auto-taint CronJob hardening
The CronJob container (runs `kubectl patch` on nodes) had no `security_context` and no resource bounds. Added:
- `security_context`: `run_as_non_root`, `read_only_root_filesystem`, `allow_privilege_escalation = false`, `capabilities { drop = ["ALL"] }`, plus a pod-level non-root + `seccomp_profile RuntimeDefault`.
- `resources`: var-driven CPU/memory requests + memory limit (small defaults: `50m` / `64Mi` / `128Mi`). New variables each have `description` + explicit `type`.

## Verification (loop)

| Step | Result |
|------|--------|
| `terraform fmt -recursive -check` | PASS (clean) |
| `terragrunt hcl fmt --check` (both units) | PASS (clean) |
| `terraform validate` (both modules) | Success |
| `terraform test` — aws-ml-artifact-store | **20 passed, 0 failed** |
| `terraform test` — aws-eks-gpu-dcgm | **6 passed, 0 failed** |
| `checkov` — aws-eks-gpu-dcgm | 5 passed, 0 failed |
| `checkov` — aws-ml-artifact-store | 10 passed, 1 failed* |
| source paths resolve | both resolve to existing module dirs; old buggy path confirmed absent |

\* The single artifact-store finding is `CKV2_AWS_62` (S3 event notifications) — **pre-existing on `main`** and outside this review's scope (IAM/TLS only). Not introduced here.

`tflint` is not installed locally; it runs in CI.

> **Apply-gated:** no `terraform apply` / `helm install` / `kubectl apply` was run. Plan-only validation throughout. Draft PR — do not merge until reviewed and CI green.

## Test plan
- [ ] CI `terraform fmt`/`validate`/`test`/`tflint`/`checkov` green
- [ ] Reviewer confirms catalog units `terragrunt init` against the corrected source paths
