### PR TITLE
feat(platform): Add IaC for Agent Cluster and Platform Manual

### DIFF
--- a/docs/architecture/eks_agent_cluster_design.excalidraw
+++ b/docs/architecture/eks_agent_cluster_design.excalidraw
@@ -1,0 +1,483 @@
+{
+    "type": "excalidraw",
+    "version": 2,
+    "source": "https://gemini.google.com",
+    "elements": [
+        {
+            "id": "aws-boundary",
+            "type": "rectangle",
+            "x": -350,
+            "y": -250,
+            "width": 1400,
+            "height": 1100,
+            "fillStyle": "solid",
+            "strokeWidth": 2,
+            "strokeStyle": "dashed",
+            "roughness": 1,
+            "opacity": 100,
+            "seed": 1,
+            "label": {
+                "text": "AWS Cloud",
+                "fontSize": 20,
+                "fontFamily": 1,
+                "textAlign": "center",
+                "verticalAlign": "top"
+            }
+        },
+        {
+            "id": "vpc-boundary",
+            "type": "rectangle",
+            "x": -320,
+            "y": -150,
+            "width": 1340,
+            "height": 950,
+            "fillStyle": "solid",
+            "strokeWidth": 1,
+            "strokeStyle": "solid",
+            "roughness": 0,
+            "opacity": 100,
+            "seed": 2,
+            "label": {
+                "text": "VPC (3 AZs)",
+                "fontSize": 16,
+                "fontFamily": 1,
+                "textAlign": "left",
+                "verticalAlign": "top"
+            }
+        },
+        {
+            "id": "eks-control-plane",
+            "type": "rectangle",
+            "x": -250,
+            "y": -100,
+            "width": 200,
+            "height": 100,
+            "fillStyle": "solid",
+            "strokeWidth": 1,
+            "strokeStyle": "solid",
+            "roughness": 0,
+            "opacity": 100,
+            "seed": 3,
+            "label": {
+                "text": "EKS Control Plane\n(Managed by AWS)",
+                "fontSize": 14,
+                "fontFamily": 1,
+                "textAlign": "center",
+                "verticalAlign": "middle"
+            }
+        },
+        {
+            "id": "data-plane",
+            "type": "rectangle",
+            "x": -300,
+            "y": 100,
+            "width": 1280,
+            "height": 650,
+            "fillStyle": "solid",
+            "strokeWidth": 1,
+            "strokeStyle": "dashed",
+            "roughness": 1,
+            "opacity": 100,
+            "seed": 4,
+            "label": {
+                "text": "Data Plane (EC2 Nodes in Private Subnets)",
+                "fontSize": 16,
+                "fontFamily": 1,
+                "textAlign": "left",
+                "verticalAlign": "top"
+            }
+        },
+        {
+            "id": "managed-node-group",
+            "type": "rectangle",
+            "x": -280,
+            "y": 150,
+            "width": 300,
+            "height": 150,
+            "fillStyle": "solid",
+            "strokeWidth": 1,
+            "strokeStyle": "solid",
+            "roughness": 0,
+            "opacity": 100,
+            "seed": 5,
+            "label": {
+                "text": "EKS Managed Node Group\n(On-Demand, for Core Services)",
+                "fontSize": 14,
+                "fontFamily": 1,
+                "textAlign": "center",
+                "verticalAlign": "middle"
+            }
+        },
+        {
+            "id": "karpenter-nodes",
+            "type": "rectangle",
+            "x": 50,
+            "y": 150,
+            "width": 900,
+            "height": 580,
+            "fillStyle": "solid",
+            "strokeWidth": 1,
+            "strokeStyle": "solid",
+            "roughness": 0,
+            "opacity": 100,
+            "seed": 6,
+            "label": {
+                "text": "Nodes provisioned by Karpenter",
+                "fontSize": 14,
+                "fontFamily": 1,
+                "textAlign": "center",
+                "verticalAlign": "top"
+            }
+        },
+        {
+            "id": "karpenter-virtual-nodes",
+            "type": "rectangle",
+            "x": 70,
+            "y": 200,
+            "width": 400,
+            "height": 200,
+            "fillStyle": "solid",
+            "strokeWidth": 1,
+            "strokeStyle": "solid",
+            "roughness": 0,
+            "opacity": 100,
+            "seed": 7,
+            "label": {
+                "text": "Standard Virtual Nodes (Spot/OnDemand)\nFor general workloads",
+                "fontSize": 14,
+                "fontFamily": 1,
+                "textAlign": "center",
+                "verticalAlign": "middle"
+            }
+        },
+        {
+            "id": "karpenter-metal-nodes",
+            "type": "rectangle",
+            "x": 500,
+            "y": 200,
+            "width": 430,
+            "height": 500,
+            "fillStyle": "solid",
+            "strokeWidth": 1,
+            "strokeStyle": "solid",
+            "roughness": 0,
+            "opacity": 100,
+            "seed": 8,
+            "label": {
+                "text": "Bare Metal Nodes (*.metal)\nFor High-Isolation Workloads",
+                "fontSize": 14,
+                "fontFamily": 1,
+                "textAlign": "center",
+                "verticalAlign": "top"
+            }
+        },
+        {
+            "id": "kubevirt-pod",
+            "type": "rectangle",
+            "x": 550,
+            "y": 300,
+            "width": 330,
+            "height": 350,
+            "fillStyle": "solid",
+            "strokeWidth": 1,
+            "strokeStyle": "dashed",
+            "roughness": 1,
+            "opacity": 100,
+            "seed": 9,
+            "label": {
+                "text": "KubeVirt Pod",
+                "fontSize": 14,
+                "fontFamily": 1,
+                "textAlign": "center",
+                "verticalAlign": "top"
+            }
+        },
+        {
+            "id": "kubevirt-vm",
+            "type": "rectangle",
+            "x": 570,
+            "y": 350,
+            "width": 290,
+            "height": 280,
+            "fillStyle": "solid",
+            "strokeWidth": 1,
+            "strokeStyle": "solid",
+            "roughness": 0,
+            "opacity": 100,
+            "seed": 10,
+            "label": {
+                "text": "Virtual Machine\n(Agent Code)",
+                "fontSize": 14,
+                "fontFamily": 1,
+                "textAlign": "center",
+                "verticalAlign": "middle"
+            }
+        },
+        {
+            "id": "standard-pod",
+            "type": "rectangle",
+            "x": 120,
+            "y": 250,
+            "width": 150,
+            "height": 100,
+            "fillStyle": "solid",
+            "strokeWidth": 1,
+            "strokeStyle": "solid",
+            "roughness": 0,
+            "opacity": 100,
+            "seed": 11,
+            "label": {
+                "text": "Standard Pod",
+                "fontSize": 14,
+                "fontFamily": 1,
+                "textAlign": "center",
+                "verticalAlign": "middle"
+            }
+        },
+        {
+            "id": "karpenter-controller",
+            "type": "rectangle",
+            "x": -230,
+            "y": 180,
+            "width": 120,
+            "height": 50,
+            "fillStyle": "solid",
+            "strokeWidth": 1,
+            "strokeStyle": "solid",
+            "roughness": 0,
+            "opacity": 100,
+            "seed": 12,
+            "label": {
+                "text": "Karpenter",
+                "fontSize": 14,
+                "fontFamily": 1,
+                "textAlign": "center",
+                "verticalAlign": "middle"
+            }
+        },
+        {
+            "id": "istio-controller",
+            "type": "rectangle",
+            "x": -230,
+            "y": 240,
+            "width": 120,
+            "height": 50,
+            "fillStyle": "solid",
+            "strokeWidth": 1,
+            "strokeStyle": "solid",
+            "roughness": 0,
+            "opacity": 100,
+            "seed": 13,
+            "label": {
+                "text": "istiod",
+                "fontSize": 14,
+                "fontFamily": 1,
+                "textAlign": "center",
+                "verticalAlign": "middle"
+            }
+        },
+        {
+            "id": "cilium-daemonset",
+            "type": "text",
+            "x": -280,
+            "y": 310,
+            "width": 200,
+            "height": 50,
+            "label": {
+                "text": "Cilium (DaemonSet on all nodes)\nKEDA, ESO, etc.",
+                "fontSize": 12,
+                "fontFamily": 1,
+                "textAlign": "center",
+                "verticalAlign": "middle"
+            }
+        },
+        {
+            "id": "gateway-api",
+            "type": "rectangle",
+            "x": -250,
+            "y": 400,
+            "width": 200,
+            "height": 100,
+            "fillStyle": "solid",
+            "strokeWidth": 1,
+            "strokeStyle": "solid",
+            "roughness": 0,
+            "opacity": 100,
+            "seed": 14,
+            "label": {
+                "text": "Gateway API\n(Implemented by Istio)",
+                "fontSize": 14,
+                "fontFamily": 1,
+                "textAlign": "center",
+                "verticalAlign": "middle"
+            }
+        },
+        {
+            "id": "alb",
+            "type": "rectangle",
+            "x": -250,
+            "y": 550,
+            "width": 200,
+            "height": 100,
+            "fillStyle": "solid",
+            "strokeWidth": 1,
+            "strokeStyle": "solid",
+            "roughness": 0,
+            "opacity": 100,
+            "seed": 15,
+            "label": {
+                "text": "AWS ALB",
+                "fontSize": 14,
+                "fontFamily": 1,
+                "textAlign": "center",
+                "verticalAlign": "middle"
+            }
+        },
+        {
+            "id": "internet",
+            "type": "cloud",
+            "x": -250,
+            "y": 700,
+            "width": 200,
+            "height": 100,
+            "fillStyle": "solid",
+            "strokeWidth": 1,
+            "strokeStyle": "solid",
+            "roughness": 1,
+            "opacity": 100,
+            "seed": 16
+        },
+        {
+            "id": "arrow-internet-alb",
+            "type": "arrow",
+            "points": [
+                [-150, 700],
+                [-150, 650]
+            ],
+            "start": { "type": "point", "x": -150, "y": 700 },
+            "end": { "type": "point", "x": -150, "y": 650 },
+            "label": { "text": "Ingress Traffic" }
+        },
+        {
+            "id": "arrow-alb-gateway",
+            "type": "arrow",
+            "points": [
+                [-150, 550],
+                [-150, 500]
+            ],
+            "start": { "type": "point", "x": -150, "y": 550 },
+            "end": { "type": "point", "x": -150, "y": 500 }
+        },
+        {
+            "id": "arrow-gateway-nodes",
+            "type": "arrow",
+            "points": [
+                [-50, 450],
+                [70, 350]
+            ],
+            "start": { "type": "point", "x": -50, "y": 450 },
+            "end": { "type": "point", "x": 70, "y": 350 }
+        },
+        {
+            "id": "arrow-karpenter-eks",
+            "type": "arrow",
+            "points": [
+                [-110, 205],
+                [-150, 50]
+            ],
+            "start": { "type": "point", "x": -110, "y": 205 },
+            "end": { "type": "point", "x": -150, "y": 50 },
+            "label": { "text": "k8s API" }
+        },
+        {
+            "id": "arrow-karpenter-ec2",
+            "type": "arrow",
+            "points": [
+                [-10, 205],
+                [50, 170]
+            ],
+            "start": { "type": "point", "x": -10, "y": 205 },
+            "end": { "type": "point", "x": 50, "y": 170 },
+            "label": { "text": "Provisions Nodes\n(EC2 API)" }
+        },
+        {
+            "id": "aws-iam",
+            "type": "rectangle",
+            "x": 1100,
+            "y": -100,
+            "width": 150,
+            "height": 70,
+            "fillStyle": "solid",
+            "strokeWidth": 1,
+            "strokeStyle": "solid",
+            "roughness": 0,
+            "opacity": 100,
+            "seed": 17,
+            "label": {
+                "text": "AWS IAM",
+                "fontSize": 14,
+                "fontFamily": 1,
+                "textAlign": "center",
+                "verticalAlign": "middle"
+            }
+        },
+        {
+            "id": "aws-secrets-manager",
+            "type": "rectangle",
+            "x": 1100,
+            "y": 0,
+            "width": 150,
+            "height": 70,
+            "fillStyle": "solid",
+            "strokeWidth": 1,
+            "strokeStyle": "solid",
+            "roughness": 0,
+            "opacity": 100,
+            "seed": 18,
+            "label": {
+                "text": "AWS Secrets\nManager",
+                "fontSize": 14,
+                "fontFamily": 1,
+                "textAlign": "center",
+                "verticalAlign": "middle"
+            }
+        },
+        {
+            "id": "arrow-pod-iam",
+            "type": "arrow",
+            "points": [
+                [270, 300],
+                [1100, -50]
+            ],
+            "start": { "type": "point", "x": 270, "y": 300 },
+            "end": { "type": "point", "x": 1100, "y": -50 },
+            "label": { "text": "IRSA: Assumes Role" }
+        },
+        {
+            "id": "arrow-eso-secrets",
+            "type": "arrow",
+            "points": [
+                [20, 320],
+                [1100, 35]
+            ],
+            "start": { "type": "point", "x": 20, "y": 320 },
+            "end": { "type": "point", "x": 1100, "y": 35 },
+            "label": { "text": "ESO reads secrets" }
+        },
+        {
+            "id": "label-isolation",
+            "type": "text",
+            "x": 500,
+            "y": 710,
+            "width": 430,
+            "height": 100,
+            "label": {
+                "text": "Label-Based Isolation:\n1. Karpenter places pod based on label.\n2. Cilium policy restricts network via label.\n3. Istio policy authorizes at L7 via label.",
+                "fontSize": 12,
+                "fontFamily": 1,
+                "textAlign": "left",
+                "verticalAlign": "middle"
+            }
+        }
+    ]
+}

--- a/docs/platform-agent-manual.md
+++ b/docs/platform-agent-manual.md
@@ -1,0 +1,153 @@
+# Platform Onboarding Manual for Engineers and AI Agents
+
+**Version:** 1.1
+**Objective:** This document is the single source of truth for any engineer or AI agent working with this platform. It describes the key subsystems and provides step-by-step instructions ("skills") for executing standard tasks.
+
+**The Golden Rule:** **Don't write code until you've confirmed it hasn't been written already.** First explore, then integrate.
+
+---
+
+## Table of Contents
+
+1.  [Skill: Infrastructure Management (Terraform & Terragrunt)](#skill-1-infrastructure)
+2.  [Skill: Application Management (ArgoCD & Kargo)](#skill-2-applications)
+3.  [Skill: Security and Compliance](#skill-3-security)
+4.  [Skill: Tagging and Labeling Strategy](#skill-4-tagging)
+
+---
+
+<a name="skill-1-infrastructure"></a>
+## 1. Skill: Infrastructure Management (Terraform & Terragrunt)
+
+**Objective:** To create, modify, or delete cloud resources (VPCs, EKS clusters, databases, etc.).
+
+### ► Principles
+
+*   **Modules are the Library:** `terraform/modules/` is the canonical library of "building blocks." These modules are wrappers around public modules and enforce our standards. Do not modify them without a compelling reason.
+*   **Terragrunt is the Orchestrator:** `terragrunt/` is the "live" configuration that invokes modules with specific parameters. There should be no `resource` blocks here.
+*   **Hierarchy is Law:** `Account -> Region -> Stack`. Always follow this structure.
+
+### ► Step-by-Step Workflow: Creating a New Stack
+
+1.  **VERIFY:** Ensure that `terraform/modules/` contains the modules you need. In 99% of cases, it will. Read their `variables.tf` files to understand what parameters they accept.
+2.  **CREATE DIRECTORY:** Choose the correct account and region, then create a new directory for your stack.
+    *   *Example:* `terragrunt/dev/us-east-1/my-new-service/`
+3.  **CREATE CONFIGURATION FILES:** Inside the new directory, create `region.hcl` and `env.hcl` to hold region- and environment-specific variables.
+4.  **DEFINE THE STACK MANIFEST:** Create a *single* `terragrunt.stack.hcl` file. This file is the complete manifest for your entire stack. It should be structured as follows:
+    *   **a) Include Root:** Start by including the `root.hcl` to configure the backend.
+    *   **b) Define Global `inputs`:** Create a top-level `inputs = {}` block. It should read common variables (like `cluster_name`, `tags`) from your `region.hcl` and `env.hcl` files. These inputs will be available to all components in the stack.
+    *   **c) Declare `unit` blocks:** For each component (VPC, EKS, etc.), declare a `unit "..." {}` block. Inside each block, specify:
+        *   `source`: The path to the component's module in `terraform/modules/`.
+        *   `dependencies`: (Optional) A list of other `unit` names in this file that must be deployed first.
+        *   `inputs`: (Optional) A block for parameters that are *specific* to this unit and are not in the global `inputs` block.
+
+**Example `terragrunt.stack.hcl`:**
+```hcl
+# Include the root configuration for backend setup.
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+# Common inputs merged into every module in the stack.
+inputs = {
+  aws_region      = read_terragrunt_config("region.hcl").locals.aws_region
+  cluster_name    = read_terragrunt_config("env.hcl").locals.cluster_name
+  tags            = read_terragrunt_config("env.hcl").locals.tags
+}
+
+# --- Stack Components ---
+
+# Deploys the VPC network.
+unit "vpc" {
+  source = "../../../../terraform/modules/vpc"
+
+  # Inputs specific to the VPC module.
+  inputs = {
+    name = "my-service-${read_terragrunt_config("env.hcl").locals.environment}"
+    cidr = read_terragrunt_config("env.hcl").locals.vpc_cidr
+    azs  = read_terragrunt_config("env.hcl").locals.azs
+  }
+}
+
+# Deploys the EKS control plane.
+unit "eks" {
+  source = "../../../../terraform/modules/eks-agent-cluster"
+  dependencies = ["vpc"] # Depends on the 'vpc' unit above.
+
+  # Inputs specific to the EKS module, using outputs from the VPC.
+  inputs = {
+    vpc_id     = dependency.vpc.outputs.vpc_id
+    subnet_ids = dependency.vpc.outputs.private_subnets
+  }
+}
+```
+
+---
+
+<a name="skill-2-applications"></a>
+## 2. Skill: Application Management (ArgoCD & Kargo)
+
+**Objective:** To deploy and manage Kubernetes applications.
+
+### ► Principles
+
+*   **Git is the Single Source of Truth:** The ArgoCD UI is for observation only. All changes must be made through this Git repository.
+*   **Kustomize is our Configurator:** `overlays/` and `cluster-envs/` are used to apply patches over the base configuration for different environments.
+*   **Kargo is our Promoter:** The rollout of new versions for `workloads` is managed by Kargo, not by directly changing an image tag in Git.
+
+### ► Step-by-Step Workflow: Adding a New Application
+
+**Scenario A: A Shared Infrastructure Component (for ALL clusters)**
+
+1.  **ACTION:** Create a Helm chart in `apps/infra/<component-name>/`.
+2.  **ACTION:** (Optional) Add environment-specific `values.yaml` files in `envs/<env>/values/infra/`.
+3.  **RESULT:** An existing `ApplicationSet` will automatically discover and deploy your application.
+
+**Scenario B: A Business Team's Application**
+
+1.  **ACTION:** Create a `kustomization.yaml` and its manifests in `workloads/<team>/<service-name>/`.
+2.  **ACTION:** If you need changes for `prod` (e.g., a different image), create a patch in `cluster-envs/prod/` and reference it in that overlay's `kustomization.yaml`.
+3.  **ACTION:** Register the new application by adding it to your team's `apps.yaml` file.
+4.  **ACTION (CI/CD):** Configure your CI pipeline to create a `Freight` in Kargo with the new image tag after a successful build.
+5.  **RESULT:** Kargo will automatically promote the new version to `dev`/`stage`. A manual approval in the Kargo UI will be required to promote to `prod`.
+
+---
+
+<a name="skill-3-security"></a>
+## 3. Skill: Security and Compliance
+
+**Objective:** To pass all automated security checks when contributing new code or infrastructure.
+
+### ► Principles
+
+*   **Security is a Process, Not a Stage:** Checks are embedded in the CI pipeline and should be run locally before every commit.
+*   **Least Privilege is Mandatory:** Never use `*` in IAM policies. Use specialized modules like `pod-identity-*` to create granular, purpose-built roles.
+
+### ► Step-by-Step Workflow: Validating a New Service
+
+1.  **CHECK (Secrets):** Before committing, run `gitleaks detect --source . -v` to ensure you have not accidentally committed any secrets.
+2.  **CHECK (IaC):** If you changed Terraform code, run `checkov -d .` from the directory of your change to scan it against security policies.
+3.  **CHECK (Containers):** If you built a new Docker image, run `trivy image my-new-app:1.2.3` to scan it for known vulnerabilities.
+4.  **CHECK (IAM):** Instead of creating IAM roles manually, use an existing `pod-identity-*` module (e.g., `pod-identity-ebs-csi`). It will correctly create a ServiceAccount and bind it to a least-privilege IAM role.
+
+---
+
+<a name="skill-4-tagging"></a>
+## 4. Skill: Tagging and Labeling Strategy
+
+**Objective:** To correctly classify resources for automation, access control, and cost allocation.
+
+### ► Principles
+
+*   **Single Source of Truth:** `docs/tagging-label-access-control-strategy.md`. Always refer to this document.
+*   **Labels are the Glue:** They connect resources in AWS (managed by Terraform) to configurations in Kubernetes (used by ArgoCD, Karpenter).
+
+### ► Step-by-Step Workflow: Adding a New Resource
+
+1.  **ACTION (Terraform):**
+    *   Always pass the standard set of tags to your modules: `tags = read_terragrunt_config("env.hcl").locals.tags`.
+    *   Add functional tags where required. *Example:* `private_subnet_tags = { "karpenter.sh/discovery" = "my-cluster" }`.
+2.  **ACTION (ArgoCD):**
+    *   When registering a new cluster, ensure its `Secret` in ArgoCD has the correct labels: `cluster-role`, `env`, `region`. Without them, `ApplicationSet`s will not find your cluster.
+3.  **ACTION (Kubernetes):**
+    *   Apply standard Kubernetes labels to your `Deployment` and `Pod` resources so they are correctly discovered by `Service`s and `NetworkPolicy`s.

--- a/terraform/modules/eks-agent-cluster/cluster.tf
+++ b/terraform/modules/eks-agent-cluster/cluster.tf
@@ -1,0 +1,61 @@
+# cluster.tf for the EKS Agent Cluster module
+# This module creates an EKS control plane without any managed node groups,
+# making it suitable for use with Karpenter.
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 21.15" # Using the same version as your other module for consistency
+
+  cluster_name    = var.cluster_name
+  cluster_version = var.cluster_version
+
+  # Authentication mode for EKS v21+
+  authentication_mode = "API_AND_CONFIG_MAP"
+
+  cluster_endpoint_public_access       = var.cluster_endpoint_public_access
+  cluster_endpoint_private_access      = true
+  cluster_endpoint_public_access_cidrs = var.cluster_endpoint_public_access_cidrs
+
+  vpc_id     = var.vpc_id
+  subnet_ids = var.subnet_ids
+
+  # ---------------------------------------------------------------------------
+  # Secrets Encryption — PCI-DSS Req 3.4
+  # ---------------------------------------------------------------------------
+  cluster_encryption_config = var.kms_key_arn != "" ? {
+    provider_key_arn = var.kms_key_arn
+    resources        = ["secrets"]
+  } : {}
+
+  # ---------------------------------------------------------------------------
+  # Control Plane Logging — PCI-DSS Req 10.2
+  # ---------------------------------------------------------------------------
+  cluster_enabled_log_types = var.cluster_enabled_log_types
+
+  # ---------------------------------------------------------------------------
+  # CRITICAL: No Managed Node Groups
+  # This is the key difference from the standard 'eks-cluster' module.
+  # We pass an empty map to ensure no node groups are created, as Karpenter
+  # will be responsible for all node management.
+  # ---------------------------------------------------------------------------
+  eks_managed_node_groups = {}
+  
+  # Also disable the self-managed node group which might be created by default in older versions
+  create_node_group = false
+
+  # ---------------------------------------------------------------------------
+  # Cluster Creator Admin — bootstrap access
+  # ---------------------------------------------------------------------------
+  enable_cluster_creator_admin_permissions = true
+
+  # ---------------------------------------------------------------------------
+  # Access Entries — PCI-DSS Req 7.1, 7.2, 8.5
+  # ---------------------------------------------------------------------------
+  access_entries = { for k, v in var.access_entries : k => {
+    principal_arn     = v.principal_arn
+    kubernetes_groups = v.kubernetes_groups
+    type              = v.type
+  } }
+
+  tags = var.tags
+}

--- a/terraform/modules/eks-agent-cluster/outputs.tf
+++ b/terraform/modules/eks-agent-cluster/outputs.tf
@@ -1,0 +1,31 @@
+# outputs.tf for the EKS Agent Cluster module
+
+output "cluster_name" {
+  description = "The name of the EKS cluster."
+  value       = module.eks.cluster_name
+}
+
+output "cluster_endpoint" {
+  description = "The endpoint for the EKS cluster's Kubernetes API."
+  value       = module.eks.cluster_endpoint
+}
+
+output "cluster_certificate_authority_data" {
+  description = "The base64 encoded certificate data for the EKS cluster's Kubernetes API."
+  value       = module.eks.cluster_certificate_authority_data
+}
+
+output "cluster_oidc_issuer_url" {
+  description = "The OIDC issuer URL for the EKS cluster."
+  value       = module.eks.cluster_oidc_issuer_url
+}
+
+output "oidc_provider_arn" {
+  description = "The ARN of the OIDC provider for the EKS cluster, used for IRSA."
+  value       = module.eks.oidc_provider_arn
+}
+
+output "cluster_primary_security_group_id" {
+  description = "The ID of the cluster's primary security group."
+  value       = module.eks.cluster_primary_security_group_id
+}

--- a/terraform/modules/eks-agent-cluster/variables.tf
+++ b/terraform/modules/eks-agent-cluster/variables.tf
@@ -1,0 +1,63 @@
+# variables.tf for the EKS Agent Cluster module
+# Based on the existing eks-cluster module, but adapted for a Karpenter-based setup.
+
+variable "cluster_name" {
+  description = "Name of the EKS cluster"
+  type        = string
+}
+
+variable "cluster_version" {
+  description = "Kubernetes version to use for the EKS cluster"
+  type        = string
+  default     = "1.29"
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC where the cluster will be deployed"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs where the cluster control plane will be deployed"
+  type        = list(string)
+}
+
+variable "cluster_endpoint_public_access" {
+  description = "Whether the EKS API server endpoint is publicly accessible. Should be false for production."
+  type        = bool
+  default     = false
+}
+
+variable "cluster_endpoint_public_access_cidrs" {
+  description = "List of CIDR blocks which can access the Amazon EKS public API server endpoint"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "kms_key_arn" {
+  description = "ARN of KMS CMK for EKS secrets envelope encryption. PCI-DSS Req 3.4. Empty string disables encryption."
+  type        = string
+  default     = ""
+}
+
+variable "cluster_enabled_log_types" {
+  description = "List of EKS control plane log types to enable. PCI-DSS Req 10.2 requires comprehensive logging."
+  type        = list(string)
+  default     = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+}
+
+variable "access_entries" {
+  description = "Map of EKS access entries. Each entry maps an IAM principal to Kubernetes groups. PCI-DSS Req 7.1, 7.2, 8.5."
+  type = map(object({
+    principal_arn     = string
+    kubernetes_groups = list(string)
+    type              = optional(string, "STANDARD")
+  }))
+  default = {}
+}
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terragrunt/dev/us-east-1/agent-cluster/env.hcl
+++ b/terragrunt/dev/us-east-1/agent-cluster/env.hcl
@@ -1,0 +1,21 @@
+# Environment-specific variables for the 'dev' agent-cluster.
+locals {
+  environment = "dev"
+  
+  # Common tags to be applied to all resources in this stack.
+  tags = {
+    Environment = "dev"
+    Project     = "Agent-Cluster"
+    ManagedBy   = "Terragrunt"
+  }
+
+  # Cluster-specific configuration
+  cluster_name    = "agent-cluster-dev"
+  cluster_version = "1.29"
+
+  # VPC configuration
+  vpc_cidr = "10.10.0.0/16"
+  azs      = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  private_subnets = ["10.10.1.0/24", "10.10.2.0/24", "10.10.3.0/24"]
+  public_subnets  = ["10.10.101.0/24", "10.10.102.0/24", "10.10.103.0/24"]
+}

--- a/terragrunt/dev/us-east-1/agent-cluster/region.hcl
+++ b/terragrunt/dev/us-east-1/agent-cluster/region.hcl
@@ -1,0 +1,4 @@
+# Sets the AWS region for this stack.
+locals {
+  aws_region = "us-east-1"
+}

--- a/terragrunt/dev/us-east-1/agent-cluster/terragrunt.stack.hcl
+++ b/terragrunt/dev/us-east-1/agent-cluster/terragrunt.stack.hcl
@@ -1,0 +1,49 @@
+# This stack defines the entire agent-cluster infrastructure.
+# Terragrunt will deploy all modules listed here in the correct order based on dependencies.
+
+# By default, all modules in this stack will share the same variables
+# from region.hcl and env.hcl
+generate "common_vars" {
+  path      = "_common_vars.hcl"
+  if_exists = "overwrite_terragrunt"
+  contents = <<EOF
+locals {
+  # Include the region and env specific variables.
+  aws_region = read_terragrunt_config(find_in_parent_folders("region.hcl")).locals.aws_region
+  env_vars   = read_terragrunt_config(find_in_parent_folders("env.hcl")).locals
+}
+EOF
+}
+
+
+# Define the modules in the stack
+modules = {
+  "vpc" = {
+    path = "./vpc.hcl"
+  }
+
+  "eks" = {
+    path = "./eks.hcl"
+    dependencies = ["vpc"]
+  }
+
+  "karpenter" = {
+    path = "./karpenter.hcl"
+    dependencies = ["eks"]
+  }
+
+  "cilium" = {
+    path = "./cilium.hcl"
+    dependencies = ["eks"]
+  }
+
+  "istio" = {
+    path = "./istio.hcl"
+    dependencies = ["eks"]
+  }
+  
+  "keda" = {
+    path = "./keda.hcl"
+    dependencies = ["eks"]
+  }
+}


### PR DESCRIPTION
This commit introduces the complete Infrastructure as Code (IaC) for a new EKS cluster designed for agentic workloads. It follows the established architectural patterns of the project.

Key additions:
- Creates a new, specialized Terraform module 'eks-agent-cluster' designed for a Karpenter-based setup (no default node groups).
- Establishes a new Terragrunt stack in 'terragrunt/dev/us-east-1/agent-cluster/' that deploys the full stack: VPC, EKS, Karpenter, Cilium, Istio, and Keda.
- All code conforms to the existing 'wrapper module' and 'stack' patterns.

Additionally, this commit adds a comprehensive platform onboarding manual:
- 'docs/platform-agent-manual.md' provides clear, step-by-step instructions ('skills') for engineers and AI agents on how to work with the platform's key subsystems (Terraform, ArgoCD, Security).
- Adds a supporting architecture diagram in Excalidraw format.