### PR TITLE
docs: portable platform specs — full reverse-engineering of the estate (specs/)

### DIFF
--- a/specs/CONVENTIONS.md
+++ b/specs/CONVENTIONS.md
@@ -1,0 +1,68 @@
+# Platform Specs — Conventions
+
+These specs are a **portable reverse-engineering of this platform's design estate**: detailed
+enough that a competent platform team can rebuild the same platform for a new client without
+reading this repository. Every spec follows the rules below.
+
+## Audience and purpose
+
+- Audience: a senior platform/infra team building a **new instance** of this platform
+  (different org, different accounts, possibly different cloud sub-choices).
+- Purpose: capture *what to build*, *why it is built that way* (decision + trade-off), and
+  *how to reproduce it* (blueprint-level detail), not to document this repo's history.
+
+## Parameterization (portability)
+
+Never hardcode client-specific identity. Use double-brace placeholders, defined once in
+`SPEC-00-overview.md`:
+
+| Placeholder | Meaning | Example value shape |
+|---|---|---|
+| `{{ORG}}` | organization / company slug | `acme` |
+| `{{DOMAIN}}` | root DNS zone | `platform.example.com` |
+| `{{MGMT_ACCOUNT_ID}}`, `{{PROD_ACCOUNT_ID}}`, … | AWS account IDs | `111111111111` |
+| `{{PRIMARY_REGION}}` / `{{DR_REGION}}` | regions | `us-east-1` / `eu-west-1` |
+| `{{VCS_ORG}}` | Git hosting org | `acme-platform` |
+| `{{STATE_BUCKET}}` | Terraform state bucket | `{{ORG}}-tf-state-{{MGMT_ACCOUNT_ID}}` |
+
+Add spec-local placeholders as needed; register any recurring one in SPEC-00.
+
+## Sanitization (hard rule — this may be shared with clients)
+
+- NO real AWS account IDs, ARNs with account IDs, real hostnames/domains, IPs (except
+  RFC1918/documentation ranges), emails, tokens, or company-identifying names from this repo.
+- Replace real values with placeholders; keep the *shape* (e.g. show a real-looking SCP JSON
+  with `{{MGMT_ACCOUNT_ID}}`).
+- Code snippets from the repo are encouraged but MUST be sanitized the same way.
+
+## Per-spec structure (every SPEC-NN file)
+
+1. **Scope & non-goals** — what this spec covers, one paragraph.
+2. **Architecture** — components and their relationships; ASCII diagram where helpful.
+3. **Decision record** — table: decision · rationale · trade-off accepted · source ADR
+   (cite as `ADR-NNNN <title>` — ADR numbers refer to this estate's `docs/adrs/`).
+4. **Implementation blueprint** — directory layout, key files, sanitized snippets of the
+   load-bearing configuration (enough to re-create, not a full dump), ordering/dependencies
+   (what must exist before what).
+5. **Parameterization table** — every placeholder this spec consumes + sizing knobs
+   (instance types, counts, CIDR ranges) with the default used here and guidance to resize.
+6. **Best practices distilled** — numbered, each with the *why*; this is the client-facing
+   value, be generous and specific.
+7. **Known pitfalls** — what this estate learned to avoid (from ADRs, fix-commits, TODOs).
+8. **Acceptance checklist** — verifiable statements ("`terragrunt run --all plan` clean from
+   an empty account", "ArgoCD app-of-apps syncs with zero manual steps") a rebuild must pass.
+9. **Dependencies on other specs** — explicit `SPEC-NN` cross-references.
+
+## Style
+
+- English only. Concrete over abstract: name the exact tools, versions (as pinned in this
+  estate: cite `versions.hcl` / `.tool-versions` values), flags, file paths.
+- "Maximally detailed" means: a reader should never have to guess a file's content shape —
+  show it. But do not paste whole files where a 15-line excerpt + description carries the design.
+- Each spec is self-contained: readable without the others except via explicit Dependencies.
+- Present tense, imperative for instructions. No history narration ("we then decided…").
+
+## File naming
+
+`specs/SPEC-NN-<kebab-slug>.md`. NN is two digits; the index lives in `specs/SPEC-INDEX.md`;
+the platform overview in `specs/SPEC-00-overview.md`.

--- a/specs/SPEC-00-overview.md
+++ b/specs/SPEC-00-overview.md
@@ -1,0 +1,390 @@
+# SPEC-00 — Platform Overview & Shared Registries
+
+> The front-matter for a portable, reverse-engineered platform estate. This document is
+> written for a **client CTO and platform lead** deciding whether — and how — to rebuild
+> this platform for a new organization. It grounds every claim in the ten domain specs
+> (`SPEC-01`…`SPEC-10`), owns the **canonical placeholder registry**, and consolidates the
+> cross-spec **as-built divergence** and **recommendation** registers a rebuild team must
+> work through. Read this before any domain spec. Follows `CONVENTIONS.md`; all identity is
+> parameterized — no real account IDs, org names, domains, emails, IPs, or bucket names appear.
+
+---
+
+## 1. What this platform is
+
+This is an **AWS-primary, multi-account Infrastructure-as-Code estate** that runs
+containerized and GPU/ML workloads on Kubernetes, delivered by GitOps, guarded by
+defense-in-depth security and full CI/CD quality gates, and observed by a self-hosted
+telemetry plane — with disaster-recovery machinery and an advisory AI operations layer on
+top. Every capability below is reproducible from the domain spec named in parentheses.
+
+- **A landing zone as code.** An AWS Organization with an 8-OU tree (Security /
+  Infrastructure / Workloads → NonProd/Prod, plus Deployments / Sandbox / Suspended) over a
+  canonical ~11-account topology (management, security, log-archive, network, shared, dev,
+  staging, prod, dr, third-party, optional sandbox). Orchestration is **Terragrunt over
+  Terraform/OpenTofu** (`root.hcl` generates backend + provider + version files; `_envcommon/`
+  kills per-account duplication), with a Terraform-only bootstrapped remote-state backend and
+  a single version-pin source of truth (`versions.hcl`). Control Tower + AFT account vending is
+  the ratified *target*, not the live path. (**SPEC-01**)
+- **A segmented network substrate.** A hub-and-spoke Transit Gateway owned by the network
+  account, deterministic non-overlapping per-environment/region VPC CIDRs, deny-by-default
+  route-table segmentation, cross-account Route 53 Resolver, and a dual-provider authoritative
+  DNS control plane (octoDNS to two providers) with a scored health monitor and a registrar-level
+  failover controller. (**SPEC-02**)
+- **A Kubernetes compute plane.** EKS control planes (private-by-default) with **Cilium**
+  (eBPF, ENI IPAM, WireGuard) as the sole CNI, **Karpenter** for just-in-time nodes on
+  **Bottlerocket**, **KEDA/HPA** for pod autoscaling, EKS Pod Identity for workload identity,
+  and dedicated clusters per specialized workload class (general, HPC/blockchain, GPU). (**SPEC-03**)
+- **GitOps delivery.** **ArgoCD** app-of-apps + ApplicationSets fan work across the cluster
+  fleet by label; **Kargo** advances an immutable Freight through a metric-gated
+  dev→integration→staging→prod promotion graph; one generic `helm/app` chart deploys every
+  workload. (**SPEC-04**)
+- **Defense-in-depth security.** A six-layer map (org → account → network → cluster → workload
+  → pipeline): SCPs + RCPs + EC2 declarative policies + break-glass; centralized audit/logging;
+  admission control (Gatekeeper/Kyverno/VAP) + image-signature verification; Pod-Identity ABAC +
+  External Secrets Operator + KMS + rotation; and a keyless-OIDC supply chain. (**SPEC-05**)
+- **CI/CD quality gates.** A GitHub Actions estate (34 workflows + 10 composite actions) wiring
+  the IaC verification loop (`fmt → validate → tflint → checkov/tfsec → plan → OPA → cost`),
+  merge-gating vs advisory checks, keyless OIDC (no long-lived cloud keys), a supply-chain chain
+  (harden-runner → build → Trivy → SBOM → cosign), scheduled drift detection, and an Infracost
+  gate — portable to GitLab CI. (**SPEC-06**)
+- **Self-hosted observability.** An LGTM-aligned signal plane (Prometheus 3.x + Thanos on S3,
+  Loki, Tempo, Pyroscope, one RED-metric source), a VictoriaMetrics variant for the GPU-inference
+  mega-cluster, DCGM GPU telemetry with a hardened auto-taint loop, ML drift/accuracy monitoring,
+  SLOs-as-code (Pyrra), severity-tiered Alertmanager routing, and OpenCost cost visibility. (**SPEC-07**)
+- **Resilience & DR.** Three decoupled resilience layers — DNS-provider failover (the Go
+  `failover-controller`), multi-region active-active via Global Accelerator anycast, and a
+  warm-standby DR account re-provisioned by IaC — plus stateful-service HA (RDS Multi-AZ, Velero,
+  immutable Object-Lock log archive, cross-region state replication) and an RTO/RPO tiering the
+  client must choose. (**SPEC-08**)
+- **An advisory AI-SRE.** A multi-agent LLM system that investigates alerts and posts
+  human-actionable recommendations to Slack but **never mutates infrastructure autonomously** —
+  "advisory-only" is enforced by four independent controls (read-only MCP → read-only RBAC →
+  egress NetworkPolicy → app-layer guardrails), with its own SLOs, cost cap, and audit trail. (**SPEC-09**)
+- **An ML/GPU serving surface.** A model-aware, KV-cache-aware inference path (WAF → Gateway API
+  Inference Extension → InferencePool/EndpointPicker → vLLM on DRA-claimed GPUs over RDMA fabric),
+  a per-machine-family GPU capacity strategy, an Airflow→MLflow→Kargo model lifecycle with
+  drift-driven retrain, and one operating model expressed across GCP, AWS, Azure, and bare-metal. (**SPEC-10**)
+
+**Read this as a design estate, not a running product.** Large parts of the ML/GPU surface
+(SPEC-10), the AI-SRE (SPEC-09), and several security/resilience units are **ratified design
+targets or partially-simulated scaffolds**, not wired production — §4 (the divergence register)
+is the authoritative catalog of what is real vs. scaffolded. A rebuild must treat those rows as
+work items, not as already-done.
+
+---
+
+## 2. Spec map
+
+| Spec | Domain | What it lets you rebuild | Key decisions inside |
+|---|---|---|---|
+| **SPEC-01** | Foundation: IaC, account topology & state | The AWS Org + 8-OU tree, ~11-account topology, Terragrunt/`_envcommon`/`catalog` skeleton, Terraform-only state bootstrap, version pins, ADR-0028 tagging taxonomy | Terragrunt over plain TF (ADR-0004); TF-only state backend (ADR-0002); OU split (ADR-0001); unified tagging (ADR-0028); Control Tower + AFT target (ADR-0035) |
+| **SPEC-02** | Network topology & DNS | Hub-spoke Transit Gateway, deterministic VPC CIDR scheme, deny-by-default segmentation, Route 53 Resolver, dual-provider octoDNS + health monitor + registrar failover | Hub-spoke TGW (ADR-0005); inter-VPC deny-by-default (ADR-0013); Cilium CNI (ADR-0003); Gateway API ingress (ADR-0009); VPC Lattice (ADR-0023) |
+| **SPEC-03** | Compute clusters (EKS/Karpenter/Cilium/KEDA) | EKS control plane, Cilium ENI dataplane, Karpenter NodePools on Bottlerocket, KEDA/HPA, Pod Identity, per-workload cluster split | Cilium replaces VPC CNI (ADR-0003); Karpenter over CAS (ADR-0007/0046); Bottlerocket (ADR-0030); Pod Identity (ADR-0018); private EKS endpoint (ADR-0010) |
+| **SPEC-04** | Delivery & GitOps | ArgoCD app-of-apps + ApplicationSets, Kargo promotion graph, the generic `helm/app` chart, PreSync migrations, drift/rollback | ArgoCD GitOps (ADR-0006); `cluster_role` label scheme (ADR-0012); Kargo promotion (ADR-0021); ArgoCD hardening (ADR-0024); PreSync migrations (ADR-0032) |
+| **SPEC-05** | Security | Org guardrails (SCP/RCP/EC2 declarative), audit/logging accounts, Pod-Identity ABAC, ESO + KMS + rotation, admission control, supply-chain gates | Two perimeters SCP+RCP (ADR-0017); break-glass (ADR-0011); Pod Identity ABAC (ADR-0018); Kyverno+VAP (ADR-0020); tier-1 supply chain (ADR-0016/0022) |
+| **SPEC-06** | CI/CD & quality gates | The GitHub Actions estate, IaC loop as CI, keyless OIDC, supply-chain build path, drift detection, Infracost gate, GitLab port | Reusable pipelines (ADR-0015); keyless OIDC + split plan/apply roles; supply chain (ADR-0016); runtime hardening (ADR-0022); cost gate (ADR-0027) |
+| **SPEC-07** | Observability | LGTM stack (Prom+Thanos/Loki/Tempo/Pyroscope), VictoriaMetrics GPU variant, DCGM + auto-taint, ML drift, Pyrra SLOs, Alertmanager routing, OpenCost | LGTM target (ADR-0026); one RED source (ADR-0026/0019); OpenCost+CUR (ADR-0027); ML drift (ADR-0038); self-serve observability (ADR-0039) |
+| **SPEC-08** | Resilience, DR & stateful services | The `failover-controller`, warm-standby DR account, RDS HA, Velero, immutable log archive, state DR, failure-mode matrix + RTO/RPO tiers | Stateful failover control loop; warm-standby DR; vanilla RDS Multi-AZ; PreSync migrations (ADR-0032); Object-Lock archive (ADR-0002); break-glass (ADR-0011) |
+| **SPEC-09** | Advisory AI-SRE | The multi-agent advisory system, four-layer advisory-only enforcement, runbook/approval engine, ClickHouse memory, MCP tool surface, meta-observability | Advisory-only invariant; 4-layer defense in depth; orchestrator+specialists over a Blackboard; GitOps-PR remediation; SOC2/on-call (ADR-0040); *no dedicated committed ADR* (see §4) |
+| **SPEC-10** | ML / GPU workloads | The inference serving reference arch, GPU capacity strategy, Airflow→MLflow→Kargo lifecycle, multi-cloud pattern (GCP/AWS/Azure/bare-metal) | Gateway API Inference Extension (ADR-0042/0047/0053); DRA over `nvidia.com/gpu` (ADR-0044); Volcano gang scheduling; Airflow orchestration (ADR-0037); *all ML ADRs Proposed/apply-gated* |
+
+### Reading / execution order for a rebuild
+
+```
+SPEC-01 → SPEC-02 → SPEC-03 → SPEC-05 → SPEC-04 → SPEC-06 → SPEC-07 → SPEC-08 → SPEC-10 → SPEC-09
+foundation  network   compute  security  delivery  ci/cd    observ.   resilience  ml/gpu   ai-sre
+```
+
+**Why this order.** SPEC-01 is the ground floor every spec assumes (accounts, Terragrunt,
+state, version pins, tagging). SPEC-02 lays the network substrate SPEC-03's clusters ride on.
+SPEC-05 precedes SPEC-04 deliberately: org guardrails, ESO/`ClusterSecretStore`, KMS, and the
+admission stack are prerequisites the GitOps delivery plane *references* (charts point at an
+`ExternalSecret`; workloads must land on a cluster that already denies-by-default), so secrets and
+admission must exist before delivery is wired. SPEC-06 guards everything and reads best once the
+delivery model it gates is understood. SPEC-07 is delivered *via* SPEC-04 and consumes SPEC-05
+secrets. SPEC-08 layers DR/stateful machinery on the running stack. SPEC-10 reuses compute +
+delivery + observability + security. SPEC-09 is last — an advisory overlay that only *consumes*
+SPEC-07 signals and *proposes* SPEC-04 PRs, mutating nothing. (SPEC-05↔SPEC-04 is a mutual
+dependency; the order above resolves it toward "secrets/admission first, delivery second".)
+
+---
+
+## 3. Shared placeholder registry (canonical)
+
+This is the **one canonical registry** for the estate. Every `{{PLACEHOLDER}}` used by any spec
+resolves here; spec-local placeholders are registered against this table. Fill this table with
+client values **first** (§7). All example shapes below are documentation placeholders (repeated-digit
+account IDs, RFC-5737/RFC-1918 IPs, `example.com`) — never real values.
+
+### 3.1 Identity & organization
+
+| Placeholder | Meaning | Specs | Example shape |
+|---|---|---|---|
+| `{{ORG}}` | Organization / company slug (bucket + WAF-ACL prefix, sandbox state bucket) | 01,02,03,05,07,08,09,10 | `acme` (lowercase, DNS-safe) |
+| `{{PROJECT}}` | Project/repo slug in role ARNs + `Project` tag (`{{PROJECT}}-terraform-*` SCP exemption). **Alias: `{{REPO}}`** | 01,05 | `platform-design` |
+| `{{ORG_ID}}` | AWS Organizations ID (perimeter SCP/RCP condition) | 02,05 | `o-0123456789` |
+| `{{DOMAIN}}` | Root authoritative DNS zone (Grafana OAuth, octoDNS, runbook URLs) | 01,02,06,07,08,10 | `platform.example.com` |
+| `{{ROOT_EMAIL_DOMAIN}}` | Root-account email domain (`aws+<role>@…`); may equal `{{DOMAIN}}` but kept distinct | 05 | `example.com` |
+| `{{VCS_ORG}}` | Git hosting org that owns the platform + GitOps repos | 01,04,06,10 | `acme-platform` |
+
+### 3.2 Accounts (12-digit AWS account IDs — repeated-digit doc shape + `# TODO: replace`)
+
+| Placeholder | Meaning | Specs | Example shape |
+|---|---|---|---|
+| `{{MGMT_ACCOUNT_ID}}` | Org management / landing-zone hub | 01,02,05 | `000000000000` |
+| `{{DEV_ACCOUNT_ID}}` | Development workloads | 01,02,03,05 | `111111111111` |
+| `{{STAGING_ACCOUNT_ID}}` | Pre-production (canonical name `stage`) | 01,02 | `222222222222` |
+| `{{PROD_ACCOUNT_ID}}` | Production workloads (also fronts CI OIDC roles, ECR) | 01,02,03,04,05,06,07 | `333333333333` |
+| `{{DR_ACCOUNT_ID}}` | Warm-standby DR for prod | 01,02,08 | `444444444444` |
+| `{{NETWORK_ACCOUNT_ID}}` | TGW hub, Route 53 Resolver, VPN, Lattice | 01,02 | `555555555555` |
+| `{{SECURITY_ACCOUNT_ID}}` | GuardDuty/SecurityHub delegated admin | 01,02,05 | `777777777777` |
+| `{{LOG_ARCHIVE_ACCOUNT_ID}}` | Centralized immutable log bucket. **Alias: `{{LOGARCHIVE_ACCOUNT_ID}}`** | 01,02,05,08 | `888888888888` |
+| `{{SHARED_ACCOUNT_ID}}` | ECR, Route 53 private zones, ACM, Service Catalog | 01,02 | `999999999999` |
+| `{{THIRDPARTY_ACCOUNT_ID}}` | Vendor IAM principals (narrow cross-org trust) | 01 | `666666666666` |
+| `{{SANDBOX_ACCOUNT_ID}}` | Optional personal escape-hatch account (S3-native-lock path) | 01,08 | `123456789012` |
+| `{{AWS_ACCOUNT_ID}}` | Generic per-pipeline account behind OIDC roles / ECR (context-resolved) | 10 | one of the above |
+
+> **Two sources of truth for account IDs** (SPEC-01 §4.5): each account's own `account.hcl` **and**
+> the `member_accounts` map in `_org/account.hcl`. Keep them in sync in one PR when onboarding an account.
+
+### 3.3 Regions
+
+| Placeholder | Meaning | Specs | Example shape |
+|---|---|---|---|
+| `{{PRIMARY_REGION}}` | Primary / aggregator / Control-Tower home region | 01,02,03,04,05,06,07,08,09,10 | `eu-west-1` |
+| `{{DR_REGION}}` | DR region (∈ `{{SECONDARY_REGIONS}}`) | 02,05,08,10 | `eu-central-1` |
+| `{{SECONDARY_REGIONS}}` | Additional active regions (list) | 01,02,03 | `["eu-west-2","eu-west-3","eu-central-1"]` |
+| `{{SECONDARY_REGION}}` | One active-active partner region (delivery) | 04 | `eu-central-1` |
+| `{{PRIMARY_REGION_SHORT}}` / `{{SECONDARY_REGION_SHORT}}` | Short region tokens in app names + value-file lookups (≤4 chars) | 04 | `euw1` / `euc1` |
+| `{{SECRETS_REGION}}` | ESO `ClusterSecretStore` region (may differ from primary — see §4/§5) | 05,07 | `eu-central-1` |
+
+### 3.4 DNS, network & failover
+
+| Placeholder | Meaning | Specs | Example shape |
+|---|---|---|---|
+| `{{PRIMARY_DNS_PROVIDER}}` | Active authoritative DNS provider. **Alias: `{{PRIMARY_DNS}}`** | 02,08 | `cloudflare` |
+| `{{SECONDARY_DNS_PROVIDER}}` | Standby authoritative DNS provider. **Alias: `{{SECONDARY_DNS}}`** | 02,08 | `route53` |
+| `{{REGISTRAR}}` | Domain registrar (drives `REGISTRAR_TYPE`) | 08 | `namecheap` / `godaddy` |
+| `{{MAIL_PROVIDER}}` | SPF include host | 02 | `_spf.google.com` |
+| `{{TGW_ASN}}` | Amazon-side TGW BGP ASN (private 64512–65534) | 02 | `64512` |
+| `{{DEPLOY_ROLE}}` | Cross-account deploy role assumed by CI | 01 | `TerragruntDeployRole` |
+| `{{OPERATOR_IP}}` | Sandbox operator public-IP allow-list (sandbox only; never a real IP) | 01 | `198.51.100.10/32` |
+| `{{ADMIN_CIDR_ALLOWLIST}}` | Operator/VPN egress CIDRs for a public API (**never** `0.0.0.0/0`) | 03 | narrow RFC-1918 range |
+
+### 3.5 State, buckets, KMS & clusters
+
+| Placeholder | Meaning | Specs | Example shape |
+|---|---|---|---|
+| `{{STATE_BUCKET}}` | Terraform state bucket | 01,02,08 | `tfstate-<account>-<region>` (org); `{{ORG}}-terraform-state-<id>` (sandbox) |
+| `{{LOG_ARCHIVE_BUCKET}}` | Central immutable log bucket | 05 | `{{ORG}}-log-archive-{{LOG_ARCHIVE_ACCOUNT_ID}}-{{PRIMARY_REGION}}` |
+| `{{ACCOUNT_EMAIL}}` | Per-account root email (plus-addressing) | 01 | `aws+<name>@{{DOMAIN}}` |
+| `{{KMS_EKS_SECRETS_KEY_ARN}}` | Secrets CMK ARN (control-plane envelope encryption) | 03 | KMS unit `key_arns["eks-secrets"]` |
+| `{{CLUSTER_NAME}}` | Cluster name pattern / Thanos dedup key | 03,07 | `<env>-<region>-platform` |
+| `{{SANDBOX_EMAIL}}` / `{{SANDBOX_USER}}` | Sandbox root email / IAM user (sandbox only) | 01 | *(sanitized)* / `sandbox-admin` |
+
+### 3.6 Repos, registries & CI
+
+| Placeholder | Meaning | Specs | Example shape |
+|---|---|---|---|
+| `{{GITOPS_REPO}}` | The single GitOps mono-repo (`argocd/ apps/ envs/ helm/ kargo/`). **See §4 D-INC: overlaps `{{ARGOCD_CONFIG_REPO}}`** | 04 | `platform-design` |
+| `{{ARGOCD_CONFIG_REPO}}` | GitOps config repo the deploy pipeline PRs into | 06,10 | `{{VCS_ORG}}/argocd` |
+| `{{PLATFORM_WORKFLOWS_REPO}}` | Shared reusable-workflow repo | 06 | `{{VCS_ORG}}/platform-workflows` |
+| `{{ECR_REGISTRY}}` | AWS image registry base | 04,10 | `{{PROD_ACCOUNT_ID}}.dkr.ecr.{{PRIMARY_REGION}}.amazonaws.com` |
+| `{{ML_IMAGE_REPO}}` | Model image registry | 10 | `{{AWS_ACCOUNT_ID}}.dkr.ecr.{{PRIMARY_REGION}}.amazonaws.com/ml` |
+| `{{GHCR_REGISTRY}}` | GHCR registry (e.g. auto-taint image) | 07 | `ghcr.io/{{VCS_ORG}}` |
+| `{{ARGOCD_SERVER}}` | ArgoCD API host (smoke/wait) | 06 | `argocd.{{DOMAIN}}` |
+| `{{CI_BOT_NAME}}` / `{{CI_BOT_EMAIL}}` | Git committer for auto-commits/PRs | 06,10 | `platform-ci[bot]` / `ci@{{DOMAIN}}` |
+| `{{CI_FEATURE_BRANCH}}` | Long-lived migration branch also gated | 06 | `feature/**` |
+
+### 3.7 Cloud identity (multi-cloud — GPU/ML)
+
+| Placeholder | Meaning | Specs | Example shape |
+|---|---|---|---|
+| `{{GCP_PROJECT_ID}}` | GCP project (GKE, GCS reference data). **Alias: `{{GCP_PROJECT}}`** | 07,10 | `acme-ml-prod` |
+| `{{AZURE_SUBSCRIPTION_ID}}` | Azure subscription (AKS estate) | 10 | `00000000-0000-0000-0000-000000000000` |
+| `{{MLFLOW_TRACKING_URI}}` / `{{AIRFLOW_BASE_URL}}` / `{{MLFLOW_S3_ENDPOINT_URL}}` | ML control-plane endpoints (per substrate; CI `vars.*`) | 10 | in-cluster service URLs |
+| `{{MODEL_ID}}` / `{{BASE_MODEL}}` | Served model / base model | 10 | `fraud-uk` / `Qwen 2.5 3B` |
+
+### 3.8 ML / observability / AI-SRE knobs
+
+| Placeholder | Meaning | Specs | Example shape |
+|---|---|---|---|
+| `{{TENANT}}` / `{{DOMAIN_SLUG}}` | ML tenant / business domain (namespace `ml-<tenant>-<domain>`) | 07 | `tenant-acme` / `hft,rtb,insurance` |
+| `{{SLUG}}` | Team/alert-name prefix (self-serve observability) | 07 | `payments` (→ `payments_HighErrorRate`) |
+| `{{XID_THRESHOLD}}` / `{{TEMP_THRESHOLD}}` | GPU auto-taint thresholds | 07 | `1` / `85` (°C) |
+| `{{PD_ROUTING_KEY}}` / `{{SLACK_WEBHOOK}}` | PagerDuty service key / Slack webhook (ESO-sourced secrets) | 07 | *(secret)* |
+| `{{AGENT_NAMESPACE}}` | AI-SRE K8s namespace | 09 | `ai-sre-system` |
+| `{{HUB_CLUSTER}}` | AI-SRE monitored hub cluster | 09 | `platform` |
+| `{{OMNISCIENCE_URL}}` / `{{OMNISCIENCE_TOKEN}}` | Knowledge-graph endpoint / token (mock by default — see §4) | 09 | real Neo4j+Qdrant service |
+| `{{CLICKHOUSE_URL}}` / `{{METRICS_MCP_URL}}` / `{{RUNBOOK_MCP_URL}}` | AI-SRE store + MCP HTTP servers | 09 | in-namespace service URLs |
+| `{{ARTIFACT_DIR}}` | AI-SRE collector mock output dir (**must contain no PII — see §4/§6**) | 09 | configurable path or disabled |
+| `{{ANTHROPIC_API_KEY}}` / `{{SLACK_BOT_TOKEN}}` / `{{SLACK_APP_TOKEN}}` | AI-SRE LLM + Slack credentials (ESO-sourced) | 09 | *(secret)* |
+
+### 3.9 Alias mapping (naming overlaps resolved)
+
+Where two specs named the same thing differently, this table fixes the **canonical** name and
+lists the alias. The domain specs are **not** edited; `SPEC-INDEX.md` carries the same table.
+
+| Canonical | Alias(es) | Alias used by | Note |
+|---|---|---|---|
+| `{{LOG_ARCHIVE_ACCOUNT_ID}}` | `{{LOGARCHIVE_ACCOUNT_ID}}` | SPEC-01, SPEC-02 | Same log-archive account; two spellings. |
+| `{{PRIMARY_DNS_PROVIDER}}` | `{{PRIMARY_DNS}}` | SPEC-02 (diagram) | Same active DNS provider. |
+| `{{SECONDARY_DNS_PROVIDER}}` | `{{SECONDARY_DNS}}` | SPEC-02 (diagram) | Same standby DNS provider. |
+| `{{GCP_PROJECT_ID}}` | `{{GCP_PROJECT}}` | SPEC-07 | Same GCP project. |
+| `{{PROJECT}}` | `{{REPO}}` | SPEC-01 | Both default `platform-design` (project/repo slug in ARNs/tags). |
+
+> **Not a clean alias — a genuine inconsistency (see §4 row D-INC):** `{{GITOPS_REPO}}` (SPEC-04,
+> "one mono-repo holds `argocd/apps/envs/helm/kargo/`") vs `{{ARGOCD_CONFIG_REPO}}` (SPEC-06/10,
+> "the `{{VCS_ORG}}/argocd` config repo the deploy pipeline PRs into"). The mono-repo model and the
+> separate-config-repo model coexist in source; a rebuild must pick one and reconcile the placeholders.
+
+---
+
+## 4. As-built divergence register
+
+The master list of "what to fix or decide before/while rebuilding". Each row is a **§7 item**
+lifted verbatim-in-summary from a domain spec (45 rows). **Type** legend: `scaffold` = designed
+but unwired/simulated/not deployed; `version-drift` = multiple pins/paths disagree; `config-bug` =
+an actual misconfiguration or interface mismatch; `missing-target` = a control/DR path that does
+not yet exist or is not hardened; `client-decision` = a "confirm intent" call the client must make.
+
+| # | Spec | Summary | Type |
+|---|---|---|---|
+| D01 | 01 | DynamoDB locking is still the non-sandbox default (`use_lockfile=false` + `terraform-locks-*`); only sandbox uses S3-native locking — plan a migration. | client-decision |
+| D02 | 01 | `_envcommon` module sources are path-based, not git-ref/registry-version pinned — a module edit hits every consumer. | version-drift |
+| D03 | 02 | TGW is a per-region hub; cross-region peering (`tgw-peers` set in `account.hcl`) is only in the catalog *template* stack, not wired live. | scaffold |
+| D04 | 02 | `dns-monitor`/`failover-controller` domain (`_health-check.example.com`) and probe region (`us-east-1`) are hard-coded to the sample. | config-bug |
+| D05 | 03 | Cilium version is pinned in three places (GitOps `1.19.4` / TF module `1.17.1` / catalog unit `1.16.5`); `1.19.4` is the as-built truth — pin one source. | version-drift |
+| D06 | 03 | Cluster Kubernetes version spread: `1.29` (dev agent-cluster) / `1.32` (catalog) / `1.34` (`_envcommon` target) — adopt `1.34` as the floor. | version-drift |
+| D07 | 03 | Istio is declared (dev `agent-cluster` lists an `istio` unit + reference manual) but no Istio module ships; the as-built mesh is sidecarless. | scaffold |
+| D08 | 03 | KEDA is deployed with zero `ScaledObject`s — the autoscaling contract exists without instances. | scaffold |
+| D09 | 04 | P1 — Two ApplicationSet families exist; only Family A is wired into the bootstrap Kustomization, so the workload/Kargo plane never comes up on a clean bootstrap. | scaffold |
+| D10 | 04 | P3 — `stage` (Family A/RollingSync/overlays) vs `staging` (Family B/Kargo) env-vocabulary drift silently no-ops mismatched files. | client-decision |
+| D11 | 04 | P5 — Argo Rollouts machinery ships in `helm/app` + ADR-0014 "synced", but no Rollouts controller runs; keep `rollout.enabled:false`. | scaffold |
+| D12 | 04 | P6 — Mixed repo-URL scheme (`https://` vs `git@`); SSH sources need a credential Secret or ArgoCD `ComparisonError`s. | config-bug |
+| D13 | 05 | ESO `ClusterSecretStore` targets `{{SECRETS_REGION}}` (`eu-central-1`) ≠ primary infra region (`eu-west-1`) — deliberate isolation or drift? | client-decision |
+| D14 | 06 | Soft-fail scanners (`tfsec`, Checkov/well-architected, `zizmor`, CodeQL) are advisory pending the hard-gate flip — a CRITICAL finding does not block today. | client-decision |
+| D15 | 06 | `terraform-compliance` BDD runs with `--no-failure`/`\|\| true` (decorative); only native `terraform test` gates. | config-bug |
+| D16 | 06 | Region inconsistency: IaC workflows hardcode `{{PRIMARY_REGION}}` (`eu-west-1`) while Terratest uses `us-east-1`. | config-bug |
+| D17 | 06 | Two overlapping Terraform versions in CI — `1.14.8` (validate/plan) vs `~1.11`/`1.11.0` (compliance/terratest). | version-drift |
+| D18 | 06 | `workflow_call` reusables live locally as mocks; in production they belong in `{{PLATFORM_WORKFLOWS_REPO}}`. | scaffold |
+| D19 | 07 | ADR-0026 says "Alloy is the single pipeline hub" but the estate ships a standalone OTel Collector (+ Fluent Bit) and no Alloy — reconcile the ADR or the tool. | client-decision |
+| D20 | 07 | ADR-0026 says "defer Pyroscope" but Pyroscope is fully deployed — the ADR is stale or the defer was overridden. | client-decision |
+| D21 | 07 | Namespace drift: prometheus-stack Application targets `monitoring` while LGTM add-ons/datasources reference `observability` (and two Prometheus service names). | config-bug |
+| D22 | 07 | VictoriaMetrics has two conflicting definitions — TF `VMCluster` (3/3/3, 500Gi, no RF) vs app Helm values (2/2/2, 100Gi, RF 2, full stack). | version-drift |
+| D23 | 07 | Loki retention conflict: values say `8760h` (365d, PCI-DSS 10.7) vs a 30-day README claim — a 12× storage difference. | client-decision |
+| D24 | 07 | Bare-metal auto-taint CronJob is the least hardened — raw manifest, no securityContext/limits/in-module RBAC. | missing-target |
+| D25 | 07 | DCGM exporter image tag drift — TF pins `4.5.0-4.2.3-ubuntu22.04` vs app Helm `4.5.0-4.3.3-ubuntu22.04`. | version-drift |
+| D26 | 07 | `observability-check` queries raw `DCGM_FI_DEV_*` names, but the gpu-inference-dcgm CSV remaps them to `dcgm_*` — the check fails for the wrong reason. | config-bug |
+| D27 | 08 | The log-archive design is not wired — `terragrunt/log-archive/<region>/` has only `region.hcl`; Object Lock/KMS/CRR are designed but not instantiated. | scaffold |
+| D28 | 08 | ML artifact store silently downgrades encryption — `kms_key_arn=""` default → AES256 (SSE-S3), not SSE-KMS; no Object Lock, no replication. | config-bug |
+| D29 | 08 | `centralized-logging` lifecycle wiring mismatch — `lifecycle_glacier_days=365` is defined-but-unused; transition keys off the unset `lifecycle_ia_days` (90). | config-bug |
+| D30 | 08 | Object Lock mode divergence — only the CloudTrail bucket is COMPLIANCE (true WORM); the general log archive is GOVERNANCE (admin can bypass). | client-decision |
+| D31 | 08 | RDS has no cross-region DR — Multi-AZ only; no read replica / no cross-region snapshot copy; DR RDS is a fresh instance. | missing-target |
+| D32 | 08 | DR account is a warm standby — `deletion_protection=false`, 7d retention, `enable_tgw_attachment=false` (not connected to the hub). | missing-target |
+| D33 | 08 | Three divergent RDS code paths — `catalog/units/rds` (7.1.0/PG17.7) vs `terraform/modules/rds` (~>6.0/PG17) vs `rds-postgres` (raw/PG16); only the catalog unit is wired. | version-drift |
+| D34 | 08 | `RequireManualAuth=false` by default — failover safety ships permissive; code comment says set `true` for prod initially. | client-decision |
+| D35 | 09 | Agents are simulated — `_run_agent` and `incident` steps 2–6 fabricate findings; a naïve deploy posts plausible-but-empty advisories. | scaffold |
+| D36 | 09 | Omniscience is a dry-run mock — default `sk_live_mock_token`/`OMNISCIENCE_DRY_RUN` writes a local JSON artifact, never touches Neo4j. | scaffold |
+| D37 | 09 | Authoring leak in `collector.py` — mock handler hard-codes a personal home path + conversation UUID as the artifact dir; must be sanitized to `{{ARTIFACT_DIR}}`. | config-bug |
+| D38 | 09 | Keyword retrieval ≠ semantic retrieval — `search_similar`/`suggest_runbook` do keyword overlap; `similarity_score` is a `1.0` placeholder. | scaffold |
+| D39 | 09 | In-memory dedup/approval/rate-limit state with `replicas:2` — state is per-pod; caps are approximate under HA (externalize to Redis). | missing-target |
+| D40 | 09 | Daily cost cap resets on a rolling 24h from process start (not UTC midnight) and is per-pod — budgeting is approximate. | missing-target |
+| D41 | 09 | No committed ADR governs the AI-SRE — the advisory-only invariant and Omniscience integration have only the unverified `ADR-0055` draft. | missing-target |
+| D42 | 10 | Two sources of truth for Volcano — chart values vs TF module disagree on `gang.enablePreemptable` and where Queue CRDs are created. | version-drift |
+| D43 | 10 | CI/CD composite-action interface drift — ML workflows call `syft-sbom`/`cosign-sign` with `image:` but actions declare `image-ref:`; `argocd-tag-bump` inputs unpassed. | config-bug |
+| D44 | 10 | Hardcoded identifiers in scaffold defaults — real VCS-org, CI-bot identity/email, placeholder-shaped tokens in actions/manifests/`.tftest.hcl` — scrub before sharing. | config-bug |
+| D45 | 10 | `busybox` model-loader stub — the vLLM init container is a placeholder; ship a real weight-pull or pods start with no model. | scaffold |
+
+> **D-INC (cross-spec inconsistency, not from a single §7):** `{{GITOPS_REPO}}` mono-repo model
+> (SPEC-04) vs `{{ARGOCD_CONFIG_REPO}}` separate-config-repo model (SPEC-06/10) — reconcile the
+> delivery-repo topology (see §3.9). Type: client-decision.
+
+**Type tally:** scaffold ×11 · version-drift ×8 · config-bug ×11 · missing-target ×6 · client-decision ×9 (+ D-INC).
+
+---
+
+## 5. Recommendations register
+
+The cross-spec "harden/decide before prod" backlog the writers flagged, deduplicated and
+attributed. Work these alongside the divergence register (§4).
+
+| # | Recommendation | Specs | Related divergences |
+|---|---|---|---|
+| R01 | **Author committed ADRs for the two ungoverned decisions** — the AI-SRE advisory-only invariant + Omniscience graph integration (only the unverified `ADR-0055` draft exists), and the Azure two-AKS ML federation (diagram-only, no ADR). | 09, 10 | D41 |
+| R02 | **Reconcile the observability stack against ADR-0026** — ratify OTel-Collector-as-hub (or adopt Alloy) and the Pyroscope decision; do not run two of the same tier. | 07 | D19, D20 |
+| R03 | **Flip advisory gates to blocking per the in-repo roadmap** — `tfsec`, Checkov/well-architected, `zizmor`, CodeQL, Access-Analyzer, `terraform-compliance` — once the finding backlog is remediated. | 06 | D14, D15 |
+| R04 | **Pin one version per component, derive the rest** — Cilium (single source), cluster K8s (`1.34` floor), CI Terraform (`1.14.8`), Volcano, DCGM image, and the three RDS paths. | 03, 06, 07, 08, 10 | D05, D06, D17, D22, D25, D33, D42 |
+| R05 | **Standardize workload identity for storage backends on Pod Identity** — the estate mixes Pod Identity (Thanos/YACE), IRSA (Loki/Pyroscope), and static S3 keys (Tempo); delete the static-key path. | 07 | — |
+| R06 | **Wire the unwired scaffolds before relying on them** — cross-region TGW peering, the log-archive `centralized-logging` unit, Family-B ApplicationSets, real Cilium/K8s pins, and the AI-SRE SDK loop + Omniscience push. | 02, 04, 08, 09 | D03, D09, D27, D35, D36 |
+| R07 | **Normalize the `stage`/`staging` env vocabulary** across Family-A/Family-B/overlays/Kargo and downstream tooling keyed on the canonical `stage` name. | 01, 04 | D10 |
+| R08 | **Reconcile the delivery-repo topology** — mono-repo (`{{GITOPS_REPO}}`) vs separate config repo (`{{ARGOCD_CONFIG_REPO}}`); pick one and align placeholders + credentials (D12 SSH creds). | 04, 06, 10 | D12, D-INC |
+| R09 | **Add cross-region RDS DR** — Multi-AZ covers AZ failure only; add a cross-region snapshot copy or read replica for regional DR, and finish the DR account (TGW attachment, deletion protection). | 08 | D31, D32 |
+| R10 | **Set `RequireManualAuth=true` for prod** on the failover controller until failover is trusted end-to-end; understand the `MaxDailyFailovers=1` strand. | 02, 08 | D34, D04 |
+| R11 | **Migrate state locking to S3-native** (`use_lockfile=true`), and **pin module sources by git-ref/registry version** instead of repo-root paths. | 01 | D01, D02 |
+| R12 | **Externalize AI-SRE per-pod state to Redis** (dedup, approvals, rate-limit, cost cap) before scaling past `replicas:1` or tightening caps; standardize on structlog. | 09 | D39, D40 |
+| R13 | **Decide the confirm-intent data-durability calls** — Object Lock GOVERNANCE→COMPLIANCE where regulation demands, Loki retention (30d vs 365d), and the ESO secrets-region isolation. | 05, 07, 08 | D13, D23, D30 |
+| R14 | **Harden the remaining gaps** — bare-metal auto-taint pod (securityContext/limits/RBAC), the `observability-check` metric-name remap, the ML CI/CD composite-action interface, and the `busybox`/`model-loader` stubs. | 07, 10 | D24, D26, D43, D45 |
+| R15 | **Scrub every authoring leak and hardcoded identifier** before sharing — the AI-SRE collector path/UUID, the ML scaffold defaults (VCS-org, CI-bot, tokens), and the sandbox account/bucket/IP. | 08, 09, 10 | D37, D44 |
+
+---
+
+## 6. Sanitization statement
+
+Estate-wide, the following classes of real values were replaced with double-brace placeholders
+(§3) while preserving the *shape* of each value, per `CONVENTIONS.md`: **AWS account IDs** (→
+repeated-digit documentation shape, e.g. `000000000000`) and any **ARNs carrying an account ID**;
+**organization / company / project slugs** (→ `{{ORG}}`, `{{PROJECT}}`, `{{VCS_ORG}}`); **DNS
+domains and hostnames** (→ `{{DOMAIN}}`, `example.com`); **S3 bucket names** that embedded the
+company name (→ `{{STATE_BUCKET}}`, `{{LOG_ARCHIVE_BUCKET}}`); **personal / root emails** (→
+`aws+<role>@{{DOMAIN}}`); **IP addresses** (kept only as RFC-1918 / RFC-5737 documentation ranges;
+real operator/office IPs → `{{OPERATOR_IP}}`); **CI-bot identities** (→ `{{CI_BOT_NAME}}` /
+`{{CI_BOT_EMAIL}}`); **registrar/DNS-provider tokens, Slack/PagerDuty keys, LLM API keys, and cloud
+credentials** (→ ESO-sourced secret placeholders); and **authoring leaks** such as personal home
+paths and conversation UUIDs found in scaffold code (→ `{{ARTIFACT_DIR}}`, flagged as D37/D44 to
+scrub). The specs also flag several source-side leaks a rebuild must still remove (sandbox account
+ID/bucket/IP in `root.hcl`; hardcoded identifiers in ML scaffold defaults). **Note:** the name
+**"Innovate Inc"** appearing in this estate's ADRs is a **fictional placeholder company**, not a
+real client — treat it as sample text, not an identity to preserve.
+
+---
+
+## 7. How to use these specs for a client build
+
+A pragmatic protocol. Do these in order; each step gates the next.
+
+1. **Fill the placeholder registry first (§3).** Replace every `{{PLACEHOLDER}}` with the client's
+   real values in one pass. Resolve the aliases (§3.9) to the canonical name. Keep the two
+   account-ID sources of truth in sync (SPEC-01 §4.5). Nothing else should start until this table
+   is complete.
+2. **Resolve the divergence register's `client-decision` rows (§4).** These are not bugs — they are
+   choices only the client can make: state-lock backend (D01), env vocabulary (D10), secrets-region
+   isolation (D13), gate-blocking timeline (D14), observability-stack ratification (D19/D20),
+   Loki retention (D23), Object-Lock mode (D30), failover auth (D34), and the delivery-repo topology
+   (D-INC). Record each decision as a committed ADR (R01).
+3. **Reconcile the `version-drift` rows to a single pin each (§4, R04)** before building — carrying
+   three Cilium pins or three RDS paths into a fresh build reproduces the drift.
+4. **Execute the specs in reading order (§2):** `01 → 02 → 03 → 05 → 04 → 06 → 07 → 08 → 10 → 09`.
+   Build each domain from its **§4 implementation blueprint**, and treat each spec's **§8 acceptance
+   checklist as the phase gate** — do not proceed to the next spec until the current one's checklist
+   passes clean (e.g. "`terragrunt run --all plan` clean from an empty account", "ArgoCD app-of-apps
+   syncs with zero manual steps", "advisory-only holds across all four enforcement layers").
+5. **Wire the `scaffold` rows as explicit work items (§4, R06),** not assumptions — the ML/GPU
+   surface, the AI-SRE agent loop, cross-region TGW peering, and the log-archive unit are designed
+   but not deployed; a rebuild must actually build them.
+6. **Run the recommendations register (§5) as the "harden before prod" backlog** — flip advisory
+   gates to blocking, standardize workload identity, add cross-region RDS DR, externalize AI-SRE
+   state, and scrub every authoring leak — before promoting anything to production.
+7. **Keep sanitization a standing rule (§6).** Every client-specific value stays a placeholder in
+   shared artifacts; verify no real account ID, ARN-with-ID, bucket, hostname, email, non-RFC-1918
+   IP, or CI-bot identity survives before any spec or plan output is shared.
+
+---
+
+## 8. Dependencies
+
+SPEC-00 owns the canonical placeholder registry (§3), the divergence register (§4), and the
+recommendations register (§5); every domain spec's §5 parameterization table and §7 known-pitfalls
+register against these. The domain specs' own `§9 Dependencies on other specs` sections define the
+inter-spec edges; the reading order in §2 is the topological resolution of those edges.

--- a/specs/SPEC-01-foundation-iac.md
+++ b/specs/SPEC-01-foundation-iac.md
@@ -1,0 +1,523 @@
+# SPEC-01 — Foundation: IaC, Account Topology & State
+
+> Portable reverse-engineering of the platform's Infrastructure-as-Code foundation:
+> the AWS Organization + OU topology, the Terragrunt-over-Terraform orchestration
+> layer, remote state, version pinning, and the tagging/naming standards that every
+> other spec builds on. Follows `CONVENTIONS.md`. All identity is parameterized; no
+> real account IDs, buckets, IPs, emails, or org names appear.
+
+---
+
+## 1. Scope & non-goals
+
+**Scope.** This spec defines the *ground floor* a new client stands up before any
+cluster or workload exists: (a) the AWS Organization and its Organizational Unit
+(OU) split; (b) the canonical multi-account topology (management + security +
+log-archive + network + shared + dev/staging/prod/dr + third-party, plus an
+optional personal sandbox); (c) the Terragrunt orchestration layer
+(`root.hcl` + `versions.hcl` + `common.hcl` + `_envcommon/` inheritance + the
+`catalog/units` + `catalog/stacks` model); (d) the Terraform-only remote-state
+backend and its bootstrap ordering; (e) exact tool/provider version pins; and
+(f) the naming and tagging conventions (ADR-0028 unified taxonomy) that make
+FinOps, observability, and incident-response joins work.
+
+**Non-goals.** VPC/CIDR design, Transit Gateway, ClusterMesh, and inter-VPC
+security (their own networking spec); EKS/Karpenter/KEDA compute (compute spec);
+SCP/RCP/GuardDuty/SecurityHub *contents* (security-guardrails spec — this spec
+covers only *where* they attach); GitOps delivery (ArgoCD/Kargo), observability,
+and GPU/ML stacks. AWS Control Tower + AFT account vending is a **design-target**
+here (ADR-0035) and is described only as the intended evolution of the live
+raw-Organizations bootstrap.
+
+---
+
+## 2. Architecture
+
+Two orthogonal axes organize the estate: **AWS accounts/OUs** (isolation +
+governance) and the **Terragrunt live tree** (DRY config resolution). They meet
+at `account.hcl` / `region.hcl`, which every unit reads via
+`find_in_parent_folders`.
+
+```
+                          AWS Organization  (management / root account)
+                          ├─ enabled policy types: SCP + TAG + RCP
+                          └─ OU tree (8 OUs, applied from management):
+   Root
+   ├── Security            → security, log-archive, third-party
+   ├── Infrastructure      → network, shared
+   ├── Workloads           (container OU; no direct accounts)
+   │   ├── NonProd         → dev, staging          (alias: Non-Production)
+   │   └── Prod            → prod, dr              (alias: Production)
+   ├── Deployments         → (reserved for AFT/CI — ADR-0035)
+   ├── Sandbox             → (per-developer, optional)
+   └── Suspended           → (incident-response quarantine)
+
+   Config-resolution chain (every unit, resolved by root.hcl):
+   ┌ versions.hcl ─ tool + provider pins (single source of truth)
+   ├ common.hcl   ─ project metadata, tag schema, region short codes
+   ├ account.hcl  ─ account_id, env, owner, cost_center, sizing knobs
+   └ region.hcl   ─ aws_region, region_short, azs
+        │
+        ▼   include "root" { find_in_parent_folders("root.hcl") }
+   root.hcl  ──generate──▶  backend.tf          (S3 + lock per account/region)
+             ──generate──▶  provider.tf         (assume_role + default_tags)
+             ──generate──▶  versions_override.tf (required_version + providers)
+        │
+        ▼
+   Live tree:  terragrunt/<account>/<region>/<stack>/terragrunt.stack.hcl
+        │            references
+        ▼
+   Catalog:   catalog/units/<unit>/terragrunt.hcl  +  catalog/stacks/<stack>
+        │            + _envcommon/<module>.hcl  (source pin + shared inputs)
+        ▼
+   Modules:   terraform/modules/<module>/   (thin wrappers over upstream modules)
+```
+
+**Bootstrap (chicken-and-egg break).** The state backend cannot live in the
+state it stores, so `bootstrap/state-backend/` is a **Terraform-only** root
+(local state, no Terragrunt) that creates the S3 bucket + DynamoDB lock table
+per account. Everything else then runs through Terragrunt against that backend.
+
+---
+
+## 3. Decision record
+
+| Decision | Rationale | Trade-off accepted | Source ADR |
+|---|---|---|---|
+| **Terragrunt** as the orchestration layer over plain Terraform / workspaces / CDKTF | `_envcommon/` kills per-account duplication; `generate` gives uniform backend + provider + `default_tags`; `dependency` gives cross-module wiring; `run --all` orders applies across accounts | Terragrunt-specific HCL learning curve; harder debugging (generated files); CI installs two tools | `ADR-0004 Terragrunt over plain Terraform` |
+| **Terraform-only state backend bootstrap** (dedicated module + script, local state, no Terragrunt wrapper) | Bucket config (versioning, KMS, Object Lock, lifecycle) is auditable IaC, not implicit Terragrunt auto-create | Bootstrap state file is committed to git (bucket/table ARNs only, no secrets); needs a privileged org-admin run | `ADR-0002 Terraform-only state backend` |
+| **Canonical OU split**: Production / Non-Production / Deployments / Suspended / Sandbox, layered over functional OUs (Security / Infrastructure / Workloads) | Blast-radius isolation, per-account cost allocation, per-OU SCP profiles; `Deployments` isolates future AFT/CI; `Sandbox` gets its own region-restrict + spend-cap profile | Doc-level alias mapping (`Prod`↔`Production`) adds cognitive load; two extra OUs add SCP-attachment entries (within AWS caps) | `ADR-0001 OU split` (folds in the multi-account strategy) |
+| **Unified platform tagging taxonomy** — five `platform:*` AWS tags mirroring five `platform.*` K8s labels, injected via `root.hcl` `default_tags` + `inputs.tags` | One taxonomy joins the AWS plane and the EKS plane for single-pane dashboards, FinOps allocation, and incident correlation | Strict enforcement overhead (untagged resources vanish from dashboards/cost); migration effort to thread `var.tags` everywhere | `ADR-0028 Unified Platform Tagging and Labeling Taxonomy` |
+| **Version pins centralized in `versions.hcl`**; every other manifest mirrors it | Single source of truth prevents drift between `required_version`, CI matrix, and tool managers | Mirrors (`.tool-versions`, `.terraform-version`, `.terragrunt-version`, `mise.toml`) must be updated in lockstep | `versions.hcl` bump policy (patch/minor = PR; major = ADR) |
+| **AWS Control Tower + AFT** as the *target* landing-zone / vending model | CT is a hard prerequisite of AFT; moves account baselining + guardrail drift to a managed control plane; vending becomes a reviewed `aft-account-request` PR | Live-org migration (not greenfield); two new management accounts; SCP-slot + Config/CloudTrail collisions to reconcile | `ADR-0035 Control Tower + AFT` (supersedes ADR-0017 item-0) |
+| **Hub-and-spoke Transit Gateway**, one TGW shared via RAM to workload accounts | Central connectivity + inspection; spoke isolation as the default | Cross-account RAM wiring; blackhole routes for env isolation | `ADR-0005 hub-spoke-transit-gateway` (detailed in networking spec) |
+
+---
+
+## 4. Implementation blueprint
+
+### 4.1 Directory layout
+
+```
+<repo-root>/
+├── bootstrap/state-backend/           # TF-only, local state — runs FIRST
+│   ├── main.tf  variables.tf  outputs.tf  README.md
+├── terraform/
+│   ├── modules/<module>/              # ~135 thin module wrappers (vpc, eks,
+│   │                                  #   organization, scps, kms, state-backend, …)
+│   ├── environments/production/       # optional flat root-module example
+│   └── README.md  QUICK_START.md
+├── terragrunt/
+│   ├── root.hcl                       # backend + provider + versions generation
+│   ├── versions.hcl                   # SINGLE SOURCE OF TRUTH for versions
+│   ├── common.hcl                     # project metadata, tag schema, region codes
+│   ├── mise.toml                      # mirrors versions.hcl
+│   ├── _envcommon/<module>.hcl        # per-module source pin + shared inputs
+│   ├── _org/                          # management account
+│   │   ├── account.hcl                # org-wide: member_accounts map, OU placement
+│   │   └── _global/<unit>/            # organization, scps, rcps, sso, cloudtrail,
+│   │                                  #   guardduty-org, security-hub, aws-config,
+│   │                                  #   iam-baseline, budgets, break-glass-user
+│   └── <account>/                     # security | log-archive | network | shared |
+│       ├── account.hcl                #   dev | staging | prod | dr | third-party | sandbox
+│       ├── _global/iam/               # account-wide (non-regional) resources
+│       └── <region>/                  # eu-west-1|2|3 | eu-central-1 (+ us-east-1 niche)
+│           ├── region.hcl
+│           └── <stack>/terragrunt.stack.hcl
+├── catalog/units/<unit>/terragrunt.hcl
+├── catalog/stacks/<stack>/terragrunt.stack.hcl
+├── .tool-versions  .terraform-version  .terragrunt-version   # mirror versions.hcl
+├── .tflint.hcl  .yamllint.yml
+└── docs/adrs/  docs/ou-structure.md  docs/account-vending.md
+```
+
+### 4.2 Version pins (exact — from `versions.hcl`, the single source of truth)
+
+| Tool / provider | Pin | Constraint form |
+|---|---|---|
+| Terraform / OpenTofu | `1.14.8` | `required_version = "= 1.14.8"` |
+| Terragrunt | `1.0.8` | `terragrunt_version_constraint = "= 1.0.8"` |
+| `hashicorp/aws` | `~> 6.0` | generated into `versions_override.tf` |
+| `hashicorp/helm` | `~> 2.12` | |
+| `hashicorp/kubernetes` | `~> 2.30` | |
+| `null` / `random` / `tls` | `~> 3.2` / `~> 3.6` / `~> 4.0` | |
+| TFLint AWS ruleset | `0.35.0` | `.tflint.hcl` |
+
+Mirrors that MUST match exactly: `.tool-versions` (`terraform 1.14.8`,
+`terragrunt 1.0.8`), `.terraform-version` (`1.14.8`), `.terragrunt-version`
+(`1.0.8`), `terragrunt/mise.toml`. Bump policy: patch/minor = PR + green CI on a
+non-prod env first; major = ADR + multi-env soak.
+
+### 4.3 `root.hcl` — the load-bearing generation logic (sanitized excerpt)
+
+```hcl
+locals {
+  versions     = read_terragrunt_config(find_in_parent_folders("versions.hcl"))
+  common       = read_terragrunt_config(find_in_parent_folders("common.hcl"))
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+
+  account_name = local.account_vars.locals.account_name
+  account_id   = local.account_vars.locals.account_id
+  aws_region   = local.region_vars.locals.aws_region
+  environment  = local.account_vars.locals.environment
+
+  is_sandbox          = local.account_name == "sandbox"      # escape-hatch branch
+  state_bucket_region = try(local.account_vars.locals.state_bucket_region, local.aws_region)
+
+  platform_tags = {                                          # ADR-0028 taxonomy
+    "platform:system"     = try(local.account_vars.locals.platform_system, local.common.locals.default_platform_system)
+    "platform:component"  = try(local.account_vars.locals.platform_component, local.common.locals.default_platform_component)
+    "platform:env"        = local.environment
+    "platform:owner"      = try(local.account_vars.locals.owner, local.common.locals.default_owner)
+    "platform:managed-by" = local.common.locals.platform_managed_by   # "terragrunt"
+  }
+}
+
+remote_state {
+  backend  = "s3"
+  generate = { path = "backend.tf", if_exists = "overwrite_terragrunt" }
+  config = merge(
+    {
+      bucket  = local.is_sandbox ? "{{ORG}}-terraform-state-${local.account_id}" : "tfstate-${local.account_name}-${local.aws_region}"
+      key     = "${local.environment}/${path_relative_to_include()}/terraform.tfstate"
+      region  = local.state_bucket_region
+      encrypt = true
+    },
+    local.is_sandbox
+      ? { use_lockfile = true,  dynamodb_table = null, dynamodb_table_tags = null }   # S3 native lock
+      : { use_lockfile = false, dynamodb_table = "terraform-locks-${local.account_name}" }  # DynamoDB (legacy)
+  )
+}
+```
+
+The provider is generated with a conditional `assume_role` (org accounts assume
+`{{DEPLOY_ROLE}}`; sandbox uses direct IAM-user creds) and `default_tags`
+carrying both the legacy cost/audit keys and the five `platform:*` keys:
+
+```hcl
+generate "provider" {
+  path = "provider.tf"  if_exists = "overwrite_terragrunt"
+  contents = <<-EOF
+    provider "aws" {
+      region = "${local.aws_region}"
+      %{if !local.is_sandbox}
+      assume_role { role_arn = "arn:aws:iam::${local.account_id}:role/{{DEPLOY_ROLE}}" }
+      %{endif}
+      default_tags { tags = { Environment = "${local.environment}", ManagedBy = "terragrunt",
+        Owner = "${local.owner}", CostCenter = "${local.cost_center}",
+        "platform:system" = "${local.platform_system}", "platform:env" = "${local.environment}", ... } }
+    }
+  EOF
+}
+```
+
+### 4.4 `_envcommon` inheritance pattern (the DRY core)
+
+Each `_envcommon/<module>.hcl` fixes the **module source** and **shared default
+inputs** once; per-env units include it with `merge_strategy = "deep"` and
+override only what differs.
+
+```hcl
+# _envcommon/eks.hcl  (shared across every <env>/<region>/eks unit)
+locals {
+  module_source = "${get_repo_root()}/<repo-subpath>/terraform/modules/eks"
+  defaults = {
+    cluster_version            = "1.34"
+    endpoint_private_access    = true
+    endpoint_public_access     = false     # non-prod may flip, with caution
+    enabled_cluster_log_types  = ["api","audit","authenticator","controllerManager","scheduler"]
+    secrets_encryption_enabled = true
+  }
+}
+terraform { source = local.module_source }
+dependency "vpc" {                         # VPC must exist before EKS
+  config_path  = "../vpc"
+  mock_outputs = { vpc_id = "vpc-mock0123", private_subnet_ids = ["subnet-mock1","subnet-mock2"] }
+  mock_outputs_allowed_terraform_commands = ["init","validate","plan"]
+}
+inputs = { cluster_version = local.defaults.cluster_version, vpc_id = dependency.vpc.outputs.vpc_id, ... }
+```
+
+Consuming unit (only the delta):
+```hcl
+include "root"      { path = find_in_parent_folders("root.hcl") }
+include "envcommon" { path = find_in_parent_folders("_envcommon/eks.hcl"), expose = true, merge_strategy = "deep" }
+inputs = { cluster_name = "platform-dev-euw1", node_groups = { general = { instance_types = ["m6i.large"], desired_size = 2 } } }
+```
+
+`_envcommon` bump policy: adding a backward-compatible default = PR + CI;
+changing a default = list every consumer (`grep -r "_envcommon/<module>.hcl" terragrunt/`)
++ non-prod soak; changing the module `source` = **ADR** (it rewrites every
+consumer's state address).
+
+### 4.5 Account topology (canonical set)
+
+| Folder | OU | Account-ID placeholder | Purpose |
+|---|---|---|---|
+| `_org/` | Root | `{{MGMT_ACCOUNT_ID}}` | Organization management / landing-zone hub |
+| `security/` | Security | `{{SECURITY_ACCOUNT_ID}}` | Delegated admin: GuardDuty, SecurityHub, Detective, Inspector, Macie |
+| `log-archive/` | Security | `{{LOGARCHIVE_ACCOUNT_ID}}` | Central immutable log bucket (CloudTrail, Config, VPC Flow, EKS audit) |
+| `network/` | Infrastructure | `{{NETWORK_ACCOUNT_ID}}` | Transit Gateway hub, Route53 resolver, inspection VPC |
+| `shared/` | Infrastructure | `{{SHARED_ACCOUNT_ID}}` | ECR, Route53 private zones, ACM authority, Service Catalog |
+| `dev/` | NonProd | `{{DEV_ACCOUNT_ID}}` | Development workloads |
+| `staging/` | NonProd | `{{STAGING_ACCOUNT_ID}}` | Pre-production (canonical name `stage`) |
+| `prod/` | Prod | `{{PROD_ACCOUNT_ID}}` | Production workloads |
+| `dr/` | Prod | `{{DR_ACCOUNT_ID}}` | Disaster recovery for prod |
+| `third-party/` | Security | `{{THIRDPARTY_ACCOUNT_ID}}` | Vendor IAM principals (narrow cross-org trust) |
+| `sandbox/` | Sandbox | `{{SANDBOX_ACCOUNT_ID}}` | *Optional* personal-account escape hatch (see §7) |
+
+Account IDs in the estate use the repeated-digit documentation shape
+(`000000000000`, `111111111111`, …) with `# TODO: replace` markers. **Two
+sources of truth exist and must stay in sync**: each account's own
+`terragrunt/<name>/account.hcl` **and** the `member_accounts` map in
+`terragrunt/_org/account.hcl` (used to create the accounts and place them in
+OUs). Every `account.hcl` declares `account_name`, `account_id`, `email`,
+`org_ou`, `environment`, `owner`, `cost_center`; workload accounts add sizing
+knobs (NAT posture, EKS node groups, RDS class, Karpenter nodepools, …).
+
+### 4.6 Region + CIDR standard
+
+Region short codes (`common.hcl` `region_short_codes`): `eu-west-1→euw1`
+(Ireland/primary), `eu-west-2→euw2` (London), `eu-west-3→euw3` (Paris),
+`eu-central-1→euc1` (Frankfurt). Non-overlapping `/16` per env×region:
+
+| Env | eu-west-1 | eu-west-2 | eu-west-3 | eu-central-1 |
+|---|---|---|---|---|
+| dev | 10.0.0.0/16 | 10.1.0.0/16 | 10.2.0.0/16 | 10.3.0.0/16 |
+| staging | 10.10.0.0/16 | 10.11.0.0/16 | 10.12.0.0/16 | 10.13.0.0/16 |
+| prod | 10.20.0.0/16 | 10.21.0.0/16 | 10.22.0.0/16 | 10.23.0.0/16 |
+| dr | 10.30.0.0/16 | 10.31.0.0/16 | 10.32.0.0/16 | 10.33.0.0/16 |
+
+### 4.7 Bootstrap ordering (zero → running)
+
+```
+0. Prereqs: management account exists; org-admin creds; mise install (pins from mise.toml).
+1. AWS Organization + OUs + member accounts:
+     terragrunt apply  terragrunt/_org/_global/organization   (from management account)
+     → enables SCP + TAG_POLICY + RESOURCE_CONTROL_POLICY; creates 8 OUs; for_each member accounts.
+2. State backend per account (TF-only, LOCAL state, run before any Terragrunt unit):
+     ./scripts/deploy-state-backends.sh apply           # assumes OrganizationAccountAccessRole
+     order: management → network → dev/staging/prod/dr (rest any order)
+     → creates s3://tfstate-<account>-<region> (+ terraform-locks-<account>), prevent_destroy=true.
+3. Guardrails from management: scps (dep: organization), rcps, sso, cloudtrail, config-org,
+     guardduty-org, security-hub, iam-baseline, budgets, break-glass-user.
+4. Network account: transit-gateway → RAM share → per-spoke tgw-attachment.
+5. Workload accounts, per region, dependency-ordered by Terragrunt:
+     Phase 1 (parallel): vpc, secrets
+     Phase 2: eks (dep vpc)
+     Phase 3 (parallel): karpenter (dep eks), monitoring (dep eks), rds (dep vpc+eks+secrets)
+     Deploy dev first, then promote config through staging → prod → dr.
+```
+
+Deploy a whole stack: `cd terragrunt/dev/eu-west-1/platform && terragrunt stack apply`.
+Whole environment: `cd terragrunt/dev && terragrunt run --all apply`.
+
+---
+
+## 5. Parameterization table
+
+| Placeholder | Meaning | Default / shape in this estate | Resize guidance |
+|---|---|---|---|
+| `{{ORG}}` | Org slug (used in sandbox state bucket) | private slug → e.g. `acme` | Lowercase DNS-safe; used in global-unique S3 names |
+| `{{VCS_ORG}}` / `{{REPO}}` | Git org / repo (`repository` local) | `{{VCS_ORG}}/{{REPO}}` | Any Git host org |
+| `{{PROJECT}}` | `project_name` in `common.hcl` | e.g. `platform-design` | Free-form; appears in the `Project` tag |
+| `{{MGMT_ACCOUNT_ID}}` … `{{SANDBOX_ACCOUNT_ID}}` | 12-digit AWS account IDs (11 accounts) | repeated-digit doc shape + TODO | Replace all; keep `_org` `member_accounts` in sync |
+| `{{PRIMARY_REGION}}` | Primary region / SecurityHub aggregator home | `eu-west-1` | Also the Control-Tower home region (permanent) |
+| `{{SECONDARY_REGIONS}}` | Additional active regions | `eu-west-2`, `eu-west-3`, `eu-central-1` | Add region folder + `region.hcl` + CIDR row |
+| `{{DEPLOY_ROLE}}` | Cross-account deploy role assumed by CI | `TerragruntDeployRole` | Must exist in every non-sandbox account |
+| `{{STATE_BUCKET}}` | State bucket name | `tfstate-<account>-<region>` (org); `{{ORG}}-terraform-state-<id>` (sandbox) | One bucket per account per region |
+| `{{ACCOUNT_EMAIL}}` | Root email per account | `aws+<name>@{{DOMAIN}}` | Use plus-addressing on one mailbox |
+| `{{SANDBOX_EMAIL}}` / `{{SANDBOX_USER}}` / `{{OPERATOR_IP}}` | Sandbox root email / IAM user / operator public IP allow-list | *(sanitized)* / `sandbox-admin` / `{{OPERATOR_IP}}/32` | Sandbox only; never ship a real personal IP or account |
+
+**Sizing knobs** (all in `account.hcl`, per environment):
+
+| Setting | dev | staging | prod | dr |
+|---|---|---|---|---|
+| NAT gateway | single | per-AZ (HA) | per-AZ (HA) | single |
+| EKS public access | yes (`0.0.0.0/0` — dev only) | no | no (private; break-glass CIDR allow-list) | no |
+| EKS instance type | `m6i.large` | `m6i.xlarge` | `m6i.2xlarge` | `m6i.xlarge` |
+| EKS nodes (min/desired/max) | 1/2/3 | 2/3/5 | 3/5/10 | 1/2/5 |
+| RDS class / multi-AZ / GB | `db.t4g.medium` / no / 20 | `db.r6g.large` / yes / 50 | `db.r6g.xlarge` / yes / 100 | `db.r6g.large` / yes / 50 |
+| Karpenter controller replicas | 2 | 2 | 3 | 2 |
+| CDE isolation (PCI-DSS) | off | off | on (dedicated nodepool + taint) | off |
+| TGW / ClusterMesh cluster-IDs | TGW off | mesh on (euw1=1, euc1=2) | per-region | off |
+
+Other knobs: KMS key inventory (`_envcommon/kms.hcl` — 10 CMKs: cloudtrail,
+aws-config, s3-data, eks-secrets, ebs, rds, sns, sqs, logs, backup; rotation on,
+30-day deletion window); TGW `amazon_side_asn_base = 64512`; budgets
+(`monthly_budget_amount` default `10000` USD, alerts at 50/80/100/110%,
+anomaly detection at `20` USD); central-log lifecycle (90d → Glacier 365d →
+expire 2555d/7y, Object Lock `GOVERNANCE` 365d).
+
+---
+
+## 6. Best practices distilled
+
+1. **One version source of truth.** All version literals live in `versions.hcl`;
+   every tool manifest mirrors it. *Why:* a single edit can't leave
+   `required_version`, the CI matrix, and `mise`/`asdf` disagreeing — the most
+   common "works on my machine" failure in multi-account IaC.
+2. **Generate backend + provider + versions; never hand-write them.** `root.hcl`
+   `generate` blocks produce `backend.tf`, `provider.tf`, `versions_override.tf`
+   for every unit. *Why:* uniform `default_tags`, uniform `assume_role`, uniform
+   state keys — zero copy-paste drift across ~135 modules.
+3. **Fix the module source + shared inputs in `_envcommon/`, override only the
+   delta in the unit.** *Why:* bumping a cross-cutting default (e.g. a new EKS
+   log type) is one edit, inherited everywhere, instead of N unit edits.
+4. **Account-per-isolation, OU-per-policy-profile.** Map accounts onto OUs whose
+   SCP profile matches their risk (NonProd/Prod/Sandbox deny-root; Deployments
+   runs programmatic IAM). *Why:* blast-radius isolation and clean per-OU SCP
+   math (AWS caps SCPs per OU).
+5. **Break the state chicken-and-egg explicitly.** Bootstrap the backend with a
+   TF-only, local-state module (`bootstrap/state-backend`) before any Terragrunt
+   unit runs; `prevent_destroy = true` on the bucket + lock table. *Why:*
+   auditable bucket config (versioning, KMS, Object Lock) and no accidental loss
+   of every unit's state.
+6. **One state bucket per account per region, one lock table per account.**
+   Key = `<env>/<path_relative_to_include()>/terraform.tfstate`. *Why:* a lost or
+   corrupted bucket is scoped to one account/region, and state keys are
+   collision-free by construction.
+7. **Tag once, at the root, with the unified taxonomy.** Inject the five
+   `platform:*` keys via `default_tags` **and** `inputs.tags` so both
+   provider-applied and module-`var.tags`-applied resources carry them; enforce
+   with a TFLint `aws_resource_missing_tags` rule. *Why:* AWS tags and K8s labels
+   share keys byte-for-byte, so Grafana/YACE/OpenCost joins and incident triage
+   work across planes.
+8. **Merge tags later-wins: legacy → `platform:*` defaults → unit `tags`.** A unit
+   that owns a logical service sets `tags["platform:system"]="auth"` and wins
+   without clobbering the other four keys. *Why:* per-service ownership without
+   losing the org-wide taxonomy.
+9. **Cross-unit data via `dependency` + `mock_outputs`, never hardcoded ARNs.**
+   Mocks are scoped to `["init","validate","plan"]` so plans work before the
+   dependency exists. *Why:* `run --all plan` stays green on an empty account and
+   real outputs flow at apply.
+10. **Deploy dev first, promote config through staging → prod → dr.** *Why:*
+    every version/default bump soaks in low-risk environments before prod.
+11. **Pin the operator blast radius.** Prod EKS endpoints are private by default;
+    if public access is ever enabled it is locked to an org-driven CIDR
+    allow-list, never `0.0.0.0/0` (dev is the only place `0.0.0.0/0` is
+    acceptable). *Why:* the API server is the single highest-value target.
+12. **Record every foundational choice as an ADR; never rewrite a ratified one.**
+    Supersede forward (ADR-0035 supersedes ADR-0017 item-0) and note corrections
+    of record. *Why:* the decision trail survives contributor turnover.
+
+---
+
+## 7. Known pitfalls
+
+1. **Stale version references in prose.** `terragrunt/README.md` ("Terraform >=
+   1.11.0, Terragrunt >= 0.68.0"), `mise.toml`'s header comment ("terraform 1.10,
+   terragrunt 0.68"), and `root.hcl`'s "Terragrunt v0.68" type-consistency note
+   all predate the current pins (**TF 1.14.8 / TG 1.0.8**). Trust `versions.hcl`
+   only; treat prose version numbers as non-authoritative and fix them on sight.
+2. **As-built divergence: DynamoDB locking is still the non-sandbox default.** `root.hcl` sets
+   `use_lockfile = false` + a `terraform-locks-<account>` table for every
+   non-sandbox account; only sandbox uses S3-native `use_lockfile = true`.
+   Current guidance prefers S3 native locking (DynamoDB is legacy) — plan a
+   migration; don't assume the estate already uses it.
+3. **The "Setup" step "Terragrunt auto-creates buckets" contradicts ADR-0002.**
+   `terragrunt/README.md`'s setup list says the backend is auto-created; ADR-0002
+   explicitly rejects that in favor of the `bootstrap/state-backend` module. Use
+   the bootstrap module; the README line is stale.
+4. **Two sources of truth for account IDs.** Each `account.hcl` **and** the
+   `_org` `member_accounts` map both carry IDs; they can drift. Update both in one
+   PR when onboarding an account, and keep the placeholder-shape TODO markers
+   until real IDs land.
+5. **Placeholder admin CIDR must be replaced before public endpoints.**
+   `_org/account.hcl` `admin_cidr_allowlist` and prod's `eks_public_access_cidrs`
+   ship as `10.0.0.0/8 # PLACEHOLDER — DO NOT ship as-is`. Replace with real
+   office/VPN egress CIDRs before ever flipping `eks_public_access` to `true`.
+6. **The sandbox account is a real personal-account escape hatch, not a template
+   member.** It hardcodes a fixed state bucket in a specific region
+   (`state_bucket_region`), skips `assume_role`, uses direct IAM-user creds, and
+   disables org features. For a client rebuild, treat `sandbox` as *optional* and
+   fully parameterized — never copy its concrete identity, IP, or bucket.
+7. **As-built divergence: module sources are path-based, not version-pinned.** `_envcommon` sources
+   read `${get_repo_root()}/.../terraform/modules/<m>`; there is no git-ref /
+   registry version on the source. Changing a module immediately affects every
+   consumer (mitigated only by the "source change = ADR" rule). A hardened
+   rebuild should pin sources by Git ref or registry version.
+8. **`staging` vs `stage` name mismatch.** The folder is `staging/` but the
+   canonical 9-account name is `stage`. Kept for backwards-compat; downstream
+   tooling that keys on the canonical name needs the alias.
+9. **OU alias cognitive load.** `Prod`↔`Production`, `NonProd`↔`Non-Production`.
+   The mapping lives in `docs/ou-structure.md`; renaming would force a state
+   migration on SCP attachments and SSO assignments (rejected in ADR-0001).
+10. **SCP-slot ceiling.** AWS caps 5 SCPs per OU (plus inheritance-only
+    `FullAWSAccess`). The estate runs 5/5 on workload OUs; Control Tower's managed
+    SCPs (ADR-0035) collide with this cap — RCPs (ADR-0017) relieve pressure by
+    moving controls off the SCP budget.
+11. **Control Tower / AFT is design-target, not built.** No `aws_controltower_*`
+    resources and no `aft-*` repos exist; the live path is raw AWS Organizations
+    via `terraform/modules/organization`. Decide CT-first vs raw-Organizations for
+    a new client up front — enrolling a live org into CT later is an L-effort
+    migration.
+12. **`_org/_global/*` units are single-consumer — don't wrap them in
+    `_envcommon`.** Their knobs live in the unit; an `_envcommon` indirection for a
+    once-globally-deployed resource is pure overhead (per the `_envcommon` README).
+
+---
+
+## 8. Acceptance checklist
+
+A rebuild passes this spec when:
+
+- [ ] `versions.hcl` is the only file containing a version literal; `.tool-versions`,
+      `.terraform-version` (`1.14.8`), `.terragrunt-version` (`1.0.8`), and
+      `mise.toml` mirror it exactly; `mise install` yields TF `1.14.8` + TG `1.0.8`.
+- [ ] `terragrunt hcl fmt --check` and `terraform fmt -recursive -check` are clean.
+- [ ] From a freshly created (empty) account, `bootstrap/state-backend` applies
+      with **local** state and creates `tfstate-<account>-<region>` +
+      `terraform-locks-<account>` (both `prevent_destroy = true`).
+- [ ] After bootstrap, `terragrunt run --all validate` and `terragrunt run --all plan`
+      are clean in a workload account with **no** hardcoded outputs (all cross-unit
+      refs resolve via `dependency` + `mock_outputs`).
+- [ ] The AWS Organization applies from the management account with **8 OUs**
+      (Security, Infrastructure, Workloads, NonProd, Prod, Deployments, Sandbox,
+      Suspended) and `enabled_policy_types` = SCP + TAG_POLICY + RCP.
+- [ ] The SCP attachment matrix matches `docs/ou-structure.md`; `workload_ou_names`
+      = `["NonProd","Prod","Sandbox"]`; no OU exceeds 5 attached SCPs.
+- [ ] Every taggable AWS resource carries all five `platform:*` keys **and** the
+      legacy cost/audit tags; the TFLint `aws_resource_missing_tags` rule passes
+      with an empty `exclude`.
+- [ ] No real account IDs, ARNs-with-IDs, buckets, hostnames, emails, or non-RFC1918
+      IPs appear in any `*.hcl`, `*.tf`, or `.tfvars`.
+- [ ] Bootstrap order holds: management account first, then network, then workload
+      accounts; a workload region deploys `vpc/secrets → eks → karpenter/monitoring/rds`.
+- [ ] Changing a default in one `_envcommon/<module>.hcl` provably propagates to
+      every consumer (verified via `grep -r "_envcommon/<module>.hcl" terragrunt/`).
+- [ ] No `terraform apply` runs from a feature branch or agent — apply is CI/CD
+      only, from `main` after merge.
+
+---
+
+## 9. Dependencies on other specs
+
+This is the foundation spec; every other spec assumes the account topology,
+Terragrunt layer, state backend, version pins, and tagging taxonomy defined here.
+Downstream specs (numbers per `SPEC-INDEX.md`):
+
+- **SPEC-00 Overview** — owns the shared placeholder registry (`{{ORG}}`,
+  `{{DOMAIN}}`, `{{*_ACCOUNT_ID}}`, `{{PRIMARY_REGION}}`, `{{STATE_BUCKET}}`).
+  This spec registers foundation-specific placeholders (§5) against it.
+- **Networking & Connectivity** — VPC/CIDR (§4.6 here is the allocation table),
+  hub-spoke Transit Gateway (ADR-0005), RAM sharing, ClusterMesh, inter-VPC
+  security (ADR-0013), VPC Lattice (ADR-0023). Consumes the network account +
+  `_envcommon/transit-gateway.hcl` defined here.
+- **Security & Guardrails** — SCP/RCP *contents*, GuardDuty/SecurityHub/Config
+  delegated-admin, IAM baseline, break-glass (ADR-0011), SSO permission sets,
+  centralized logging (ADR-0017, ADR-0028 enforcement side). This spec fixes only
+  *where* those attach (the OU tree).
+- **Compute & Autoscaling** — EKS (`_envcommon/eks.hcl`), Karpenter (ADR-0007),
+  KEDA/HPA/WPA, Bottlerocket (ADR-0030), node strategy (ADR-0046). Consumes the
+  per-account sizing knobs in §5.
+- **GitOps Delivery** — ArgoCD app-of-apps (ADR-0006), Kargo promotion (ADR-0021),
+  and the `versions/` application-version-manifest system (distinct from
+  `versions.hcl`: it is the Kargo→ArgoCD image-promotion source of truth, not the
+  tool pins).
+- **Account Vending (target state)** — Control Tower + AFT (ADR-0035), the
+  `Deployments` OU tenant, and `docs/account-vending.md`. Supersedes the raw
+  `terraform/modules/organization` bootstrap this spec currently documents.
+- **Observability & FinOps** — depends on the ADR-0028 taxonomy (ADR-0026,
+  ADR-0027) for the cross-plane joins.

--- a/specs/SPEC-02-network-dns.md
+++ b/specs/SPEC-02-network-dns.md
@@ -1,0 +1,608 @@
+# SPEC-02 — Network Topology & DNS
+
+> Portable reverse-engineering of the platform's network and DNS design. A senior
+> platform team can rebuild the same connectivity substrate for a new client from this
+> spec alone. Global placeholders (`{{…}}`) are defined in `SPEC-00-overview.md` and shared
+> with `SPEC-01`; spec-local placeholders are registered in the Parameterization table (§5).
+> No real account IDs, ARNs, hostnames, or non-documentation IPs appear.
+
+---
+
+## 1. Scope & non-goals
+
+This spec covers the **AWS network substrate** and the **DNS control plane** for a
+multi-account, multi-region platform: the hub-and-spoke Transit Gateway (TGW) topology,
+the deterministic per-environment/region VPC CIDR allocation scheme, subnet/AZ layout,
+egress/ingress paths, VPC interface/gateway endpoints, cross-account Route 53 Resolver,
+the inter-VPC segmentation security model, cross-region TGW peering, the multi-geo /
+multi-cloud edges (bare-metal DC, GCP), and the DNS stack — authoritative-zone sync across
+two providers (octoDNS), a DNS health monitor, and a registrar-level DNS failover
+controller. It states the **CNI network rationale** (Cilium) only at the level that shapes
+VPC/CIDR/east-west design.
+
+**Non-goals.** Cluster-internal networking detail — Cilium install, `CiliumNetworkPolicy`
+authoring, Gateway API `HTTPRoute` mechanics, ClusterMesh operational runbooks — belong to
+**SPEC-03 (Compute Clusters)**; this spec sets the substrate and stops at that
+boundary. Account/OU structure, Terragrunt orchestration, remote state, and version pins
+belong to **SPEC-01 (Foundation: IaC, Account Topology & State)**. Secrets, KMS, IAM
+identity, SCP/GuardDuty *contents*, and WAF/CDN edge security are only cross-referenced.
+
+---
+
+## 2. Architecture
+
+### 2.1 Component map
+
+```
+                          Registrar (nameserver authority for {{DOMAIN}})
+                               ▲  UpdateNameservers()  (failover / failback)
+                               │
+                    ┌──────────┴───────────┐
+                    │  failover-controller │  Go, 30s tick, 5-state machine + safety guards
+                    │ HEALTHY→…→FAILED_OVER │  reads health scores from Postgres
+                    └──────────┬───────────┘
+                               │ reads dns_provider_health_score (0–100)
+                    ┌──────────┴───────────┐        ┌───────────────────────┐
+                    │     dns-monitor      │───────▶│  Postgres (health DB) │
+                    │ Go, 30s, dig NS TXT, │        └───────────────────────┘
+                    │ score 0–100, Prom    │
+                    └──────────────────────┘
+    authoritative zone data (YAML)                 in-cluster record automation
+        │  octoDNS plan/apply                         │  external-dns (Route53), upsert-only
+        ▼                                             ▼
+ ┌─────────────────┐   ┌─────────────────┐     ┌──────────────────────────────┐
+ │ {{PRIMARY_DNS}} │   │ {{SECONDARY_DNS}}│     │  EKS clusters (Cilium CNI)   │
+ │  (cloudflare)   │   │   (route53)     │     │  Gateway API → NLB (SPEC-03) │
+ └─────────────────┘   └─────────────────┘     └──────────────────────────────┘
+
+ AWS network substrate (Network account owns the hub):
+
+   Internet                                          Internet
+      │ ingress (NLB per Gateway)                        ▲ egress
+      ▼                                                  │
+ ┌──────────────────────────────── Spoke VPC (per env × region) ─────────────────┐
+ │  public /20 × AZ   private /20 × AZ   database /20 × AZ                        │
+ │      │ IGW              │ NAT GW (1/AZ, HA)      │                             │
+ │      └── ALB/NLB        └── nodes/pods ──────────┴── RDS                       │
+ │                          │  (2 gateway + 13 interface VPC endpoints)          │
+ │                          └──────────── TGW attachment (inert until routed) ───┼──┐
+ └───────────────────────────────────────────────────────────────────────────────┘  │
+                                                                                       ▼
+                      ┌───────────────── Transit Gateway (Network acct) ──────────────┐
+                      │  ASN {{TGW_ASN}} · default assoc/propagation = DISABLE        │
+                      │  custom route tables:  prod  |  nonprod  |  shared            │
+                      │  RAM-shared to all workload accounts                          │
+                      │  blackhole CIDRs enforce env isolation                        │
+                      └───────┬───────────────────────────┬──────────────────────────┘
+              route53-resolver│ (inbound+outbound, DNS 53)│ TGW peering (cross-region, scaffolded)
+              remote-access-VPN│ (ops/standard sub-pools)  ▼
+                               │                   TGW (peer region euc1) — staging CIDRs
+                               ▼
+                       Legacy estate (admin VPC already attached; join via TGW, no new peering)
+```
+
+### 2.2 Layers
+
+1. **L3 substrate — hub-and-spoke TGW.** One TGW per region in the Network account, hub
+   for all inter-VPC/inter-account traffic. Reachability is an **explicit allow-list**
+   (`default_route_table_association = disable`, `default_route_table_propagation =
+   disable`); three custom route tables (`prod`, `nonprod`, `shared`) enforce environment
+   isolation. Cross-region is a **second TGW + peering attachment**, not a global mesh.
+2. **VPC plane.** Each `environment × region` pair owns a deterministic `/16`. Subnets are
+   `/20` slices (private/public/database) derived by `cidrsubnet`. NAT is HA (one per AZ)
+   by default. VPC Flow Logs on (PCI-DSS Req 10, 365-day retention). Two gateway endpoints
+   (S3, DynamoDB) + 13 interface endpoints keep AWS-API traffic off the NAT path.
+3. **Segmentation security model.** Deny-by-default TGW route tables (Layer 1) + security
+   groups (Layer 2) + NACL backstop (Layer 3) + future centralized inspection VPC
+   (Layer 4). A cross-estate remote-access VPN joins a legacy flat-peering estate through
+   the TGW with **trust sub-pools** (ops vs standard) so a standard client can never
+   transit to prod.
+4. **Identity-scoped resource access.** VPC Lattice resource gateway (TCP-only,
+   single-region) exposes a shared resource (e.g. RDS) by **IAM identity**, bypassing the
+   NLB and — intra-region — the TGW for that flow. Complements, does not replace, the TGW
+   model.
+5. **East-west between clusters.** Default is **Cilium ClusterMesh** over the peered TGW
+   (non-overlapping routable pod CIDRs, ENI/native mode); SG ports `2379` (etcd), `4240`
+   & `4244` (health), `51871` (WireGuard). A selection matrix falls back to PrivateLink /
+   VPC Lattice / internal-NLB+Route53-PHZ / private ingress per flow shape. The
+   GPU-inference cluster instead joins the TGW via **TGW Connect (GRE+BGP)** propagating
+   its pod CIDR `100.64.0.0/10`.
+6. **DNS control plane.** Authoritative zones are declared as YAML and pushed to **two**
+   providers by octoDNS. `dns-monitor` scores each provider's health; `failover-controller`
+   swaps registrar nameservers when the primary degrades. In-cluster records are automated
+   by `external-dns` (upsert-only). Cross-account private resolution uses Route 53 Resolver
+   inbound/outbound endpoints in the Network VPC.
+
+---
+
+## 3. Decision record
+
+| Decision | Rationale | Trade-off accepted | Source ADR |
+|---|---|---|---|
+| Hub-and-spoke **Transit Gateway**, owned by the Network account; custom route tables, no default assoc/propagation | Scales past peering combinatorics (N·(N-1)/2); segmentation becomes route-table policy, not per-pair bookkeeping; single point for future inspection VPC | ~$36/mo per attachment + inter-VPC data-processing charge; RT bookkeeping grows; cross-region needs a 2nd TGW | `ADR-0005 Hub-and-spoke connectivity via AWS Transit Gateway` |
+| **Deny-by-default inter-VPC model**: TGW route-table segmentation + SG + NACL backstop + (future) inspection VPC; cross-estate VPN via TGW with ops/standard **trust sub-pools** | Guarantees prod isolation even with a cross-estate VPN + legacy flat peering; "who can reach prod" is a one-line answer; incremental | More RT/SG/NACL bookkeeping; VPN allow-list is change-controlled; sequencing gate before enabling routing | `ADR-0013 Inter-VPC access security model` |
+| **VPC Lattice resource connectivity** for cross-account/VPC TCP resource access (RDS), alongside the TGW model | Unit of control becomes the **IAM identity**, not the network path; drops NLB + intra-region TGW from that flow; centralized RAM sharing | TCP-only, **single-region only**; a second authZ surface to keep consistent with SGs | `ADR-0023 VPC Lattice resource connectivity` |
+| **Cilium** as EKS CNI (over aws-vpc-cni / Calico) | eBPF dataplane; transparent WireGuard pod-to-pod encryption (data-in-transit baseline); L3/L4/L7 DNS-aware policy; Hubble flow logs; higher pod density; **ClusterMesh** | Team learns Cilium CRDs; upgrade lifecycle decoupled from EKS add-ons; kernel ≥5.10 | `ADR-0003 Cilium over aws-vpc-cni` |
+| **Cilium Gateway API** ingress; one NLB per `Gateway`, TLS terminated at edge | No extra controller/pods; LB provisioned per Gateway not per Ingress; standards-aligned; Hubble-visible | Team learns Gateway API; CRDs must precede the Cilium chart; not all NGINX annotations port | `ADR-0009 Cilium Gateway API ingress` |
+| **EKS public endpoint + parameterised CIDR allow-list**, fail-closed `[]` default, private access always on | Makes the allow-list a first-class tightenable variable instead of an invisible implicit `0.0.0.0/0`; prod ships private-only / narrow corp-CIDR | Non-prod ships a documented `0.0.0.0/0`; tightening must be validated against every CI runner IP | `ADR-0010 EKS public endpoint CIDR allow-list` |
+| Cross-cluster: **peered TGW substrate + Cilium ClusterMesh default**, PrivateLink / Lattice / NLB+Route53 / ingress fallback matrix | Non-overlapping routable pod CIDRs (ENI/native) enable zero-proxy-hop pod-to-pod routing; one substrate reused; identity-first fallbacks for overlap/vendor cases | ClusterMesh valid **only** while pod CIDRs stay non-overlapping & routable; cert exchange + apply gate | `ADR-0043 EKS cross-cluster connectivity`, `ADR-0019 Harvest Cilium eBPF capabilities` |
+| Multi-region parity as a **per-region stamp** (VPC+TGW+ClusterMesh), active/active with an asymmetric (scale-to-zero, spot-first) secondary; **no cross-region GPU pool**; serving failover is DNS-level, batch is region-pinned | Mirrors the GKE etalon; bounds per-region GPU cost/quota; region drops out of rotation on health-signal loss | Extra per-region TGW/peering cost; cross-region cert-exchange overhead; batch re-queues rather than fails over | `ADR-0044 AWS EKS GPU ML foundation multiregion`, `ADR-0036 GKE ML infra parity multiregion` |
+| **Bare-metal DC networking** via Cilium kube-proxy-less + LB-IPAM + BGP control-plane to ToR (no cloud LB) | On-prem has no cloud NLB; BGP advertises service VIPs to the DC fabric; keeps one CNI/policy model across cloud and metal | DC BGP peering to operate (hold-timer 180s), MTU 9000 end-to-end; MetalLB only as documented fallback | `ADR-0051 Bare-metal networking Cilium LB + BGP` |
+
+---
+
+## 4. Implementation blueprint
+
+### 4.1 Directory layout
+
+```
+terragrunt/
+  root.hcl                       # backend (S3 native lock), provider-generate, ADR-0028 tags
+  versions.hcl                   # tool + provider version pins (single source of truth)
+  common.hcl                     # region catalog (4-region EU footprint), tag defaults
+  _org/account.hcl               # org-wide admin_cidr_allowlist placeholder (10.0.0.0/8)
+  network/                       # THE HUB — Network account
+    account.hcl                  # tgw_peers, vpn_connections, dns_forwarding_rules, inter_vpc_security
+    eu-west-1/                   # ANCHOR region — richest topology
+      region.hcl                 # aws_region, region_short, azs[]
+      connectivity/terragrunt.stack.hcl   # 8 units: vpc, transit-gateway, ram-share,
+                                 #   tgw-route-tables, vpn-connection, route53-resolver,
+                                 #   + remote-access-vpn, inter-vpc-security (ADR-0013)
+      transit-gateway/terragrunt.hcl      # standalone TGW unit (pins ASN 64512)
+      lattice-resource/terragrunt.hcl     # ADR-0023 VPC Lattice resource GW
+    {eu-west-2,eu-west-3,eu-central-1}/connectivity/terragrunt.stack.hcl  # 6 units (no VPN/inter-VPC-sec)
+    _global/iam/terragrunt.hcl   # cross-account networking roles
+  {dev,staging,prod,dr}/<region>/…         # spoke VPCs (attach to hub TGW; attach gated off)
+  uk/{primary,standby}/…         # bare-metal Talos DC estate (ADR-0049/0051), dc.hcl hierarchy
+  gcp-staging/europe-west9/…     # GCP GKE estate (project.hcl), independent cross-cloud edge
+catalog/units/                   # reusable Terragrunt units (thin; config via inputs)
+  vpc, transit-gateway, tgw-route-tables, tgw-attachment, tgw-peering, ram-share,
+  route53-resolver, vpn-connection, remote-access-vpn, inter-vpc-security, vpc-endpoints,
+  vpc-lattice-resource, global-accelerator, nlb-ingress, gpu-inference-tgw-connect,
+  clustermesh-connect, clustermesh-sg-rules
+terraform/modules/               # the modules the units source
+dns-sync/                        # octoDNS: zones/*.yaml, config/octodns-config.yaml, scripts/
+dns-monitor/                     # Go: dig-based provider health scorer → Postgres + Prom
+failover-controller/             # Go: registrar-nameserver failover state machine
+apps/infra/external-dns/         # in-cluster Route53 record automation (GitOps, default off)
+```
+
+**Regional asymmetry:** all four EU regions run the same 6-unit connectivity stack; only
+`eu-west-1` adds `remote-access-vpn` + `inter-vpc-security` and standalone
+`transit-gateway`/`lattice-resource` units. The catalog `transit-gateway` unit does **not**
+pin `amazon_side_asn` (module default `64512`); only the standalone eu-west-1 unit pins it.
+
+**Ordering / dependencies (what must exist before what):**
+
+1. `root.hcl` backend bootstrapped (`--backend-bootstrap`) — S3 native locking.
+2. Network VPC → TGW → RAM-share → **then** workload spoke attachments (attachments are
+   **inert** until `inter-vpc-security` / `tgw-route-tables` add routes).
+3. `remote-access-vpn` before `inter-vpc-security` (needs trust sub-pool CIDRs); TGW before both.
+4. **Sequencing gate:** keep `enable_vpn_routing = false` until (a) network VPC + attachment
+   applied **and** (b) `enable_prod_nacl_backstop` applied — else the standard VPN sub-pool
+   transiently reaches prod through the TGW.
+5. Cross-region: both regional TGWs exist → `tgw-peering` → routes → ClusterMesh cert
+   exchange into Secrets Manager → flip `clustermesh_connect_enabled = true`.
+6. DNS: authoritative zones exist at both providers → `dns-monitor` seeded with provider
+   rows → `failover-controller` starts in `HEALTHY`.
+
+### 4.2 CIDR allocation scheme (deterministic, overlap-free)
+
+Each `environment × region` pair maps to a unique `/16` so VPCs can peer/attach without
+overlap. From `catalog/units/vpc/terragrunt.hcl`:
+
+```hcl
+# Second octet block encodes environment; third the region index within the block.
+#   dev: 10.0-3 · staging: 10.10-13 · prod: 10.20-23 · dr: 10.30-33
+#   network: 10.40-43 · management: 10.50-53 · reserved: 10.54-99 (future accounts)
+cidr_map = {
+  dev-eu-west-1     = "10.0.0.0/16"    staging-eu-west-1    = "10.10.0.0/16"
+  dev-eu-west-2     = "10.1.0.0/16"    staging-eu-central-1 = "10.13.0.0/16"
+  prod-eu-west-1    = "10.20.0.0/16"   dr-eu-west-1         = "10.30.0.0/16"
+  network-eu-west-1 = "10.40.0.0/16"   management-eu-west-1 = "10.50.0.0/16"
+  # …full dev/staging/prod/dr/network/management × eu-west-1/2/3 + eu-central-1 grid
+}
+vpc_cidr = cidr_map["${environment}-${aws_region}"]
+
+# Subnets: /20 slices of the /16 via cidrsubnet(cidr, 4, index)
+private_subnets  = [for i,az in azs : cidrsubnet(vpc_cidr, 4, i)]      # idx 0..N
+public_subnets   = [for i,az in azs : cidrsubnet(vpc_cidr, 4, i + 4)]  # idx 4..N+4
+database_subnets = [for i,az in azs : cidrsubnet(vpc_cidr, 4, i + 8)]  # idx 8..N+8
+```
+
+For a 3-AZ region on `10.20.0.0/16` (prod-eu-west-1): private `10.20.0/20, .16/20, .32/20`;
+public `.64/20, .80/20, .96/20`; database `.128/20, .144/20, .160/20`. VPC module:
+`terraform-aws-modules/vpc/aws` **v6.6.0**; NAT HA (`single_nat_gateway = false`, but DR/dev
+flip to `true`); Flow Logs → CloudWatch, `ALL` traffic, 365-day retention, 60s aggregation.
+The GPU-inference cluster's pod CIDR `100.64.0.0/10` (CGNAT) is deliberately outside the
+`10/8` VPC plan so it can be BGP-propagated without collision.
+
+### 4.3 TGW hub + route tables (sanitized)
+
+`terraform/modules/transit-gateway/main.tf` — the load-bearing isolation defaults:
+
+```hcl
+resource "aws_ec2_transit_gateway" "this" {
+  amazon_side_asn                 = var.amazon_side_asn   # {{TGW_ASN}}, default 64512
+  auto_accept_shared_attachments  = "enable"
+  default_route_table_association = "disable"             # <- explicit allow-list
+  default_route_table_propagation = "disable"             # <- no implicit leakage
+  dns_support                     = "enable"
+  vpn_ecmp_support                = "enable"
+}
+resource "aws_ec2_transit_gateway_route_table" "this" { for_each = var.route_tables }  # prod|nonprod|shared
+resource "aws_ec2_transit_gateway_route" "blackhole_cross_env" { for_each = var.blackhole_cidrs }  # blackhole = true
+# RAM share to workload accounts; allow_external_principals = false (stay in-org)
+```
+
+Unit inputs (`network/eu-west-1/transit-gateway/terragrunt.hcl`): `amazon_side_asn = 64512`;
+`route_tables = { prod = {}, nonprod = {}, shared = {} }`; `ram_principals =
+[{{DEV_ACCOUNT_ID}}, {{STAGING_ACCOUNT_ID}}, {{PROD_ACCOUNT_ID}}, {{DR_ACCOUNT_ID}},
+{{SECURITY_ACCOUNT_ID}}, {{LOGARCHIVE_ACCOUNT_ID}}, {{SHARED_ACCOUNT_ID}}]`. Route-table
+intent: `prod` (Prod VPCs only, propagation off), `nonprod` (dev+staging), `shared` (ECR,
+Route 53 PHZs, inspection VPC). Cross-env reachability requires an **explicit per-CIDR
+route**; default is none. Module outputs: `transit_gateway_id`, `route_table_ids` (map),
+`ram_resource_share_arn`.
+
+### 4.4 Cross-region TGW peering (scaffolded, not yet live)
+
+`terraform/modules/tgw-peering` creates a requester attachment locally and an accepter via
+an **aliased provider** (`provider = aws.peer`), then adds `peer_cidrs` into every
+`local_route_table_ids` entry. Driven from `network/account.hcl`:
+
+```hcl
+enable_tgw_peering = true
+tgw_peers = {
+  "eu-central-1" = { tgw_id = "", cidrs = ["10.13.0.0/16"] }  # staging-euc1
+  "eu-west-1"    = { tgw_id = "", cidrs = ["10.10.0.0/16"] }  # staging-euw1
+}
+```
+
+**Status:** these locals are set, but the `tgw-peering` unit is wired only into the catalog
+*template* stack — no live region connectivity stack consumes it yet. Cross-region routing
+is a design-target to be wired per-region (see §7).
+
+### 4.5 Route 53 Resolver (cross-account/on-prem DNS)
+
+`terraform/modules/route53-resolver` places **inbound** (on-prem/VPN → resolve AWS private
+zones) and **outbound** (AWS → resolve partner/on-prem domains) endpoints in the Network VPC
+private subnets (≥2 AZ). A dedicated SG permits DNS `53/tcp`+`53/udp` from `allowed_cidrs`
+(default `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`). **FORWARD** rules map partner
+domains to target IPs and are associated to the VPC:
+
+```hcl
+forwarding_rules = {                    # from network/account.hcl dns_forwarding_rules
+  # partner-internal = { domain = "internal.partner.example",
+  #   target_ips = [{ ip = "10.100.0.53" }, { ip = "10.100.1.53" }] }
+}
+```
+
+The internal shared zone is a **PRIVATE** Route 53 zone (resolvable only inside associated
+VPCs); VPN clients resolve it via the network-VPC association + DNS push. The public apex
+(`{{DOMAIN}}`) lives outside AWS DNS and is untouched by the private boundary (ADR-0013).
+
+### 4.6 DNS zone hierarchy & dual-provider sync (octoDNS)
+
+Authoritative records for `{{DOMAIN}}` are declared as YAML and reconciled to **both**
+providers. `dns-sync/config/octodns-config.yaml`:
+
+```yaml
+providers:
+  config:     { class: octodns.provider.yaml.YamlProvider, directory: ./zones, default_ttl: 300 }
+  cloudflare: { class: octodns_cloudflare.CloudflareProvider, token: env/CLOUDFLARE_TOKEN }
+  route53:    { class: octodns_route53.Route53Provider }   # creds via IRSA (AWS_ROLE_ARN)
+zones:
+  {{DOMAIN}}.:
+    sources: [config]
+    targets: [cloudflare, route53]        # <- primary + secondary kept in lockstep
+```
+
+`dns-sync/zones/{{DOMAIN}}.yaml` (sanitized shape) carries apex `A`, `MX`, SPF `TXT`, `www`,
+`api` `CNAME`, and a `_health-check` `TXT` canary (`ttl 60`) that the monitor/failover
+components probe:
+
+```yaml
+'':          [ {type: A, value: 192.0.2.10, ttl: 300},
+               {type: MX, values: [{exchange: mail.{{DOMAIN}}., preference: 10}], ttl: 3600},
+               {type: TXT, value: "v=spf1 include:{{MAIL_PROVIDER}} ~all", ttl: 3600} ]
+api:         [ {type: CNAME, value: api-lb.{{PRIMARY_REGION}}.elb.amazonaws.com., ttl: 300} ]
+_health-check: [ {type: TXT, value: canary-record-for-monitoring, ttl: 60} ]
+```
+
+`scripts/validate-sync.sh` `dig +short +norecurse`s each provider's nameservers for `A/TXT/
+CNAME`, sorts, and `diff`s them to detect **cross-provider drift**.
+
+### 4.7 DNS health monitor (`dns-monitor`, Go)
+
+A 30-second loop reads provider rows from Postgres (`dns_providers WHERE status != 'failed'`),
+`dig`s each nameserver for `_health-check.{{DOMAIN}}` (TXT, `RecursionDesired=false`, 5s
+timeout), records each check into `health_check_results` (fields: `provider_id,
+nameserver_address, query_domain, response_time_ms, success, error_message, check_location,
+check_timestamp`), exports Prometheus metrics (`dns_query_duration_seconds`,
+`dns_query_success_total`, `dns_query_failure_total`, `dns_provider_health_score`), and
+computes a **0–100 health score**:
+
+```
+score = successRate*60 + latencyScore*30 + consistencyScore*10
+latencyScore = 1.0 if avg < 50ms;  → 0.0 linearly by 1000ms
+```
+
+### 4.8 DNS failover controller (`failover-controller`, Go)
+
+A separate 30-second state machine reads the monitor's health scores (5-minute lookback) and,
+on sustained primary-provider degradation, **swaps the registrar's nameservers** to the
+secondary provider — DNS-provider-level failover, not record-level. States/thresholds
+(`statemachine.go`):
+
+```
+HEALTHY ─(primary<0.5)→ DEGRADED ─(3 consecutive<0.5)→ FAILING_OVER
+   ▲                        │(recovers ≥0.5)                 │(update NS + verify propagation)
+   │                        ▼                                ▼
+   └──(failback, NS→primary)── RECOVERING ←(primary>0.7)── FAILED_OVER
+        cooldown 10m stable        │(primary<0.5 again → abort back to FAILED_OVER)
+```
+
+`DegradeThreshold=0.5`, `ConsecutiveDegradedChecksRequired=3`, `RecoveryThreshold=0.7`,
+`HealthScoreWindow=5m`. Safety guardrails (`safety.go`, `DefaultSafetyParams`) gate every
+transition: `MinTimeInState=5m`, `FailoverCooldown=1h`, `MaxDailyFailovers=1`,
+`RecoveryCooldown=10m`, `RequireManualAuth=false` (**set true in prod initially**). A
+`validTransitions` map rejects any topologically-invalid jump. State persists to `STATE_FILE`
+(default `/var/lib/failover-controller/state.json`, fields: `current_state,
+last_transition_time` (RFC3339)`, daily_failover_count, primary_provider_id,
+secondary_provider_id`); HTTP `:8080` serves `/metrics /healthz /readyz /state`. The
+registrar is an **interface** (`RegistrarClient`) with a `Mock` default — real
+Namecheap/GoDaddy/Cloudflare-Registrar impls are selected by `REGISTRAR_TYPE`;
+`VerifyPropagation` should query public resolvers (`8.8.8.8`, `1.1.1.1`) and require
+agreement. This is the same controller ADR-0036/0044 reuse for cross-region **serving**
+failover (a region drops out of DNS rotation on health-signal loss; batch/training is
+region-pinned and re-queued, never failed over).
+
+### 4.9 In-cluster record automation (`external-dns`)
+
+GitOps-managed, **disabled by default**. Provider `aws` (Route 53), `policy: upsert-only`
+(never deletes), `registry: txt` with `txtOwnerId`/`txtPrefix` for ownership, `sources:
+[service, ingress]`, `region: ""` so each cluster manages **its own** zone (multi-region
+safe). IRSA/Pod-Identity grants `route53:ChangeResourceRecordSets` + `List*`. `domainFilters`
+scope which zones it may touch; `evaluateTargetHealth: true` on ALIAS records.
+
+### 4.10 VPC endpoints, VPN, Lattice, ingress, Global Accelerator
+
+- **VPC endpoints** (`catalog/units/vpc-endpoints` → `terraform-aws-modules/vpc/aws//modules/
+  vpc-endpoints` v6.6.0): **2 gateway** (S3, DynamoDB) + **13 interface** endpoints — `ssm`,
+  `ssmmessages`, `ec2messages`, `ec2`, `ecr.api`, `ecr.dkr`, `sts`, `sns`, `sqs`, `logs`,
+  `monitoring`, `secretsmanager`, `kms` (`private_dns_enabled = true`). Removes NAT
+  data-processing cost for AWS-API calls and is required for SSM Session Manager + private
+  ECR pulls. Requires a pre-wired SG allowing `443` from the VPC CIDR (unit passes `[]`).
+- **remote-access-VPN** (`remote-access-vpn`, ADR-0013; deps `../vpc`, `../kms`): AL2023 host
+  in the Network account behind a public NLB (`TCP_UDP`, `target_type=ip`,
+  `preserve_client_ip=false`); host SG never sees `0.0.0.0/0` (only the NLB); SSM not SSH;
+  ops sub-pool `10.100.0.0/24` (→prod/shared/legacy), standard sub-pool `10.100.1.0/24`
+  (→shared only), client pool `10.100.0.0/20`; secrets under `org/network/remote-access-vpn`;
+  SNS `network-alerts` + EC2 auto-recovery + `NetworkOut` anomaly alarm.
+- **Site-to-site VPN** (`vpn-connection`; dep `../transit-gateway`): partner/on-prem tunnels
+  terminating on the TGW; `vpn_connections` from `account.hcl` (empty by default; example
+  `bgp_asn = 65001`).
+- **VPC Lattice resource** (`vpc-lattice-resource`, ADR-0023): Resource Gateway in the owning
+  VPC private subnets + `type=ARN` Resource Configuration (RDS ARN, port `5432`) + Service
+  Network + RAM org-share + IAM auth policy scoped to `{{ORG_ID}}` (`aws:PrincipalOrgID`).
+- **nlb-ingress** (`nlb-ingress`; deps `../vpc`, `../eks`): public NLB, TLS on `443` via ACM,
+  `ssl_policy = ELBSecurityPolicy-TLS13-1-2-2021-06`, TCP health check `/healthz`,
+  `deregistration_delay = 30`; the regional endpoint that Global Accelerator targets.
+- **Global Accelerator** (`global-accelerator`, multi-region active/active; place under
+  `_global/`): anycast listeners `443`/`80` TCP, `client_affinity=SOURCE_IP`, one endpoint
+  group per regional NLB with health checks + `traffic_dial_percentage`; flow logs → S3.
+  `enabled`/endpoint-groups filled per-estate (`enable_global_accelerator`).
+
+### 4.11 Multi-geo / multi-cloud edges
+
+- **AWS multi-region:** the region-0 stamp (VPC + TGW + optional ClusterMesh) repeats per
+  region; canonical footprint is the 4-region EU set `eu-west-1/2/3`, `eu-central-1`
+  (`common.hcl region_short_codes`). `dr/` mirrors the prod network topology across all four
+  regions on the `10.30–33` block, but its **TGW attachment is gated off**
+  (`enable_tgw_attachment = false`, `transit_gateway_id = ""`) until the network-account TGW
+  exists; DR also runs `single_nat_gateway = true`, `eks_public_access = false`,
+  `rds_multi_az = true`. Cross-region east-west rides peered TGW + ClusterMesh:
+  `clustermesh-connect` reads peer TLS from **AWS Secrets Manager** per region (gated by
+  `clustermesh_connect_enabled`, default false); `clustermesh-sg-rules` opens node-SG ingress
+  for ports `2379`/`4240`/`4244`/`51871` (gated by `enable_clustermesh`, default false).
+- **Bare-metal DC (`terragrunt/uk/`, ADR-0049/0051):** a production Talos estate with
+  `primary` (active) + `standby` (hot-standby) DCs, hierarchy via `dc.hcl`/`env.hcl` (not
+  account/region). No cloud LB — Cilium **kube-proxy-less + LB-IPAM + BGP** advertises service
+  VIPs (from a `CiliumLoadBalancerIPPool` carved from the DC service-VIP CIDR) to ToR switches
+  via `CiliumBGPClusterConfig`. Load-bearing config: BGP **hold timer 180s**, **MTU 9000**
+  end-to-end (100 GbE), `max-prefix` sized on the ToR; MetalLB is a documented fallback only.
+  Module contract (`baremetal-cilium-lb`): `bgp_peers = [{ peer_address, peer_asn, local_asn,
+  hold_time_seconds = 180 }]`, `lb_ipam_pools = [{ name, cidr }]`, `mtu` default 9000.
+- **GCP (`terragrunt/gcp-staging/europe-west9`, Paris):** a GKE GPU estate — custom-mode VPC
+  `subnet_cidr = 10.200.0.0/16`, Cloud Router + Cloud NAT, private Google API access,
+  secondary IP ranges for GKE pods/services, Cloud Armor edge (ADR-0042, default off). This is
+  an **independent** estate: there is **no Interconnect/Cloud VPN to AWS** — GCP↔AWS
+  integration is by independent estates + DNS failover only (ADR-0036 rejects cross-cloud GPU
+  pooling).
+
+---
+
+## 5. Parameterization table
+
+| Placeholder / knob | Meaning | Default in this estate | Resize guidance |
+|---|---|---|---|
+| `{{DOMAIN}}` | Root authoritative DNS zone | `example.com` (source) | Client apex; drives octoDNS zone, `_health-check`, external-dns `domainFilters` |
+| `{{PRIMARY_DNS_PROVIDER}}` / `{{SECONDARY_DNS_PROVIDER}}` *(spec-local)* | The two authoritative providers kept in lockstep | `cloudflare` / `route53` | Any octoDNS-supported pair; failover swaps NS between them |
+| `{{MAIL_PROVIDER}}` *(spec-local)* | SPF include host | `_spf.google.com` (source) | Client mail provider's SPF include |
+| `{{TGW_ASN}}` *(spec-local)* | Amazon-side TGW BGP ASN | `64512` | Private ASN 64512–65534; must differ from peer TGW / on-prem ASN |
+| `{{NETWORK_ACCOUNT_ID}}` | Hub (TGW owner) account | `555555555555` | Owns TGW, resolver, VPN, Lattice service network |
+| `{{DEV/STAGING/PROD/DR/SECURITY/LOGARCHIVE/SHARED_ACCOUNT_ID}}` | TGW-share RAM principals | `1…`/`2…`/`3…`/`4…`/`7…`/`8…`/`9…` | Match SPEC-01 account map; add new spokes to `ram_principals` |
+| `{{MGMT_ACCOUNT_ID}}` | Org management account | `000000000000` | `organization_arn` populated after org creation |
+| `{{ORG_ID}}` *(spec-local)* | AWS Organization ID | `o-placeholderorg` | Lattice auth policy `aws:PrincipalOrgID` |
+| `{{STATE_BUCKET}}` | TF state bucket | `{{ORG}}-terraform-state-<account_id>` (eu-central-1, S3 native lock) | See SPEC-01; sanitized from source's company-named bucket |
+| `{{PRIMARY_REGION}}` / `{{DR_REGION}}` | Anchor / DR regions (`{{DR_REGION}}` ∈ `{{SECONDARY_REGIONS}}`) | `eu-west-1` / DR on `10.30–33` | Reset to client anchor; single-region TGW is v1-acceptable |
+| VPC `/16` per env×region | `cidr_map` scheme | `10.<env-block>.<region-idx>.0/16` | Keep 2nd octet = env, 3rd = region; reserve `10.54–99`; never overlap legacy/on-prem |
+| Subnet size | `cidrsubnet(cidr,4,i)` | `/20` × AZ, 3 tiers | Shrink prefix delta for more/smaller subnets; keep private/public/database offsets 0/4/8 |
+| GPU-inference pod CIDR | TGW-Connect BGP propagation | `100.64.0.0/10` (CGNAT) | Keep outside the `10/8` VPC plan to avoid collision |
+| GCP `subnet_cidr` | GKE estate VPC | `10.200.0.0/16` | Keep clear of the AWS `10/8` plan if the estates are ever joined |
+| `single_nat_gateway` | NAT HA | `false` (1 NAT/AZ); `true` in DR/dev | `true` to cut cost; keep HA in prod |
+| VPN sub-pools | Trust segmentation | ops `10.100.0.0/24`, std `10.100.1.0/24`, pool `10.100.0.0/20` | Size to remote-user count; only ops→prod |
+| Resolver `allowed_cidrs` | Who may query resolver | RFC1918 supernets | Tighten to actual spoke/on-prem ranges |
+| TGW route tables | Segmentation | `prod`, `nonprod`, `shared` | Add `inspection` when the inspection VPC lands |
+| ClusterMesh SG ports | East-west | `2379`, `4240`, `4244`, `51871` | Fixed by Cilium; open only between peer VPC CIDRs |
+| BGP hold timer / MTU (bare metal) | DC fabric | `180s` / `9000` | Match ToR config; 9000 requires end-to-end jumbo frames |
+| Failover thresholds | State-machine tuning | degrade `0.5`, 3 checks, recover `0.7`, window `5m` | Loosen for flaky links; tighten for stricter SLAs |
+| Failover safety | Anti-flap guards | `MinTimeInState 5m`, `FailoverCooldown 1h`, `MaxDailyFailovers 1`, `RecoveryCooldown 10m`, `RequireManualAuth false` | Raise `MaxDailyFailovers`/lower cooldown only with confidence; **set `RequireManualAuth=true` for prod** |
+| Tool/provider pins (`versions.hcl`) | Reproducible builds | Terraform `1.14.8`, Terragrunt `1.0.8`, AWS provider `~> 6.0`, VPC module `6.6.0` | Bump via ADR (major) / green-CI PR (minor); keep single source of truth |
+
+---
+
+## 6. Best practices distilled
+
+1. **Make reachability an allow-list, not a default.** Disable TGW default route-table
+   association *and* propagation; every attachment associates to an explicit custom route
+   table. *Why:* "can dev reach prod?" is answered by reading one route table, not auditing a
+   mesh.
+2. **Add a blackhole backstop even where no route exists.** Blackhole prod↔nonprod CIDRs.
+   *Why:* a mistaken future route is silently dropped instead of quietly bridging environments.
+3. **Allocate CIDRs deterministically from a single map**, encoding environment and region in
+   fixed octets with a reserved growth band. *Why:* guarantees the non-overlap that peering,
+   ClusterMesh routable pod IPs, and legacy-estate joins all require — without a spreadsheet.
+4. **Keep pod CIDRs non-overlapping and routable** (Cilium ENI/native). *Why:* it's the single
+   biggest enabler of zero-proxy-hop ClusterMesh; overlap permanently forecloses routable
+   methods and forces proxied fallbacks.
+5. **Two authoritative DNS providers, one declarative source.** Push identical zone YAML to
+   both via octoDNS and diff for drift. *Why:* a single provider outage otherwise takes down
+   the platform's entire name resolution.
+6. **Fail over DNS at the nameserver, gated by health scoring — not by a human paging at 3am.**
+   A scored monitor + a guarded state machine with cooldowns and a daily cap removes toil while
+   preventing flap. *Why:* automated failover is only safe with anti-oscillation guards and a
+   manual-auth switch for prod.
+7. **Separate the health signal from the actor.** `dns-monitor` scores; `failover-controller`
+   acts. *Why:* the actor stays simple/testable; the scorer can evolve without touching
+   failover logic.
+8. **Terminate the VPN's blast radius with trust sub-pools**, and make a negative test
+   (non-ops client must NOT reach prod) an acceptance requirement. *Why:* a flat VPN pool + any
+   legacy peering silently recreates a transitive path to prod.
+9. **Two independent enforcement layers must agree.** DB SGs accept only the SG/CIDR the TGW
+   route table also permits; NACLs backstop at the subnet. *Why:* a single misedited layer
+   doesn't open a path.
+10. **Prefer identity-scoped resource access for single-region TCP resources** (VPC Lattice +
+    IAM auth) over an NLB+TGW path. *Why:* the unit of control becomes the caller's identity;
+    drops standing NLB/TGW plumbing for that flow.
+11. **Keep AWS-API traffic inside the VPC** with gateway + interface endpoints for the core
+    services. *Why:* removes NAT data-processing cost and egress exposure for control-plane
+    calls, and is a hard prerequisite for SSM/ECR on private subnets.
+12. **Externalise the EKS public CIDR allow-list; never rely on the implicit `0.0.0.0/0`.**
+    Fail-closed `[]`; private access always on; prod narrow or private-only. *Why:* an implicit
+    wide-open endpoint is invisible in review and can't be tightened without a module change.
+13. **Gate every dangerous flip behind an explicit boolean with a documented sequence**
+    (`enable_vpn_routing`, `enable_prod_nacl_backstop`, `clustermesh_connect_enabled`,
+    `enable_tgw_attachment` — all default false). *Why:* ordering mistakes transiently breach
+    isolation.
+14. **One CNI/policy model across cloud and metal.** Cilium everywhere; bare-metal uses
+    LB-IPAM+BGP instead of a cloud LB. *Why:* one `CiliumNetworkPolicy` mental model and Hubble
+    observability spanning every estate.
+15. **Pin tool/provider versions in one file and bump by policy.** *Why:* reproducible plans
+    across CI/dev/prod; majors get an ADR + multi-env soak.
+
+---
+
+## 7. Known pitfalls
+
+1. **The sequencing gate is real.** Flipping `enable_vpn_routing=true` before the network VPC/
+   attachment **and** the prod NACL backstop are applied lets the standard VPN sub-pool reach
+   prod through the TGW. Keep it `false` until both hold (ADR-0013).
+2. **Implicit `0.0.0.0/0`.** Leaving `cluster_endpoint_public_access_cidrs` unset means AWS
+   applies `0.0.0.0/0`. Non-prod ships an *explicit, documented* `0.0.0.0/0`; do **not** let
+   prod inherit it (ADR-0010).
+3. **As-built divergence:** **TGW is a per-region hub — cross-region needs a second TGW +
+   peering, and it is not wired live yet.** `enable_tgw_peering=true` + `tgw_peers` are set in `network/account.hcl`, but
+   the `tgw-peering` unit is only in the catalog *template* stack. Wire it per-region and add
+   the peer CIDRs to **every** local route table, or cross-region east-west silently fails.
+4. **VPC Lattice resource connectivity is TCP-only and single-region-only.** A non-TCP or
+   cross-region resource flow must stay on the ADR-0013 TGW/NLB path; a permissive
+   `vpc-lattice:*` auth policy over-shares — scope to specific principals (ADR-0023).
+5. **ClusterMesh holds only while pod CIDRs stay non-overlapping & routable.** A future
+   overlapping-CIDR cluster pair takes routable methods off the table (fall back to
+   PrivateLink/Lattice/ingress). Verify CIDR planning *before* promising ClusterMesh.
+6. **The registrar client ships as a Mock; `VerifyPropagation` always returns true.** In
+   production, wire a real `RegistrarClient` and a real propagation check that polls public
+   resolvers — otherwise failover reports success without actually moving traffic.
+7. **`MaxDailyFailovers=1` + `RequireManualAuth=false`.** Defaults allow exactly one automatic
+   failover/day with no human in the loop. For prod, start with `RequireManualAuth=true`; a
+   persistent outage past the daily cap will **not** auto-fail again (intentional — page on it).
+8. **Failover state is a local JSON file.** Without a PersistentVolume for `STATE_FILE`, a
+   rescheduled pod reloads default (`HEALTHY`) state and loses failover counters/cooldowns.
+9. **octoDNS drift is detected, not auto-healed.** `validate-sync.sh` prints drift and has a
+   `TODO` to emit a metric/DB row — wire it to alerting; a silent one-provider divergence
+   undermines the dual-provider premise.
+10. **As-built divergence:** **dns-monitor/failover domain and probe region are hard-coded to
+    the sample.** `checkProvider` probes `_health-check.example.com`; `CheckLocation` is hard-coded
+    `us-east-1`. Parameterise both to `{{DOMAIN}}` and the real probe region before use.
+11. **Legacy-side return routes + prod NACL backstop are cross-account, out-of-repo
+    design-targets** (owned by legacy-ops / prod-account VPC unit). If they aren't added,
+    ops-pool reachability is one-way.
+12. **Company-identifying leakage in state config.** The source state bucket is named after the
+    company; always parameterise to `{{STATE_BUCKET}}` and scrub account IDs/ARNs before sharing.
+13. **TGW attachment cost creep.** ~$36/mo per attachment plus inter-VPC data processing — an
+    unbounded spoke count is a FinOps issue; consolidate where segmentation allows.
+
+---
+
+## 8. Acceptance checklist
+
+A rebuild passes when all hold:
+
+- [ ] `terragrunt run --all plan` is clean from an empty Network account (backend bootstrapped
+      with `--backend-bootstrap`, S3 native locking).
+- [ ] The TGW has `default_route_table_association = disable` **and**
+      `default_route_table_propagation = disable`; route tables `prod`, `nonprod`, `shared`
+      exist; the RAM share targets exactly the intended workload accounts.
+- [ ] No route table grants a dev/standard source a path into prod; prod↔nonprod CIDRs are
+      blackholed.
+- [ ] Every workload VPC's `/16` comes from `cidr_map` with **no overlaps** across
+      environments, regions, DR, GCP (`10.200/16`), the GPU-inference pod CIDR
+      (`100.64.0.0/10`), and legacy/on-prem ranges; subnets are the expected `/20` slices.
+- [ ] VPC Flow Logs are enabled (365-day retention); the 2 gateway + 13 interface endpoints exist.
+- [ ] Route 53 Resolver inbound + outbound endpoints are up in ≥2 AZ; SG allows only DNS `53`
+      from `allowed_cidrs`; the internal shared zone is PRIVATE.
+- [ ] octoDNS applies the zone to **both** providers; `validate-sync.sh` reports **zero drift**;
+      the `_health-check` TXT canary resolves at both.
+- [ ] `dns-monitor` exports `dns_provider_health_score` for every provider and is scraped by
+      Prometheus.
+- [ ] `failover-controller` starts in `HEALTHY`, persists state to a **PV**, exposes `/state`,
+      and (in a drill) transitions `HEALTHY→DEGRADED→FAILING_OVER→FAILED_OVER` then fails back
+      after the recovery cooldown; `RequireManualAuth=true` in prod.
+- [ ] A **negative VPN test** confirms a standard (non-ops) client cannot reach prod;
+      `enable_vpn_routing` was flipped **only after** the VPC/attachment + NACL backstop.
+- [ ] Cross-region: the second TGW + peering exists, peer CIDRs are in every local route table,
+      and (if used) ClusterMesh certs are exchanged into Secrets Manager before
+      `clustermesh_connect_enabled=true`; SG ports `2379/4240/4244/51871` are open only between
+      peer VPC CIDRs.
+- [ ] EKS endpoints set `cluster_endpoint_public_access_cidrs` explicitly (never implicit
+      `0.0.0.0/0`); prod is private-only or a narrow corp/VPN CIDR.
+- [ ] `external-dns` (if enabled) is `upsert-only` with `txt` registry ownership and per-cluster
+      zone scoping.
+- [ ] Bare-metal DC: Cilium BGP sessions to the ToR are up (hold-timer 180s), service VIPs come
+      from a `CiliumLoadBalancerIPPool`, and MTU 9000 is end-to-end.
+
+---
+
+## 9. Dependencies on other specs
+
+- **SPEC-00 — Overview:** global placeholder registry (`{{DOMAIN}}`, `{{ORG}}`, account IDs,
+  `{{PRIMARY_REGION}}`/`{{DR_REGION}}`, `{{STATE_BUCKET}}`), the region footprint, and the
+  ADR-0028 tagging taxonomy consumed by every unit here.
+- **SPEC-01 — Foundation: IaC, Account Topology & State:** the OU split (ADR-0001) and the
+  account-ID map that becomes the TGW `ram_principals`; the Terragrunt `root.hcl`/`versions.hcl`
+  /`common.hcl` + `catalog/units` model this spec's units plug into; remote state + version
+  pins; `organization_arn`/`{{ORG_ID}}` used by the Lattice auth policy. (SPEC-01 explicitly
+  defers VPC/CIDR/TGW/ClusterMesh/inter-VPC to this spec.)
+- **SPEC-03 — Compute Clusters:** Cilium install & CRDs, `CiliumNetworkPolicy` authoring,
+  Gateway API `HTTPRoute`s, NLB-per-Gateway ingress, ClusterMesh operational detail, and the
+  bare-metal Talos cluster — this spec sets the VPC/CIDR/east-west substrate they run on
+  (ADR-0003/0009/0019/0043/0051).
+- **SPEC-05 — Security:** GuardDuty on the Network account, VPC Flow Logs
+  destination/KMS, the (future) inspection VPC + AWS Network Firewall, and SCP/NACL prod
+  backstops referenced by ADR-0013.
+- **SPEC — Observability:** Prometheus scrape of `dns-monitor`/`failover-controller` metrics and
+  Hubble flow logs; Grafana surfaces exposed via the Gateway API.
+- **SPEC — Edge / Inference Serving:** Global Accelerator + WAF/CloudFront fronting public
+  inference endpoints (ADR-0042/0047) that consume the regional NLBs defined here.
+```

--- a/specs/SPEC-03-compute-clusters.md
+++ b/specs/SPEC-03-compute-clusters.md
@@ -1,0 +1,658 @@
+# SPEC-03 — Compute Clusters (EKS + Karpenter + Cilium + KEDA)
+
+> Portable reverse-engineering of the platform's Kubernetes compute layer. A competent
+> platform team can rebuild this compute plane for a new client from this document alone.
+> Placeholders (`{{...}}`) follow `SPEC-00-overview.md`; spec-local ones are registered in
+> §5. All values are sanitized per `CONVENTIONS.md` (no real account IDs, ARNs, IPs, hosts).
+
+---
+
+## 1. Scope & non-goals
+
+This spec covers the **Kubernetes compute plane**: the EKS control plane, node lifecycle
+(Karpenter-driven, Bottlerocket-based), the CNI/dataplane (Cilium — eBPF, ENI mode), the
+in-cluster autoscaling stack (Karpenter for nodes; KEDA + HPA + optional Watermark
+PodAutoscaler for pods), the cluster-critical add-on baseline, workload identity (EKS Pod
+Identity), and the **multi-cluster boundary** decisions (which workloads get a dedicated
+cluster and why). It defines cluster sizing/parameterization, the upgrade strategy, and the
+deployment ordering that lets a Cilium-on-EKS bring-up succeed on the first apply.
+
+**Non-goals** (owned by sibling specs): the AWS Organization/account/OU landing zone,
+Terragrunt skeleton, remote state, and version-pin machinery (SPEC-01 Foundation);
+VPC/subnet/Transit-Gateway/ClusterMesh L3 fabric and inter-VPC security (SPEC-02
+Network & DNS); SCP/RCP/GuardDuty/SecurityHub contents, SSO permission-set *definitions*,
+and secrets management (ESO/KMS) (SPEC-05 Security — this spec consumes them); GitOps
+delivery (ArgoCD app-of-apps, the ApplicationSet `cluster_role` label scheme, Kargo, Argo
+Rollouts, concrete KEDA `ScaledObject`s) (SPEC-04 Delivery); observability backends
+(Prometheus/Thanos/Loki/Hubble-UI wiring) (SPEC-07 Observability); and the GPU/ML and
+bare-metal compute planes, which **reuse** this plane's EKS+Karpenter+Cilium patterns but are
+specified separately (SPEC-10 ML workloads). This spec references those boundaries where the
+compute plane depends on them.
+
+---
+
+## 2. Architecture
+
+### 2.1 Component overview
+
+```
+                         ┌─────────────────────────────────────────────┐
+                         │  EKS control plane (managed)                │
+                         │  • private API endpoint (public = fail-closed)│
+                         │  • KMS envelope encryption for secrets       │
+                         │  • 5 control-plane log types → CloudWatch    │
+                         │  • authentication_mode = API_AND_CONFIG_MAP  │
+                         │  • EKS Access Entries ← SSO permission sets  │
+                         └───────────────┬─────────────────────────────┘
+                    OIDC (IRSA, bootstrap) │ + EKS Pod Identity (workloads)
+        ┌────────────────────────────────┼────────────────────────────────┐
+   ┌────▼─────┐  system managed NG    ┌───▼───────┐  Karpenter NodePools     │
+   │ system   │  (Bottlerocket,       │ workload  │  (Bottlerocket)          │
+   │ NodeGroup│  tainted until CNI)   │ nodes     │  x86 / arm64 / c-series /│
+   └────┬─────┘                       └───┬───────┘  spot-flexible / cde …    │
+        │ CoreDNS, Cilium agents,         │ application workloads            │
+        │ Karpenter ctrl, KEDA, ESO       │                                  │
+        └───────────────┬─────────────────┘                                  │
+                        │                                                    │
+     ┌──────────────────▼───────────────────────────────────────────────┐   │
+     │ Cilium CNI (kube-system) — replaces AWS VPC CNI                   │   │
+     │  • IPAM=eni (VPC-routable pod IPs), routingMode=native (no overlay)│   │
+     │  • kube-proxy replacement (eBPF) — OFF on general, ON for GPU/BM  │   │
+     │  • WireGuard transparent encryption; SPIRE mutual-auth available  │   │
+     │  • Hubble · Maglev LB · BBR bandwidth mgr · local-redirect policy │   │
+     │  • Cilium Gateway API (primary L7)   · optional ClusterMesh       │   │
+     │  • default-deny CiliumClusterwideNetworkPolicy baseline          │   │
+     └──────────────────────────────────────────────────────────────────┘   │
+     ┌──────────────────────────────────────────────────────────────────┐   │
+     │ Autoscaling: Karpenter (nodes) · KEDA (events) · HPA (CPU/mem)    │   │
+     │             · Watermark PodAutoscaler (optional, off default)     │   │
+     └──────────────────────────────────────────────────────────────────┘───┘
+```
+
+### 2.2 Design invariants
+
+- **No AWS VPC CNI, no Fargate, no Istio.** Cilium is the sole CNI (the `vpc-cni` managed
+  add-on is intentionally *absent*). All nodes are EC2 (a small managed "system" group +
+  Karpenter). The mesh is **sidecarless**: east-west security is Cilium eBPF + WireGuard
+  (transparent transit encryption), with optional Cilium+SPIRE mutual auth; L7 ingress is
+  **Cilium Gateway API** (ADR-0009), Envoy Gateway secondary for advanced L7 (ADR-0025).
+  Istio appears only in design docs and a dev experimental stack — no Istio module ships.
+- **Bottlerocket node OS** (ADR-0030): immutable, read-only-root, SELinux-enforcing, no
+  SSH/shell/package-manager; API/TOML-configured; kernel 6.12 on `aws-k8s-1.33/1.34/1.35`.
+- **Two node tiers per cluster.** A tainted managed **system** group bootstraps
+  cluster-critical workloads (CoreDNS, Cilium agents, Karpenter controller, KEDA, ESO);
+  Karpenter provisions everything else just-in-time.
+- **Karpenter replaces Cluster Autoscaler** (ADR-0007/0046): no autoscaling ASG node
+  groups; Karpenter picks instance type/size/AZ/capacity-type per pod requests, sub-~60 s,
+  and consolidates aggressively.
+- **Private-by-default control plane** (ADR-0010): `endpoint_public_access` fail-closed
+  (`_cidrs = []`); a per-account CIDR allow-list is the *only* source of public reach and
+  must never be `0.0.0.0/0` in staging/prod.
+- **EKS Pod Identity is the default workload identity** (ADR-0018); IRSA (OIDC) is retained
+  only for bootstrap components that need identity before/around the agent (Cilium
+  operator, Karpenter controller) and for Fargate (which Pod Identity does not support).
+- **Everything is a Terragrunt unit.** Each concern (`eks`, `cilium`, `karpenter-iam`,
+  `karpenter-controller`, `karpenter-nodepools`, `keda`, `hpa-defaults`, `wpa`) is its own
+  unit, composed by a `terragrunt.stack.hcl` and ordered by `dependency` blocks.
+
+### 2.3 Deployment ordering (per cluster)
+
+The mainline `platform` stack composes catalog units in dependency order:
+
+```
+vpc, secrets ─▶ eks ─▶ cilium ─▶ karpenter-iam ─▶ karpenter-controller ─▶ karpenter-nodepools
+               eks ─▶ keda / hpa-defaults / wpa / monitoring        rds ← (vpc, eks, secrets)
+```
+
+Cilium lands **after** the control plane but **before** Karpenter NodePools (nodes need a
+working CNI to reach `Ready`). On strict greenfield bring-ups the `eks` unit is split into
+`eks-cluster` + `eks-nodes` (see the sandbox `minimal-platform` stack) so Cilium installs
+between control-plane creation and first node join — this breaks the CNI chicken-and-egg
+cycle (§7).
+
+---
+
+## 3. Decision record
+
+Cite as `ADR-NNNN <title>` — numbers refer to this estate's `docs/adrs/`. Statuses shown as
+observed (`Accepted` = live; `Proposed` = plan/validate-only, apply-gated).
+
+| Decision | Rationale | Trade-off accepted | Source ADR (status) |
+|---|---|---|---|
+| **Cilium (eBPF) replaces AWS VPC CNI on all EKS clusters**; `vpc-cni` add-on disabled; policy = `CiliumNetworkPolicy`/`CiliumClusterwideNetworkPolicy`. Run **ENI IPAM** so pods keep VPC-routable IPs. | eBPF avoids iptables overhead (~20–30% lower latency in source benchmarks); transparent WireGuard pod-to-pod encryption without sidecars; L3/L4/L7 DNS-aware policy; Hubble flow logs/service maps; ClusterMesh for cross-region. | Team learns Cilium CRDs; loses VPC-CNI security-groups-for-pods (policy moves entirely to Cilium); operator upgrades decouple from the EKS add-on lifecycle (mitigated by pinning the chart + gated upgrades). Kernel floor **5.10+** (met by AL2023/Bottlerocket). | ADR-0003 (Accepted) |
+| **Karpenter replaces Cluster Autoscaler**; capacity shaped by `NodePool` + `EC2NodeClass` (pinned **v1 API**). | Bin-packs from real pod requests across a broad instance set, spot-prioritised; provisions in <~60 s via direct EC2 API; active consolidation; disruption budgets absorb rolling updates + spot interruptions; Graviton/arm64 defaults trivial. | EKS-specific (not portable); must author NodePool/EC2NodeClass CRDs; **no ASG lifecycle hooks / warm pools**; needs proper PDBs on workloads; a small managed system group still hosts the controller. | ADR-0007 (Accepted); ADR-0046 (Proposed) |
+| **Bottlerocket node OS**; `ami_family="Bottlerocket"`, `amiSelectorTerms:[{alias:bottlerocket@latest}]`, AL2023 a commented fallback. | Immutable, read-only root, SELinux, no SSH/shell/pkg-mgr, atomic image updates; kernel 6.12 unblocks netkit (≥6.8); dedicated FIPS + NVIDIA variants. | No SSH/shell debugging (use disabled-by-default admin container); two-volume `/dev/xvda`+`/dev/xvdb` layout on every EC2NodeClass; privileged/hostPath DaemonSets may need Bottlerocket-aware config; **no in-place AL2023→Bottlerocket conversion** (roll fresh nodes). | ADR-0030 (Accepted) |
+| **Spot-first, on-demand-fallback**; per-pool `spot_percentage`; reliability-critical tiers pin 0% spot. | Cost: default pools run 70–100% spot; consolidation + diversity dodge interruptions. | Spot reclaim needs interruption-tolerant workloads + PDBs + the SQS interruption queue; capacity-type is a per-pool knob teams must set correctly. | ADR-0046 (Proposed) |
+| **EKS Pod Identity as default workload identity**; `PodIdentityAssociation` (SA↔role), trust = `pods.eks.amazonaws.com` with `sts:AssumeRole`+`sts:TagSession`; least-privilege via **ABAC on 6 injected session tags**. IRSA → legacy. | IRSA roles bake the OIDC issuer into the trust policy (per-cluster, non-portable) and multiply roles; the `eks-pod-identity-agent` add-on is already installed; one role reused across clusters; cross-account via `targetRoleArn`. | A coexistence window (two identity mechanisms); ABAC is condition-heavy (wrong-tag-key bugs); **never** put IRSA + Pod Identity on one SA (undocumented precedence); **Fargate unsupported**; Karpenter nodes must run the agent DaemonSet before cutover. | ADR-0018 (Implemented) |
+| **Harvest latent Cilium/eBPF features** on the 1.19 dataplane: kube-proxy replacement, Maglev LB, BBR bandwidth mgr, local-redirect, Hubble metrics, Tetragon (observe-first), OBI/Beyla tracing; pilot ClusterMesh + netkit. | Already paying for the eBPF dataplane; Hubble UI is the missing operator surface; Tetragon (eBPF, can enforce) chosen over Falco. | More Cilium surface to run; per-node eBPF overhead; **netkit is beta, no in-place veth→netkit migration** (roll fresh nodes, kernel ≥6.8); SPIFFE mutual auth **deferred** (WireGuard already covers transit). | ADR-0019 (Partial) |
+| **Private EKS endpoint + parameterized public CIDR allow-list**; `public_access` opt-in, `_cidrs` fail-closed `[]`. | Fail-closed default; CI may open dev narrowly; prod/staging stay private-only; the CIDR is visible in review and tightenable without a module change. | Operators reach private clusters via VPN/bastion/SSM; dev's explicit `["0.0.0.0/0"]` is a documented dev-only accepted risk. | ADR-0010 (Accepted) |
+| **Cilium Gateway API = primary L7 ingress** (`gatewayAPI.enabled=true`, `GatewayClass cilium`); **Envoy Gateway = secondary** for rate-limit / ext-proc (AI-gateway) / WASM / circuit-breaking. | Enabling Gateway API adds a watch loop to the existing operator (zero extra pods); LBs provisioned per `Gateway` (not per `Ingress` → lower ALB sprawl); traffic visible in Hubble; Envoy is additive (own dataplane, not a CNI, no conflict). | Gateway API CRDs must install before the Cilium release (sync-wave ordering) or upgrades fail; not all NGINX Ingress annotations map; two ingress dataplanes can drift (pin both). | ADR-0009 (Accepted); ADR-0025 (Implemented) |
+| **Dedicated clusters per specialized workload class** (general `platform`, dev `agent-cluster`, `blockchain` HPC, `gpu-analysis`, prod `gpu-inference`, sandbox `minimal-platform`) rather than one shared cluster. | Blast-radius isolation + capacity/tenancy separation (spot vs on-demand, GPU, PCI-CDE, low-latency HPC). GPU foundation is a greenfield `aws-eks-gpu-*` module set at parity with the GKE etalon. | More clusters to run/upgrade; cross-cluster traffic needs ClusterMesh/Gateway; higher baseline cost; two parallel GPU estates in-repo (`aws-eks-gpu-*` vs legacy `gpu-inference-*`). | ADR-0044 (Proposed); estate-wide pattern |
+| **Break-glass IAM users are destroy-protected** (`prevent_destroy=true` + `force_destroy=false`). | Last-resort access when SSO is down must survive a stray `terraform destroy`/`moved` at *plan* time. | `terraform destroy` on such an account always fails for that user until the lifecycle block is removed via a reviewed PR (intended friction). *(Foundation/IAM concern — see SPEC-01; noted here because it gates cluster admin access.)* | ADR-0011 (Accepted) |
+
+---
+
+## 4. Implementation blueprint
+
+### 4.1 Directory layout
+
+```
+terraform/modules/
+  eks/                     # wraps terraform-aws-modules/eks/aws — mainline cluster
+  eks-agent-cluster/       # EKS control plane with ZERO node groups (Karpenter-only)
+  eks-addons/              # managed add-on baseline
+  cilium/ gpu-inference-cilium{,-advanced,-encryption}/ baremetal-cilium-lb/
+  karpenter/               # controller Helm release (custom module)
+  karpenter-nodepools/     # NodePool + EC2NodeClass CRDs (per-pool, for_each)
+  keda/ hpa-defaults/ wpa/ # pod autoscaling
+catalog/units/{eks,cilium,karpenter-iam,karpenter-controller,karpenter-nodepools,keda,hpa-defaults,wpa}/
+catalog/stacks/platform/terragrunt.stack.hcl        # composes the units
+terragrunt/<env>/<region>/platform/terragrunt.stack.hcl   # live composition
+terragrunt/<env>/account.hcl                         # ALL sizing knobs live here
+apps/infra/cilium/                                   # GitOps (ArgoCD) Cilium chart + values
+kubernetes/karpenter/                                # GitOps NodePool YAML + templates
+```
+
+> Note the estate has **two Karpenter delivery paths**: (a) Terraform `karpenter-nodepools`
+> (module renders NodePool/EC2NodeClass from `account.hcl`, `ami_family=Bottlerocket`
+> default) and (b) a **GitOps** path (`kubernetes/karpenter/*.yaml` + `templates/*.tpl` +
+> `render-templates.sh`) applied via `kubectl`/ArgoCD. Pick one per cluster; do not run both
+> against the same pools. The GitOps YAMLs additionally carry IMDS hardening and
+> `instance-category/generation/cpu` requirements (§4.4).
+
+**Version pins** (single source of truth: `terragrunt/versions.hcl`; mirrored to
+`.tool-versions`):
+
+| Tool / provider / chart | Pin |
+|---|---|
+| Terraform / OpenTofu | `1.14.8` (`= 1.14.8`) |
+| Terragrunt | `1.0.8` |
+| provider `aws` / `helm` / `kubernetes` | `~> 6.0` / `~> 2.12` / `~> 2.30` |
+| EKS module `terraform-aws-modules/eks/aws` | `21.15.1` (`~> 21.15`) |
+| Karpenter chart | `1.10.0` (history `1.1.1`→`1.8.1`→`1.10.0`) |
+| **Cilium** | **`1.19.4` live via GitOps** (`apps/infra/cilium`, wrapper chart `1.1.0`, W4 uplift from `1.17.1`). ⚠ Drift: TF `cilium` module default `1.17.1`; catalog `cilium` unit input `1.16.5`. Reconcile before rebuild. |
+| KEDA chart | `2.16.1` (no `ScaledObject`s shipped — teams add their own) |
+| Gateway API CRDs / Envoy Gateway | `1.2.1` / `v1.8.x` |
+| K8s cluster version | `1.32` (catalog default) · `1.34` (`_envcommon/eks.hcl` target) · `1.29` (dev agent-cluster) |
+
+> `versions.hcl` bump policy: patch/minor → PR + green CI on a non-prod env first;
+> **major → ADR required + multi-env soak.**
+
+### 4.2 EKS control plane (mainline `eks` unit)
+
+The catalog `eks` unit sources the registry module and disables VPC CNI:
+
+```hcl
+# catalog/units/eks/terragrunt.hcl
+terraform { source = "tfr:///terraform-aws-modules/eks/aws?version=21.15.1" }
+
+inputs = {
+  cluster_name    = "${local.environment}-${local.aws_region}-platform"   # {{CLUSTER_NAME}}
+  cluster_version = "1.32"
+
+  cluster_endpoint_public_access       = local.account_vars.locals.eks_public_access
+  cluster_endpoint_private_access      = true
+  cluster_endpoint_public_access_cidrs = try(local.account_vars.locals.eks_public_access_cidrs, [])  # ADR-0010, default []
+
+  enable_irsa               = true
+  cluster_encryption_config = { provider_key_arn = dependency.kms.outputs.key_arns["eks-secrets"], resources = ["secrets"] }
+  cluster_enabled_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+
+  # Add-on baseline — vpc-cni intentionally ABSENT (Cilium is the CNI)
+  cluster_addons = {
+    coredns                = { most_recent = true, configuration_values = jsonencode({
+                                 tolerations = [{ key = "node.cilium.io/agent-not-ready", operator = "Exists", effect = "NoSchedule" }] }) }
+    kube-proxy             = { most_recent = true }
+    eks-pod-identity-agent = { most_recent = true }        # ADR-0018
+  }
+
+  node_security_group_tags = { "karpenter.sh/discovery" = local.cluster_name }   # Karpenter SG discovery
+
+  # System managed node group — bootstraps cluster-critical pods, tainted until Cilium ready
+  eks_managed_node_groups = {
+    system = {
+      ami_type       = "BOTTLEROCKET_x86_64"               # ADR-0030
+      platform       = "bottlerocket"
+      instance_types = local.account_vars.locals.eks_instance_types
+      min_size       = local.account_vars.locals.eks_min_size
+      max_size       = local.account_vars.locals.eks_max_size
+      desired_size   = local.account_vars.locals.eks_desired_size
+      taints = { cilium = { key = "node.cilium.io/agent-not-ready", value = "true", effect = "NO_SCHEDULE" } }
+    }
+  }
+
+  enable_cluster_creator_admin_permissions = true          # DISABLE after bootstrap; rely on access_entries
+  access_entries = {                                       # SSO permission-set roles → K8s groups
+    platform_engineer = { principal_arn = "${local.sso_role_prefix}/AWSReservedSSO_PlatformEngineer_*", kubernetes_groups = ["platform-operators"], type = "STANDARD" }
+    readonly_access   = { principal_arn = "${local.sso_role_prefix}/AWSReservedSSO_ReadOnlyAccess_*",  kubernetes_groups = ["platform-viewers"],   type = "STANDARD" }
+    developer_access  = { principal_arn = "${local.sso_role_prefix}/AWSReservedSSO_DeveloperAccess_*", kubernetes_groups = ["platform-viewers"],   type = "STANDARD" }
+  }
+}
+```
+
+The **`eks-agent-cluster`** module is the Karpenter-only variant (the platform-agent-manual's
+canonical EKS compute module): identical control-plane posture but
+`eks_managed_node_groups = {}` and `create_node_group = false` — *all* node management is
+Karpenter's. Used by the dev `agent-cluster` stack.
+
+### 4.3 Cilium CNI (`cilium` unit + `terraform/modules/cilium`; live chart `apps/infra/cilium`)
+
+General clusters run **ENI IPAM / native-routing** with eBPF features on. Load-bearing values
+(sanitized excerpt from the live GitOps chart, Cilium 1.19.4):
+
+```yaml
+eni: { enabled: true, awsEnablePrefixDelegation: true, updateEC2AdapterLimitViaAPI: true, awsReleaseExcessIPs: true }  # Bottlerocket+ENI
+ipam:        { mode: eni }
+routingMode: native                 # no overlay/tunnel — pods get VPC IPs (no VXLAN anywhere)
+cni:         { chainingMode: none, exclusive: true }
+kubeProxyReplacement: false         # general clusters KEEP kube-proxy (flip per-account after validation)
+k8sServicePort: 443                 # + k8sServiceHost = <cluster endpoint> when replacement=true
+encryption:  { enabled: true, type: wireguard, nodeEncryption: false }        # in-transit encryption
+authentication.mutual.spire: { enabled: true, trustDomain: cluster.local }    # optional mTLS (SPIFFE deferred, ADR-0019)
+loadBalancer:{ algorithm: maglev }
+bpf:         { masquerade: true, preallocateMaps: true, tproxy: true }
+bandwidthManager: { enabled: true, bbr: true }
+localRedirectPolicy: true
+gatewayAPI:  { enabled: true, enableAlpn: true }                              # ADR-0009, GatewayClass cilium
+hubble:      { enabled: true, relay: {replicas: 2}, ui: {enabled: true}, metrics: {enabled: [dns,drop,tcp,flow,port-distribution,icmp,httpV2]} }
+operator:    { replicas: <prod:2/nonprod:1>, priorityClassName: system-cluster-critical, tolerations: [{operator: Exists}], extraEnv: [{name: AWS_REGION, value: <region>}] }
+cluster:     { name: <=32 chars, id: <clustermesh id or 0> }
+clustermesh: { useAPIServer: <enable_clustermesh> }
+```
+
+- **IRSA for the operator (and agent):** a dedicated IAM role (`<cluster>-cilium-operator`)
+  grants EC2 ENI APIs (`Create/Attach/Detach/Delete/ModifyNetworkInterface`,
+  `Assign/UnassignPrivateIpAddresses`, `Describe*`, scoped `CreateTags` on
+  `network-interface/*`). Without it, ENI mode fails immediately. Both `cilium` and
+  `cilium-operator` service accounts are annotated with the role ARN.
+- **Default-deny** ships as a `CiliumClusterwideNetworkPolicy` (`default-deny-all`) applied
+  via `kubectl_manifest` (apply-time GVK validation — the CRD is created by the same Helm
+  release, so `kubernetes_manifest`'s plan-time check would fail). It permits only
+  `reserved:init`, `kube-apiserver`/`host`, and kube-dns (UDP/TCP 53).
+- **GPU-inference clusters differ:** `ipam.mode = cluster-pool` (`100.64.0.0/10`, `/24`
+  blocks) + `autoDirectNodeRoutes` + `bgpControlPlane.enabled`, and
+  **`kubeProxyReplacement: true`** (kube-proxy-less). Bare-metal is also kube-proxy-less
+  (LB-IPAM + BGP, ADR-0051). No overlay anywhere (`routingMode: native` universally).
+
+### 4.4 Karpenter (IAM · controller · NodePools — three units)
+
+**Controller** (`terraform/modules/karpenter`, chart `1.10.0`, OCI
+`oci://public.ecr.aws/karpenter`): installed in `kube-system`, 2–3 replicas + PDB
+(`minAvailable: 1`); controller resources `500m/512Mi` → `1000m/1Gi`; runs on the system
+group (`nodeSelector karpenter.sh/controller=true`, tolerates `CriticalAddonsOnly`).
+Settings use **EKS Pod Identity** (`settings.clusterName/clusterEndpoint/interruptionQueue`)
+and the SQS **interruption queue** for spot-termination warnings. **Node auto-repair** is on
+(`featureGates.nodeRepair = true`, v1.10 alpha; requires the `eks-node-monitoring-agent`
+add-on; disruption hard-capped at **20%** of a NodePool independent of budgets).
+
+**NodePools + EC2NodeClasses** (`karpenter-nodepools`, one pair per `var.nodepool_configs`
+entry, `for_each`-generated as `kubernetes_manifest`). EC2NodeClass (`karpenter.k8s.aws/v1`):
+
+```yaml
+amiSelectorTerms: [{ alias: "bottlerocket@latest" }]     # or al2023@latest for VPC-CNI
+role: <karpenter node IAM role>
+subnetSelectorTerms:        [{ tags: { "karpenter.sh/discovery": <cluster> } }]
+securityGroupSelectorTerms: [{ tags: { "karpenter.sh/discovery": <cluster> } }]
+metadataOptions: { httpTokens: required, httpEndpoint: enabled, httpPutResponseHopLimit: 2, httpProtocolIPv6: disabled }  # CDE uses hopLimit 1
+blockDeviceMappings:                                     # Bottlerocket = 2 volumes
+  - deviceName: /dev/xvda  { volumeSize: 4Gi,  volumeType: gp3, encrypted: true }                       # OS
+  - deviceName: /dev/xvdb  { volumeSize: 50Gi, volumeType: gp3, encrypted: true, iops: 3000, throughput: 125 }  # data
+userData: |                                              # Bottlerocket TOML (not cloud-init)
+  [settings.kubernetes]
+  cluster-name = "<cluster>"
+  [settings.kubernetes.node-labels]
+  "karpenter.sh/nodepool" = "<pool>"
+placement: { placementGroupName: <opt>, availabilityZone: <opt> }   # HPC single-AZ pinning
+```
+
+NodePool (`karpenter.sh/v1`) generated from per-pool knobs:
+
+```yaml
+requirements:
+  - karpenter.sh/capacity-type ∈ (spot%>=100 → [spot]; <=0 → [on-demand]; else [spot,on-demand])
+  - kubernetes.io/arch          ∈ architectures            # [amd64] / [arm64]
+  - kubernetes.io/os            ∈ [linux]
+  - karpenter.k8s.aws/instance-family ∈ instance_families  # e.g. [m6i,m6a,m5,m5a]
+  - karpenter.k8s.aws/instance-size   ∈ instance_sizes     # optional
+taints / startupTaints: <per pool>
+expireAfter: <expire_after, default 720h>                  # node max-lifetime (30d → AMI refresh)
+limits:     { cpu: <cpu_limit>, memory: "<memory_limit>Gi" }
+disruption: { consolidationPolicy: <WhenEmptyOrUnderutilized|WhenEmpty>, consolidateAfter: <30s..Never>,
+              budgets: <default [{nodes:"10%"}] or scheduled per-pool> }
+weight: <lower = higher priority>
+```
+
+The **GitOps** NodePools (`kubernetes/karpenter/*.yaml`) express finer requirements —
+`karpenter.k8s.aws/instance-category ∈ [c,m,r(,t)]`, `instance-generation Gt 5`,
+`instance-cpu ∈ [...]`, `topology.kubernetes.io/zone` — and add IMDS hardening. Canonical
+pools: **x86-general-purpose** (al2023, `weight 10`), **arm64-graviton** (Bottlerocket,
+Graviton4/3/2 families, `weight 20`), **c-series-compute** (taint
+`workload-type=compute-intensive`, `weight 15`), **spot-flexible** (100% spot, multi-arch,
+`consolidateAfter 15s`, `weight 50`), **cde-nodes** (Bottlerocket, Intel-only, on-demand,
+taint `pci-dss=cde`, `expireAfter 720h`, `WhenEmpty`/`Never`), and **dev-general-purpose**
+(business-hours scale-to-zero: `budgets: [{nodes:"0", schedule:"0 20 * * 1-5", duration:11h}, {nodes:"10%"}]`).
+
+### 4.5 Autoscaling stack (pods)
+
+- **KEDA** (`keda` unit, chart `2.16.1`): event-driven scaling (SQS depth, Prometheus, cron,
+  …), can scale to zero. Operator + metrics-server replicas env-sized; Prometheus metrics on.
+  This spec owns the autoscaling **contract**; concrete `ScaledObject`/`TriggerAuthentication`
+  instances ship per-workload via SPEC-04's delivery machinery (none are committed in the
+  estate today — see §7). The canonical shape (SQS-depth worker, scale-to-zero, identity via
+  the operator's Pod Identity) is:
+
+  ```yaml
+  apiVersion: keda.sh/v1alpha1
+  kind: ScaledObject
+  metadata: { name: video-worker, namespace: workloads }
+  spec:
+    scaleTargetRef: { name: video-worker }
+    minReplicaCount: 0            # scale-to-zero
+    maxReplicaCount: 50
+    cooldownPeriod: 300
+    triggers:
+      - type: aws-sqs-queue
+        metadata:
+          queueURL: https://sqs.{{PRIMARY_REGION}}.amazonaws.com/{{PROD_ACCOUNT_ID}}/video-jobs
+          queueLength: "5"        # target messages-per-replica
+          awsRegion: {{PRIMARY_REGION}}
+          identityOwner: operator # use the KEDA operator's EKS Pod Identity (ADR-0018)
+  ```
+- **HPA defaults** (`hpa-defaults` unit): platform-component HPAs, e.g. **CoreDNS**
+  `min 2 / max 10`, CPU 70% + memory 80% targets, 300 s scale-down stabilization. Gated by
+  `enable_hpa_defaults` (off in dev).
+- **Watermark PodAutoscaler** (`wpa` unit, Datadog chart): optional watermark/latency
+  autoscaling, **off by default** (`enable_wpa = false`).
+
+### 4.6 Ordering & dependencies (what must exist before what)
+
+```
+KMS(eks-secrets) ─┐
+VPC (private subnets + karpenter.sh/discovery tags) ─┴─▶ eks ─▶ cilium ─▶ karpenter-iam
+                                                                     │        │
+                                                      karpenter-controller ◀──┘
+                                                                     │
+                                              karpenter-nodepools (needs cilium + iam + controller)
+eks ─▶ keda | hpa-defaults | wpa | monitoring         rds ← (vpc, eks, secrets)
+```
+
+`karpenter-nodepools` declares `dependency` on **eks, karpenter-iam, karpenter-controller,
+and cilium** (Bottlerocket nodes need the CNI). Each unit's Kubernetes/Helm providers
+authenticate via the `aws eks get-token` exec-plugin against the dependency's cluster
+outputs; the controller unit also declares an `aws.virginia` (us-east-1) alias for the ECR
+Public token Karpenter's OCI chart needs.
+
+---
+
+## 5. Parameterization table
+
+All sizing lives in `terragrunt/<env>/account.hcl`. Placeholders consumed here (recurring
+ones defined in `SPEC-00-overview.md`; spec-local ones marked ✦):
+
+| Placeholder | Meaning | Example shape |
+|---|---|---|
+| `{{ORG}}` | org slug | `acme` |
+| `{{PRIMARY_REGION}}` / `{{SECONDARY_REGIONS}}` | regions | `eu-west-1` / `["eu-central-1", …]` |
+| `{{DEV/STAGING/PROD_ACCOUNT_ID}}` | workload account IDs | `111111111111` (dummy) |
+| ✦ `{{CLUSTER_NAME}}` | cluster-name pattern | `<env>-<region>-platform` |
+| ✦ `{{KMS_EKS_SECRETS_KEY_ARN}}` | secrets CMK ARN | KMS unit `key_arns["eks-secrets"]` |
+| ✦ `{{ADMIN_CIDR_ALLOWLIST}}` | operator/VPN egress CIDRs for public API | narrow RFC1918 range, **never** `0.0.0.0/0` |
+
+### 5.1 Cluster sizing knobs (defaults observed; resize per client)
+
+| Setting (`account.hcl`) | dev | staging | prod | dr | Guidance |
+|---|---|---|---|---|---|
+| `eks_instance_types` (system NG) | `m6i.large` | `m6i.xlarge` | `m6i.2xlarge` | `m6i.xlarge` | System group only hosts CoreDNS/Cilium/Karpenter/KEDA/ESO — keep small. |
+| `eks_min/desired/max_size` | `1/2/3` | `2/3/5` | `3/5/10` | `1/2/5` | Size for add-on HA, not app load (Karpenter runs the rest). |
+| `eks_public_access` / `_cidrs` | `true` / `["0.0.0.0/0"]` | `false` / `[]` | `false` / `[]` | `false` / `[]` | dev-only open access is a deliberate exception; prod/staging private-only (ADR-0010). |
+| `cluster_version` | env-set (`1.29` agent-cluster) | env-set | `1.32` (catalog) | env-set | `_envcommon` target `1.34`; upgrade one minor at a time (§7). |
+| `cilium_replace_kube_proxy` | per-env | `false` (initial) | per-env | per-env | Start with kube-proxy present; flip after validation. GPU/bare-metal = kube-proxy-less. |
+| `single_nat_gateway` | `true` | `false` (HA) | `false` (HA) | `true` | NAT posture (SPEC-02); affects node egress cost. |
+| `karpenter_controller_replicas` / `_log_level` | `2` / `info` | `2` / `info` | `3` / `warn` | — | Controller HA + verbosity. |
+| `keda_operator/metrics_replicas` | `1/1` | `2/2` | `3/3` | — | Size for CRD watch load. |
+| `enable_hpa_defaults` / `enable_wpa` | `false` / `false` | `true` / `false` | `true` / `false` | — | WPA optional. |
+| `enable_clustermesh` | `false` | `true` | per-env | — | Cross-region service discovery; needs per-region `clustermesh_cluster_ids`. |
+| `enable_cde_isolation` | `false` | `false` | `true` | — | PCI CDE: dedicated `cde` NodePool + taint + policies. |
+
+### 5.2 Karpenter NodePool knobs (`karpenter_nodepools` map)
+
+Per-pool fields (`karpenter-nodepools`): `enabled`, `cpu_limit`, `memory_limit`,
+`spot_percentage` (0 = on-demand only, 100 = spot only), `instance_families`,
+`instance_sizes`, `excluded_instance_types`, `architectures` (`amd64`/`arm64`),
+`consolidation_policy` (`WhenEmptyOrUnderutilized` | `WhenEmpty`), `consolidate_after`
+(`30s`…`Never`), `weight`, `expire_after` (default `720h`), `taints`/`startup_taints`,
+`labels`, `disruption_budgets` (optional `schedule`/`duration`), and HPC options
+`placement_group_name`, `availability_zone`, `block_device_overrides` (io2/high-IOPS).
+
+**Representative prod pools** (illustrative; resize per client):
+
+| Pool | families | arch | spot % | cpu/mem limit | consolidate | notes |
+|---|---|---|---|---|---|---|
+| `x86` | `m6i,m6a,m5,m5a` | amd64 | 70 | 2000 / 4000Gi | `WhenEmptyOrUnderutilized` @300s | general purpose |
+| `arm64` | `m6g,m7g,c6g,c7g` | arm64 | 70 | 1000 / 2000Gi | @300s | Graviton, cheapest |
+| `c-series` | `c6i,c6a,c5,c5a` | amd64 | 60 | 500 / 1000Gi | @300s | CPU-bound/batch |
+| `spot-flexible` | wide | amd64 | 100 | (disabled in prod) | @300s | max savings, interruption-tolerant |
+| `cde` | `c6i,c7i,m6i,m7i` | amd64 | **0** | 32 / 64Gi | **`WhenEmpty` / Never** | PCI CDE, on-demand, taint `pci-dss=cde:NoSchedule`, `expireAfter 720h` |
+
+dev/staging use the same pools at smaller limits and shorter `consolidate_after` (`30–60s`).
+Specialized clusters define their own pools — e.g. staging **blockchain**
+(execution/consensus/mev/bitcoin, 0% spot, cluster placement group, io2/gp3 high-IOPS,
+`Never` consolidation, slashing-risk taints) and staging **gpu-analysis**
+(`g5`/`g4dn` A10G/T4, `nvidia.com/gpu` taint, placement group, business-hours disruption
+budgets).
+
+---
+
+## 6. Best practices distilled
+
+1. **Never run VPC CNI and Cilium together.** Omit the `vpc-cni` add-on entirely and install
+   Cilium before nodes carry workloads. *Why:* two CNIs both program the dataplane and race
+   for pod IPs.
+2. **Keep the managed system node group tiny and tainted.** Taint it
+   `node.cilium.io/agent-not-ready:NoSchedule` and tolerate that taint on CoreDNS so nothing
+   schedules before the CNI is `Ready`; let Karpenter own everything else. *Why:* avoids
+   scheduling pods onto nodes with no working network.
+3. **Run Cilium in ENI + native-routing on general EKS** for VPC-routable pod IPs and no
+   tunnel overhead; enable `awsEnablePrefixDelegation` for pod density and `awsReleaseExcessIPs`
+   for Bottlerocket. Reserve cluster-pool IPAM + BGP for GPU/bare-metal. *Why:* matches
+   VPC-CNI reachability while keeping eBPF benefits.
+4. **Set `AWS_REGION` explicitly on the Cilium operator** and give it
+   `system-cluster-critical` priority + `{operator: Exists}` toleration. *Why:* in ENI mode
+   the operator calls `DescribeInstanceTypes`; the SDK can't infer region from IMDS in the
+   operator pod, and bootstrap taints otherwise leave it `Pending`.
+5. **Roll out kube-proxy replacement gated.** Ship general clusters *with* kube-proxy
+   (`kubeProxyReplacement: false`), validate Cilium stability, then flip per env; run
+   GPU/bare-metal kube-proxy-less from the start. *Why:* de-risks a dataplane-wide change on
+   live clusters.
+6. **Express node strategy declaratively in NodePools, not imperatively.** Encode instance
+   families/category/generation, arch, spot ratio, consolidation policy, disruption budgets,
+   and `expireAfter` as data (`account.hcl` / GitOps YAML) so capacity policy is PR-reviewable.
+7. **Tune `spot_percentage` and disruption per workload class.** 0% spot +
+   `WhenEmpty`/`Never` for reliability-critical tiers (payments/CDE, blockchain slashing
+   risk, GPU SLA, training gangs); high spot + aggressive consolidation for stateless/batch.
+   Freeze disruption in business hours with scheduled budgets
+   (`{nodes:"0", schedule:"0 9 * * 1-5", duration:"10h"}`).
+8. **Diversify instance families for spot resilience** so Karpenter can dodge capacity
+   shortfalls and interruptions.
+9. **Bottlerocket needs a two-volume layout** (`/dev/xvda` OS 4Gi, `/dev/xvdb` data) and TOML
+   userData, not cloud-init; encrypt both volumes; harden IMDS (`httpTokens: required`, hop
+   limit 2, CDE hop limit 1). *Why:* wrong layout starves container storage; it's Bottlerocket's model.
+10. **Prefer EKS Pod Identity for app workloads; reserve IRSA for bootstrap + Fargate.**
+    Install `eks-pod-identity-agent`; keep IRSA only for Cilium operator and Karpenter
+    (identity before/around the agent) and Fargate (unsupported by Pod Identity). Never put
+    both on one SA. Scope least-privilege via ABAC on the 6 injected session tags. *Why:*
+    fewer per-role OIDC trust policies; portable roles (ADR-0018).
+11. **Encrypt secrets at rest (KMS envelope) and traffic in transit (WireGuard),** enable all
+    five control-plane log types → CloudWatch, and ship a default-deny baseline. *Why:*
+    PCI-DSS Req 3.4/4.1/10.2 and defense-in-depth; these are `account.hcl`-independent invariants.
+12. **Fail closed on the API endpoint.** Default `eks_public_access_cidrs = []`; require an
+    explicit, narrow, account-scoped allow-list to open it; never `0.0.0.0/0` outside dev.
+13. **Enable Karpenter node auto-repair with the Node Monitoring Agent add-on.** The 20%
+    per-NodePool cap plus your disruption budgets bound the blast radius of a correlated
+    health-signal failure. *Why:* self-healing without draining a whole pool.
+14. **Turn on the eBPF features you already pay for:** Maglev LB, BBR bandwidth manager,
+    local-redirect policy, Hubble metrics, Tetragon (observe-first) — near-free once Cilium is
+    the dataplane (ADR-0019). Defer SPIFFE mutual auth while WireGuard covers transit.
+15. **Give every cluster a default-deny baseline** (`CiliumClusterwideNetworkPolicy`) that
+    still allows DNS + apiserver, then open flows explicitly per namespace. Apply it with
+    `kubectl_manifest` (apply-time CRD validation), not `kubernetes_manifest`.
+16. **Split `eks` into `eks-cluster` + `eks-nodes` for strict first-boot** so Cilium installs
+    between control-plane creation and first node join (breaks the CNI chicken-and-egg cycle
+    on greenfield accounts).
+17. **Isolate specialized workloads into their own clusters**, not just namespaces:
+    HPC/blockchain, GPU, PCI-CDE, and the general platform have different tenancy, capacity,
+    and blast-radius needs.
+18. **Pick one Karpenter delivery path per cluster** (Terraform-rendered *or* GitOps YAML);
+    running both against the same pool names causes drift and thrash.
+
+---
+
+## 7. Known pitfalls
+
+- **Cilium operator stuck `Pending` on bring-up.** Key-specific tolerations are insufficient;
+  nodes also carry kubelet `not-ready`/`unreachable` taints during bootstrap. Fix:
+  `tolerations: [{operator: Exists}]` + `priorityClassName: system-cluster-critical`
+  (Round 11 post-mortem).
+- **Operator crash-loops "Missing Region" in ENI mode.** `DescribeInstanceTypes` via IRSA
+  can't infer region from IMDS in the operator pod. Fix: set `AWS_REGION` in operator
+  `extraEnv` (Round 13 finding).
+- **`kubernetes_manifest` fails at plan time for CRDs created in the same apply.** Use
+  `gavinbunney/kubectl` `kubectl_manifest` for the Cilium default-deny policy; NodePool/
+  EC2NodeClass manifests apply only after the Karpenter controller unit installs the chart CRDs.
+- **CNI chicken-and-egg on greenfield.** Nodes never reach `Ready` if they join before Cilium
+  exists. Either taint the system group until agent-ready (mainline) or split
+  `eks-cluster`/`eks-nodes` (minimal-platform).
+- **`cluster.name` > 32 chars breaks the Cilium chart.** When ClusterMesh is off, the module
+  truncates `cluster_name` to 32 chars for local identity.
+- **Bottlerocket ≠ AL2023 config.** The EC2NodeClass must switch AMI alias *and* block-device
+  layout *and* userData format together; mixing them yields unschedulable/mis-provisioned nodes.
+  No in-place AL2023→Bottlerocket conversion — roll fresh nodes.
+- **Spot without PDBs or interruption tolerance = outages.** Wire the SQS interruption queue
+  and use interruption-tolerant workloads; `cde`, blockchain, and training pools deliberately
+  use 0% spot.
+- **Leaving `enable_cluster_creator_admin_permissions = true` after bootstrap** is a standing
+  admin backdoor — disable it and rely on `access_entries` once RBAC is applied.
+- **As-built divergence: Cilium version is pinned in three places.** Live GitOps chart
+  `1.19.4` (`apps/infra/cilium`), TF `cilium` module default `1.17.1`, catalog `cilium` unit
+  input `1.16.5`; the reference manuals cite yet another aspirational `1.18.x`. **Authority
+  ruling for a rebuild:** what GitOps reconciles is what actually runs, so **`1.19.4` is the
+  as-built truth**. Guidance: **pin ONE version in a single source** (`versions.hcl` *or* the
+  GitOps chart) and derive every other reference from it — do not carry three independent pins.
+- **As-built divergence: cluster Kubernetes version spread.** `1.29` (dev agent-cluster),
+  `1.32` (catalog `eks` unit), `1.34` (`_envcommon/eks.hcl` target); manuals cite `1.33`.
+  **Recommendation:** adopt the estate's own declared target — **`1.34` (`_envcommon`)** — as
+  the floor for new builds, and converge the older clusters up one minor at a time.
+- **As-built divergence: Istio is declared but not deployed.** The reference manual documents
+  Istio sidecar + multi-cluster and the dev `agent-cluster` stack **lists an `istio` unit**,
+  but **no Istio module ships** and nothing (ztunnel/waypoint/istio-cni) is deployed. The
+  as-built mesh is **sidecarless**: Cilium eBPF + WireGuard + optional SPIRE mTLS; L7 = Cilium
+  Gateway API (ADR-0009) + Envoy Gateway secondary (ADR-0025). **Recommendation:** remove the
+  `istio` unit (or explicitly mark it experimental) — the sidecarless design is the documented
+  target; do not assume a service mesh unless a cluster explicitly opts in.
+- **As-built divergence: KEDA is deployed with zero `ScaledObject`s.** The `keda` unit
+  installs the controller everywhere, but no `ScaledObject`/`TriggerAuthentication` instances
+  are committed — the autoscaling *contract* exists without instances. (The vLLM autoscaler
+  today is a plain `autoscaling/v2` HPA on custom `vllm:num_requests_*` metrics, not KEDA.)
+  **Recommendation:** ship concrete instances via the delivery layer (SPEC-04) using the §4.5
+  template; treat KEDA presence-without-instances as intentional platform capability, not dead
+  config.
+- **`eks_agent_cluster_design.excalidraw` is an unlabeled wireframe** (no text). The EKS
+  compute design lives in code (`terraform/modules/eks-agent-cluster`) and the
+  platform-agent-manual, not the diagram.
+
+### Upgrade strategy
+
+- **One minor at a time**, non-prod first (dev → staging → prod → dr), driven by the
+  `cluster_version` knob in `account.hcl`; **majors of any pinned tool require an ADR +
+  multi-env soak** (`versions.hcl` bump policy).
+- **Control plane before data plane:** bump `cluster_version`, let the managed system group
+  roll (Bottlerocket managed-node-group update), then let Karpenter recycle nodes.
+  `expireAfter` (default `720h`) guarantees nodes churn onto new AMIs within the window; drain
+  faster by lowering it or forcing consolidation. The PCI `cde` pool's `expireAfter 720h` is a
+  compliance control (30-day forced AMI refresh).
+- **Add-ons `most_recent = true`** track the cluster version on apply; validate CoreDNS and
+  `eks-pod-identity-agent` compatibility per minor.
+- **Cilium/Karpenter/KEDA chart bumps** go through the same non-prod-first PR flow; flip risky
+  Cilium features (kube-proxy replacement, netkit) gated on fresh node groups.
+
+### Multi-cluster boundaries
+
+| Cluster | Where | Node strategy | Why its own cluster |
+|---|---|---|---|
+| `platform` (general) | every env × region | system NG + Karpenter x86/arm64/c-series/spot(/cde) | Default tenancy; app workloads. |
+| `agent-cluster` (dev) | `dev/us-east-1` | Karpenter-only (`eks-agent-cluster`, no NG) + Cilium + KEDA (+experimental istio unit) | Isolated agent workloads; mesh experimentation (not mainline). |
+| `blockchain` (HPC) | `staging/eu-central-1` | on-demand-only pools, cluster placement groups, io2/gp3 high-IOPS, `Never` consolidation | Slashing risk (no spot), low-latency P2P, single-AZ locality. |
+| `gpu-analysis` | `staging/eu-west-3` | GPU pools (A10G `g5` / T4 `g4dn`) + CPU coordination, placement groups | GPU tenancy, real-time SLA, video-pipeline isolation. |
+| `gpu-inference` (prod) | `prod/eu-west-1` | H100 (`p5.48xlarge`) MNG + Karpenter GPU, cluster-pool IPAM + BGP, kube-proxy-less | Prod inference SLA + GPU fabric (ADR-0044/0046). |
+| `minimal-platform` | `sandbox` | split `eks-cluster`+`eks-nodes`, single NAT, IP-locked public API | Cheapest bring-up; validates the split-unit ordering. |
+
+**ClusterMesh** (Cilium) provides cross-region service discovery within an env (staging
+`eu-west-1`↔`eu-central-1`, per-cluster IDs, apiserver over internal NLB, TLS material
+exchanged via Secrets Manager, SG rules opening etcd/2379 · WireGuard/51871 · Hubble/4244).
+It is gated (`clustermesh_connect_enabled`) until both peers' certs are exchanged — the L3/mesh
+fabric is SPEC-02's subject.
+
+---
+
+## 8. Acceptance checklist
+
+A rebuild passes when:
+
+- [ ] `terragrunt stack plan` on `terragrunt/<env>/{{PRIMARY_REGION}}/platform` is clean from a
+      bootstrapped-but-empty account (mock outputs satisfy `init/validate/plan`).
+- [ ] The EKS control plane comes up **private-only** in staging/prod
+      (`cluster_endpoint_public_access = false`, `_cidrs = []`); dev is the only env with a
+      non-empty allow-list and it is explicit.
+- [ ] `kubectl get nodes` shows only the **system** Bottlerocket group until Cilium is `Ready`;
+      the `node.cilium.io/agent-not-ready` taint clears after the agent starts.
+- [ ] `kubectl -n kube-system get ds cilium` is fully rolled out; `cilium status` reports
+      **IPAM: ENI**, **routing: native**, and kube-proxy replacement at the env-configured mode.
+      The `vpc-cni` add-on is **absent**.
+- [ ] `kubectl get ciliumclusterwidenetworkpolicy default-deny-all` exists and DNS + apiserver
+      still work; the Cilium GatewayClass `cilium` is present.
+- [ ] `kubectl get deploy -n kube-system karpenter` is Available with the configured replicas +
+      PDB; `kubectl get nodepool` / `kubectl get ec2nodeclass` list every enabled pool.
+- [ ] A test Deployment with `nodeSelector karpenter.sh/nodepool=<pool>` provisions a matching
+      **Bottlerocket** node of the right family/arch/capacity-type, later consolidated when idle
+      per `consolidate_after`.
+- [ ] Spot interruptions are handled (SQS queue drains warnings; pods reschedule); 0%-spot pools
+      (`cde`, blockchain, training) only ever get on-demand nodes.
+- [ ] `eks-pod-identity-agent`, `coredns`, `kube-proxy` add-ons are present/healthy; a workload
+      assumes an AWS role via a `PodIdentityAssociation` with no IRSA wiring; no SA carries both
+      IRSA + Pod Identity.
+- [ ] KEDA is installed and a sample `ScaledObject` scales its target (including to zero); the
+      CoreDNS HPA exists where `enable_hpa_defaults = true`.
+- [ ] Control-plane logs (all 5 types) reach CloudWatch; secrets are KMS-encrypted at rest;
+      WireGuard node-to-node encryption is active.
+- [ ] `enable_cluster_creator_admin_permissions` is disabled post-bootstrap; SSO roles map to
+      `platform-operators`/`platform-viewers` via access entries.
+- [ ] A minor-version upgrade rolls dev → staging → prod one step at a time with no manual node
+      surgery (managed group rolls; Karpenter recycles within `expireAfter`).
+
+---
+
+## 9. Dependencies on other specs
+
+- **SPEC-00 — Overview**: defines shared placeholders (`{{ORG}}`, `{{PRIMARY_REGION}}`,
+  account IDs) consumed here.
+- **SPEC-01 — Foundation (IaC, account topology, state)**: the 9-account Control Tower landing
+  zone, the Terragrunt `root.hcl`/`versions.hcl`/`_envcommon`/`catalog` skeleton this plane's
+  units plug into, tool/provider version pins, and the tagging taxonomy (ADR-0028).
+- **SPEC-02 — Network & DNS**: VPC/subnet layout, the `karpenter.sh/discovery` subnet + SG
+  tags, NAT posture, Transit Gateway, and the Cilium **ClusterMesh** L3 fabric this plane rides
+  on.
+- **SPEC-04 — Delivery (GitOps)**: ArgoCD app-of-apps, the ApplicationSet `cluster_role` label
+  scheme (ADR-0012), Kargo promotion, Argo Rollouts, the `kubernetes/karpenter/` GitOps
+  NodePool path, and the concrete KEDA `ScaledObject`/`TriggerAuthentication` instances (§4.5
+  template) that deploy *onto* these clusters.
+- **SPEC-05 — Security (incl. secrets)**: SCP/RCP/GuardDuty/SecurityHub, SSO permission sets
+  that back EKS access entries, Pod Security Admission, Falco/Tetragon runtime policy, PCI-CDE
+  isolation contents, the break-glass procedure (ADR-0011), and secrets management — the
+  `eks-secrets` CMK (control-plane envelope encryption), External Secrets Operator (ADR-0008,
+  cutover on Pod Identity per ADR-0018), and ClusterMesh TLS material in Secrets Manager.
+- **SPEC-07 — Observability**: Hubble UI, Prometheus/Thanos/VictoriaMetrics, DCGM, OpenCost,
+  and the metrics this plane emits (ADR-0026/0027).
+- **SPEC-10 — ML workloads (incl. GPU inference)**: the specialized GPU/ML plane that reuses
+  this spec's EKS + Karpenter + Cilium patterns — GPU NodePools + GPU Operator + DRA + Volcano
+  (ADR-0044/0046), EFA fabric (ADR-0045), and the bare-metal Talos plane (ADR-0049–0054).
+```

--- a/specs/SPEC-04-delivery-gitops.md
+++ b/specs/SPEC-04-delivery-gitops.md
@@ -1,0 +1,610 @@
+# SPEC-04 — Delivery & GitOps Machinery
+
+> Reverse-engineered, portable blueprint for the continuous-delivery layer: ArgoCD (app-of-apps +
+> ApplicationSets), Kargo environment promotion, and the Helm/Kustomize/golden-path conventions that
+> feed them. A competent platform team can rebuild this delivery plane for a new client from this
+> spec alone. Placeholders follow `SPEC-00-overview.md`; spec-local placeholders are registered in
+> §5.
+
+---
+
+## 1. Scope & non-goals
+
+**Scope.** This spec covers *how declarative desired state in Git becomes running workloads across a
+fleet of Kubernetes clusters, and how a change moves from `dev` to `prod`*. Concretely: the ArgoCD
+bootstrap-from-zero sequence (cluster exists → ArgoCD installed via Terragrunt → root Application →
+ApplicationSets → waves); the ApplicationSet topology (infra, role-apps, observability,
+multi-cluster infra, platform-workloads, GPU-inference); the ArgoCD `AppProject` and RBAC boundary;
+the Kargo `Warehouse → Stage → Freight` promotion graph with metric-gated verification; the generic
+`helm/app` chart and its Deployment-vs-Rollout / PreSync-migration behaviours; the `apps/`,
+`envs/`, `templates/golden-paths/` conventions; and drift/rollback handling.
+
+**Non-goals.** Cluster/networking provisioning (SPEC covering EKS/Talos foundations), the observability
+backend that *produces* the promotion-gate metrics (Tempo/Prometheus RED metrics — a dependency, not a
+deliverable here), the CI pipelines that *build and push* images and open GitOps PRs (SPEC covering
+CI/supply-chain), and secret material itself. Secret **delivery** is described only at the boundary
+(how ArgoCD/Helm reference an `ExternalSecret`); the secret backend, `ClusterSecretStore`, and IRSA
+wiring live in **SPEC-05 (secrets)**.
+
+---
+
+## 2. Architecture
+
+### 2.1 Component overview
+
+```
+                          ┌──────────────────────────────────────────────┐
+   Terragrunt (SPEC-02)   │  cluster exists (EKS / Talos)                 │
+   installs ArgoCD via    │  platform-crds unit ── ArgoCD unit (Helm)     │
+   Helm, then applies ────┼──►  argocd/bootstrap/root-app.yaml            │
+   the root Application    └───────────────────┬──────────────────────────┘
+                                               │  (app-of-apps root)
+                          ┌────────────────────▼───────────────────────────┐
+                          │  Application: bootstrap → path argocd/bootstrap │
+                          │  (Kustomization lists the ApplicationSets)      │
+                          └────────────────────┬───────────────────────────┘
+        ┌───────────────────────┬──────────────┼───────────────────┬─────────────────────┐
+        ▼                       ▼              ▼                   ▼                     ▼
+  infra-appset          role-apps-appset  observability-appset  multicluster-infra-appset
+  apps/infra/*          apps/cluster-     apps/infra/           apps/infra/*  (region-aware
+  → ALL clusters        roles/<role>/*    observability/*       values, RollingSync by env)
+  (git-dir × clusters)  → clusters by     → ALL clusters
+                        cluster-role      (sync-wave 5)
+                        (RollingSync by env)
+
+  ── second delivery family (Helm + Kargo, top-level argocd/*.yaml) ─────────────────────
+  platform-infra           platform-workloads          gpu-inference-infra
+  (Helm apps/infra/*        (helm/app × 5 teams × 4     (apps/infra/* to
+   with envs/ values)        envs, Kargo-driven tags)    cluster-type=gpu-inference)
+                                   ▲
+                                   │ argocd-update
+                     ┌─────────────┴───────────────┐
+                     │  Kargo (kargo-config App)    │
+                     │  Warehouse → Stage → Freight │
+                     │  dev→integration→staging→prod│
+                     └──────────────────────────────┘
+```
+
+### 2.2 Two ApplicationSet families (important)
+
+The estate contains **two overlapping delivery generations** that coexist:
+
+| Family | Files | Render engine | Env overlays | Delivered by |
+|---|---|---|---|---|
+| **A — bootstrap** | `argocd/bootstrap/applicationsets/{infra,role-apps,observability,multicluster-infra}-appset.yaml` | plain manifests + Kustomize overlays (`argocd/overlays/<role>-<env>/`) | Kustomize | `root-app` → `argocd/bootstrap` Kustomization |
+| **B — workloads/Helm** | `argocd/applicationset.yaml` (platform-infra), `applicationset-workloads.yaml`, `applicationset-multicluster.yaml`, `applicationset-gpu-inference.yaml`, `appproject-workloads.yaml`, `kargo-bootstrap.yaml` | `helm/app` chart + `envs/<env>/values/**` | Helm value files | **not** listed in the bootstrap Kustomization — see §7 pitfall P1 |
+
+Family A uses the `cluster-role` label + `apps/cluster-roles/<role>` + Kustomize overlays. Family B
+uses the generic `helm/app` chart, per-env Helm values, and Kargo image promotion. A rebuild should
+pick **one** family as canonical; this spec documents both because both are live in source.
+
+### 2.3 The promotion plane (Kargo)
+
+Kargo sits **above** ArgoCD: it advances a *Freight* (an immutable image-digest + git bundle) through
+an ordered `Stage` graph and, at each stage, edits the GitOps repo (image tag/digest in
+`envs/<env>/values/<team>/values.yaml` and `versions/<env>/versions.yaml`) then calls `argocd-update`.
+ArgoCD then reconciles the change. There is **no Argo Rollouts controller deployed** in this estate,
+so Kargo promotes ArgoCD `Application`s *directly* (not canaries-within-an-environment). The
+`helm/app` chart *ships* Rollout machinery (§4.6) as a design-target toggle.
+
+```
+Warehouse (watches ECR digest + git path)
+   │  new Freight
+   ▼
+Stage: dev ─auto─► integration ─auto─► staging ─gate─► prod (manual, digest-pinned)
+        │             │                   │              │
+   health-check   +integration-test  +prometheus     +prometheus 5xx+p95
+                                      5xx+p95          +smoke+integration
+```
+
+---
+
+## 3. Decision record
+
+| Decision | Rationale | Trade-off accepted | Source ADR |
+|---|---|---|---|
+| **ArgoCD** for all K8s delivery, app-of-apps layout | Continuous reconciliation + self-heal + a UI load-bearing for multi-team self-service; sync waves order deploys without external orchestration | Another on-cluster component to operate/upgrade; ArgoCD does not manage encrypted secrets (pushed to ESO) | `ADR-0006 ArgoCD for GitOps` |
+| **ApplicationSet cluster-generator selects on a `cluster-role` label** | One AppSet definition fans out across the clusters×git matrix; label is a cluster *identity* claim distinct from account name (`env`) | An intentional mismatch (account "shared" vs role "platform") must be documented so nobody "fixes" it | `ADR-0012 cluster_role label scheme` |
+| **Kargo** as the environment-promotion layer, pinned to GA (chart wraps upstream `~1.9`) | Explicit, auditable `Warehouse→Stage→Freight` promotion; metric-gated instead of one-shot job probes; reuses the already-authored 5×4 graph | Another control-plane component; gates now depend on the Tempo RED-metrics feed being live | `ADR-0021 Kargo promotion layer` |
+| **Enable four ArgoCD 3.3.6 capabilities with no upgrade**: PreDelete hooks, shallow clone, server-side diff/apply, ApplicationSet RollingSync | All ship on the running version; kill spurious `OutOfSync`, cut repo-server memory, order teardown, add a dev→prod soak gradient | Four behaviours to configure/validate; SSA changes field-ownership semantics teams must learn | `ADR-0024 ArgoCD operational hardening` |
+| **Argo Rollouts canary** machinery lives in the shared `helm/app` chart (Gateway-API traffic plugin + analysis), gated behind `rollout.enabled` | Progressive delivery available per-service without diverging pod specs; default `Deployment` stays backward-compatible | Rollouts controller is *not* deployed here — the block is a design-target toggle, not wired in | `ADR-0014 Argo Rollouts canary` |
+| **DB migrations via an ArgoCD PreSync Job**, not per-pod init containers | Runs exactly once per sync, before Sync-phase resources, with a clean pass/fail signal; old replicas keep serving on failure | Schema *rollback* is not automated (use expand/contract) | `ADR-0032 DB migrations via PreSync Jobs` |
+| **Secrets delivered out-of-band via External Secrets Operator**, referenced (never embedded) by charts | ArgoCD/Git never holds plaintext; `ExternalSecret` pulls from AWS Secrets Manager/Parameter Store at runtime | ESO is a delivery dependency; IRSA binding must exist first | `ADR-0008 External Secrets Operator` (detail in SPEC-05) |
+| **Unified `platform.*` taxonomy labels** stamped by every AppSet and rendered resource | One label join powers Grafana, Cilium policy, OpenCost, Velero, Trivy across compute + cloud resources | Chart *fails render* if `platform.system/component/owner` are empty (intentional CI gate) | `ADR-0028 unified tagging taxonomy` |
+| **Golden-path template directories** (no Backstage scaffolder) for new dashboards/model-services/pipelines/tenants | Copy-substitute-commit onboarding without standing up an IDP; lives in Git next to what it deploys | Manual placeholder substitution; ADR still *Proposed* (apply-gated) | `ADR-0041 golden-paths collaboration` |
+
+---
+
+## 4. Implementation blueprint
+
+### 4.1 Directory layout (delivery-relevant subtrees)
+
+```
+argocd/
+├── bootstrap/                          # FAMILY A — delivered by root-app
+│   ├── root-app.yaml                   # the single Application ArgoCD is pointed at
+│   ├── kustomization.yaml              # lists the 4 bootstrap AppSets + ../config
+│   ├── applicationsets/
+│   │   ├── infra-appset.yaml           # apps/infra/* → ALL clusters (excl. observability)
+│   │   ├── role-apps-appset.yaml       # apps/cluster-roles/<role>/* → clusters by label, RollingSync
+│   │   ├── observability-appset.yaml   # apps/infra/observability/* → ALL clusters
+│   │   └── multicluster-infra-appset.yaml  # infra → clusters with a region label, region-aware
+│   └── cluster-secrets/                # ArgoCD cluster registration Secrets (templates)
+│       ├── in-cluster-template.yaml
+│       └── staging-euc1.yaml / staging-euw1.yaml
+├── config/argocd-cmd-params-cm.yaml    # ADR-0024: server-side diff + shallow clone
+├── applicationset.yaml                 # FAMILY B — platform-infra (Helm, envs/ values)
+├── applicationset-workloads.yaml       # FAMILY B — 5 teams × 4 envs, Kargo-driven
+├── applicationset-multicluster.yaml    # FAMILY B — active-active staging, region-aware
+├── applicationset-gpu-inference.yaml   # FAMILY B — cluster-type=gpu-inference only
+├── appproject-workloads.yaml           # AppProject: RBAC/namespace/resource allowlist
+├── kargo-bootstrap.yaml                # Application that syncs kargo/ (recurse)
+├── cluster-envs/{base,dev,stage,integration,prod}/   # Kustomize env bases (commonLabels)
+├── overlays/<role>-<env>/              # 20 role×env Kustomize overlays (Family A)
+└── workloads/<team>/<env>.yaml         # explicit per-app Applications (legacy, pre-AppSet)
+
+kargo/
+├── projects/<project>.yaml             # Project + promotionPolicies (auto vs manual per stage)
+├── warehouses/<project>.yaml           # image (ECR) + git subscriptions
+├── stages/<project>/{dev,integration,staging,prod}.yaml   # promotion steps + verification
+└── analysis-templates/                 # health-check, smoke, integration, prometheus 5xx/p95
+
+helm/app/                               # the ONE generic application chart (v0.4.0)
+├── Chart.yaml  values.yaml  README.md
+└── templates/{deployment,rollout,service,service-canary,hpa,pdb,httproute,
+              externalsecret,migration-job,analysistemplate,servicemonitor,...}.yaml
+
+apps/                                   # delivered manifests / Helm value roots
+├── infra/<component>/                  # shared infra charts (cilium, cert-manager, kargo, …)
+├── cluster-roles/<role>/<app>/         # role-scoped apps (backend, dex, listeners, velocity, 3rd-party)
+├── chains/ listeners/ mono/ protocols/ direct/   # per-team workload manifests / values
+└── direct/hello-world/helmrelease.yaml # smallest reference app
+
+envs/<env>/values/{infra,<team>}/*.yaml # per-environment Helm value overrides (Kargo writes here)
+versions/<env>/versions.yaml            # human-readable version manifest (Kargo writes here)
+templates/golden-paths/<path>/          # copy-substitute-commit onboarding templates
+catalog/units/argocd/terragrunt.hcl     # how ArgoCD itself is installed (bootstrap-from-zero)
+```
+
+### 4.2 Bootstrap-from-zero ordering (what must exist before what)
+
+1. **Cluster exists.** EKS (or Talos) is provisioned by Terragrunt (SPEC-02). The ArgoCD unit
+   `dependency`s on `eks` and `platform-crds`.
+2. **CRDs first.** A `platform-crds` unit pre-installs CRDs (ArgoCD, Kargo, Gateway API, ESO,
+   monitoring) so Helm-managed CRDs never race with Applications that consume them.
+3. **ArgoCD installed by Terragrunt/Helm** — *not* by ArgoCD itself (chicken-and-egg). The
+   `catalog/units/argocd` unit renders `helm`/`kubernetes` providers with an `aws eks get-token`
+   exec auth and applies the ArgoCD chart:
+
+   ```hcl
+   # catalog/units/argocd/terragrunt.hcl  (sanitized)
+   terraform { source = "${get_repo_root()}/.../terraform/modules/argocd" }
+   dependency "eks"           { config_path = "../eks" }
+   dependency "platform_crds" { config_path = "../platform-crds" }   # CRDs before ArgoCD
+   inputs = {
+     chart_version = try(local.account_vars.locals.argocd_chart_version, null)
+     ha_enabled    = try(..., local.environment == "prod")   # HA only in prod
+     enable_dex    = try(..., false)
+   }
+   ```
+   ArgoCD here is **3.3.6 (chart 9.5.1)**; `application.namespaces` is set at chart level.
+4. **Root Application applied.** Terragrunt (or a one-shot `kubectl apply`) creates
+   `argocd/bootstrap/root-app.yaml` — the *only* object pointed at by hand. It is self-managed
+   thereafter (`selfHeal`, `prune`):
+
+   ```yaml
+   # argocd/bootstrap/root-app.yaml (sanitized)
+   kind: Application            # name: bootstrap, namespace: argocd
+   spec:
+     source: { repoURL: git@github.com:{{VCS_ORG}}/{{GITOPS_REPO}}.git, targetRevision: HEAD, path: argocd/bootstrap }
+     destination: { server: https://kubernetes.default.svc, namespace: argocd }
+     syncPolicy:
+       automated: { prune: true, selfHeal: true }
+       syncOptions: [CreateNamespace=true, ServerSideApply=true]
+       retry: { limit: 3, backoff: { duration: 5s, factor: 2, maxDuration: 3m } }
+   ```
+5. **Bootstrap Kustomization fans out.** `argocd/bootstrap/kustomization.yaml` lists the four
+   Family-A ApplicationSets **and** `../config` (the ADR-0024 params ConfigMap). Applying it creates
+   the AppSets, which enumerate `apps/**` × registered cluster secrets and generate child
+   Applications.
+6. **Cluster registration.** Each managed cluster is registered as an ArgoCD cluster `Secret`
+   (`argocd.argoproj.io/secret-type: cluster`) carrying the routing labels (§4.3). The local cluster
+   uses `in-cluster-template.yaml`; remote clusters use per-region secrets.
+7. **Waves reconcile in order.** Within a sync, `argocd.argoproj.io/sync-wave` orders resources
+   (CRDs/PreDelete < migrations wave `-1` < workloads; observability trace-lane uses waves 10→15→20).
+   RollingSync (§4.4) then soaks `dev → stage/integration → prod`.
+8. **Kargo activated (Family B).** `kargo-bootstrap.yaml` + `appproject-workloads.yaml` +
+   `applicationset-workloads.yaml` bring up the promotion plane; the `kargo-config` Application syncs
+   the whole `kargo/` tree recursively.
+
+### 4.3 Cluster label contract (the selector that drives everything)
+
+Every ArgoCD cluster `Secret` MUST carry:
+
+```yaml
+metadata:
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+    cluster-role: dex          # one of: dex | backend | 3rd-party | velocity | listeners
+    env: dev                   # one of: dev | stage | integration | prod
+    region: {{PRIMARY_REGION}} # required for multi-cluster ApplicationSets
+    region-short: {{PRIMARY_REGION_SHORT}}   # used in Application names + value-file lookups
+    # cluster-type: gpu-inference   # optional; routes to the GPU AppSet, excluded from platform-infra
+```
+
+`cluster-role` is a cluster **identity** claim; the account name travels separately as `env`
+(ADR-0012). AppSets `matchExpressions` on these labels; a mismatch silently produces **zero**
+Applications (§7 P2).
+
+### 4.4 ApplicationSet patterns (sanitized excerpts)
+
+**Matrix (git-dir × clusters) → all clusters** — `infra-appset`:
+
+```yaml
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - matrix:
+        generators:
+          - git: { repoURL: https://github.com/{{VCS_ORG}}/{{GITOPS_REPO}}.git, revision: HEAD,
+                   directories: [ { path: apps/infra/* }, { path: apps/infra/observability, exclude: true } ] }
+          - clusters: { selector: {} }        # every registered cluster
+  template:
+    metadata:
+      name: '{{.path.basename}}-{{.name}}'
+      labels:                                 # ADR-0028 taxonomy stamped at generation time
+        platform.system: '{{.path.basename}}'
+        platform.component: infra
+        platform.env: '{{.metadata.labels.env}}'
+        platform.owner: platform
+        platform.managed-by: argocd
+    spec:
+      destination: { server: '{{.server}}', namespace: '{{.path.basename}}' }
+      syncPolicy: { automated: { prune: true, selfHeal: true }, syncOptions: [CreateNamespace=true, ServerSideApply=true] }
+```
+
+**Cluster-role fan-out + RollingSync** — `role-apps-appset` (the ADR-0024 dev→prod soak):
+
+```yaml
+generators:
+  - matrix:
+      generators:
+        - clusters: { selector: { matchExpressions: [ { key: cluster-role, operator: In,
+                        values: [dex, backend, 3rd-party, velocity, listeners] } ] } }
+        - git: { directories: [ { path: 'apps/cluster-roles/{{.metadata.labels.cluster-role}}/*' } ] }
+strategy:
+  type: RollingSync
+  rollingSync:
+    steps:
+      - matchExpressions: [ { key: env, operator: In, values: [dev] } ]                  # maxUpdate 100%
+      - matchExpressions: [ { key: env, operator: In, values: [stage, integration] } ]   # maxUpdate 50%
+      - matchExpressions: [ { key: env, operator: In, values: [prod] } ]                 # maxUpdate 25% (canary wave)
+# source path resolves to argocd/overlays/<cluster-role>-<env>/<app> (Kustomize overlay)
+```
+
+**Workload AppSet (Family B, Kargo-driven, multi-source Helm)** — `applicationset-workloads.yaml`:
+
+```yaml
+generators:
+  - matrix:
+      generators:
+        - list: { elements: [ {team: mono,namespace: mono}, {team: chains,...}, {team: direct,...},
+                              {team: protocols,...}, {team: listeners,...} ] }        # 5 teams
+        - list: { elements: [ {env: dev,autoSync: true}, {env: integration,autoSync: true},
+                              {env: staging,autoSync: true}, {env: prod,autoSync: false} ] }  # 4 envs
+template:
+  metadata:
+    annotations:
+      kargo.akuity.io/authorized-stage: '{{ .team }}:{{ .env }}'      # Kargo may edit only its own app
+      platform.io/version-manifest: 'versions/{{ .env }}/versions.yaml'
+  spec:
+    project: platform-workloads
+    sources:                                                          # multi-source: chart + $values ref
+      - repoURL: git@github.com:{{VCS_ORG}}/{{GITOPS_REPO}}.git
+        path: helm/app
+        helm:
+          releaseName: '{{ .team }}'
+          valueFiles: [ $values/envs/{{ .env }}/values/{{ .team }}/values.yaml,   # Kargo writes image.tag here
+                        $values/apps/{{ .team }}/values.yaml ]
+          values: |
+            image: { repository: "{{ECR_REGISTRY}}/{{ .team }}" }
+      - repoURL: git@github.com:{{VCS_ORG}}/{{GITOPS_REPO}}.git
+        ref: values
+    destination: { namespace: '{{ .env }}-{{ .namespace }}' }        # e.g. prod-chains
+    syncPolicy:
+      {{- if eq .autoSync true }}automated: { prune: true, selfHeal: true }{{- end }}   # prod = manual
+      syncOptions: [CreateNamespace=true, ServerSideApply=true, PruneLast=true, RespectIgnoreDifferences=true]
+    ignoreDifferences: [ { group: apps, kind: Deployment, jqPathExpressions: [.spec.replicas] } ]  # HPA owns replicas
+syncPolicy: { preserveResourcesOnDeletion: true }
+strategy: { type: RollingSync, rollingSync: { steps: [ dev, integration, staging, prod ] } }
+```
+
+Key cross-cutting AppSet conventions: `goTemplate: true` + `missingkey=error` (fail on a missing
+label rather than render empty); `RespectIgnoreDifferences` + a `.spec.replicas` ignore so the HPA
+owns replica count; `preserveResourcesOnDeletion` so deleting the AppSet does not nuke live workloads;
+`prod` autoSync **off** (human-gated). The multi-cluster and GPU AppSets add: a `region`/`region-short`
+selector for active-active staging (deploy `{{PRIMARY_REGION}}` first, then `{{SECONDARY_REGION}}`),
+Cilium global-service annotations (`service.global: true, globalAffinity: local`), and a
+`cluster-type: gpu-inference` `NotIn`/`matchLabels` split so GPU clusters get VictoriaMetrics +
+`values-gpu-inference.yaml` and skip the standard observability stack.
+
+**AppProject boundary** — `appproject-workloads.yaml` constrains the blast radius: `sourceRepos`
+pinned to the one GitOps repo; `destinations` limited to `{dev,integration,staging,prod}-*`
+namespaces on the in-cluster server; a `namespaceResourceWhitelist` (Deployment, StatefulSet,
+Service, ConfigMap, Secret, HPA, PDB, NetworkPolicy, Ingress, ExternalSecret, ServiceMonitor,
+Job/CronJob) and `clusterResourceWhitelist` of just `Namespace`.
+
+### 4.5 ArgoCD operational hardening (ADR-0024, no version bump)
+
+`argocd/config/argocd-cmd-params-cm.yaml` (delivered via the bootstrap Kustomization):
+
+```yaml
+data:
+  controller.diff.server.side: "true"   # diff via API server → kills spurious OutOfSync from webhook/defaulting
+  reposerver.git.shallow:      "true"   # depth=1 fetch → less repo-server memory, faster reconcile
+```
+
+Note the two-layer SSA: `controller.diff.server.side` (this CM) controls the **diff**; per-Application
+`syncOptions: [ServerSideApply=true]` controls the **apply**. Both are needed for the full
+"no spurious OutOfSync" benefit. RollingSync (§4.4) and PreDelete hooks (drain/deregister before
+teardown) are the other two capabilities.
+
+### 4.6 The generic `helm/app` chart (v0.4.0)
+
+One chart deploys every workload. Load-bearing behaviours:
+
+- **Deployment *or* Rollout**, mutually exclusive, sharing one `app.podSpec` helper so the two kinds
+  never diverge. `rollout.enabled: true` renders an Argo Rollouts canary with the Gateway-API traffic
+  plugin (rewrites `HTTPRoute` backendRef weights; default ladder `10→30→50→100`), each step gated by
+  a Prometheus `AnalysisTemplate` (5xx `<1%`, p95 `<500ms`). Design-target here (no Rollouts
+  controller deployed).
+- **PreSync migration Job** (`migrations.enabled`): annotated `argocd.argoproj.io/hook: PreSync`,
+  `hook-delete-policy: HookSucceeded,BeforeHookCreation`, `sync-wave: "-1"`. Runs once per sync before
+  any Sync-phase resource; a failure marks the Application `Failed` and old pods keep serving. Reuses
+  the app image by default; DB creds come only from the ESO secret via `envFrom`; `backoffLimit: 0`.
+- **Secure-by-default pod spec**: `runAsNonRoot`, `readOnlyRootFilesystem`, `drop: [ALL]`,
+  `seccompProfile: RuntimeDefault`, `automountToken: false`, default requests `100m/128Mi`, limits
+  `500m/256Mi`, `terminationGracePeriodSeconds: 35` + `preStop sleep 5`.
+- **Taxonomy gate (ADR-0028)**: the chart **fails `helm template`/`lint`** if `platform.system`,
+  `platform.component`, or `platform.owner` is empty — a misconfigured release never reaches a cluster.
+- **ExternalSecret** template (delivery boundary only — see SPEC-05) and a `ServiceMonitor`.
+
+### 4.7 Kargo promotion (Family B)
+
+**Project** declares which stages auto-promote:
+
+```yaml
+kind: Project   # kargo/projects/chains.yaml
+spec:
+  promotionPolicies:
+    - { stage: dev, autoPromotionEnabled: true }
+    - { stage: integration, autoPromotionEnabled: true }
+    - { stage: staging, autoPromotionEnabled: true }
+    - { stage: prod, autoPromotionEnabled: false }        # human gate
+```
+
+**Warehouse** subscribes to an image repo (ECR) and a git path; a new digest/tag mints Freight:
+
+```yaml
+kind: Warehouse   # kargo/warehouses/chains.yaml
+spec:
+  subscriptions:
+    - image: { repoURL: {{ECR_REGISTRY}}/chains, semverConstraint: ">=0.1.0", discoveryLimit: 5 }
+    - git:   { repoURL: git@github.com:{{VCS_ORG}}/{{GITOPS_REPO}}.git, includePaths: [apps/chains/**] }
+```
+
+**Stage** promotion steps are pure GitOps writes + an ArgoCD nudge — Kargo never `kubectl apply`s:
+
+```yaml
+kind: Stage   # kargo/stages/chains/prod.yaml
+spec:
+  requestedFreight: [ { origin: { kind: Warehouse, name: chains }, sources: { stages: [staging] } } ]  # prod ← staging
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone      # checkout main → ./src
+        - uses: yaml-update    # versions/prod/versions.yaml: image.tag AND image.digest (prod pins digest)
+        - uses: yaml-update    # envs/prod/values/chains/values.yaml: image.tag  ← what ArgoCD reads
+        - uses: git-commit     # "chore(chains): promote to prod v<tag>"
+        - uses: git-push
+        - uses: argocd-update  # apps: [chains-prod]  → triggers ArgoCD reconcile
+  verification:
+    analysisTemplates: [health-check, smoke-test, integration-test, prometheus-5xx-error-rate, prometheus-p95-latency]
+```
+
+Verification tightens down the graph: `dev` → `health-check` only; `integration` → `+integration-test`;
+`staging`/`prod` → `+` the two Prometheus gates. `dev`/`staging` request Freight `direct: true`
+(auto-advance from Warehouse); `integration`/`staging`/`prod` request from the previous stage,
+enforcing linear progression. Prod additionally writes `image.digest` (immutable pin).
+
+**Metric gate** (Prometheus provider, reading Tempo metrics-generator RED metrics — ADR-0019 dep):
+
+```yaml
+kind: AnalysisTemplate   # prometheus-p95-latency
+spec:
+  args: [ {name: service, value: ".*"}, {name: namespace, value: default},
+          {name: prometheus-address, value: http://kube-prometheus-stack-prometheus.observability.svc:9090},
+          {name: latency-threshold-ms, value: "500"} ]
+  metrics:
+    - name: p95-latency-ms
+      provider: { prometheus: { query: |
+          histogram_quantile(0.95, sum by (le) (rate(
+            http_server_request_duration_seconds_bucket{service_name=~"{{args.service}}", namespace="{{args.namespace}}"}[5m]))) * 1000 } }
+      successCondition: result[0] < {{args.latency-threshold-ms}}
+      failureCondition: result[0] >= {{args.latency-threshold-ms}} * 2
+      interval: 60s, count: 5      # 5-minute observation window
+```
+
+ML pipelines reuse the identical machinery: a `ml-pipeline-*` Warehouse tracks an ECR/GHCR model image
+by **digest** (`tagSelectionStrategy: Digest` — only cosign-signed/SBOM-attested images promote), and
+the Stage `yaml-update`s the serving chart's `image.tag` (e.g. `apps/infra/mlflow-baremetal/values.yaml`).
+
+### 4.8 Environment promotion & rollback story
+
+- **Promote.** CI builds+pushes an image and (per ADR-0015) opens a PR bumping the tag — *or* Kargo's
+  Warehouse detects the new digest. Kargo auto-advances `dev → integration → staging`; each hop
+  commits the new tag into `envs/<env>/values/<team>/values.yaml`, ArgoCD reconciles, verification
+  runs. **Prod** requires a manual, digest-pinned Kargo promotion (human approval + ticket).
+- **Rollback.** Because desired state *is* the Git commit, rollback = revert the promotion commit (or
+  re-promote the prior Freight, which is digest-addressed). ArgoCD self-heals to the reverted state.
+  For a failed migration, set `migrations.enabled: false` on the re-sync (image-only rollback); schema
+  down-migrations are the tool's responsibility (expand/contract).
+- **Drift.** `selfHeal: true` reverts any out-of-band `kubectl` edit on the next reconcile.
+  Server-side diff (§4.5) ensures the drift signal is real, not a webhook artefact. `.spec.replicas`
+  is deliberately ignored so the HPA is authoritative.
+
+---
+
+## 5. Parameterization table
+
+| Placeholder | Meaning | Default in this estate | Resize guidance |
+|---|---|---|---|
+| `{{VCS_ORG}}` | Git hosting org (SPEC-00) | *(org slug)* | one org owns the GitOps mono-repo |
+| `{{GITOPS_REPO}}` *(spec-local)* | single GitOps mono-repo name | `platform-design` | one repo holds `argocd/ apps/ envs/ helm/ kargo/`; split only at very large scale |
+| `{{PRIMARY_REGION}}` / `{{SECONDARY_REGION}}` | active-active regions | `eu-west-1` / `eu-central-1` | add a region = register a cluster secret with `region`/`region-short`; RollingSync deploys primary-first |
+| `{{PRIMARY_REGION_SHORT}}` / `{{SECONDARY_REGION_SHORT}}` | short region tokens in app names/value files | `euw1` / `euc1` | keep ≤4 chars; used literally in `values-<short>.yaml` lookups |
+| `{{ECR_REGISTRY}}` *(spec-local)* | image registry base | `{{PROD_ACCOUNT_ID}}.dkr.ecr.{{PRIMARY_REGION}}.amazonaws.com` | any OCI registry; Warehouses subscribe per-team `.../<team>` |
+| `{{PROD_ACCOUNT_ID}}` etc. | AWS account IDs (SPEC-00) | *(12-digit)* | one per account in the OU split |
+| **Sizing knob** | | | |
+| cluster-role values | workload tiers | `dex, backend, 3rd-party, velocity, listeners` | rename to the client's tiers; must match `role-apps-appset` selector AND `overlays/<role>-<env>/` dirs |
+| workload teams × envs | Family-B matrix | `5 teams × 4 envs = 20 apps` | edit the two `list` generators in `applicationset-workloads.yaml` |
+| env names | Kargo/workload envs | `dev, integration, staging, prod` | ⚠ Family-A cluster label uses `stage`, Family-B uses `staging` — see P3 |
+| RollingSync `maxUpdate` | fleet canary width | `100% / 50% / 25%` (dev/stage+int/prod) | lower prod % for larger fleets |
+| ArgoCD version / HA | control plane | `3.3.6` (chart `9.5.1`), `ha_enabled = (env==prod)` | HA in prod only; pin `argocd_chart_version` per account |
+| Kargo version | promotion plane | chart `~1.9` (locked `1.9.8`), appVersion `1.9.0` | stage a major bump in a non-prod Project first |
+| `helm/app` version | app chart | `0.4.0` (appVersion `1.0`) | bump per chart change; every workload rides one chart |
+| gate thresholds | promotion safety | 5xx `<1%`, p95 `<500ms`, window `5×60s` | start permissive in `dev`, tighten toward `prod` via per-Stage `args` |
+
+---
+
+## 6. Best practices distilled
+
+1. **Point ArgoCD at exactly one object.** The `root-app` Application is the only hand-applied
+   manifest; everything else is generated. *Why:* a single, self-healing entrypoint means "rebuild the
+   control plane" is `apply root-app.yaml` — no snowflake bootstrap script to drift.
+2. **Install the GitOps engine with the IaC tool, not with itself.** Terragrunt installs ArgoCD (and
+   CRDs) via Helm; ArgoCD then manages everything *including its own config*. *Why:* breaks the
+   chicken-and-egg and keeps day-2 ArgoCD config (`argocd-cmd-params-cm`) under GitOps.
+3. **Make the cluster a queryable set, not a list.** ApplicationSets select clusters by *labels*
+   (`cluster-role`, `env`, `region`, `cluster-type`), so onboarding a cluster is "create a labelled
+   Secret" and it auto-receives the right apps. *Why:* fleet growth costs zero AppSet edits.
+4. **`goTemplateOptions: ["missingkey=error"]` everywhere.** *Why:* a missing cluster label should
+   *fail loudly*, never silently render an Application into the wrong namespace or with an empty name.
+5. **Bake a dev→prod soak into the fleet rollout.** RollingSync steps keyed on the `env` label promote
+   `dev (100%) → stage/integration (50%) → prod (25%)`, pausing on any degraded Application. *Why:* one
+   bad generated Application can otherwise land on every cluster at once.
+6. **Server-side diff *and* server-side apply.** Enable both (they are different layers). *Why:*
+   eliminates spurious `OutOfSync` from webhook/defaulting mutation across the whole matrix — the
+   alternative (`ignoreDifferences` per field) is unbounded maintenance that masks real drift.
+7. **Let the autoscaler own what it owns.** `ignoreDifferences` on `.spec.replicas` +
+   `RespectIgnoreDifferences`. *Why:* otherwise ArgoCD and the HPA fight every reconcile.
+8. **Promote by committing, verify by metric.** Kargo edits a value file and pushes; verification is a
+   Prometheus RED-metric gate (5xx/p95), not a one-shot probe. *Why:* "it responded once" ≠ "it is
+   healthy under traffic"; and a git commit is an auditable, revertible promotion record.
+9. **Pin prod by digest, gate prod by a human.** Prod Stage writes `image.digest` and
+   `autoPromotionEnabled: false`; the workload AppSet sets prod `autoSync: false`. *Why:* immutable,
+   reproducible prod artifacts with a deliberate human checkpoint.
+10. **Migrate with a PreSync Job, never an init container.** One Job per sync, before Sync-phase
+    resources, clean pass/fail. *Why:* avoids racing migrations across a rolling update and leaves old
+    replicas serving on failure.
+11. **One generic chart, many services.** Every workload rides `helm/app`; per-service difference is a
+    values file. *Why:* security posture, taxonomy labels, probes, and canary machinery are fixed once
+    and inherited everywhere; drift between services is impossible.
+12. **Fail the render on missing ownership labels.** The chart hard-errors without
+    `platform.system/component/owner`. *Why:* turns "who owns this / what does it cost" into a
+    render-time invariant, powering Grafana/OpenCost/Cilium joins for free.
+13. **Constrain blast radius with an AppProject.** Whitelist source repo, destination namespaces, and
+    resource kinds for the workload project. *Why:* a compromised or buggy AppSet cannot deploy
+    cluster-scoped resources or escape its `<env>-*` namespaces.
+14. **`preserveResourcesOnDeletion` on workload AppSets.** *Why:* deleting/renaming an AppSet must not
+    prune live production workloads out from under traffic.
+
+---
+
+## 7. Known pitfalls
+
+- **As-built divergence:** **P1 — Two ApplicationSet families, only one wired.** `argocd/bootstrap/kustomization.yaml` lists
+  the four *Family-A* AppSets + `../config` but **not** the top-level *Family-B* files
+  (`applicationset-workloads.yaml`, `appproject-workloads.yaml`, `kargo-bootstrap.yaml`,
+  `applicationset.yaml`, `applicationset-gpu-inference.yaml`). Nothing in-repo applies them, so on a
+  clean bootstrap the workload/Kargo plane never comes up. A rebuild must add these to an app-of-apps
+  (or a second bootstrap Kustomization) — or pick one family as canonical and delete the other.
+- **P2 — Label/selector mismatch → zero Applications.** ADR-0012's founding bug: the AppSet selected
+  `cluster_role: platform` while the cluster secret was labelled `shared`, so the AppSet produced
+  **zero** Applications and workloads silently never deployed. Always dry-run AppSet output after any
+  label or selector change; treat "0 generated" as an error.
+- **As-built divergence:** **P3 — `stage` vs `staging` drift.** Family-A cluster labels + `role-apps` RollingSync use `stage`;
+  Family-B workloads + Kargo use `staging`; overlays are named `<role>-stage`. A value file or
+  selector using the wrong spelling silently no-ops. Normalize the env vocabulary on rebuild.
+- **P4 — Gates depend on a live metrics feed.** The Prometheus 5xx/p95 templates read Tempo
+  metrics-generator RED metrics (ADR-0019). Without that feed the gate has no data and fails
+  open/closed. Sequence the observability trace-lane *before* flipping Stages from `health-check` to
+  metric gates.
+- **As-built divergence:** **P5 — Rollouts referenced but not deployed.** `helm/app` ships `rollout.yaml` + analysis and ADR-0014
+  is "synced", but no Argo Rollouts controller runs here. `rollout.enabled: true` renders a `Rollout`
+  CRD nothing reconciles. Keep `rollout.enabled: false` until the controller is actually installed.
+- **As-built divergence:** **P6 — Repo URL scheme is mixed.** Some manifests use `https://github.com/...` (git-dir generators,
+  root-app) and others `git@github.com:...` (Helm multi-source, Kargo). SSH-based sources need a repo
+  credential Secret in `argocd`/`kargo`; HTTPS public reads do not. Standardize and provision creds
+  accordingly, or ArgoCD reports `ComparisonError` on the SSH sources.
+- **P7 — Shallow clone needs a resolvable revision.** `reposerver.git.shallow` fetches depth=1;
+  `targetRevision: HEAD` on a rolling branch fetches only the tip (desired), but a floating tag that
+  moves can surprise. Prefer concrete SHAs for reproducible prod syncs.
+- **P8 — Namespaces aren't Helm-rendered.** `CreateNamespace=true` makes ArgoCD create the namespace,
+  so `helm/app` cannot label it. Ship an explicit `Namespace` manifest (with `platform.*` labels) or a
+  Kyverno mutation, else namespace-level taxonomy/policy selectors miss.
+
+---
+
+## 8. Acceptance checklist
+
+A rebuild passes when:
+
+- [ ] From an empty cluster, applying **only** `argocd/bootstrap/root-app.yaml` (after Terragrunt
+      installs ArgoCD + CRDs) results in a fully-synced app-of-apps with **zero** manual `kubectl apply`
+      of child manifests.
+- [ ] `argocd app list` shows the expected generated Applications for every registered cluster; no
+      AppSet produces **0** Applications (P2 guard).
+- [ ] `argocd-cmd-params-cm` has `controller.diff.server.side=true` and `reposerver.git.shallow=true`;
+      a steady-state fleet shows **no spurious `OutOfSync`**.
+- [ ] Role-apps / infra ApplicationSets use `RollingSync` keyed on the `env` label; a change lands in
+      `dev` first and pauses the rollout on any degraded Application before `prod`.
+- [ ] The workload AppProject (`platform-workloads`) restricts sources to the one GitOps repo,
+      destinations to `{dev,integration,staging,prod}-*`, and resources to the kind whitelist.
+- [ ] `helm template helm/app` **fails** when `platform.system/component/owner` are unset, and
+      **succeeds** with them set; every rendered resource carries the five `platform.*` labels.
+- [ ] A Kargo `dev` promotion auto-commits an image-tag bump into `envs/dev/values/<team>/values.yaml`
+      and `versions/dev/versions.yaml`, and ArgoCD reconciles it; `prod` requires a manual,
+      digest-pinned promotion and the prod Application has `autoSync: false`.
+- [ ] Staging/prod Stages run the Prometheus 5xx + p95 `AnalysisTemplate`s and block promotion when a
+      threshold is breached (with the metrics feed live).
+- [ ] Enabling `migrations.enabled` renders a PreSync Job (`sync-wave: -1`) that runs once before the
+      Deployment/Rollout; a failing migration marks the Application `Failed` with old pods still serving.
+- [ ] Reverting a promotion commit rolls the environment back via self-heal with no manual cluster
+      surgery.
+- [ ] Deleting a workload ApplicationSet does **not** prune live workloads
+      (`preserveResourcesOnDeletion: true`).
+
+---
+
+## 9. Dependencies on other specs
+
+- **SPEC-02 (Terragrunt / IaC foundation)** — provisions the cluster and runs the `catalog/units/argocd`
+  unit that installs ArgoCD + CRDs (the pre-`root-app` steps of §4.2). The `never_apply`/CI-only apply
+  discipline governs how this delivery plane's Terragrunt units reach prod.
+- **SPEC-05 (Secrets)** — owns the External Secrets Operator, `ClusterSecretStore`, IRSA/Pod-Identity
+  bindings, and rotation. This spec only references `ExternalSecret` at the chart boundary
+  (§4.6, ADR-0008); ArgoCD/Git never hold plaintext.
+- **SPEC (Observability)** — supplies the Tempo metrics-generator RED metrics + Prometheus that the
+  Kargo/Rollouts `AnalysisTemplate` gates query (ADR-0019/0026); without it promotion gates have no
+  data (P4). Also consumes the `platform.*` taxonomy (ADR-0028) for dashboards.
+- **SPEC (CI / supply chain)** — builds and signs images (cosign/SBOM), pushes to ECR, and opens the
+  GitOps PRs (or feeds the Kargo Warehouse) that this plane consumes (ADR-0015/0016/0022/0048).
+- **SPEC (Networking / connectivity)** — Cilium ClusterMesh global services + Gateway API `HTTPRoute`
+  that the multi-cluster AppSet annotations and the chart's canary traffic-shifting rely on
+  (ADR-0009/0043).
+- **SPEC (Platform overview / taxonomy)** — defines the `platform.*` label taxonomy (ADR-0028) stamped
+  by every ApplicationSet and rendered resource, and the OU/account model behind the account-id
+  placeholders.
+```

--- a/specs/SPEC-05-security.md
+++ b/specs/SPEC-05-security.md
@@ -1,0 +1,551 @@
+# SPEC-05 — Security
+
+> Portable reverse-engineering of this platform's security estate. A senior platform
+> team can rebuild the same defense-in-depth posture for a new client from this file
+> alone. All client-identifying values are placeholders (see §5); replace them, do not
+> invent real account IDs, ARNs, domains, or emails.
+
+## 1. Scope & non-goals
+
+This spec captures the platform's **security controls end to end**: the AWS Organization
+guardrail plane (SCPs, RCPs, EC2 declarative policies, break-glass), the multi-account
+audit/logging foundation (CloudTrail, Config, GuardDuty, Security Hub, dedicated
+`security` and `log-archive` accounts), workload identity (EKS Pod Identity / IRSA with
+ABAC), secrets management (External Secrets Operator + Secrets Manager + KMS + automated
+rotation), Kubernetes runtime security (default-deny network policy, admission control,
+securityContext standards, runtime eBPF observability), and the CI/CD supply-chain +
+policy-as-code gates (Checkov, Conftest/OPA, Access Analyzer, Trivy, cosign/SBOM,
+Harden-Runner, zizmor). It is organized as a **six-layer defense-in-depth map**:
+`org → account → network → cluster → workload → pipeline`.
+
+**Non-goals.** Network topology (VPC/TGW/subnet design) lives in the networking spec;
+this spec only references the *security-relevant* slices (data perimeter, inter-VPC
+segmentation intent, WAF). Cluster provisioning, GitOps mechanics, cost, and
+observability internals live in their own specs and are cross-referenced in §9. This spec
+does not cover application-level authnz inside individual services.
+
+## 2. Architecture
+
+### 2.1 Defense-in-depth map (six layers)
+
+```
+                        ┌──────────────────────────────────────────────────────────┐
+LAYER 0  ORG            │  AWS Organizations (management account)                    │
+(preventive,            │   • SCPs  (principal-side) — deny leave-org, root use,     │
+ org-wide)              │            region lock, CloudTrail/GuardDuty tamper,       │
+                        │            S3-public, unencrypted-EBS, org data perimeter  │
+                        │   • RCPs  (resource-side) — deny external principals on    │
+                        │            S3/STS/KMS/SecretsManager/SQS                    │
+                        │   • EC2 Declarative Policies — IMDSv2, block public AMI/EBS │
+                        │   • Break-glass IAM user (prevent_destroy + MFA + alarm)   │
+                        └───────────────┬──────────────────────────────────────────┘
+                                        │ inherited by every account/OU
+        ┌───────────────────────────────┼───────────────────────────────┐
+LAYER 1 │ ACCOUNT   security acct        │  log-archive acct   workload accts (dev/…/prod)
+(detect,│  • GuardDuty deleg-admin       │  • central log bucket   • CloudTrail→log-archive
+ audit) │  • Security Hub (CIS/PCI/FSBP) │    (Object Lock+KMS)     • Config→log-archive
+        │  • Config aggregator           │  • VPC Flow / EKS audit  • IAM Identity Center SSO
+        └───────────────────────────────┴───────────────────────────────┘
+LAYER 2  NETWORK   • default-deny SGs + NACL backstop • TGW segmented route tables
+(perimeter)        • WAF (managed rules + rate-limit) on internet-facing serving fronts
+                   • Cilium identity-based CiliumClusterwideNetworkPolicy default-deny
+LAYER 3  CLUSTER   • Admission: Gatekeeper + Kyverno + ValidatingAdmissionPolicy (VAP)
+(admission)        • Pod Security Admission (restricted) • image signature verification
+                   • Bottlerocket immutable, read-only-root, SELinux node OS
+LAYER 4  WORKLOAD  • EKS Pod Identity (ABAC session tags) / IRSA (legacy)
+(identity+data)    • ESO + Secrets Manager + KMS CMK • least-privilege bucket-scoped IAM
+                   • securityContext: runAsNonRoot, drop ALL caps, readOnlyRootFS, no-priv-esc
+                   • Tetragon eBPF runtime tracing policies
+LAYER 5  PIPELINE  • Checkov + Conftest/OPA on plan JSON • Access Analyzer policy-diff gate
+(supply chain)     • Trivy + CodeQL + gitleaks + cosign keyless sign + Syft SBOM attest
+                   • Harden-Runner egress monitoring • zizmor Actions SAST • SHA-pinned uses:
+```
+
+### 2.2 Account topology (security-relevant)
+
+Two dedicated non-workload accounts under the `Security` OU implement separation of duties:
+
+- **`security`** — delegated administrator for GuardDuty, Security Hub, (and Detective /
+  Inspector / Macie when enabled); cross-region aggregation home is `{{PRIMARY_REGION}}`.
+  Runs no EKS/RDS (`enable_eks = false`, `enable_rds = false`).
+- **`log-archive`** — holds the single centralized, immutable log bucket (Object Lock +
+  KMS + replication). Every other account ships CloudTrail, Config snapshots, VPC Flow
+  Logs, and EKS audit/authenticator logs here via cross-account write policies.
+
+The **management** account owns the Organization, all guardrail policies, the org
+CloudTrail trail, the KMS keys, the break-glass user, and IAM Identity Center.
+
+### 2.3 Policy evaluation order (the mental model reviewers must hold)
+
+For any API call, AWS evaluates in this order — an explicit `Deny` at any layer is final:
+
+```
+Organizations SCP  →  Resource-based policy  →  Identity-based (IAM) policy
+        │                                               │
+        └────────────►  Resource Control Policy (RCP) ◄─┘   (RCP evaluates AFTER the others)
+```
+
+SCPs bound what a **caller inside the org** may do; RCPs bound what an **external
+principal** may do to *our* resources. They are the two halves of the AWS data perimeter.
+
+## 3. Decision record
+
+| Decision | Rationale | Trade-off accepted | Source ADR |
+|---|---|---|---|
+| Canonical 5-OU split (Production / Non-Production / Deployments / Suspended / Sandbox) layered over functional OUs (Security / Infrastructure / Workloads) | AFT vending and sandboxes need distinct SCP profiles without touching workload OUs | Alias mapping (`Prod`↔`Production`) adds cognitive load; +12 live SCP attachments; chose doc-mapping over a state-migrating rename | ADR-0001 OU split |
+| SCP guardrail set attached per-OU + broad SCPs at root to dodge the 5-SCP-per-target cap | AWS hard-limits 5 SCPs/target incl. inherited `FullAWSAccess`; broad controls (S3-public, EBS-encryption, data-perimeter) sit at root | Root slots are scarce (data-perimeter burns one); exemption ARNs must be maintained | ADR-0001, ADR-0017 |
+| EKS public API endpoint kept, gated by an **explicit CIDR allow-list** variable (fail-closed `[]`, never implicit `0.0.0.0/0`); prod private-only | CI runners have dynamic IPs and need API access without bastion/VPN; externalizing the list makes the open default visible in review | Non-prod may carry a documented `0.0.0.0/0`; accepted risk vs NAT-EIP/bastion cost | ADR-0010 |
+| Break-glass IAM user protected by `prevent_destroy` **and** `force_destroy = false`, MFA-enforced, usage-alarmed | `force_destroy` only fails at apply; `prevent_destroy` errors at plan before any API call — last-resort access must survive `terraform destroy` | `terraform destroy` always fails while a break-glass user exists until the lifecycle block is removed via reviewed PR (intentional friction) | ADR-0011 |
+| Deny-by-default inter-VPC model: segmented TGW route tables, default-deny SGs, prod NACL backstop, optional inspection VPC (Network Firewall) | Merging estates + cross-estate VPN could create a transitive dev→prod path; TGW route tables are the single reviewed segmentation point | More route/SG/NACL bookkeeping; VPN sub-pool membership is change-controlled | ADR-0013 |
+| Tier-1 CI supply-chain hardening: dep-scan, secrets-scan, SAST, image signing, manifest validation, smoke — **zero new long-lived secrets** | ADR-0015 baseline (Trivy OS scan + SBOM) misses app-dep CVEs, secrets, SAST, provenance; keyless OIDC avoids key sprawl | +4–7 min/build (SAST long pole); more moving parts | ADR-0016 |
+| Resource-side data perimeter (**RCPs**) + EC2 Declarative Policies + full-IAM SCPs + Access Analyzer CI gate | Perimeter was principal-side only; nothing protected resources from external principals; root SCP slots were full; policies were reviewed by eye | Two new policy types + new eval-order mental model; Access Analyzer checks are a paid feature | ADR-0017 |
+| **EKS Pod Identity** as default workload identity (IRSA → legacy), least-privilege via **ABAC** session tags | IRSA trust is per-cluster (non-portable roles, role sprawl); Pod Identity reuses one role across clusters; ABAC scopes by injected tags | Coexistence window; ABAC is condition-heavy (wrong tag key/case is a new bug class); Fargate stays on IRSA | ADR-0018 |
+| **Kyverno + ValidatingAdmissionPolicy** alongside Gatekeeper; image-signature verification at **admission** (not GitOps) | ArgoCD can only verify GnuPG-signed git commits, not cosign/OCI signatures; VAP runs in-process via CEL (no webhook) for trivial checks | Two admission engines + VAP to operate; `verifyImages` adds admission latency | ADR-0020 |
+| CI runtime hardening: **zizmor** (Actions SAST) + **Harden-Runner** (runner egress monitoring), audit → block | Matches the 2025 `tj-actions/changed-files` class: workflows were never SAST-linted; runners had zero runtime egress visibility | Block mode needs a maintained egress allow-list; zizmor surfaces a backlog | ADR-0022 |
+| ArgoCD operational hardening (PreDelete hooks, shallow clone, server-side diff/apply, progressive ApplicationSet rollout) on the running 3.3.6 | All four ship in the current version for free; fix deletion ordering, repo-server cost, spurious `OutOfSync`, and the missing dev→prod rollout gradient | Server-side apply changes field-ownership semantics teams must learn | ADR-0024 |
+| **Bottlerocket** as EKS node OS (immutable, read-only-root, SELinux-enforcing, no SSH/shell/pkg-mgr) | AL2023 default carries a large mutable host attack surface invisible to in-cluster controls | No SSH debugging (admin container, disabled by default); two-volume layout; FIPS/GPU are separate variants | ADR-0030 |
+| Automated secret rotation: Secrets Manager rotation Lambda + ESO auto-refresh of pods | Static long-lived secrets are standing-credential risk; PCI-DSS 3.6.4/8.3.9 require a cryptoperiod; rotated value must reach running pods | Rotation Lambda is real code to own (VPC ENIs, RDS reachability); `refreshInterval` adds `GetSecretValue` cost | ADR-0031 |
+| Control Tower landing zone + AFT for account vending | AFT hard-requires a deployed Control Tower landing zone (the load-bearing prerequisite ADR-0017 omitted) | Migrating a live populated org; +2 management accounts; home-region lock-in | ADR-0035 |
+| SOC2 posture: GCP org-policy parity, keyless cross-cloud WIF, control-to-evidence matrix, ML on-call | Controls were AWS/K8s-heavy and never mapped to an audit framework; GCP had no deny-list plane; cross-cloud identity was static-key | Org-policy is high-blast-radius; WIF setup non-trivial; matrix must be maintained | ADR-0040 |
+| WAF-fronted, model-aware inference serving front (Gateway API Inference Extension + Endpoint Picker on Envoy Gateway) | A naive L4 `ClusterIP` LB is model/cache-blind; WAF adds managed rule groups + per-client rate limiting at the public edge | Inference extension is young (CRD pin required); WAF may false-positive on long prompts (start in count mode) | ADR-0047 |
+
+## 4. Implementation blueprint
+
+### 4.1 Directory layout (security-bearing paths)
+
+```
+terragrunt/_org/                      # Organization + guardrail plane (management acct)
+  account.hcl                         #   mgmt account id, org name, member accounts
+  _global/organization/               #   OU tree + member accounts
+  _global/scps/                       #   principal-side SCPs (→ modules/scps)
+  _global/rcps/                       #   resource-side RCPs (→ modules/rcps), staged rollout
+  _global/break-glass-user/           #   emergency IAM user (→ modules/break-glass-user)
+  _global/cloudtrail/                 #   org-wide trail → log-archive bucket
+  _global/guardduty-org/              #   all protection plans, delegated admin
+  _global/security-hub/               #   CIS + PCI-DSS + AWS FSBP standards
+  _global/aws-config/                 #   recorder incl. global (IAM) resources
+  _global/iam-baseline/               #   password policy + enforce-MFA + root-key Config rule
+  _global/sso/                        #   IAM Identity Center permission sets + assignments
+terragrunt/security/account.hcl       # security account (GuardDuty/SecurityHub deleg-admin home)
+terragrunt/log-archive/account.hcl    # centralized immutable log bucket
+terraform/modules/scps|rcps|break-glass-user|iam-baseline|waf|secret-rotation|...
+checkov-policies/*.json               # custom Checkov Well-Architected checks
+tests/opa/*.rego                      # Conftest/OPA policies (run on plan JSON)
+network-policies/                     # baseline K8s NetworkPolicy + Cilium clusterwide deny
+apps/infra/{gatekeeper,kyverno,tetragon,cluster-secret-store}/   # runtime security
+catalog/units/pod-identity-*/         # Pod Identity associations (ESO, LB-ctrl, ...)
+.github/workflows/{conftest-opa,policy-access-check,container-build}.yml
+.github/actions/{harden-runner,cosign-sign,syft-sbom,sast-codeql,secrets-scan}/
+docs/break-glass-procedure.md         # the runbook §4.5 distills
+```
+
+### 4.2 Guardrail inventory (control · layer · enforced by · file)
+
+| Control | Layer | Enforced by | File |
+|---|---|---|---|
+| Deny leave organization | org | SCP `DenyLeaveOrganization` (all non-root OUs) | `terraform/modules/scps/main.tf` |
+| Deny root user in member accounts | org | SCP `DenyRootAccountUsage` (`workload_ou_names`: NonProd, Prod, Sandbox) | `modules/scps/main.tf` |
+| Region lock (EU + us-east-1 globals) | org | SCP `RestrictToEURegions` (exempts OAAR + `{{PROJECT}}-terraform-*`) | `modules/scps/main.tf` |
+| Deny CloudTrail tamper (no exemptions) | org | SCP `DenyDisableCloudTrail` | `modules/scps/main.tf` |
+| Deny GuardDuty tamper (no exemptions) | org | SCP `DenyGuardDutyChanges` | `modules/scps/main.tf` |
+| Deny S3 public-access changes (terraform-exempt) | org (root) | SCP `DenyS3PublicAccess` | `modules/scps/main.tf` |
+| Require EBS encryption (no exemptions) | org (root) | SCP `RequireEBSEncryption` (`ec2:Encrypted=false`) | `modules/scps/main.tf` |
+| Identity perimeter (`aws:PrincipalOrgID`) | org (root) | SCP `DataPerimeter-DenyExternalPrincipals` | `modules/scps/main.tf` |
+| Quarantine suspended accounts | org | SCP `DenyAllSuspended` (OAAR carve-out) | `modules/scps/main.tf` |
+| Resource perimeter on S3/STS/KMS/SecretsMgr/SQS | org | RCP `RCP-DataPerimeter-DenyExternalAccess` (staged→root) | `modules/rcps/main.tf` |
+| IMDSv2 required, block public AMI/EBS snapshot | org | EC2 Declarative Policies (retires `require_imdsv2` SCP) | ADR-0017 (pending) |
+| Break-glass destroy protection + MFA + alarm | org | `prevent_destroy`, deny-without-MFA inline policy, CloudWatch alarm | `modules/break-glass-user/main.tf` |
+| Root access-key detection | account | Config rule `IAM_ROOT_ACCESS_KEY_CHECK` | `modules/iam-baseline/main.tf` |
+| Strong password policy + enforce-MFA | account | `aws_iam_account_password_policy` + `enforce_mfa` policy | `modules/iam-baseline/main.tf` |
+| Org CloudTrail (KMS-encrypted) → log-archive | account | `modules/cloudtrail` (depends on org + KMS) | `_org/_global/cloudtrail/` |
+| Config recorder (all + global IAM) → log-archive | account | `modules/aws-config` | `_org/_global/aws-config/` |
+| GuardDuty all plans (S3/EKS audit+runtime/EBS malware/RDS/Lambda) | account | `modules/guardduty-org`, delegated admin | `_org/_global/guardduty-org/` |
+| Security Hub (CIS + PCI-DSS + AWS FSBP) | account | `modules/security-hub` (after GuardDuty+Config) | `_org/_global/security-hub/` |
+| Centralized immutable logs (Object Lock+KMS+replication) | account | `_envcommon/centralized-logging.hcl` | `terragrunt/log-archive/` |
+| Least-privilege SSO permission sets | account | IAM Identity Center (`PT4H`/`PT8H` sessions, prod = ReadOnly for engineers) | `_org/_global/sso/` |
+| K8s default-deny ingress+egress | network | `NetworkPolicy default-deny-all` | `network-policies/default-deny-all.yaml` |
+| Cilium identity-based clusterwide deny | network | `CiliumClusterwideNetworkPolicy default-deny-<ns>` | `network-policies/gpu-inference/00-default-deny.yaml` |
+| WAF (managed rules + rate limit + logging) | network | `aws_wafv2_web_acl` (`rate_limit` default 2000/5-min) | `terraform/modules/waf/main.tf` |
+| Require securityContext (runAsNonRoot, no priv-esc, non-privileged) | cluster | Gatekeeper `K8sRequireSecurityContext` (enforce=deny) | `apps/infra/gatekeeper/templates/constraints/require-security-context.yaml` |
+| Image signature verification, block `:latest`, require limits | cluster | Kyverno `ImageValidatingPolicy` + VAP (CEL) | `apps/infra/kyverno/templates/vap/` |
+| Immutable node OS | cluster | Bottlerocket (`ami_family`/`amiSelectorTerms`) | `catalog/units/*-nodes`, `*-nodepools` |
+| Workload identity (Pod Identity + ABAC) | workload | `PodIdentityAssociation` + `aws:PrincipalTag/*` conditions | `catalog/units/pod-identity-*/` |
+| Secrets from Secrets Manager (no plaintext in Git) | workload | ESO `ClusterSecretStore` + `ExternalSecret` | `apps/infra/cluster-secret-store/` |
+| Automated secret rotation | workload | Secrets Manager rotation Lambda + ESO refresh | `terraform/modules/secret-rotation/` |
+| Runtime eBPF tracing (exec, privileged syscalls, sensitive files) | workload | Tetragon `TracingPolicy` | `apps/infra/tetragon/templates/` |
+| Custom Well-Architected IaC checks | pipeline | Checkov custom policies (S3 SSE, IAM password, RDS backup, gp3) | `checkov-policies/*.json` |
+| OPA guardrails on plan JSON | pipeline | Conftest (S3-public, SG-ingress, encryption-at-rest, required-tags, no-hardcoded-creds) | `tests/opa/*.rego` |
+| Policy-diff cannot widen access | pipeline | IAM Access Analyzer `CheckNoNewAccess`/`CheckAccessNotGranted` | `.github/workflows/policy-access-check.yml` |
+| Image CVE scan (CRITICAL/HIGH) | pipeline | Trivy (`aquasecurity/trivy-action`) → SARIF | `.github/workflows/container-build.yml` |
+| Keyless image signing + SBOM attestation | pipeline | cosign (GitHub OIDC / Fulcio+Rekor) + Syft | `.github/actions/{cosign-sign,syft-sbom}` |
+| Runner egress monitoring | pipeline | StepSecurity Harden-Runner (audit→block) | `.github/actions/harden-runner` |
+| Actions workflow SAST | pipeline | zizmor → Code Scanning | `.github/workflows/zizmor.yml` |
+| Secrets / SAST / dependency scan | pipeline | gitleaks, CodeQL, pip-audit/npm-audit/osv-scanner | `.github/actions/{secrets-scan,sast-codeql,*-dep-scan}` |
+
+### 4.3 Org guardrails — SCP & RCP shape (sanitized)
+
+Nine SCP resources live in `modules/scps/main.tf`. The two perimeter-critical ones:
+
+```hcl
+# Principal-side identity perimeter — attached at ROOT (applies to every account).
+# IfExists semantics prevent false-trips on STS calls lacking a resolved OrgID.
+resource "aws_organizations_policy" "deny_external_principals" {
+  name = "DataPerimeter-DenyExternalPrincipals"
+  type = "SERVICE_CONTROL_POLICY"
+  content = jsonencode({ Version = "2012-10-17", Statement = [{
+    Sid = "DenyNonOrgPrincipals", Effect = "Deny", Action = "*", Resource = "*"
+    Condition = {
+      StringNotEqualsIfExists = { "aws:PrincipalOrgID" = var.organization_id }   # {{ORG_ID}}
+      BoolIfExists            = { "aws:PrincipalIsAWSService" = "false" }         # service carve-out
+      ArnNotLike = { "aws:PrincipalArn" = [
+        "arn:aws:iam::*:role/OrganizationAccountAccessRole",
+        "arn:aws:iam::*:role/{{PROJECT}}-terraform-*",
+      ] }
+    }
+  }] })
+}
+```
+
+```hcl
+# Resource-side perimeter (RCP) — deny external principals acting on OUR resources.
+# RCPs have a SEPARATE slot budget from the 5/5 SCP cap. Staged in a Policy-Staging
+# OU, then PROMOTED to root additively (for_each over target_ou_ids).
+resource "aws_organizations_policy" "org_perimeter" {
+  name = "RCP-DataPerimeter-DenyExternalAccess"
+  type = "RESOURCE_CONTROL_POLICY"
+  content = jsonencode({ Version = "2012-10-17", Statement = [{
+    Sid = "DenyExternalAccessToResources", Effect = "Deny"
+    Principal = { AWS = "*" }
+    Action    = ["s3:*", "sts:*", "kms:*", "secretsmanager:*", "sqs:*"]
+    Resource  = "*"
+    Condition = {
+      StringNotEqualsIfExists = { "aws:PrincipalOrgID" = var.organization_id }  # {{ORG_ID}}
+      BoolIfExists            = { "aws:PrincipalIsAWSService" = "false" }
+    }
+  }] })
+}
+```
+
+**Exemption philosophy** (must be reproduced): security SCPs that protect the audit trail
+(`DenyDisableCloudTrail`, `DenyGuardDutyChanges`, `RequireEBSEncryption`) carry **no
+exemptions**. Region-lock, S3-public, and the perimeters exempt only
+`OrganizationAccountAccessRole` (account vending) and `{{PROJECT}}-terraform-*` (the CI/CD
+apply role) — and only where those principals legitimately need it. Broad security SCPs
+(`DenyS3PublicAccess`, `RequireEBSEncryption`, `DataPerimeter-*`) attach at **root** to
+avoid the 5-SCP-per-OU limit; the rest attach per-OU. `DenyRootAccountUsage` attaches to
+`workload_ou_names` (NonProd, Prod, Sandbox); `Deployments` is excluded (its accounts run
+CI/AFT tooling under programmatic principals).
+
+### 4.4 Break-glass user (ADR-0011)
+
+```hcl
+resource "aws_iam_user" "this" {
+  name          = "break-glass-${var.account_name}"
+  path          = "/break-glass/"
+  force_destroy = false                    # apply-time backstop
+  lifecycle { prevent_destroy = true }     # plan-time protection — removal needs a reviewed PR
+}
+# Inline "deny everything unless aws:MultiFactorAuthPresent" policy + AdministratorAccess
+# (effective only AFTER the user enrolls MFA and calls sts:GetSessionToken --serial-number).
+# CloudWatch metric filter on { $.userIdentity.userName = "break-glass-<acct>" } → alarm → SNS.
+```
+Access key and console login are **opt-in** (`create_access_key`/`create_console_login`
+default `false`): flip on a single bootstrap apply, capture the secret into the team
+password manager, then revert.
+
+### 4.5 Break-glass procedure (design)
+
+The **management account root** is the most privileged identity (can close the org, edit
+SCPs, delete CloudTrail, reach any account via `OrganizationAccountAccessRole`). Day-to-day
+uses IAM Identity Center + delegated-admin roles in `security`; root is used **only when no
+other path works** (Identity Center/IdP outage, billing-only operations, recovery from a
+lockout-inducing SCP, closing the org). Pre-conditions and runbook:
+
+- **Pre-conditions (one-time):** MFA on root (two independent admins hold devices, both
+  required); 32+ char generated password in an **offline** password-manager vault
+  accessible only to platform-team-leads; **zero** root access keys (Config rule
+  `IAM_ROOT_ACCESS_KEY_CHECK` alerts on creation); org CloudTrail covers all root activity;
+  an EventBridge rule on `userIdentity.type == "Root"` pages the on-call SNS topic
+  (chatops + pager).
+- **Procedure:** (1) file a justification ticket + get a second-admin ack; (2) retrieve
+  credentials via `scripts/break-glass.sh request --reason …` (records reason to logs,
+  never prints/persists the password or MFA); (3) sign in from a clean incognito profile
+  with MFA; (4) keep the session < 15 min, do **not** create keys/users or touch
+  CloudTrail/GuardDuty/SCPs/the log bucket; (5) sign out + `release` (rotates the password,
+  links CloudTrail events to the ticket); (6) post-incident review within 24 h.
+- **Related controls:** member-account `DenyLeaveOrganization` / `DenyDisableCloudTrail`
+  SCPs do **not** apply to the management root by design — break-glass is the only
+  sanctioned path to those operations, which is exactly why every use alarms.
+
+### 4.6 Workload identity — Pod Identity + ABAC (ADR-0018)
+
+```hcl
+# Trust: the EKS Pod Identity service principal, account-scoped, WITH sts:TagSession
+# (required so ABAC session tags can be injected).
+statement {
+  actions    = ["sts:AssumeRole", "sts:TagSession"]
+  principals { type = "Service", identifiers = ["pods.eks.amazonaws.com"] }
+  condition { test = "StringEquals", variable = "aws:SourceAccount"
+              values = [data.aws_caller_identity.current.account_id] }  # {{PROD_ACCOUNT_ID}} etc.
+}
+# Permission: bucket-scoped S3 + ABAC — principal AND resource must both be tagged
+# platform:system = ml-pipeline. A mis-tagged caller or an untagged bucket is denied.
+condition { test = "StringEquals", variable = "aws:PrincipalTag/platform:system", values = [local.platform_system] }
+condition { test = "StringEquals", variable = "aws:ResourceTag/platform:system",  values = [local.platform_system] }
+```
+ESO authenticates via its **own** controller SA bound through a `PodIdentityAssociation`
+(not `serviceAccountRef`); no SA may carry both `eks.amazonaws.com/role-arn` (IRSA) and a
+Pod Identity association. ABAC scopes on six injected session tags (`eks-cluster-name`,
+`kubernetes-namespace`, `kubernetes-service-account`, `kubernetes-pod-name`,
+`kubernetes-pod-uid`, `eks-cluster-arn`). Fargate lacks Pod Identity → stays on IRSA;
+Karpenter nodes must run the Pod Identity agent DaemonSet.
+
+### 4.7 Artifact-store IAM / S3-TLS hardening (`aws-ml-artifact-store`, ADR-0048)
+
+The bucket-provisioning module bundles the CIS-aligned S3 baseline every data bucket
+should replicate: `BucketOwnerEnforced` (IAM-only, no ACLs); all-four public-access-block;
+a bucket policy `DenyInsecureTransport` (`aws:SecureTransport=false` → CIS 2.1.1); SSE-KMS
+(AES256 fallback) with `bucket_key_enabled`; versioning (audit chain); lifecycle
+STANDARD-IA → Glacier-IR → Expire; a **standalone managed** IAM policy (CIS 1.16, not
+inline) scoped to *this* bucket + ABAC; `prevent_destroy` on the bucket. Resources are
+gated behind `create_resources = false` (apply only after explicit human approval).
+
+### 4.8 Secrets — ESO + Secrets Manager + KMS + rotation
+
+- **`ClusterSecretStore`** (`external-secrets.io/v1`) provider `aws` / `service:
+  SecretsManager`, region `{{SECRETS_REGION}}`, auth via the ESO controller SA
+  (`external-secrets/external-secrets`). Multi-cloud: a parallel `gcp-secrets-manager`
+  store exists for GCP-backed secrets (e.g. the MLflow DB connection).
+- **`ExternalSecret`** manifests materialize each secret with a `refreshInterval` (e.g.
+  `1h`); the remote key path convention is `/<platform-system>/<name>` (e.g.
+  `/ml-pipeline/mlflow-db-connection`). No plaintext secret ever lives in Git (ADR-0006).
+- **Rotation** (`modules/secret-rotation`): `aws_secretsmanager_secret` (customer-managed
+  KMS CMK) + `aws_secretsmanager_secret_rotation` (`automatically_after_days` or cron) +
+  a rotation Lambda (custom handler or AWS RDS single/alternating-user template). IAM is
+  scoped to the single secret ARN + its CMK; the Lambda runs in-VPC
+  (`AWSLambdaVPCAccessExecutionRole`) to reach private RDS. Stakater Reloader (or an ESO
+  content checksum) rolls consuming pods when the value changes.
+
+### 4.9 Runtime security — network, admission, node OS, eBPF
+
+- **Network:** apply `default-deny-all` (ingress+egress) **first**, then layer
+  `allow-from-same-namespace` and `allow-dns-egress` (UDP/TCP 53 to `kube-system`). On
+  Cilium clusters, `CiliumClusterwideNetworkPolicy` binds to **pod identity (labels)**, not
+  IPs — policy survives pod restarts, Karpenter replacement, and spot eviction. The
+  clusterwide default-deny permits only intra-namespace, CoreDNS, kube-apiserver, and
+  Hubble-relay flows.
+- **Admission:** Gatekeeper `K8sRequireSecurityContext` (`enforcementAction: deny`,
+  graduated warn→deny after an audit soak; `excludedNamespaces` = kube-system, kube-public,
+  gatekeeper-system, monitoring, external-secrets) forbids `runAsNonRoot != true`,
+  `allowPrivilegeEscalation`, and `privileged`. Kyverno (v1.18.1) adds `ImageValidatingPolicy`
+  (keyless cosign verification against a Fulcio identity + Rekor inclusion, `mutateDigest`,
+  `failurePolicy: Enforce` in prod), securityContext mutation, and default-deny NetworkPolicy
+  generation. VAP (CEL, in-process) blocks `:latest` and requires CPU/memory limits.
+- **Node OS:** Bottlerocket — read-only root, SELinux-enforcing, no SSH/shell/package
+  manager; two-volume gp3-encrypted layout (`/dev/xvda` OS, `/dev/xvdb` data); config via
+  userData TOML (no bash bootstrap). FIPS and NVIDIA-GPU are separate pinned variants.
+- **securityContext standard** (workload default, e.g. the inference Endpoint Picker):
+  `runAsNonRoot: true`, `runAsUser: <nobody>`, `allowPrivilegeEscalation: false`,
+  `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]`, plus **bounded** resource
+  requests/limits so no ext-proc/sidecar can OOM-pressure a node. **Documented exception:**
+  the DCGM GPU-metrics exporter needs `runAsNonRoot: false` + `SYS_ADMIN` for device
+  access — it still pins `readOnlyRootFilesystem: true` to bound the exception.
+- **Runtime eBPF:** Tetragon `TracingPolicy` objects observe process exec, privileged
+  syscalls, and sensitive-file access.
+
+### 4.10 Policy-as-code & supply chain (pipeline layer)
+
+- **Checkov** custom checks (`checkov-policies/*.json`) encode Well-Architected rules: S3
+  SSE present (`WA_AWS_1`, MEDIUM), IAM password requires numbers (`WA_SEC_IAM_1`, HIGH),
+  RDS backup retention > 0 (`WA_REL_RDS_1`, MEDIUM), EBS = gp3 (`WA_COST_EBS_1`, LOW).
+- **Conftest/OPA** (`tests/opa/*.rego`, run on `terragrunt show -json tfplan`): no public
+  S3 (ACL + all-four public-access-block), no unrestricted SG ingress (`0.0.0.0/0` /
+  `::/0`, with a **port-443 carve-out**), encryption-at-rest across 10+ resource types,
+  required tags (`Environment`/`Team`/`ManagedBy`), no hardcoded credentials (allow-lists
+  Secrets-Manager/SSM references + `(sensitive value)`). The `conftest-opa.yml` workflow
+  also runs `opa check --strict` + `opa test` so the `*_test.rego` unit tests actually
+  execute in CI.
+- **Access Analyzer gate** (`policy-access-check.yml`): on any change to `modules/{scps,rcps}`,
+  `CheckNoNewAccess` proves the diff grants no new effective access and
+  `CheckAccessNotGranted` proves named sensitive actions stay denied. **Gate on the JSON
+  `result` field, not the CLI exit code** (the CLI can exit 0 on a FAIL). Advisory first,
+  flip `ADVISORY: "false"` to block.
+- **Container supply chain** (`container-build.yml`): Harden-Runner (audit) as the *first*
+  step → Trivy CRITICAL/HIGH → SARIF upload → Syft SBOM → push by digest → **cosign keyless
+  sign + SBOM attestation** via the job's GitHub OIDC identity. All third-party `uses:` are
+  SHA-pinned with a version comment; AWS auth is OIDC only (no long-lived keys). zizmor
+  SASTs the workflows themselves; gitleaks/CodeQL/pip-audit/npm-audit/osv-scanner cover
+  secrets, SAST, and dependencies (ADR-0016/0022).
+
+### 4.11 Ordering / dependencies (what must exist before what)
+
+1. **Organization** (OUs + member accounts) → everything else in `_org/`.
+2. **KMS** keys → CloudTrail, Config, log-archive bucket encryption.
+3. **CloudTrail + Config** → **GuardDuty** → **Security Hub** (findings aggregation order).
+4. **`RESOURCE_CONTROL_POLICY` + EC2-declarative policy types enabled** in the org →
+   RCP/declarative modules can attach.
+5. RCP: attach to the **Policy-Staging OU first**, soak, then additively promote to root.
+6. **`eks-pod-identity-agent` addon** + ESO upgraded to v2.6.0 → Pod Identity units.
+7. `catalog/units/github-oidc` deployed + `TERRAFORM_PLAN_ROLE_ARN` set → the Conftest gate
+   runs (else it skips with an informational PR comment).
+8. Network `default-deny-all` applied **before** any allow policy.
+
+## 5. Parameterization table
+
+| Placeholder | Meaning | Default in this estate | Resize guidance |
+|---|---|---|---|
+| `{{ORG}}` | org / company slug | `platform` | naming prefix for buckets, WAF ACLs |
+| `{{PROJECT}}` | project/repo slug in role ARNs | `platform-design` | drives `{{PROJECT}}-terraform-*` SCP exemptions |
+| `{{ORG_ID}}` | AWS Organizations id | `o-…` | perimeter SCP/RCP condition value |
+| `{{MGMT_ACCOUNT_ID}}` | management account | `000000000000` (placeholder) | owns org, guardrails, trail, KMS, break-glass |
+| `{{SECURITY_ACCOUNT_ID}}` | security account | `777777777777` (placeholder) | GuardDuty/Security Hub delegated admin |
+| `{{LOG_ARCHIVE_ACCOUNT_ID}}` | log-archive account | `888888888888` (placeholder) | centralized immutable log bucket |
+| `{{PROD_ACCOUNT_ID}}`, `{{DEV_ACCOUNT_ID}}`, … | workload accounts | per-account `account.hcl` | one Pod-Identity trust scope each |
+| `{{PRIMARY_REGION}}` | home / aggregation region | `eu-west-1` | GuardDuty/Config aggregator home; region-lock set |
+| `{{DR_REGION}}` | DR region | (per estate) | replication target for log-archive |
+| `{{SECRETS_REGION}}` | ESO Secrets Manager region | `eu-central-1` | set on `ClusterSecretStore` |
+| `{{ROOT_EMAIL_DOMAIN}}` | root-account email domain | `example.com` | `aws+<role>@{{ROOT_EMAIL_DOMAIN}}` |
+| `{{LOG_ARCHIVE_BUCKET}}` | central log bucket | `{{ORG}}-log-archive-{{LOG_ARCHIVE_ACCOUNT_ID}}-{{PRIMARY_REGION}}` | globally-unique name |
+| `allowed_regions` | SCP region allow-list | EU + `us-east-1` (globals) | set to client compliance geos |
+| `cluster_endpoint_public_access_cidrs` | EKS API allow-list | prod `[]` (private), dev `["0.0.0.0/0"]` | tighten to CI IP ranges |
+| `rate_limit` (WAF) | per-IP requests / 5-min | `2000` | raise for high-QPS inference |
+| `log_retention_days` (WAF) | WAF log retention | `365` | set to compliance retention |
+| `automatically_after_days` | secret rotation period | per-secret | PCI cryptoperiod |
+| SSO `session_duration` | permission-set TTL | `PT4H` (admin/billing) / `PT8H` (else) | shorten for stricter regimes |
+| `workload_ou_names` | OUs getting `DenyRootAccount` | `["NonProd","Prod","Sandbox"]` | add new workload OUs |
+
+**Pinned tool versions** (from `terragrunt/versions.hcl` / `.tool-versions`): Terraform
+`1.14.8`, Terragrunt `1.0.8`, AWS provider `~> 6.0`; CI pins Conftest `0.57.0`, OPA
+`1.17.1`, Kyverno `1.18.1`, ArgoCD `3.3.6` (chart `9.5.1`). Bump patch/minor via green-CI
+PR; majors need an ADR.
+
+## 6. Best practices distilled
+
+1. **Two perimeters, not one.** Pair a principal-side SCP (`aws:PrincipalOrgID`) with a
+   resource-side RCP on S3/STS/KMS/SecretsManager/SQS. An SCP alone cannot stop a public
+   bucket or over-broad KMS grant from punching out of the org; the RCP closes that gap and
+   spends a *separate* slot budget. — *Why: SCPs gate callers, RCPs gate your resources.*
+2. **Spend root SCP slots deliberately.** AWS caps 5 SCPs per target (incl. inherited
+   `FullAWSAccess`). Put broad org-wide controls (S3-public, EBS-encryption, data-perimeter)
+   at root and OU-specific ones per-OU. Prefer RCPs and EC2 declarative policies to relieve
+   the cap. — *Why: you will hit 5/5 and be unable to add a control mid-incident.*
+3. **No exemptions on audit-trail controls.** CloudTrail/GuardDuty tamper denies and
+   mandatory-encryption denies must have zero carve-outs; only region-lock and the
+   perimeters exempt the vending role and the CI apply role. — *Why: an exemption on the
+   audit trail is an exfiltration path.*
+4. **Protect emergency access at plan time.** `prevent_destroy` on the break-glass user
+   errors before any API call; `force_destroy=false` is only the apply-time backstop. Keep
+   the access key opt-in and alarm every use. — *Why: `terraform destroy` must never be able
+   to silently delete your last-resort identity.*
+5. **Machine-check every policy diff.** Replace review-by-eye of SCP/RCP edits with IAM
+   Access Analyzer `CheckNoNewAccess`/`CheckAccessNotGranted`, and **gate on the JSON
+   `result` field, not the exit code**. — *Why: a reviewer cannot reliably reason about
+   deny-logic diffs; the CLI can exit 0 on a FAIL.*
+6. **Workload identity by attribute, not by role-per-workload.** Use EKS Pod Identity with
+   ABAC session tags so one role is reused across clusters and least-privilege is expressed
+   as `aws:PrincipalTag`/`aws:ResourceTag` equality. Require `sts:TagSession` in the trust
+   policy. — *Why: IRSA role sprawl is non-portable and unauditable at scale.*
+7. **Verify image signatures at admission, not at GitOps sync.** ArgoCD verifies GnuPG git
+   commits, not cosign/OCI signatures — put keyless verification (Fulcio identity + Rekor
+   inclusion, `mutateDigest`, `failurePolicy: Enforce` in prod) in Kyverno. — *Why: the
+   GitOps layer structurally cannot check container provenance.*
+8. **Default-deny the network, then allow narrowly.** Apply `default-deny-all` first; on
+   Cilium bind policy to pod identity (labels) so it survives IP churn from restarts, spot
+   eviction, and Karpenter. — *Why: IP-based policy breaks the moment a pod moves.*
+9. **Shrink the host, not just the container.** Bottlerocket (read-only root, SELinux, no
+   SSH/shell/pkg-mgr, atomic updates) removes a mutable host attack surface that in-cluster
+   controls cannot see. Standardize `runAsNonRoot`, drop ALL capabilities,
+   `readOnlyRootFilesystem`, and **bounded** resources; document each exception (e.g. DCGM)
+   and keep every other hardening flag on. — *Why: a compromised container on a mutable host
+   is a foothold; on an immutable host it is contained.*
+10. **No standing credentials, anywhere.** Secrets live only in Secrets Manager (ESO
+    materializes them, ADR-0006 keeps Git plaintext-free), rotate on a defined cryptoperiod
+    with a rotation Lambda + ESO refresh, and encrypt with customer-managed KMS CMKs. CI
+    signs keylessly via OIDC and adds **zero** new long-lived secrets. — *Why: a leaked
+    static secret is valid until someone notices; a rotated/federated one self-heals.*
+11. **Enforce TLS and public-access-block on every bucket.** `BucketOwnerEnforced`,
+    all-four public-access-block, and a `DenyInsecureTransport` bucket policy
+    (`aws:SecureTransport=false`) are the non-negotiable S3 baseline (CIS 2.1.1). — *Why:
+    SSE at rest is worthless if the object travels in plaintext.*
+12. **Ship security gates advisory, graduate to blocking.** RCP staged in a Policy-Staging
+    OU → root; Gatekeeper warn → deny after an audit soak; Harden-Runner audit → block;
+    Access Analyzer + Conftest advisory → merge-blocking; WAF count → block. — *Why: a
+    fail-closed control shipped blocking on day one causes an outage and gets disabled.*
+
+## 7. Known pitfalls
+
+- **5-SCP-per-OU cap is real and inherited.** `FullAWSAccess` counts. Placing a control at
+  the wrong level (OU vs root) or adding one control too many silently fails to attach.
+- **RCPs evaluate *after* identity/SCP/resource policy** — a new mental model. A
+  mis-scoped RCP deny is final and can break log delivery / cross-service calls; that is why
+  it must be staged in a small OU first (keep the AWS-service-principal carve-out).
+- **`prevent_destroy` blocks `terraform destroy` for the whole account** while a break-glass
+  user exists — expected, but surprises operators tearing down an environment.
+- **Both workload-identity mechanisms on one SA is undocumented/unsupported.** After a Pod
+  Identity cutover, ensure no SA still carries `eks.amazonaws.com/role-arn`. Fargate cannot
+  use Pod Identity; Karpenter nodes must run the Pod Identity agent DaemonSet.
+- **ABAC is case- and key-sensitive.** A wrong tag key or a resource missing
+  `platform:system` yields a silent `AccessDenied`, not a plan error — a new bug class.
+- **The Conftest gate is a no-op without OIDC.** It skips (with a PR comment) until
+  `catalog/units/github-oidc` is deployed and `TERRAFORM_PLAN_ROLE_ARN` is set — don't
+  mistake "skipped" for "passed".
+- **Access Analyzer custom policy checks are a paid feature** — the workflow only runs on
+  PRs touching `modules/{scps,rcps}` to bound cost.
+- **WAF false-positives on long inference prompts.** Start managed rules + rate-limit in
+  count mode and tune before flipping to block.
+- **Bottlerocket has no SSH/shell.** Debugging requires the admin/control container
+  (disabled by default); DaemonSets assuming a writable root or host paths may break —
+  pilot on a fresh node group.
+- **Rotation fires immediately on enable** (`rotate_immediately` defaults true) — every
+  consumer must already read from Secrets Manager, or auth breaks on first rotation; a
+  Lambda that cannot reach private RDS leaves rotation stuck in `AWSPENDING`.
+- **AFT hard-requires a deployed Control Tower landing zone** (ADR-0017 omitted this;
+  ADR-0035 corrects it). Enrolling a live org must delete pre-existing Config recorders
+  before Audit/Log-Archive enrolment, and reconcile CT managed-SCPs against the 5/5 cap.
+- **As-built divergence (confirm intent):** the ESO `ClusterSecretStore` targets a
+  different region (`{{SECRETS_REGION}}`, `eu-central-1` as-built) than primary infra
+  (`{{PRIMARY_REGION}}`, `eu-west-1`); may be deliberate secrets-region isolation or drift
+  — a rebuild must decide explicitly.
+
+## 8. Acceptance checklist
+
+- [ ] `terragrunt run --all plan` is clean from an empty management account after
+  Organization + KMS exist; SCP/RCP modules plan with `mock_outputs` before the org applies.
+- [ ] All nine SCPs attach without exceeding 5 per target; broad controls verified at root.
+- [ ] A non-org principal is denied on S3/STS/KMS/SecretsManager/SQS (RCP live at root); an
+  AWS service principal (log delivery) is **not** denied.
+- [ ] A member-account root call is denied; disabling CloudTrail/GuardDuty is denied with no
+  exemption; creating an unencrypted EBS volume is denied.
+- [ ] `terraform destroy` on any account with a break-glass user **fails** at plan; a
+  simulated break-glass sign-in raises the CloudWatch alarm → SNS within the expected delay.
+- [ ] GuardDuty (all plans), Config (incl. global IAM), Security Hub (CIS+PCI+FSBP) are
+  enabled; findings aggregate in `security`; logs land in the `log-archive` Object-Lock bucket.
+- [ ] `IAM_ROOT_ACCESS_KEY_CHECK` reports compliant (root has no access key); password
+  policy + enforce-MFA applied.
+- [ ] A PR that widens an SCP/RCP fails `CheckNoNewAccess` (gate reads JSON `result`); a PR
+  adding a public S3 ACL / `0.0.0.0/0` non-443 SG ingress / unencrypted store fails Conftest.
+- [ ] A container image is pushed by digest, cosign-signed keylessly, and carries a signed
+  SBOM attestation; an unsigned image is rejected at admission in prod.
+- [ ] `default-deny-all` (and the Cilium clusterwide deny) is applied before any allow;
+  a pod without a compliant securityContext is rejected by Gatekeeper.
+- [ ] Every workload authenticates via Pod Identity/IRSA with no static keys; ABAC denies a
+  mis-tagged caller; ESO materializes secrets with no plaintext in Git.
+
+## 9. Dependencies on other specs
+
+- **SPEC-00 Overview** — global placeholder registry (`{{ORG}}`, account IDs, regions).
+- **SPEC-01 Foundation / IaC** — Terragrunt structure, `versions.hcl` pins, `root.hcl`
+  backend, and the module/unit conventions this spec's security modules follow.
+- **SPEC — Organization / Landing Zone** — OU tree, member accounts, Control Tower + AFT
+  vending (ADR-0001, ADR-0035) that this spec's guardrails attach to.
+- **SPEC — Networking** — VPC/TGW segmentation, inspection VPC, and the LB/Gateway objects
+  that WAF and the inference serving front bind to (ADR-0013, ADR-0047).
+- **SPEC — Clusters (EKS/Bottlerocket/Cilium)** — node OS, CNI identity model, and the
+  admission stack this spec configures (ADR-0003, ADR-0030).
+- **SPEC — GitOps / ArgoCD** — how `network-policies`, `gatekeeper`, `kyverno`, `tetragon`,
+  and `cluster-secret-store` are delivered and the ArgoCD hardening (ADR-0006, ADR-0024).
+- **SPEC — CI/CD Pipelines** — reusable workflows, SHA-pinning, and the supply-chain gates
+  (ADR-0015, ADR-0016, ADR-0022) this spec's policy checks plug into.
+- **SPEC — Observability** — GuardDuty/Security Hub/CloudTrail routing and the SOC2
+  control-to-evidence matrix + on-call (ADR-0026, ADR-0040).
+```

--- a/specs/SPEC-06-cicd-quality.md
+++ b/specs/SPEC-06-cicd-quality.md
@@ -1,0 +1,604 @@
+# SPEC-06 — CI/CD & Quality Gates
+
+> Portable reverse-engineering spec. Rebuild the platform's continuous-integration,
+> supply-chain, and quality-gate estate for a new client without reading the source repo.
+> Placeholders (`{{...}}`) are defined in `SPEC-00-overview.md`; spec-local ones are listed in §5.
+
+---
+
+## 1. Scope & non-goals
+
+This spec defines the **GitHub Actions CI/CD estate** that guards the Infrastructure-as-Code
+(Terraform/OpenTofu + Terragrunt), Kubernetes/Helm manifests, container services, and ML
+pipelines of the platform. It covers: the full workflow inventory (34 workflows + 10 composite
+actions); the IaC verification loop wired as CI (`fmt → validate → tflint → checkov/tfsec →
+plan → OPA/conftest → cost`); the split between **merge-gating** and **advisory** checks; the
+**keyless OIDC** authentication model (no long-lived cloud keys in CI); the supply-chain chain
+(harden-runner → build → Trivy → SBOM → cosign keyless sign); scheduled **drift detection**;
+the **Infracost** cost gate; reusable/`workflow_call` pipeline factoring; the Go/controller test
+strategy (`go-ci`, Terratest, OPA unit tests, BDD compliance); Dependabot posture; branch
+protection assumptions; and how a client re-wires the same gates in GitLab CI.
+
+**Non-goals.** This spec does *not* define: the runtime Kubernetes admission-policy layer
+(Kyverno/VAP — `ADR-0020`, see the cluster-security spec); the ArgoCD/Kargo GitOps delivery
+internals beyond the CI→CD handoff (`ADR-0006`, `ADR-0021`, see the delivery spec); the Terraform
+module design itself (see the IaC spec); or the observability/alerting backends (see the
+observability spec). It defines the *gates and their contracts*, not the modules they inspect.
+
+---
+
+## 2. Architecture
+
+### 2.1 Two planes: PR-time gates vs post-merge delivery
+
+```
+ Developer ──PR──▶  ┌──────────────────────── PR GATES (block merge) ─────────────────────────┐
+                    │  IaC loop:   fmt ▶ validate ▶ tflint ▶ (tfsec|checkov*) ▶ plan ▶ OPA*   │
+                    │  Cost:       infracost diff  (block > $BLOCK_THRESHOLD, label bypass)    │
+                    │  Manifests:  helm lint ▶ kubeconform -strict ▶ conftest                  │
+                    │  Code:       go build/test/gosec* · CodeQL* · dep-scan · secret-scan     │
+                    │  Hygiene:    yamllint · shellcheck · zizmor* · validate-agents · versions│
+                    └───────────────┬─────────────────────────────────────────────────────────┘
+                                    │  branch protection: required checks must be green
+                          merge to  ▼  main
+ ┌──────────────────────── POST-MERGE (mutate / deliver) ─────────────────────────────────┐
+ │  terragrunt-apply  (push→main, GitHub Environment approval for staging/prod)            │
+ │  container-build   (push→main → build ▶ Trivy ▶ SBOM ▶ push ECR ▶ cosign keyless sign)  │
+ │  reusable-deploy-via-argocd  (bump image tag+digest in config repo → ArgoCD/Kargo sync) │
+ │  ml-pipeline[-aws|-baremetal]  (train ▶ eval-debate gate ▶ register ▶ Kargo promote)    │
+ │  generate-diagrams / generate-inventory  (auto-commit docs back to main)                │
+ └──────────────────────────────────────────────────────────────────────────────────────────┘
+ ┌──────────────────────── SCHEDULED (non-gating) ───────────────────────────────────────┐
+ │  drift-detection  (cron 06:00 UTC daily) → open/close GitHub Issues (alert-only)        │
+ │  terratest        (cron 02:00 UTC nightly) → real infra integration tests → issue       │
+ └──────────────────────────────────────────────────────────────────────────────────────────┘
+   * = advisory today (soft-fail); designed to flip to blocking once the backlog is clean.
+```
+
+### 2.2 Gate categories
+
+- **Hard gates (fail the PR):** `terragrunt-validate`, `terraform-validate` (fmt/validate/tflint),
+  `terragrunt-plan` (summary job), `terraform-compliance` (native `terraform test` only),
+  `conftest-opa` (OPA unit tests always; conftest when OIDC wired), `secret-scan` (gitleaks),
+  `yaml-lint`, `shellcheck`, `helm-validate`, `k8s-validate`, `version-manifest-validate`,
+  `ml-monitoring-baremetal-validate`, `validate-agents`, `infracost` (over block threshold),
+  `reusable-dep-scan` (default), and `reusable-build-and-push`'s Trivy (default `exit-code: 1`).
+- **Advisory (soft-fail, report-only) today:** `tfsec`, `terraform-validate`'s Trivy+Checkov steps,
+  `well-architected` (Checkov `soft_fail: true`), `terraform-compliance`'s BDD job, `zizmor`,
+  `reusable-sast` (CodeQL), `go-ci` (`continue-on-error: true`), `policy-access-check`
+  (`ADVISORY: true`), `container-build`'s Trivy (`exit-code: 0`). These upload SARIF to the
+  GitHub Security tab and/or post PR comments; they are staged to become blocking (tracked as
+  "Phase 1.1" of the in-repo sync roadmap) once the finding backlog is remediated.
+
+### 2.3 The IaC verification loop as CI
+
+The repo-enforced local loop (`fmt → validate → tflint → checkov → plan`) is decomposed across
+workflows so each stage is an independently required status check:
+
+| Loop stage | Workflow · job | Blocking? |
+|---|---|---|
+| `terragrunt hcl format --check` | `terragrunt-validate` / `hclfmt` | **hard** |
+| `terraform fmt -check -recursive` | `terraform-validate` / `fmt-check` | **hard** |
+| `terraform validate` (per module, `-backend=false`) | `terraform-validate` / `validate` (matrix) | **hard** |
+| `tflint --recursive` (`--minimum-failure-severity error`) | `terraform-validate` / `tflint` | **hard** |
+| `tfsec` HIGH+ | `tfsec` (all jobs `soft_fail`) | advisory |
+| `checkov` CIS | `terraform-validate` / `checkov-cis` (`soft_fail`), `well-architected` | advisory |
+| `terragrunt plan` (per changed unit, OIDC) | `terragrunt-plan` / `plan` → `plan-status` | **hard** (summary) |
+| OPA policy on plan JSON (conftest) | `conftest-opa` | **hard** (when OIDC wired) |
+| Infracost diff vs base | `infracost` | **hard** over threshold |
+
+**Apply never runs from a PR or feature branch.** `terragrunt-apply` triggers only on `push` to
+`main` (post-merge) and serializes (`concurrency: cancel-in-progress: false`, `max-parallel: 1`),
+with staging/prod gated by GitHub Environment protection (required reviewers).
+
+---
+
+## 3. Decision record
+
+| Decision | Rationale | Trade-off accepted | Source ADR |
+|---|---|---|---|
+| Reusable `workflow_call` pipelines (`reusable-*.yml`) + local composite actions in `.github/actions/` | DRY: one hardened build/scan/sign/deploy path reused by every service repo; the platform team owns the pipeline, app teams only pass `with:` inputs | Indirection; callers must keep input contracts in sync; local mocks here shadow a shared `{{PLATFORM_WORKFLOWS_REPO}}` in production | `ADR-0015 reusable-ci-pipelines` |
+| Keyless OIDC to the cloud (`aws-actions/configure-aws-credentials`, GCP WIF) — **no static keys** | Short-lived, per-run, per-role credentials; nothing to leak or rotate; scoped plan-vs-apply roles | Requires an IAM OIDC provider + trust policy per role; steps must degrade gracefully when the role var is unset (forks) | `ADR-0015`, `ADR-0022` |
+| Split IaC roles: `TERRAFORM_PLAN_ROLE_ARN` (read-only) vs `TERRAFORM_APPLY_ROLE_ARN` (write) | Least privilege: PRs can only plan; write is reachable only post-merge from `main` | Two roles + two trust policies to maintain | `ADR-0015` |
+| Tier-1 supply-chain: Trivy scan → Syft SBOM → cosign **keyless** sign-by-digest → SBOM attest | Provenance + tamper evidence on every pushed image; sign the *digest*, not a mutable tag | Sigstore/Fulcio/Rekor dependency; cosign verify must be enforced at admission to have teeth | `ADR-0016 tier1-supply-chain-hardening` |
+| CI runtime hardening: `step-security/harden-runner` (egress audit) first step; `zizmor` Actions-SAST; third-party actions SHA-pinned with version comment | Detect exfiltration/tampering in the runner; catch template-injection & unpinned-action risks in our own workflows | `audit` mode does not yet *block* egress; SHA pins need Renovate to stay current | `ADR-0022 ci-supply-chain-runtime-hardening` |
+| Access-Analyzer policy gate on SCP/RCP diffs (`check-no-new-access`, `check-access-not-granted`) | Prove an org-policy change grants **no new effective access** and keeps sensitive actions denied, before it reaches `main` | Paid AWS feature → bounded to PRs touching `modules/{scps,rcps}`; advisory until backlog clean | `ADR-0017 resource-side-perimeter-and-declarative-org-controls` |
+| Infracost PR gate with warn ($100) + block ($500) thresholds and a `cost-approved` label bypass | Make monthly cost delta visible on every IaC PR and hard-stop runaway spend without a human-in-loop escape hatch | Estimate ≠ bill; label bypass is an honor-system escape hatch | `ADR-0027 kubernetes-cost-opencost-cur` (PR-time complement to runtime OpenCost) |
+| Scheduled drift detection → GitHub Issues (alert-only, no auto-remediation) | Daily proof that `main` still matches reality; a human decides apply-vs-import | Drift can persist a day; remediation is manual | (drift design; complements `ADR-0048`, `ADR-0038`) |
+| OPA/conftest against plan JSON **plus** `opa test` rego unit tests | Policy-as-code enforced on real plans; policies themselves are unit-tested so a bad rule can't ship | Requires a plan (hence OIDC) for the conftest half; unit half always runs | `ADR-0028 unified-platform-tagging-and-labeling-taxonomy` (tag/label policies) |
+| Native `terraform test` gates; `terraform-compliance` BDD is advisory | HCL-native tests are deterministic and offline; BDD `.feature` suite is exploratory | Two overlapping test frameworks to maintain | `ADR-0004 terragrunt-over-plain-terraform` |
+| Terratest nightly (real infra) separate from PR path | Real create/destroy integration coverage without slowing or paying on every PR | Costs real cloud spend nightly; flakes open issues, not block merges | (test strategy) |
+| ECR pull-through cache + registry hardening for image pulls | Reduce Docker Hub rate-limit/exfil risk; cache upstream images in-account | Cache warm-up; registry IAM to maintain | `ADR-0029 ecr-pull-through-cache` |
+| ML CI/CD as control-plane only: CI triggers Airflow DAG, polls an **eval-debate** gate, registers to MLflow, promotes via Kargo | Training stays on the cluster (GPU); CI orchestrates and gates on eval, keeping GitHub runners cheap | CI depends on live Airflow/MLflow endpoints; eval gate is a timed poll | `ADR-0037 ml-cicd-pipeline-mlflow`, `ADR-0048 aws-ml-cicd-registry-drift` |
+| Version-pin tooling in `versions.hcl` mirrored to `.tool-versions`; bump policy = PR (minor) / ADR (major) | One source of truth for TF/TG versions across `root.hcl`, CI matrices, and asdf/mise | Manual mirror between the two files | (see IaC spec; `ADR-0002 tf-only-state-backend`) |
+
+---
+
+## 4. Implementation blueprint
+
+### 4.1 Directory layout
+
+```
+.github/
+├── dependabot.yml                  # gomod, github-actions, docker, terraform ecosystems
+├── zizmor.yml                      # Actions-SAST config
+├── workflows/                      # 34 workflows (see §4.6 matrix)
+│   ├── terragrunt-validate.yml     ├── terragrunt-plan.yml      ├── terragrunt-apply.yml
+│   ├── terraform-validate.yml      ├── terraform-compliance.yml ├── tfsec.yml
+│   ├── well-architected.yml        ├── conftest-opa.yml         ├── policy-access-check.yml
+│   ├── infracost.yml               ├── drift-detection.yml      ├── terratest.yml
+│   ├── secret-scan.yml             ├── zizmor.yml               ├── shellcheck.yml
+│   ├── yaml-lint.yml               ├── go-ci.yml                ├── helm-validate.yml
+│   ├── k8s-validate.yml            ├── version-manifest-validate.yml
+│   ├── container-build.yml         ├── validate-agents.yml      ├── generate-diagrams.yml
+│   ├── generate-inventory.yml      ├── ml-pipeline.yml          ├── ml-pipeline-aws.yml
+│   ├── ml-pipeline-baremetal.yml   ├── ml-monitoring-baremetal-validate.yml
+│   ├── reusable-build-and-push.yml ├── reusable-deploy-via-argocd.yml
+│   ├── reusable-manifest-validate.yml ├── reusable-sast.yml     ├── reusable-dep-scan.yml
+│   └── reusable-pipeline-demo.yml
+└── actions/                        # 10 local composites (SHA-pinned third-party inside)
+    ├── harden-runner/  argocd-tag-bump/  argocd-wait-sync-and-smoke/  cosign-sign/
+    ├── manifest-validate/  syft-sbom/  trivy-scan/  sast-codeql/
+    └── node-dep-scan/  python-dep-scan/
+scripts/
+    detect-drift.sh  policy-access-check.sh  break-glass.sh  deploy-state-backends.sh
+    preflight-check.sh  validate.sh  cleanup.sh  version-diff.sh  validate-agents.py
+    generate-infra-diagrams.py
+tests/
+    terraform/   # Terratest (Go): vpc_test.go s3_test.go eks_test.go + helpers/ fixtures/
+    opa/         # rego deny rules + *_test.rego unit tests
+    compliance/  # terraform-compliance BDD *.feature
+    integration/ e2e/ gpu-inference/   # controller & cluster tests
+terragrunt/versions.hcl  +  .tool-versions   # pinned tool versions (mirrored)
+```
+
+### 4.2 Tool & action version pins (as pinned in this estate)
+
+`terragrunt/versions.hcl` (source of truth) + `.tool-versions` (mirror):
+
+```hcl
+terraform_version  = "1.14.8"      # = pinned; CI env TF_VERSION
+terragrunt_version = "1.0.8"       # = pinned; CI env TG_VERSION
+provider_versions = { aws = "~> 6.0", helm = "~> 2.12", kubernetes = "~> 2.30",
+                      null = "~> 3.2", random = "~> 3.6", tls = "~> 4.0" }
+```
+
+CI-pinned tool versions: TFLint `v0.53.0`, tfsec `v1.28.11`, Conftest `0.57.0`, OPA `1.17.1`,
+kubeconform `v0.6.7`, Helm `3.16.2`/`3.17.0`, Go `1.22`, Python `3.12`/`3.10`, Node `20`,
+gosec `v2.22.0`, pip-audit `2.7.3`, osv-scanner `1.9.1`, cosign `v2.4.1`, syft via
+`anchore/sbom-action`, Kubernetes schema target `1.32.0`.
+
+Action-pin convention (`ADR-0022`): platform-owned actions use tag pins (`@v4`, `@v6`); the most
+security-sensitive third-party actions are **commit-SHA pinned with a version comment** so Renovate
+(`ADR-0015`) can bump them — e.g. `step-security/harden-runner@9af89fc7...  # v2.19.4`,
+`sigstore/cosign-installer@1aa8e0f...  # v3.7.0`, `zizmorcore/zizmor-action@5f14fd08...  # v0.5.6`,
+`aws-actions/configure-aws-credentials@e3dd6a42...  # v4.0.2`.
+
+### 4.3 IaC PR gate — the load-bearing pieces
+
+**Change detection → dynamic matrix** (shared shape across `terragrunt-plan`, `conftest-opa`,
+`infracost`): diff against the base, keep only IaC files under known env roots, emit a JSON array:
+
+```yaml
+- run: |
+    git diff --name-only origin/main...HEAD \
+      | grep -E '\.(hcl|tf|tfvars)$' \
+      | grep -E '^terragrunt/(dev|staging|prod|management|log-archive|security|network|third-party)/|^catalog/units/' \
+      | xargs -n1 dirname | sort -u | jq -R -s -c 'split("\n") | map(select(length>0))'
+```
+
+**OIDC plan step** (soft when the role var is unset, so forks/mock repos pass):
+
+```yaml
+- name: Configure AWS credentials via OIDC
+  uses: aws-actions/configure-aws-credentials@v6
+  if: vars.TERRAFORM_PLAN_ROLE_ARN != ''       # skip on forks → advisory no-op
+  continue-on-error: true
+  with:
+    role-to-assume: ${{ vars.TERRAFORM_PLAN_ROLE_ARN }}   # arn:aws:iam::{{PROD_ACCOUNT_ID}}:role/...
+    aws-region: {{PRIMARY_REGION}}
+- run: terragrunt plan -no-color -out=tfplan && terragrunt show -json tfplan > plan.json
+```
+
+**Summary gate job** turns a fan-out matrix into one required check:
+
+```yaml
+plan-status:
+  needs: [detect-changes, plan]
+  if: always()
+  steps:
+    - run: |
+        if [ "${{ needs.plan.result }}" = "failure" ]; then
+          echo "::error::Terragrunt plan failed"; exit 1
+        fi
+```
+
+**tflint** is the hard security-lint gate; **tfsec/checkov are soft** today:
+
+```yaml
+- run: tflint --recursive --config "$(pwd)/.tflint.hcl" --format compact \
+        --minimum-failure-severity error --chdir terraform/modules
+- uses: bridgecrewio/checkov-action@v12
+  with: { directory: terraform/modules, soft_fail: true, skip_check: "CKV_AWS_144,CKV_AWS_41,..." }
+```
+
+### 4.4 OPA/conftest gate (`conftest-opa.yml`)
+
+Two independent hard sub-gates aggregated by `opa-status`:
+
+```yaml
+# (1) Always runs — no cloud creds needed — unit-tests the policies themselves:
+- run: |
+    opa check --strict tests/opa/
+    opa test tests/opa/ -v          # runs *_test.rego (platform_tags_*_test.rego, ...)
+# (2) Per changed module — conftest against the plan JSON (needs OIDC plan):
+- run: |
+    conftest test plan.json --policy "$GITHUB_WORKSPACE/tests/opa" --output json
+```
+The github-script step calls `core.setFailed(...)` on a conftest `failure`, which fails the job →
+`opa-status` blocks the merge. Policies in `tests/opa/` enforce: no public S3
+(`s3_no_public_access.rego`), no `0.0.0.0/0` SG ingress (`no_unrestricted_sg_ingress.rego`),
+required platform tags (`platform_tags*.rego`, `required_tags.rego` — `ADR-0028`), no hardcoded
+credentials (`no_hardcoded_credentials.rego`), encryption at rest (`encryption_at_rest.rego`).
+
+### 4.5 Supply-chain build path (`container-build.yml` + composites)
+
+Order is load-bearing — **harden-runner must be the first step**:
+
+```yaml
+permissions: { id-token: write, contents: read, security-events: write }
+steps:
+  - uses: ./.github/actions/harden-runner        # egress-policy: audit — FIRST
+  - uses: actions/checkout@v4
+  - uses: aws-actions/configure-aws-credentials@v6   # OIDC, if vars.AWS_ROLE_ARN != ''
+    with: { role-to-assume: ${{ vars.AWS_ROLE_ARN }}, aws-region: {{PRIMARY_REGION}} }
+  - uses: aws-actions/amazon-ecr-login@v2
+  - uses: docker/build-push-action@v6            # build+load, push:false (scan before push)
+  - uses: aquasecurity/trivy-action@v0.35.0      # exit-code:0 here (advisory), sarif upload
+  - uses: ./.github/actions/syft-sbom            # spdx-json SBOM artifact
+  - id: push-ecr
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && vars.AWS_ROLE_ARN != ''
+    uses: docker/build-push-action@v6            # push:true only post-merge
+  - if: steps.push-ecr.outputs.digest != ''
+    uses: ./.github/actions/cosign-sign          # keyless sign the DIGEST + attest SBOM
+    with: { image-ref: "${{ steps.meta.outputs.image }}@${{ steps.push-ecr.outputs.digest }}" }
+```
+
+The reusable variant (`reusable-build-and-push.yml`) is the hardened default: same chain but Trivy
+`exit-code: "1"` (**blocking**) and `sign: true` by default. Callers pass
+`app_name`/`ecr_repository`/`build_context` and get back `image_uri`, `image_digest`, `image_tag`
+as `workflow_call` outputs. `reusable-pipeline-demo.yml` shows the canonical chain:
+`build (reusable-build-and-push) → deploy (reusable-deploy-via-argocd)` wired through job outputs.
+The signed ECR image is addressed as
+`{{PROD_ACCOUNT_ID}}.dkr.ecr.{{PRIMARY_REGION}}.amazonaws.com/<repo>@sha256:...`.
+
+### 4.6 Full pipeline matrix
+
+| Workflow | Trigger | Gate/Advisory | Tools | Failure means |
+|---|---|---|---|---|
+| `terragrunt-validate` | PR/push (`terragrunt,catalog`) | **Gate** | `terragrunt hcl format`, brace check | HCL unformatted / malformed |
+| `terraform-validate` | PR/push (`terraform,catalog`) | **Gate** (fmt/validate/tflint); advisory (trivy/checkov) | `terraform fmt/validate`, `tflint`, Trivy, Checkov | Module invalid or lint error |
+| `terragrunt-plan` | PR (IaC paths) | **Gate** (summary) | Terragrunt plan + OIDC, PR comment | Plan errored for a changed unit |
+| `terragrunt-apply` | push→main / dispatch | Post-merge deploy | Terragrunt apply + OIDC, Slack notify | Apply failed (Slack alert) |
+| `terraform-compliance` | PR/push (`*.tf`,`*.feature`) | **Gate** (native `terraform test`); advisory (BDD) | `terraform test`, `terraform-compliance` | Native module test failed |
+| `tfsec` | PR/push (IaC) | Advisory | tfsec HIGH+ → SARIF + PR comment | (reported, not blocked) |
+| `well-architected` | PR/push (`terraform`) | Advisory | Checkov `soft_fail` | (reported) |
+| `conftest-opa` | PR (IaC + `tests/opa`) | **Gate** (unit always; conftest w/ OIDC) | `opa check/test`, `conftest` | Policy violation / bad rego |
+| `policy-access-check` | PR (`scps,rcps`) / dispatch | Advisory (`ADVISORY:true`) | AWS Access Analyzer custom checks | SCP/RCP widens access (reported) |
+| `infracost` | PR (IaC) | **Gate** over $500 | `infracost breakdown/diff`, PR comment | Monthly delta > block threshold |
+| `drift-detection` | cron 06:00 UTC daily / dispatch | Scheduled (non-gating) | `scripts/detect-drift.sh`, Issues API | Opens a `drift,automated` issue |
+| `terratest` | cron 02:00 UTC / PR (test paths) / dispatch | Gate (unit); nightly (integration) | Go, Terratest, OIDC | Unit build/vet fail; nightly issue |
+| `secret-scan` | PR/push | **Gate** | `gitleaks` (+ SARIF) | Secret detected |
+| `zizmor` | PR/push (`.github/**`) | Advisory | `zizmor` Actions-SAST → SARIF | (reported via Code Scanning) |
+| `shellcheck` | PR/push (`*.sh`) | **Gate** (severity=error) | `shellcheck` | Shell script error |
+| `yaml-lint` | PR/push (`*.yml`) | **Gate** | `yamllint` | YAML lint violation |
+| `go-ci` | PR/push (Go dirs) | Advisory (`continue-on-error`) | `go build/test -race`, `gosec` | (reported) |
+| `helm-validate` | PR/push | **Gate** | `helm template` \| `kubeconform -strict` | Chart renders invalid manifests |
+| `k8s-validate` | PR/push (`k8s,argocd,...`) | **Gate** | `kubeconform -strict` (matrix) | Manifest schema invalid |
+| `version-manifest-validate` | PR/push (`versions/**`) | **Gate** | `ajv` schema, tag regex | Bad version manifest |
+| `ml-monitoring-baremetal-validate` | PR (ML-mon paths) | **Gate** | helm lint, yamllint, terragrunt validate | Chart/label/HCL invalid |
+| `container-build` | PR/push (service dirs) | Advisory scan; post-merge push+sign | Trivy, Syft, cosign, ECR | (scan reported; push/sign on main) |
+| `validate-agents` | PR/push | **Gate** | `scripts/validate-agents.py` | Agent manifest invalid |
+| `generate-diagrams` | PR (artifact)/push (commit) | Non-gating | `scripts/generate-infra-diagrams.py` | (auto-commit on main) |
+| `generate-inventory` | push (`apps,envs,argocd`) | Non-gating | shell, Helm | (auto-commits `DEPLOYMENTS.md`) |
+| `ml-pipeline` | dispatch / push (`models,adapters`) | Release (eval-gated) | GCP WIF, Airflow, MLflow, Kargo | Train/eval-debate gate failed |
+| `ml-pipeline-aws` | same | Release (eval-gated) | AWS OIDC, ECR, Airflow, MLflow | same (AWS variant) |
+| `ml-pipeline-baremetal` | same (`staging/prod`) | Release (eval-gated) | Airflow, MLflow+MinIO, cosign | same (Talos/UK-isolated) |
+| `reusable-build-and-push` | `workflow_call` | **Gate** (Trivy `exit-code:1`) | build, Trivy, Syft, cosign | CRITICAL/HIGH CVE in image |
+| `reusable-deploy-via-argocd` | `workflow_call` | Deploy (GitOps) | `argocd-tag-bump` (PR to config repo) | Bump PR fails (prod = human gate) |
+| `reusable-manifest-validate` | `workflow_call` | Gate (lint/kubeconform); advisory (conftest) | helm, kubeconform, conftest | Rendered chart invalid |
+| `reusable-sast` | `workflow_call` | Advisory (`fail_on_error:false`) | CodeQL | (reported via Code Scanning) |
+| `reusable-dep-scan` | `workflow_call` | **Gate** (default) | pip-audit / npm audit + osv-scanner | CRITICAL/HIGH dependency CVE |
+| `reusable-pipeline-demo` | dispatch only | Manual demo | chains the two reusables | n/a |
+
+### 4.7 Drift detection & the cost gate
+
+`drift-detection.yml` runs `scripts/detect-drift.sh --environment <env> --report-format json`
+(exit `1` = drift, `0` = clean, `2` = script error) per env matrix, then the `report` job parses the
+JSON and, per drifted env, **creates or comments on** a GitHub Issue labeled `drift,automated`;
+`close-resolved` closes issues once drift clears. **Alert-only — never auto-applies** (the issue body
+carries `terragrunt run --all apply` / `terraform import` guidance for a human).
+
+`infracost.yml` sets `WARN_THRESHOLD: 100`, `BLOCK_THRESHOLD: 500` (USD/month), checks out base +
+PR SHAs, runs `infracost breakdown` on each then `infracost diff --compare-to`, posts/updates one
+PR comment, and enforces: `cost-approved` label ⇒ pass; else abs monthly increase `> $500` ⇒
+`exit 1`; `> $100` ⇒ warning only. `secrets.INFRACOST_API_KEY` is the only secret.
+
+### 4.8 Test strategy (`tests/`, controllers, `go-ci`)
+
+- **Terratest (Go, `tests/terraform/`).** `vpc_test.go`, `s3_test.go`, `eks_test.go` + `helpers/`
+  (`SkipIfShort`, `SkipIfCI`) + `fixtures/`. Three tiers: **unit** (`go build/vet`, no creds — the
+  PR gate), **plan** (`terraform plan` only, needs OIDC), **integration** (`defer terraform.Destroy()`,
+  real infra, nightly). `terratest.yml` runs unit+plan on PR and integration nightly (`0 2 * * *`).
+- **OPA unit tests (`tests/opa/*_test.rego`).** Run by `opa test` in `conftest-opa` with no cloud
+  creds — the policies are tested before they gate any plan.
+- **BDD compliance (`tests/compliance/*.feature`).** `terraform-compliance` runs these against plan
+  JSON but with `--no-failure` (advisory); native `terraform test` is the enforcing layer.
+- **Controllers (`dns-monitor`, `failover-controller`, `services/hello-world`).** `go-ci.yml`:
+  `go build`, `go test -race`, `gosec` — advisory (`continue-on-error: true`) today.
+- **Cluster tests (`tests/integration/`, `tests/e2e/`, `tests/gpu-inference/`).** Python integration
+  (`test_dns_sync.py`, `test_state_machine.py`, `test_health_monitoring.py`), a full-failover E2E, and
+  GPU-inference YAML checks (DRA scheduling, NCCL benchmark, gang recovery).
+
+### 4.9 Dependabot posture (`.github/dependabot.yml`)
+
+Five update streams: `gomod` (weekly, `/dns-monitor`, `/failover-controller`), `github-actions`
+(weekly, `/`), `docker` (weekly, both controllers), `terraform` (monthly, `/terraform/modules`).
+Dependabot covers *version freshness*; Renovate (`ADR-0015`) owns the SHA-pin bumps for
+security-sensitive third-party actions. `reusable-dep-scan` (pip-audit/npm+osv) covers *CVE* gating
+at PR time; the three are complementary.
+
+### 4.10 Branch protection assumptions
+
+Branch protection on `main` is the enforcement point — the workflows only *produce* checks; they
+block nothing unless `main` requires them. Assume, per rebuild:
+
+- Require a PR before merge to `main` (no direct pushes, except the bot carve-out for
+  `generate-diagrams`/`generate-inventory`, which push `[skip ci]` commits).
+- Required status checks = every §2.2 hard gate (summary jobs where a matrix fans out:
+  `plan-status`, `opa-status`, `compliance-summary`). Advisory gates are **not** required.
+- Require branches up to date before merge; dismiss stale approvals; require conversation
+  resolution.
+- GitHub **Environments** `development` / `staging` / `production` carry the deploy approvals —
+  `terragrunt-apply` and ML `deploy` map the target env to an Environment, and staging/prod require
+  reviewers. This, not an `if:`, is the apply gate.
+- Enable Code Scanning; make the advisory scanners' Code-Scanning checks *required* only when you
+  flip them to blocking.
+
+### 4.11 Ordering / dependencies (what must exist before what)
+
+1. `versions.hcl` + `.tool-versions` (pins) → every workflow's `setup-*` step reads these.
+2. GitHub OIDC provider + IAM roles (`TERRAFORM_PLAN_ROLE_ARN`, `..._APPLY_...`, `ECR_PUSH_ROLE_ARN`,
+   `POLICY_CHECK_ROLE_ARN`, `AWS_CI_ROLE_ARN`) → OIDC steps are no-ops until these repo
+   variables/secrets exist (deliberate, so the repo is CI-green from an empty account).
+3. Remote state backend (`scripts/deploy-state-backends.sh`, `ADR-0002`) → before any `plan`/`apply`.
+4. `tests/opa/` policies + `.tflint.hcl`, `.checkov.yml`, `.gitleaks.toml`, `.yamllint.yml`,
+   `.audit-ignore`, `zizmor.yml` config → before the corresponding gates bite.
+5. Branch protection with the hard-gate jobs as required checks → last, once they pass on a PR.
+6. `{{PLATFORM_WORKFLOWS_REPO}}` + `{{ARGOCD_CONFIG_REPO}}` + `ARGOCD_BOT_TOKEN` → before
+   reusable build/deploy pipelines can push image bumps.
+
+### 4.12 Porting the gates to GitLab CI
+
+The design maps cleanly onto GitLab — the pieces and their GitLab equivalents:
+
+| GitHub Actions piece | GitLab CI equivalent |
+|---|---|
+| Reusable `workflow_call` workflow | `include:` a template + `extends:` / hidden `.job` anchors; or a CI/CD **component** (`spec: inputs:`) |
+| Composite action (`.github/actions/*`) | shared job template in `{{PLATFORM_WORKFLOWS_REPO}}` + `include:` |
+| OIDC `configure-aws-credentials` | GitLab OIDC `id_tokens:` + `aws sts assume-role-with-web-identity` (or `assume_role_with_web_identity`) |
+| `permissions: id-token: write` | `id_tokens: { AWS_TOKEN: { aud: ... } }` |
+| `on: pull_request` + `paths:` | `rules: - if: '$CI_PIPELINE_SOURCE == "merge_request_event"' changes:` |
+| `on: schedule` (drift/nightly) | pipeline **schedules** + `rules: - if: '$CI_PIPELINE_SOURCE == "schedule"'` |
+| Required status checks | Merge-request **approval rules** + "pipelines must succeed" |
+| GitHub Environment approvals | **Protected environments** with required approvers |
+| SARIF → Code Scanning | GitLab **SAST/Container-Scanning reports** (`artifacts: reports: sast/…`) |
+| `gitleaks`, `trivy`, `checkov`, `tflint`, `conftest`, `infracost` | identical CLIs in `script:` — the tools are portable; only the wiring changes |
+| Dynamic matrix (`fromJson(detect-changes)`) | `parallel: matrix:` or child-pipeline `trigger:` with a generated YAML |
+| Auto-commit back to `main` | job with a project **access token**/CI push + `[skip ci]` (`$CI_COMMIT_MESSAGE`) |
+| Dependabot | GitLab **Dependency Scanning** + **Renovate** (self-hosted) for version bumps |
+
+Keep the reusable pieces reusable: put the hardened build/scan/sign template and the IaC-loop
+template in a central project and `include:` them, exactly as the reusable workflows are meant to
+live in `{{PLATFORM_WORKFLOWS_REPO}}` here.
+
+### 4.13 Adoption order (which gates first)
+
+For a client standing this up incrementally, land gates in this order (cheapest/safest → deepest):
+
+1. **Hygiene, no creds:** `yaml-lint`, `shellcheck`, `secret-scan` (gitleaks), `terragrunt-validate`,
+   `terraform-validate` (fmt/validate/tflint). Instant value, zero cloud wiring.
+2. **Policy-as-code, no creds:** `opa test` half of `conftest-opa`; `helm-validate`, `k8s-validate`,
+   `version-manifest-validate`. Still no cloud role required.
+3. **OIDC + plan-time depth:** wire `TERRAFORM_PLAN_ROLE_ARN`, then `terragrunt-plan`, the conftest
+   half of `conftest-opa`, and `infracost` (advisory first, then flip the block threshold on).
+4. **Supply chain:** `harden-runner` + `reusable-build-and-push` (Trivy blocking, SBOM, cosign),
+   `reusable-dep-scan`, `zizmor`, `reusable-sast`.
+5. **Post-merge delivery:** `terragrunt-apply` (with Environment approvals), `reusable-deploy-via-argocd`.
+6. **Scheduled + advanced:** `drift-detection`, `terratest` nightly, `policy-access-check`
+   (flip `ADVISORY:false` once clean), ML pipelines.
+
+Flip advisory scanners (`tfsec`, `checkov`/`well-architected`, `zizmor`, CodeQL, Access-Analyzer)
+to blocking only after their finding backlog is remediated.
+
+---
+
+## 5. Parameterization table
+
+### 5.1 Placeholders (register recurring ones in SPEC-00)
+
+| Placeholder | Meaning | Default/shape here |
+|---|---|---|
+| `{{VCS_ORG}}` | Git hosting org | (SPEC-00) |
+| `{{PRIMARY_REGION}}` | CI cloud region | `eu-west-1` (Terratest uses `us-east-1`) |
+| `{{PROD_ACCOUNT_ID}}` | account behind OIDC roles | (SPEC-00; never literal in workflows) |
+| `{{DOMAIN}}` | root DNS zone | (SPEC-00) |
+| `{{ARGOCD_CONFIG_REPO}}` | GitOps config repo the deploy pipeline PRs into | `{{VCS_ORG}}/argocd` |
+| `{{PLATFORM_WORKFLOWS_REPO}}` | shared reusable-workflow repo | `{{VCS_ORG}}/platform-workflows` |
+| `{{ARGOCD_SERVER}}` | ArgoCD API host (smoke/wait action) | `argocd.{{DOMAIN}}` |
+| `{{CI_BOT_NAME}}` / `{{CI_BOT_EMAIL}}` | git committer for auto-commits/PRs | `platform-ci[bot]` / `ci@{{DOMAIN}}` |
+| `{{CI_FEATURE_BRANCH}}` | long-lived migration branch also gated | `feature/**` |
+
+**GitHub Actions variables (`vars.*`) — OIDC role ARNs & endpoints (never hardcode):**
+`TERRAFORM_PLAN_ROLE_ARN`, `TERRAFORM_APPLY_ROLE_ARN`, `POLICY_CHECK_ROLE_ARN`, `AWS_ROLE_ARN`,
+`ECR_PUSH_ROLE_ARN`, `AWS_CI_ROLE_ARN`, `AWS_ACCOUNT_ID`, `AWS_REGION`, `GCP_WIF_PROVIDER`,
+`GCP_CI_SERVICE_ACCOUNT`, `ML_IMAGE_REPO`, `AIRFLOW_BASE_URL`, `MLFLOW_TRACKING_URI`,
+`AIRFLOW_BAREMETAL_BASE_URL`, `MLFLOW_BAREMETAL_TRACKING_URI`, `MLFLOW_S3_ENDPOINT_URL`.
+
+**Secrets (`secrets.*`):** `INFRACOST_API_KEY`, `SLACK_WEBHOOK_URL`, `ARGOCD_BOT_TOKEN`,
+`AIRFLOW_API_TOKEN`, `AIRFLOW_BAREMETAL_API_TOKEN`, `MLFLOW_S3_ACCESS_KEY_ID`,
+`MLFLOW_S3_SECRET_ACCESS_KEY`, `GITHUB_TOKEN` (built-in).
+
+### 5.2 Sizing / policy knobs
+
+| Knob | Default here | Guidance to resize |
+|---|---|---|
+| Infracost `WARN_THRESHOLD` / `BLOCK_THRESHOLD` | `$100` / `$500`/mo | Set block to a real per-PR risk budget; keep the `cost-approved` label escape hatch |
+| Drift cron | `0 6 * * *` (before EU workday) | Match the team's timezone; keep `cancel-in-progress: false` |
+| Terratest cron | `0 2 * * *` nightly | Off-hours; integration matrix = the modules you can afford to create nightly |
+| Kubernetes schema target | `1.32.0` | Track the cluster's control-plane minor |
+| Trivy severity gate | `CRITICAL,HIGH` | Add `MEDIUM` once the backlog is clean |
+| gosec excludes | `G104,G114,G306` | Narrow as findings are fixed |
+| `terragrunt-apply` parallelism | `max-parallel: 1` | Keep serial for shared state; per-env roles allow more |
+| Access-Analyzer `ADVISORY` | `true` | Flip to `false` to make SCP/RCP checks blocking (`ADR-0017` step 6) |
+| Soft-fail scanners (`tfsec`, `checkov`, `zizmor`, CodeQL) | soft today | Flip `soft_fail:false` / `fail_on_error:true` per gate once clean |
+| ML eval-debate poll | `40 × 30s` (20 min) | Size to the real DAG runtime + margin |
+
+---
+
+## 6. Best practices distilled
+
+1. **Never store long-lived cloud keys in CI.** Every cloud call uses OIDC/WIF to assume a
+   short-lived, per-run role. *Why:* nothing to leak, nothing to rotate, and plan-vs-apply roles
+   enforce least privilege at the credential layer, not just in code.
+2. **Split read (plan) and write (apply) roles, and make apply unreachable from a PR.** Plan runs on
+   PRs with a read-only role; apply runs only on `push → main` with a write role, serialized, behind
+   GitHub Environment approvals for staging/prod. *Why:* a malicious PR can never mutate infra.
+3. **Degrade OIDC steps gracefully** with `if: vars.<ROLE> != ''` + `continue-on-error`. *Why:* the
+   repo stays CI-green from an empty account / a fork / a mock, so onboarding isn't blocked on IAM.
+4. **Turn a fan-out matrix into one required check** via an `if: always()` summary job that `exit 1`s
+   on any child failure. *Why:* branch protection needs a stable check name even when the matrix is
+   dynamic (`fromJson(detect-changes.outputs.modules)`).
+5. **Detect changes and scope every IaC gate to changed units.** *Why:* PR feedback in minutes, and
+   cost/plan calls are bounded to what actually changed.
+6. **Unit-test your policies, not just your infra.** `opa test tests/opa/*_test.rego` runs
+   unconditionally (no cloud creds) so a broken `deny` rule fails before it can wave a bad plan
+   through. *Why:* policy-as-code is code; ship it tested.
+7. **Scan before you push; sign the digest after.** Build+load locally → Trivy → SBOM, then push,
+   then cosign **keyless** sign the immutable `@sha256:` digest and attest the SBOM. *Why:* you never
+   publish an unscanned image, and the signature binds to content, not a movable tag.
+8. **`harden-runner` is the first step of every build job** in `audit` mode. *Why:* it baselines the
+   runner's egress so you can later flip to `block` with an allowlist and catch exfiltration.
+9. **SHA-pin security-sensitive third-party actions with a version comment**, and let Renovate bump
+   them. *Why:* tag pins are mutable; SHA pins are not, and the comment keeps them readable/bumpable.
+10. **Stage gates advisory-first, then flip to blocking.** New scanners (`tfsec`, `checkov`,
+    `zizmor`, CodeQL, Access-Analyzer) land as soft-fail + SARIF, and become blocking once the finding
+    backlog is remediated. *Why:* you get visibility immediately without wedging the merge queue.
+11. **Cost is a gate, not a report.** Infracost warns at one threshold and *blocks* at another, with a
+    labelled human override. *Why:* a comment nobody reads is not a control.
+12. **Drift is proven daily and surfaced as an issue, not auto-fixed.** *Why:* a human decides
+    apply-vs-`terraform import`; auto-remediation on a scheduled job is how you amplify a mistake.
+13. **Factor the pipeline into reusable `workflow_call` workflows + composite actions.** The platform
+    team owns the hardened path; app repos pass `with:` inputs and inherit signing/scanning for free.
+    *Why:* DRY across dozens of service repos and one place to raise the security bar.
+14. **Keep ML CI as a control plane.** CI triggers the training DAG, polls a quantitative
+    **eval-debate** gate, registers to MLflow, and promotes via Kargo — it does not train on the
+    runner. *Why:* GPU training belongs on the cluster; CI's job is orchestration and gating.
+15. **One source of truth for versions** (`versions.hcl` → `.tool-versions` mirror), consumed by
+    `root.hcl`, CI matrices, and asdf/mise. *Why:* the local loop and CI run byte-identical tool
+    versions, so "works on my machine" and "passes in CI" converge.
+
+---
+
+## 7. Known pitfalls
+
+1. **OIDC-less repos silently skip the deep gates.** When `TERRAFORM_PLAN_ROLE_ARN` is unset, the
+   plan/conftest/access-analyzer steps become advisory no-ops and the PR still goes green. Great for
+   forks; **dangerous if production believes those gates ran.** Assert the role vars are set on the
+   real repo (see §8) and treat "skipped" ≠ "passed".
+2. **As-built divergence:** soft-fail scanners give a false sense of coverage. Advisory gates
+   (`tfsec`, `well-architected`/Checkov, `zizmor`, CodeQL) are **pending the hard-gate flip per the
+   in-repo roadmap** — a CRITICAL finding does **not** block today. Track that backlog explicitly or
+   it never happens.
+3. **As-built divergence:** `terraform-compliance` BDD is decorative until wired to fail. It runs
+   with `--no-failure` *and* `|| true`; only the native `terraform test` job actually gates. Don't
+   mistake a green compliance job for enforced compliance.
+4. **As-built divergence:** region inconsistency. IaC workflows hardcode `{{PRIMARY_REGION}}`
+   (`eu-west-1`) while Terratest uses `us-east-1`. Parameterize both or integration tests hit the
+   wrong partition.
+5. **As-built divergence:** two overlapping Terraform versions in CI — `1.14.8` (validate/plan) vs
+   `~1.11` / `1.11.0` (compliance/terratest). Converge them or a module that passes `validate` can
+   fail `terraform test` on a version-gated feature.
+6. **Auto-commit workflows push straight to `main`.** `generate-diagrams` and `generate-inventory`
+   commit with `[skip ci]` / `contents: write`. If branch protection ever requires a PR for `main`,
+   these break — carve out the bot or convert them to PRs.
+7. **cosign signatures without admission enforcement are theater.** Signing images is only a control
+   if the cluster *verifies* the signature at admission (Kyverno/VAP, `ADR-0020`). Ship both.
+8. **Infracost is an estimate, and the `cost-approved` label is an honor system.** A mislabeled PR
+   bypasses the block. Restrict who can add the label.
+9. **Access-Analyzer gating must read the JSON `result`, not the CLI exit code** — the AWS CLI can
+   exit `0` on a `FAIL` result (`ADR-0017`). `policy-access-check.sh` handles this; a hand-rolled
+   reimplementation will silently pass failing policies.
+10. **ML pipelines depend on live external endpoints** (Airflow, MLflow, MinIO). The eval gate is a
+    bounded poll (40 × 30s = 20 min); a slow DAG times out and fails the release even when training
+    would have succeeded. Size the poll to the real DAG runtime.
+11. **Dependabot ≠ CVE gate.** Dependabot only opens version-bump PRs; the blocking CVE check is
+    `reusable-dep-scan`. Enabling one is not enabling the other.
+12. **As-built divergence:** `workflow_call` reusables live locally here as mocks. In production they
+    belong in `{{PLATFORM_WORKFLOWS_REPO}}`
+    (`uses: {{PLATFORM_WORKFLOWS_REPO}}/.github/workflows/<wf>.yml@<ref>`). Don't ship the local
+    copies to every service repo — centralize them.
+
+---
+
+## 8. Acceptance checklist
+
+A rebuild passes when:
+
+- [ ] From a clean checkout, `terragrunt hcl format --check` and `terraform fmt -check -recursive`
+      are clean; `tflint --recursive` reports no error-severity findings.
+- [ ] A PR touching one Terragrunt unit triggers **only** that unit's plan (dynamic matrix works),
+      and `plan-status` is a single required check.
+- [ ] With OIDC roles configured, `terragrunt-plan`, `conftest-opa`, and `policy-access-check`
+      actually assume a role and run against real plan JSON (job logs show `Assumed role`, not
+      "skipped").
+- [ ] `opa test tests/opa/` passes and runs on a PR **with no cloud credentials**.
+- [ ] A PR that adds a public S3 bucket / `0.0.0.0/0` SG ingress / an untagged resource is **blocked**
+      by `conftest-opa`.
+- [ ] A PR whose estimated monthly cost delta exceeds `$500` is **blocked** by `infracost`, and adding
+      the `cost-approved` label unblocks it.
+- [ ] A committed secret is caught by `secret-scan` (gitleaks) and the PR is blocked.
+- [ ] `container-build` on a non-`main` PR **builds + scans but does not push**; a `push → main`
+      builds, pushes to ECR, and **cosign-signs the digest** (verify with `cosign verify`).
+- [ ] `reusable-build-and-push` fails the build on a seeded CRITICAL CVE (`exit-code: 1`).
+- [ ] `terragrunt apply` **cannot** be triggered from a feature branch or a PR; staging/prod applies
+      require a GitHub Environment reviewer.
+- [ ] The daily drift job opens a `drift,automated` issue on injected drift and closes it once the
+      drift is reconciled.
+- [ ] Branch protection lists every §2.2 hard gate as a required status check; advisory gates are not
+      required.
+- [ ] `helm-validate` / `k8s-validate` block a PR that renders a schema-invalid manifest.
+- [ ] `versions.hcl` and `.tool-versions` agree, and CI uses those exact versions.
+
+---
+
+## 9. Dependencies on other specs
+
+- **SPEC-00 — Overview:** global placeholders (`{{VCS_ORG}}`, `{{PRIMARY_REGION}}`,
+  `{{PROD_ACCOUNT_ID}}`, `{{DOMAIN}}`) and the estate map.
+- **SPEC-01 — Foundation / IaC:** the modules, `root.hcl`, remote state backend (`ADR-0002`), and
+  `versions.hcl` these gates inspect; the local verification loop this spec wires into CI.
+- **SPEC-04 — GitOps Delivery:** ArgoCD (`ADR-0006`), Kargo promotion (`ADR-0021`), the
+  `{{ARGOCD_CONFIG_REPO}}` that `reusable-deploy-via-argocd` PRs into, and Argo Rollouts canary
+  (`ADR-0014`) that consumes signed images.
+- **SPEC-05 — Security (identity, org-guardrails, cluster policy, supply chain):** the OIDC provider
+  + IAM roles behind every `vars.*_ROLE_ARN` and the SCP/RCP modules (`ADR-0017`) that
+  `policy-access-check` guards; the runtime Kyverno/VAP admission layer (`ADR-0020`) that must
+  *verify* the cosign signatures this pipeline produces and the tag/label taxonomy (`ADR-0028`) the
+  OPA policies enforce; and the deeper supply-chain hardening — `ADR-0016` (tier-1) and `ADR-0022`
+  (runtime: harden-runner, zizmor, SHA-pinning).
+- **SPEC-10 — ML Platform:** Airflow/MLflow/Kargo topology and the eval-debate gate (`ADR-0037`,
+  `ADR-0038`, `ADR-0048`) that `ml-pipeline*` orchestrates.
+- **Cost — no dedicated spec.** The Infracost PR gate (§4.7) is the canonical cost-control home in
+  this estate; it complements runtime OpenCost/CUR (`ADR-0027`), which lives with the cluster
+  platform, not in a standalone cost spec.

--- a/specs/SPEC-07-observability.md
+++ b/specs/SPEC-07-observability.md
@@ -1,0 +1,783 @@
+# SPEC-07 — Observability
+
+> Portable reverse-engineering of the platform's observability estate: metrics, logs,
+> traces, profiles, GPU/ML observability, SLOs, alerting, and cost visibility. A
+> competent platform team can rebuild the same observability plane for a new client
+> from this document without reading the source repository.
+
+---
+
+## 1. Scope & non-goals
+
+**Scope.** This spec defines the platform's **signal plane**: how metrics, logs, traces,
+continuous profiles, GPU telemetry, ML-quality signals, and cost data are collected,
+stored, queried, alerted on, and presented — across a fleet of Kubernetes clusters on
+AWS (EKS), GCP (GKE), and bare-metal (Talos). It covers the Prometheus/Thanos + Grafana
+LGTM-aligned stack, the VictoriaMetrics variant used on the largest GPU-inference
+cluster, DCGM GPU observability (including the hardened auto-taint CronJob), the
+Evidently+whylogs ML-drift stack, SLOs-as-code (Pyrra), the Alertmanager routing and
+on-call philosophy, self-serve per-team observability, and the CI that validates all of
+it. It also documents which signals the platform treats as **load-bearing** and how the
+stack scales with cluster count.
+
+**Non-goals.** (a) The **AI-SRE system** itself — its agents, MCP servers, orchestration,
+and ClickHouse analytics store — is specified in **SPEC-09**; this spec covers only its
+*monitoring-integration surface* (the `ai_sre_*` metrics it exposes and how they are
+scraped), and cross-references SPEC-09 for everything else. (b) The **compute/GPU
+substrate** (node pools, Karpenter, EFA/InfiniBand fabric, Talos) and the **network plane**
+(Cilium, DNS) are owned by **SPEC-03** (compute/GPU day-2) and **SPEC-02** (network/DNS);
+here we consume their signals, not provision them. (c) **Secret delivery** (External Secrets Operator, secret
+stores) is owned by **SPEC-05**; here we only name the secrets we consume. (d)
+**Progressive-delivery** analysis (Argo Rollouts / Kargo) is owned by the **SPEC-04**
+delivery spec; we document the two analysis queries because they read the observability
+plane.
+
+---
+
+## 2. Architecture
+
+### 2.1 Signal-by-signal target (LGTM-aligned)
+
+The estate ratifies a single coherent target per signal (source: `ADR-0026 Observability
+target architecture`). Every "add a new tool" decision is gated as **additive vs
+rip-and-replace**:
+
+| Signal | Chosen tool | Long-term store | Explicitly rejected (either/or) |
+|---|---|---|---|
+| Metrics | **Prometheus 3.x** (native histograms on) | **Thanos on S3** | **Mimir** (same tier as Thanos — rip-and-replace) |
+| Metrics (GPU-inference cluster) | **VictoriaMetrics cluster** (MetricsQL) | VM `vmstorage` | kube-prometheus-stack (too heavy at 5 000 GPU nodes) |
+| Logs | **Loki** (SimpleScalable) | S3 | — |
+| Traces | **Tempo** (distributed) + **OBI/Beyla** eBPF trace lane | S3 | — |
+| RED metrics | **exactly one** source: **Tempo metrics-generator** | (remote-write → Prometheus) | OBI metrics **and** span-metrics (double-RED = double cost) |
+| Profiles | **Pyroscope** (microservices) | S3 | — (ADR-0026 says *defer*; estate ships it — see §7) |
+| Pipeline hub | **OTel Collector** (gateway + agent) | — | (ADR-0026 names *Alloy*; estate ships OTel — see §7) |
+| SLO engine | **Pyrra** (built-in UI) → `PrometheusRule` | — | Sloth (generator-only, no UI) |
+| Dashboards | **Grafana** (dashboards-as-code via ConfigMap sidecar) | — | Perses (optional) |
+| K8s cost | **OpenCost** + AWS CUR/Athena | S3/Athena | Kubecost Enterprise (day-one) |
+| CloudWatch bridge | **YACE** (yet-another-cloudwatch-exporter) | (into Prometheus) | — |
+
+### 2.2 Data-flow diagram
+
+```
+                                   ┌──────────────────────── per workload cluster ────────────────────────┐
+  targets                          │                                                                      │
+  ───────                          │   ServiceMonitor / PodMonitor / PrometheusRule (CRDs)                 │
+  app /metrics ───────────────────►│        │  discovered by                                              │
+  kube-state-metrics ─────────────►│        ▼                                                              │
+  node-exporter (DaemonSet) ──────►│   ┌──────────────┐  2h local     ┌──────────────┐  S3 (1y)           │
+  DCGM exporter (GPU DaemonSet) ──►│   │ Prometheus   │──sidecar──────►│   Thanos     │───► {{ORG}}-thanos │
+  cAdvisor / kubelet ─────────────►│   │  3.x (×2 HA) │               │ sidecar→store │      -metrics-* S3  │
+  YACE (CloudWatch) ──────────────►│   └──────┬───────┘               └──────┬───────┘                    │
+  Karpenter / ArgoCD / Cilium ────►│          │ native histograms            │ downsample raw30d/5m90d/1h1y│
+                                   │          │                              ▼                             │
+  app OTLP / Jaeger / Zipkin ─────►│   ┌──────────────┐   traces    ┌──────────────┐  Thanos Query        │
+  OBI/Beyla (eBPF, DaemonSet) ────►│   │ OTel Collector│──otlp──────►│    Tempo     │  Frontend ◄── Grafana│
+                                   │   │ gateway+agent │  metrics-gen└──────┬───────┘                     │
+  Fluent Bit (log DaemonSet) ─────►│   └──────┬───────┘   ──RED remote-write─┘ → Prometheus               │
+                                   │          │ logs                                                       │
+  pod profiles (annotated) ───────►│   ┌──────▼───────┐         ┌──────────────┐        ┌──────────────┐   │
+                                   │   │     Loki     │         │  Pyroscope   │        │ Alertmanager │   │
+                                   │   │ (S3, 365d)   │         │ (S3, 7d)     │        │  (×3 quorum) │   │
+                                   │   └──────────────┘         └──────────────┘        └──────┬───────┘   │
+                                   │                                                          │ routes     │
+                                   │   Pyrra ──► SLO recording+burn-rate PrometheusRules      ▼            │
+                                   │   OpenCost ──► per-namespace $ (CUR/Athena reconciled)  Slack /       │
+                                   └─────────────────────────────────────────────────────── PagerDuty ────┘
+                                                    │ (single pane)
+                                                    ▼
+                                          ┌───────────────────┐
+                                          │      Grafana      │  Prometheus + Thanos + Loki + Tempo +
+                                          │  (dashboards-as-  │  Pyroscope + ClickHouse-AI-SRE datasources
+                                          │   code, OAuth SSO)│
+                                          └───────────────────┘
+```
+
+### 2.3 GPU-inference cluster variant (VictoriaMetrics)
+
+The largest cluster (GPU inference, up to **5 000 GPU nodes**) replaces
+kube-prometheus-stack + Thanos with a **VictoriaMetrics cluster** operated by the VM
+Operator, which auto-converts the same Prometheus CRDs (`ServiceMonitor → VMServiceScrape`,
+`PodMonitor → VMPodScrape`, `PrometheusRule → VMRule`). Rationale: ~10× lower memory per
+active series and native clustering (no Thanos sidecar) at GPU-metric cardinality.
+`vmagent` scrapes → `vminsert` → `vmstorage` (30d) → `vmselect`; `vmalert` evaluates
+`VMRule`s; a co-located `alertmanager` fans out. HPA reads vLLM metrics from `vmselect`
+via prometheus-adapter (`custom.metrics.k8s.io`).
+
+### 2.4 Namespaces and identity
+
+- Charts target namespace **`observability`** (LGTM components, Pyrra) or **`monitoring`**
+  (prometheus-stack ArgoCD Application, team `PrometheusRule`s). *This split is real in
+  the estate and a known drift — see §7.*
+- Storage-backend identity is **mixed by design**: Thanos + YACE use **EKS Pod Identity**
+  (no SA role annotation); Loki + Pyroscope use **IRSA**; Tempo uses **static S3 keys via
+  ESO**. A rebuild should standardize on one (Pod Identity recommended) — see §6/§7.
+
+---
+
+## 3. Decision record
+
+| Decision | Rationale | Trade-off accepted | Source ADR |
+|---|---|---|---|
+| LGTM-aligned target, one tool per signal; gate every addition as additive-vs-replace | Stops per-signal tool sprawl and paying for two overlapping long-term tiers | Multi-component stack to pin and operate; phased rollout | `ADR-0026` |
+| Prometheus **3.x** with native histograms (`native-histograms`, `scrape-native-histograms`) | Lower-cardinality, higher-fidelity latency histograms; future OTLP path | Requires kube-prometheus-stack ≥66 / appVersion ≥3.0; migration is a deliberate config step | `ADR-0026` |
+| **Thanos on S3**, not Mimir | Thanos already runs; Mimir is same-tier rip-and-replace for no needed capability | Operate querier/store/compactor; downsampling to keep 1y affordable | `ADR-0026` |
+| **Exactly one** RED-metric source = Tempo metrics-generator (OBI metrics off) | Two RED sources = double series + reconciliation pain | OBI is trace-only; RED depends on Tempo generator being healthy | `ADR-0026`, `ADR-0019` |
+| **VictoriaMetrics** for the GPU-inference cluster | ~10× memory efficiency + native clustering at 5 000-node GPU cardinality | A second metrics TSDB to know; MetricsQL≈PromQL but not identical | (gpu-inference cluster design) |
+| **Pyrra** for SLOs-as-code (over Sloth) | Built-in SLO UI + generates recording/burn-rate `PrometheusRule`s | One more operator; dashboards-as-code escaping in JSON | `ADR-0026` |
+| **OpenCost + AWS CUR/Athena** for K8s cost, reconciled to amortized bill | Per-namespace/workload $ that matches the invoice on an RI/SP/Spot estate | CUR→S3→Glue→Athena→IAM plumbing; cost lags the bill | `ADR-0027` |
+| **DCGM exporter** per GPU node + **hardened auto-taint CronJob** | Turn XID/ECC/thermal faults into cordon actions without a human in the loop | CronJob needs `nodes: patch`; DCGM exporter must run privileged/root | `ADR-0044`, `ADR-0049/0050` |
+| **ML observability** = whylogs (drift) + Evidently (accuracy) → Prometheus, reuse Grafana/Thanos/Alertmanager | Feature drift *and* model-quality as first-class Prom metrics; no second pane | Two tools to operate; reference-dataset lifecycle; retrain-storm risk | `ADR-0038` |
+| **Alertmanager → Slack (warning) + PagerDuty (critical)**; drift-critical → retrain webhook | Severity-tiered routing; automated retrain on material drift | PagerDuty/Slack are external deps; retrain de-dup needed to avoid storms | `ADR-0038`, `ADR-0040` |
+| **Self-serve observability** via templated Grafana folder + dashboard + `PrometheusRule` + RBAC per team, GitOps-delivered | Team autonomy without platform tickets or blast radius; no new operator | Second dashboard still needs a PR; Grafana folder RBAC is a one-time manual step | `ADR-0039` |
+| **Backstage deferred**; ship lightweight self-serve first | Avoids an abandoned portal with no owner; template PR maps 1:1 to a future scaffolder | Less polished UX until three revisit conditions are met | `ADR-0039`, `ADR-0034` |
+| **ML on-call track + tested runbooks**; repo-anchored SOC2 evidence | ML incidents get a rotation; auditors resolve controls to code+CI+runtime signal | ML PagerDuty service is a follow-up; matrix must be maintained | `ADR-0040` |
+| Every metric/label carries the platform taxonomy (`platform_system` etc.) | Single-pane `$system` dashboards + multi-tenant isolation via label scoping | KSM `metricLabelsAllowlist` needed; dots→underscores in PromQL | `ADR-0028` |
+
+---
+
+## 4. Implementation blueprint
+
+### 4.1 Directory layout
+
+```
+apps/infra/observability/
+├── prometheus-stack/            # umbrella: kube-prometheus-stack + thanos subcharts
+│   ├── Chart.yaml               # chart prometheus-stack v1.2.0, appVersion v3.12.0
+│   ├── Chart.lock               # kube-prometheus-stack 86.2.0, thanos 15.7.29
+│   ├── values.yaml              # HA Prometheus, native histograms, Grafana, Alertmanager
+│   ├── values-thanos.yaml       # Thanos querier/store/compactor/downsampling
+│   ├── values-production.yaml   # prod sizing (4h/90GB, shards 2, 16CPU/128Gi)
+│   ├── argocd-application.yaml   # sync-wave "10", automated prune+selfHeal
+│   └── templates/
+│       ├── external-secrets.yaml         # grafana admin/oauth, alertmanager slack/pagerduty
+│       ├── thanos-objstore-secret.yaml   # objstore config (bucket/endpoint), auth=PodIdentity
+│       └── prometheusrules/slo-rules.yaml # SLI/SLO recording + alert rules + error budget
+├── loki-stack/                  # Loki SimpleScalable + Fluent Bit DaemonSet
+├── tempo/                       # Tempo distributed + metrics-generator (RED source)
+├── otel-collector/              # gateway (Deployment) + agent (DaemonSet)
+├── obi/                         # OBI/Beyla eBPF trace lane (DaemonSet)
+├── pyroscope/                   # Pyroscope microservices + agent DaemonSet
+├── yace/                        # CloudWatch → Prometheus bridge
+├── pyrra/                       # SLO engine: ServiceLevelObjective CRDs
+└── grafana-dashboards/          # dashboards-as-code (ConfigMap sidecar) + datasources
+
+apps/infra/dcgm-exporter/        # GPU telemetry DaemonSet (GitOps app)
+apps/infra/ml-monitoring/        # Evidently drift-exporter + whylogs + retrain-trigger
+apps/infra/grafana-self-serve/   # per-team folder+dashboard+PrometheusRule+RBAC chart
+apps/infra/victoriametrics/      # VM cluster Helm values (gpu-inference)
+apps/infra/opencost/             # K8s cost allocation (ADR-0027)
+
+terraform/modules/
+├── aws-eks-gpu-dcgm/            # DCGM exporter + hardened auto-taint CronJob (EKS)
+├── gpu-inference-dcgm/         # DCGM + in-module VMRule GPU alerts + tainter
+├── baremetal-gpu-dcgm/         # DCGM (Talos) — least hardened, raw manifest CronJob
+├── gpu-inference-victoriametrics/  # VMCluster CR (vminsert/vmselect/vmstorage)
+└── monitoring/                 # legacy grafana.tf / prometheus.tf (superseded by charts)
+
+k8s/monitoring/                 # dns-failover PrometheusRule + ServiceMonitor
+ai-sre/observability/           # ai_sre_* metric definitions (SPEC-09 integration surface)
+.github/workflows/ml-monitoring-baremetal-validate.yml  # helm-lint + yamllint + tg-validate
+```
+
+### 4.2 Prometheus (load-bearing config excerpt)
+
+```yaml
+# apps/infra/observability/prometheus-stack/values.yaml (sanitized excerpt)
+kube-prometheus-stack:
+  prometheus:
+    prometheusSpec:
+      replicas: 2                     # HA, pod-anti-affinity per hostname + zone-preferred
+      retention: 2h                   # local; Thanos handles long-term (prod: 4h/90GB)
+      retentionSize: "45GB"
+      walCompression: true
+      enableFeatures: [native-histograms, scrape-native-histograms]   # ADR-0026, Prom 3.x
+      shards: 1                       # raise to 2-4 above ~5M samples/s (prod: 2)
+      serviceMonitorNamespaceSelector: {any: true}     # discover across all namespaces
+      ruleSelector: {matchLabels: {prometheus: kube-prometheus}}
+      resources:                      # sized for ~10M active series @ 5k nodes/100k pods
+        requests: {cpu: 4000m, memory: 32Gi}
+        limits:   {cpu: 8000m, memory: 64Gi}
+      externalLabels:                 # Thanos multi-cluster keys
+        cluster: '{{ .Values.global.clusterName | default "{{CLUSTER_NAME}}" }}'
+        region:  '{{ .Values.global.region | default "{{PRIMARY_REGION}}" }}'
+        replica: $(POD_NAME)
+      thanos:
+        image: quay.io/thanos/thanos:v0.36.1
+        objectStorageConfig: {existingSecret: {name: thanos-objstore-secret, key: objstore.yml}}
+      priorityClassName: system-cluster-critical
+  kube-state-metrics:
+    metricLabelsAllowlist:            # ADR-0028: expose taxonomy for PromQL joins
+      - "pods=[platform.system,platform.component,platform.env,platform.owner]"
+```
+
+### 4.3 Thanos long-term tier (from `values-thanos.yaml`)
+
+- **Query Frontend** (2→3 replicas) with memcached results/label cache, 24h split-interval.
+- **Query** dedups on `replica`/`prometheus_replica`; DNS-discovers sidecars + store-gateway.
+- **Store Gateway** (2→3) index-cache 2→4GB, 50→100Gi gp3.
+- **Compactor** (1, leader-elected) — **downsampling ENABLED**, retention
+  **raw 30d / 5m 90d / 1h 1y** (prod 1h=365d).
+- **Ruler DISABLED** (rules stay in Prometheus/kube-prometheus-stack).
+- Object store: `s3://{{ORG}}-thanos-metrics-{{PRIMARY_REGION}}` (prod:
+  `…-prod-…`), SSE-S3, 128MB part-size; lifecycle IA@30d → Glacier-IR@90d → delete@365d;
+  auth via **EKS Pod Identity** (SA `thanos`, no role annotation).
+
+### 4.4 Alertmanager routing (the on-call spine)
+
+```yaml
+# values.yaml → alertmanager.alertmanagerSpec.config (sanitized)
+route:
+  receiver: 'slack-general'
+  group_by: ['alertname','cluster','namespace']
+  group_wait: 30s ; group_interval: 5m ; repeat_interval: 4h
+  routes:
+  - matchers: [severity = critical]  # → PagerDuty AND Slack (continue:true)
+    receiver: 'pagerduty-critical' ; continue: true ; group_wait: 10s ; repeat_interval: 5m
+  - matchers: [severity = critical]
+    receiver: 'slack-critical' ; group_wait: 10s
+  - matchers: [team = platform]      # team fan-out
+    receiver: 'slack-platform'
+  - matchers: [namespace =~ "app-.*"]
+    receiver: 'slack-apps'
+  - matchers: [alertname = Watchdog] # dead-man's switch → null (verifies pipeline is alive)
+    receiver: 'null'
+inhibit_rules:                       # critical inhibits warning/info (same ns+alertname);
+  # NodeDown inhibits PodNotReady; NodeDraining inhibits NodeFilesystemAlmostOutOfSpace
+replicas: 3                          # quorum; PDB minAvailable 2
+```
+
+Secrets `alertmanager-slack-secret` and `alertmanager-pagerduty-secret` are mounted from
+ESO at `/etc/alertmanager/secrets/<name>/…` and read via `*_file` directives (no plaintext
+in values). **Severity model:** `critical` → PagerDuty page + `#alerts-critical`; `warning`
+→ Slack only; `Watchdog` → null (its *absence* is the alert). ML-drift `critical` additionally
+routes to a **retrain webhook** (see §4.7).
+
+### 4.5 GPU observability — DCGM exporter + hardened auto-taint CronJob
+
+DCGM exporter runs as a DaemonSet on GPU nodes (**must be privileged / `runAsUser: 0`** for
+NVML), exposes `:9400/metrics`, scraped every 15–30 s. It emits GPU util, framebuffer
+memory, temperature, power, **XID errors**, ECC SBE/DBE, NVLink bandwidth, and clock-throttle
+reasons. Per cluster type:
+
+| | EKS (`aws-eks-gpu-dcgm`) | GPU-inference (`gpu-inference-dcgm`) | Bare-metal (`baremetal-gpu-dcgm`) |
+|---|---|---|---|
+| DCGM chart | `4.2.3` | `4.5.0` (+ custom metrics CSV) | `3.6.1` |
+| Tainter schedule | `*/5 * * * *` | `*/2 * * * *` | `*/2 * * * *` |
+| Tainter image | `bitnami/kubectl:1.34` | `bitnami/kubectl:1.30` | `{{GHCR_REGISTRY}}/gpu-health-autotaint:0.1.0` |
+| securityContext on tainter | **full** (drop-ALL, RO-root, non-root, uid 65532, seccomp RuntimeDefault) | hardened (drop-ALL, RO-root, uid 65534) | **none** (raw manifest — hardening gap) |
+| In-module alert rules | no (via self-serve) | **yes — VMRule** | no |
+| SM release label | `kube-prometheus-stack` | `victoria-metrics` | `victoria-metrics` |
+
+The **hardened auto-taint CronJob** (the reference pattern) reads DCGM XID metrics and
+cordons faulty nodes:
+
+```hcl
+# terraform/modules/gpu-inference-dcgm/main.tf — kubernetes_cron_job_v1.gpu_health_tainter
+schedule            = var.taint_cron_schedule   # "*/2 * * * *"
+concurrency_policy  = "Forbid"                  # never overlap
+starting_deadline_seconds = 60
+# container:
+image   = "bitnami/kubectl:1.30"
+command = ["/bin/sh","-c"]
+args    = [<<-EOT
+  set -euo pipefail
+  wget -qO- http://dcgm-exporter.${namespace}.svc.cluster.local:9400/metrics \
+    | grep '^dcgm_xid_errors_total' \
+    | ... # parse hostname="" label + value
+  # taint when XID >= threshold, untaint on recovery:
+  kubectl taint node "$NODE" gpu-health=unhealthy:NoSchedule --overwrite
+EOT
+]
+security_context {                              # container
+  allow_privilege_escalation = false
+  read_only_root_filesystem  = true
+  run_as_non_root            = true
+  run_as_user                = 65534
+  capabilities { drop = ["ALL"] }
+}
+restart_policy = "Never" ; backoff_limit = 0
+node_selector  = { "kubernetes.io/os" = "linux" }   # run on NON-GPU nodes (no chicken-and-egg)
+# RBAC (in-module): ClusterRole nodes[get,list,patch] + pods[get,list] + metrics.k8s.io[get,list]
+```
+
+In-module GPU alert rules (VMRule, `gpu-inference-dcgm`):
+
+| Alert | Condition | Severity | For |
+|---|---|---|---|
+| `GpuXidErrorDetected` | `increase(dcgm_xid_errors_total[2m]) >= {{XID_THRESHOLD}}` (1) | critical | 0m |
+| `GpuXidErrorCriticalBurst` | `increase(dcgm_xid_errors_total[5m]) >= 5` | page | 0m |
+| `GpuHighTemperature` | `dcgm_gpu_temp_celsius > {{TEMP_THRESHOLD}}` (85) | warning | 5m |
+| `GpuCriticalTemperature` | `dcgm_gpu_temp_celsius > 95` | critical | 1m |
+| `GpuDoubleBitEccError` | `increase(dcgm_ecc_dbe_volatile_total[5m]) > 0` | critical | 0m |
+| `GpuSingleBitEccErrorRate` | `rate(dcgm_ecc_sbe_volatile_total[10m])*60 > 10` | warning | 5m |
+| `GpuNvLinkBandwidthLow` | `dcgm_nvlink_bandwidth_total_mbps < 100 and on(...) dcgm_gpu_utilization > 50` | warning | 10m |
+| `DcgmExporterDown` | `up{job="dcgm-exporter"} == 0` | warning | 2m |
+| `GpuNodeTainted` | `kube_node_spec_taint{key="gpu-health",value="unhealthy"} == 1` | critical | 0m |
+
+### 4.6 VictoriaMetrics (GPU-inference cluster)
+
+```hcl
+# terraform/modules/gpu-inference-victoriametrics/main.tf — VMCluster "gpu-inference-metrics"
+retentionPeriod = "30d"
+vminsert  { replicaCount = 3 ; resources req cpu2/mem4Gi lim cpu4/mem8Gi }
+vmselect  { replicaCount = 3 ; cacheMountPath = "/select-cache" }
+vmstorage { replicaCount = 3 ; storage gp3 500Gi ; storageDataPath = "/vmstorage-data" }
+# scrapes: VMServiceScrape dcgm-exporter (15s), cilium-agent (30s); VMNodeScrape kubelet-cadvisor
+```
+
+> **Drift:** the app-level Helm values (`apps/infra/victoriametrics/values.yaml`) declare a
+> *fuller* stack — 2/2/2 replicas + `replicationFactor: 2` + `vmagent`/`vmalert`/`alertmanager`
+> + 100Gi — while the Terraform module defines only the `VMCluster` (3/3/3, 500Gi, no RF).
+> A rebuild must pick one source of truth (see §7).
+
+### 4.7 ML observability (drift + accuracy + retrain trigger)
+
+Deployed as `apps/infra/ml-monitoring/` (ArgoCD wave `20`, after prometheus-stack wave 10):
+
+- **whylogs** inline profiler → Pushgateway → feature distributions
+  (`ml_monitoring_feature_psi_score`, `…_kl_divergence`, `…_dataset_drift_score`,
+  `…_drift_detected`).
+- **Evidently** `drift-exporter` Deployment (`:8001/metrics`, one per `(tenant,domain)`) →
+  model quality (`ml_monitoring_model_accuracy`, `…_f1_score`, `…_precision/recall/rmse`,
+  `…_test_suite_result`).
+- **`ml-retrain-trigger`** Deployment (`:8080/webhook`, `:9090/metrics`) — receives the
+  Alertmanager webhook, de-duplicates per `(tenant,domain)` in a 15-min window, calls
+  Airflow `POST /api/v1/dags/train_domain_adapter/dagRuns`, falls back to a K8s Job on
+  Airflow 5xx, and records `ml_monitoring_retrain_triggers_total{outcome}`.
+
+Default drift thresholds (Helm `driftExporter.defaultThresholds`, per-tenant overridable):
+
+| Metric | Warning | Critical | Window |
+|---|---|---|---|
+| `ml_monitoring_dataset_drift_score` | > 0.20 | > 0.40 | 1h |
+| `ml_monitoring_feature_psi_score` | > 0.10 | > 0.25 | 1h |
+| `ml_monitoring_feature_kl_divergence` | > 0.10 | > 0.30 | 1h |
+| `ml_monitoring_model_accuracy` | < 0.85 | < 0.75 | 1h rolling |
+| `ml_monitoring_model_f1_score` | < 0.80 | < 0.65 | 1h rolling |
+| `ml_monitoring_drift_detected` | — | == 1 sustained 15m | — |
+
+ML Alertmanager overlay (ships as a *commented-ready patch* per cloud): two routes matching
+`platform_system=ml-monitoring, severity=critical` — one to `ml-drift-pagerduty`
+(`continue: true`), one to `ml-retrain-webhook` (`repeat_interval: 6h` to prevent retrain
+storms) → `http://ml-retrain-trigger.ml-monitoring.svc:8080/webhook`, bearer token from ESO.
+Bare-metal adds a `cluster = {{CLUSTER_NAME}}` matcher and a Vault-backed token.
+
+### 4.8 SLOs-as-code (Pyrra)
+
+```yaml
+# apps/infra/pyrra/templates/slo-availability.yaml — pyrra.dev/v1alpha1 ServiceLevelObjective
+target: "99.9" ; window: 28d       # api-availability
+indicator: {ratio: {errors: http_requests_total{job="api-server",code=~"5.."},
+                    total:  http_requests_total{job="api-server"}, grouping: [handler]}}
+# slo-latency.yaml: api-latency-p99, target 99, 28d, le="0.5" (≤500ms)
+```
+
+Pyrra (operator "kubernetes" mode, `genericRules.enabled`) generates the recording rules
+and multi-window burn-rate `PrometheusRule`s; UI on `:9099`.
+
+### 4.9 Dashboards-as-code
+
+Grafana persistence is **off**; every dashboard is a ConfigMap labelled `grafana_dashboard:
+"1"` (datasources labelled `grafana_datasource: "1"`), picked up by the Grafana sidecar.
+Provisioned datasources: **Prometheus** (default), **Thanos** (long-range), **Loki**,
+**Tempo** (tracesToLogs→Loki, tracesToMetrics→Prometheus), **Pyroscope**, and
+**ClickHouse-AI-SRE** (SPEC-09). SSO via Google OAuth (`allowed_domains: {{DOMAIN}}`,
+Admin allow-list by email); local admin break-glass stays enabled so an OAuth
+misconfiguration cannot lock everyone out.
+
+### 4.10 Ordering / dependencies (what must exist before what)
+
+1. **Secret stores + ESO** (SPEC-05) — Thanos objstore config, Grafana admin/OAuth,
+   Alertmanager Slack/PagerDuty, Tempo/Pyroscope S3, Airflow API creds.
+2. **Object storage** — S3 buckets (Thanos, Loki, Tempo, Pyroscope) + CUR/Athena for cost;
+   workload identity (Pod Identity/IRSA) bound.
+3. **prometheus-stack** (ArgoCD wave 10) — Prometheus operator CRDs, Prometheus, Thanos,
+   Grafana, Alertmanager, KSM, node-exporter. CRDs must exist before any `ServiceMonitor`/
+   `PrometheusRule`.
+4. **LGTM add-ons** (wave 10) — Loki+Fluent Bit, Tempo (+metrics-generator), OTel Collector,
+   OBI, Pyroscope, YACE, Pyrra, grafana-dashboards.
+5. **GPU DCGM** — after GPU node pools + GPU operator; then the auto-taint CronJob (needs
+   `nodes: patch`).
+6. **ml-monitoring** (wave 20) — after prometheus-stack; needs reference datasets in
+   object storage + Airflow endpoint.
+7. **grafana-self-serve** (wave 30) — after all observability; per-team Applications.
+
+---
+
+## 5. Parameterization table
+
+| Placeholder | Meaning | Default in this estate | Resize guidance |
+|---|---|---|---|
+| `{{ORG}}` | org slug (bucket/prefix) | — | prefixes all S3 buckets |
+| `{{PRIMARY_REGION}}` | metrics/logs/traces region | `us-east-1` | co-locate buckets + clusters |
+| `{{SECRETS_REGION}}` | ESO ClusterSecretStore region *(spec-local)* | `eu-central-1` | region of the secret manager backing observability secrets |
+| `{{CLUSTER_NAME}}` | Prometheus `externalLabels.cluster` *(spec-local)* | `eks-prod-{{PRIMARY_REGION}}` | unique per cluster (Thanos dedup key) |
+| `{{DOMAIN}}` | root DNS / Grafana OAuth domain | `example.com` | `grafana.{{DOMAIN}}`, `runbooks.{{DOMAIN}}` |
+| `{{PROD_ACCOUNT_ID}}` | AWS account for ECR/ARNs | `123456789012` | ECR registry for drift-exporter image |
+| `{{GCP_PROJECT}}` | GCP project for GCS reference data *(spec-local)* | `your-project` | `gs://{{GCP_PROJECT}}-ml-reference-data` |
+| `{{TENANT}}` / `{{DOMAIN_SLUG}}` | ML tenant / business domain *(spec-local)* | `tenant-acme` / `hft,rtb,insurance` | one namespace per `(tenant,domain)` |
+| `{{PD_ROUTING_KEY}}` | PagerDuty service key *(spec-local, secret)* | ESO-sourced | separate ML routing key = follow-up |
+| `{{SLACK_WEBHOOK}}` | Slack webhook URL *(spec-local, secret)* | ESO-sourced | per-channel receivers |
+
+**Sizing knobs (defaults → resize):**
+
+| Knob | Default (base → prod) | Resize rule |
+|---|---|---|
+| Prometheus replicas | 2 | keep 2 for HA; scale vertically first |
+| Prometheus shards | 1 → 2 | +1 shard per ~5M samples/s |
+| Prometheus resources | 4CPU/32Gi → 8CPU/64Gi (limit 8/64 → 16/128) | ~3KB × active series (~30GB @ 10M) |
+| Prometheus local retention | 2h → 4h | Thanos owns long-term; keep small |
+| Thanos downsample retention | raw 30d / 5m 90d / 1h 1y (prod 1h=365d) | lengthen 1h tier for longer trend history |
+| Alertmanager replicas | 3 (PDB minAvailable 2) | quorum; do not drop below 3 |
+| VM cluster (gpu-inference) | vminsert/vmselect/vmstorage 3/3/3, vmstorage 500Gi, 30d | scale `vmstorage` replicas + PVC with node count |
+| DCGM scrape interval | 15s (VM) / 30s (Prom) | 15s for fast XID detection on large GPU fleets |
+| Auto-taint schedule | `*/2` (GPU-inference/BM) / `*/5` (EKS) | tighten to `*/1` for very large fleets |
+| Loki retention | 365d (values) *(README says 30d — reconcile)* | set per compliance (e.g. PCI-DSS 10.7 = 1y) |
+| Tempo retention | 14d (336h) | traces are bulky; keep short |
+| Pyroscope retention | 7d (168h) | profiles are bulky; keep short |
+| ML drift thresholds | see §4.7 | override per `(tenant,domain)` |
+
+---
+
+## 6. Best practices distilled
+
+1. **Ratify one tool per signal and gate every addition as additive-vs-rip-and-replace.**
+   *Why:* the failure mode of observability is not "missing a tool" but "running two of the
+   same tier" (Thanos+Mimir, Alloy+OTel, OBI-metrics+span-metrics). A written target turns
+   every new tool into an explicit decision instead of quiet cost creep.
+2. **Keep Prometheus local retention tiny (2–4h) and push everything to object storage via
+   Thanos with downsampling.** *Why:* Prometheus RAM scales with active series; long local
+   retention is the fastest way to OOM at fleet scale. Downsampling (5m/1h) is what makes a
+   1-year window affordable.
+3. **Emit exactly one RED-metric source.** *Why:* span-metrics from Tempo's generator, OBI
+   eBPF metrics, and OTel span-metrics processors all produce the same `http_server_*`
+   series. Two sources double cost and force reconciliation; pick the generator and turn
+   the others off (OBI stays a *trace* lane).
+4. **Dashboards and alert rules are code, never clicked.** *Why:* Grafana persistence off +
+   ConfigMap sidecar + `PrometheusRule` CRDs make the whole signal-presentation layer
+   GitOps-reconciled and reviewable; a UI edit that isn't in Git is drift by definition.
+5. **Carry the platform taxonomy on every metric** (`platform_system/component/env/owner`
+   via KSM `metricLabelsAllowlist`). *Why:* it enables one `$system` single-pane dashboard,
+   PromQL cost joins (`… * on(pod,namespace) group_left(...) kube_pod_labels`), and
+   structural multi-tenant isolation — separate series → separate alerts → no cross-tenant
+   false pages.
+6. **Tier alert severity to route, and run a dead-man's switch.** *Why:* `critical` →
+   PagerDuty page, `warning` → Slack keeps humans un-fatigued; the always-firing `Watchdog`
+   routed to `null` means *absence* of Watchdog proves the whole pipeline is alive. Add
+   inhibition rules (node-down inhibits pod-not-ready) to kill alert storms at the source.
+7. **Turn hardware faults into actions, safely.** *Why:* an XID/ECC/thermal fault should
+   cordon the node without waiting for a human. The auto-taint CronJob does this, but runs
+   **on non-GPU nodes** (no chicken-and-egg), with **least-privilege RBAC** (`nodes: patch`
+   only) and a **fully hardened pod** (drop-ALL, read-only root, non-root, seccomp). The
+   DCGM exporter itself is the *only* component allowed to be privileged/root — because NVML
+   requires it.
+8. **Make ML quality a first-class Prometheus signal, not a second pane.** *Why:* feeding
+   whylogs drift and Evidently accuracy into the *same* Grafana/Thanos/Alertmanager stack
+   means SREs debug models with the tools they already use, and a critical drift alert can
+   automatically fire a retrain — with a de-dup window + `repeat_interval` guarding against
+   retrain storms.
+9. **Give teams self-serve rails, not tickets — with blast-radius fences.** *Why:* a
+   templated folder + dashboard + `PrometheusRule` + namespace-scoped RBAC lets a team ship
+   alerts by PR without touching platform rules; alert names are prefixed with the team slug
+   (`{{SLUG}}_HighErrorRate`) to prevent `alertname` collisions, and a Kyverno label policy
+   stops namespace-escape via label forgery.
+10. **Reconcile cost to the real bill.** *Why:* naive K8s cost tools price against on-demand
+    list rates and overstate spend on an RI/SP/Spot estate. OpenCost + CUR/Athena grounds
+    per-namespace $ in the amortized, discounted invoice so the numbers are trusted.
+11. **Standardize workload identity for storage backends.** *Why:* the estate mixes Pod
+    Identity (Thanos/YACE), IRSA (Loki/Pyroscope), and static keys (Tempo). Static S3 keys
+    are the one long-lived credential the security posture forbids elsewhere — a rebuild
+    should put every backend on Pod Identity (or IRSA) and delete the static-key path.
+12. **Validate the whole signal plane in CI without applying it.** *Why:* `helm lint` +
+    `helm template` + `yamllint` + a taxonomy `grep` + `terragrunt validate` catch broken
+    dashboards, unrenderable rules, and missing labels before merge — apply stays CI/CD-only
+    from `main`.
+
+---
+
+## 7. Known pitfalls
+
+1. **As-built divergence — ADR-0026 says "Alloy is the single pipeline hub; no separate OTel Collector" — but the
+   estate ships a full standalone OTel Collector (gateway+agent) and no Alloy at all**, with
+   Fluent Bit (not Alloy) shipping logs. The intent (one hub) holds, but the *tool* diverged.
+   A rebuild should pick one — either adopt Alloy as ADR-0026 states, or amend the ADR to
+   ratify OTel Collector as the hub — and not run both.
+2. **As-built divergence — ADR-0026 says "defer Pyroscope" — but Pyroscope is fully deployed** (microservices,
+   S3, agent DaemonSet). Either the ADR is stale or the defer was overridden; reconcile the
+   decision record before a client audit.
+3. **As-built divergence — namespace drift:** the prometheus-stack ArgoCD Application targets `monitoring` while
+   the LGTM add-ons and datasource URLs reference `observability`; the Prometheus Service is
+   referenced as both `…kube-prometheus-prometheus` and `…kube-prom-prometheus`. Pick one
+   namespace and one service name or datasources silently point at nothing.
+4. **As-built divergence — VictoriaMetrics has two conflicting definitions** — the Terraform `VMCluster` (3/3/3,
+   500Gi, no `replicationFactor`, no `vmagent`/`vmalert`/`alertmanager`) vs the app Helm
+   values (2/2/2, 100Gi, RF 2, full stack). Only one can be the source of truth.
+5. **As-built divergence (confirm intent) — Loki retention conflict:** `limits_config.retention_period: 8760h` (365d, cited for
+   PCI-DSS 10.7) in values vs a 30-day claim in the README. Confirm the real requirement —
+   a 12× storage difference.
+6. **As-built divergence — bare-metal auto-taint CronJob is the least hardened** — it's a raw
+   `kubernetes_manifest` with **no securityContext, no resource limits, and no in-module
+   RBAC** (RBAC "granted by the GitOps layer"). Bring it up to the GPU-inference module's
+   hardened pattern before production.
+7. **As-built divergence — DCGM exporter image tag drift:** Terraform pins `4.5.0-4.2.3-ubuntu22.04` while the app
+   Helm values use `4.5.0-4.3.3-ubuntu22.04` (different DCGM version). Pin once.
+8. **As-built divergence — `observability-check` queries raw `DCGM_FI_DEV_*` metric names, but the
+   gpu-inference-dcgm CSV remaps them to `dcgm_*`.** If the remap CSV is loaded, the
+   validation Job's queries return empty and the check fails for the wrong reason — align
+   the metric names.
+9. **Retrain-storm risk:** a high-frequency drift alert can fire multiple DAG runs. The
+   defenses (15-min per-`(tenant,domain)` de-dup + `repeat_interval: 6h` + Airflow
+   serialization) must all be present, or a flapping model floods the training cluster.
+10. **Grafana folder RBAC and folder permissions are provisioned once and not reconciled by
+    ArgoCD** — a UI edit to folder permissions silently persists. Document "edit values, not
+    the UI" and treat the one-time Grafana service-account/user setup as a runbook step.
+11. **Cross-namespace ESO for the retrain token:** the ml-monitoring chart creates
+    `alertmanager-retrain-token` in the `ml-monitoring` namespace, but Alertmanager reads it
+    from *its own* namespace — a second (Cluster)ExternalSecret is required or the webhook
+    auth silently fails.
+12. **Thanos Ruler is disabled** — all alerting evaluates in Prometheus. That's fine, but a
+    long-range (multi-hour) alert expression that outlives local retention will not evaluate;
+    keep alert lookbacks inside the 2–4h window or move them to a recording rule.
+13. **`kubeScheduler`/`etcd`/`kubeProxy` default rules are toggled off for EKS** (managed
+    control plane). On a self-managed or bare-metal cluster these must be re-enabled or you
+    go blind on the control plane.
+
+> **Recommendation:** items 1–8 are the estate's **As-built divergences** (scaffold-vs-target
+> / drift gaps); reconcile them against the ADR set — especially the two ADR-0026
+> contradictions (items 1–2) — and raise them with the ADR-set owner before a client rebuild.
+> The finalizer collects these into SPEC-00's recommendations.
+
+---
+
+## 8. Acceptance checklist
+
+A rebuild passes when:
+
+- [ ] `kube-prometheus-stack` reports Prometheus **3.x** with `native-histograms` +
+      `scrape-native-histograms` enabled; `prometheus --version` confirms ≥3.0.
+- [ ] Thanos (not Mimir) is the long-term tier; compactor shows downsampling on with
+      retention raw 30d / 5m 90d / 1h ≥1y; the S3 bucket receives blocks.
+- [ ] Exactly **one** RED-metric source is active (Tempo metrics-generator); OBI metrics and
+      OTel span-metrics are off (no duplicate `http_server_*` series).
+- [ ] Grafana loads with all datasources green (Prometheus, Thanos, Loki, Tempo, Pyroscope,
+      ClickHouse-AI-SRE) and OAuth SSO works with local-admin break-glass intact.
+- [ ] Alertmanager has 3 replicas; a synthetic `critical` alert pages PagerDuty **and**
+      posts to `#alerts-critical`; a `warning` posts to Slack only; `Watchdog` is silenced.
+- [ ] `kube_pod_labels` carries `label_platform_system/component/env/owner` (KSM allowlist)
+      and the `$system` single-pane dashboard renders.
+- [ ] DCGM exporter is scraped on every GPU node; `DCGM_FI_DEV_GPU_UTIL` series count =
+      GPU nodes × GPUs-per-node; XID/ECC/NVLink metrics present.
+- [ ] The auto-taint CronJob runs on non-GPU nodes, has `nodes: patch` (only), a hardened
+      pod (drop-ALL, RO-root, non-root, seccomp), and a forced XID → cordon works end-to-end.
+- [ ] SLO `PrometheusRule`s from Pyrra exist (recording + multi-window burn-rate); the SLO
+      dashboard shows availability + error budget.
+- [ ] ml-monitoring drift-exporter (`:8001/metrics`) and retrain-trigger are up; a forced
+      critical drift alert fires the retrain webhook and Airflow (or the K8s Job fallback)
+      records `ml_monitoring_retrain_triggers_total{outcome="success"}`.
+- [ ] OpenCost per-namespace cost reconciles to the amortized CUR invoice (RI/SP/Spot, not
+      list price).
+- [ ] A new team onboards by PR (values.yaml + Application) and gets a scoped folder,
+      dashboard, `PrometheusRule`, and namespace RBAC — with **zero** platform tickets.
+- [ ] CI (`ml-monitoring-baremetal-validate` + terraform/helm validate) is green: `helm
+      lint`/`template`, `yamllint`, taxonomy `grep`, `terragrunt validate` — no apply.
+- [ ] `tests/gpu-inference/observability-check.yaml` passes: VM healthy, all DCGM families
+      present, ClickHouse logs reachable with recent rows, ≥1 alert rule evaluating.
+
+---
+
+## 9. Metrics / alerts inventory (reference tables)
+
+### 9.1 System SLO alerts (`prometheus-stack/…/slo-rules.yaml`)
+
+| Alert | Condition | Severity | Runbook |
+|---|---|---|---|
+| `APIServerAvailabilityBelowSLO` | `apiserver:availability:sli < 0.9995` (5m) | critical | `/slo/apiserver-availability` |
+| `APIServerLatencyAboveSLO` | `apiserver:latency:p99:sli > 1s` (10m) | warning | `/slo/apiserver-latency` |
+| `CoreDNSSuccessRateBelowSLO` | `coredns:success_rate:sli < 0.999` (5m) | critical | `/slo/coredns-availability` |
+| `CoreDNSLatencyAboveSLO` | `coredns:latency:p99:sli > 30ms` (10m) | warning | `/slo/coredns-latency` |
+| `PodStartupTimeAboveSLO` | `kubelet:pod_start_duration:p99 > 60s` (10m) | warning | `/slo/pod-startup-time` |
+| `NetworkErrorRateAboveSLO` | `network:error_rate:sli > 10 err/s` (10m) | warning | `/slo/network-errors` |
+| `PVCProvisioningSuccessRateBelowSLO` | `< 0.99` (10m) | warning | `/slo/pvc-provisioning` |
+| `PVCProvisioningLatencyAboveSLO` | `p99 > 60s` (10m) | warning | `/slo/pvc-provisioning-latency` |
+| `NodeAvailabilityBelowSLO` | `node:availability:sli < 0.99` (5m) | critical | `/slo/node-availability` |
+| `NodeCPUSaturationAboveSLO` | `> 0.80` (15m) | warning | `/slo/cpu-saturation` |
+| `NodeMemorySaturationAboveSLO` | `> 0.80` (15m) | warning | `/slo/memory-saturation` |
+| `ErrorBudgetExhausted` | apiserver/coredns 30d budget `< 0` (1h) | critical | `/slo/error-budget-exhausted` |
+| `ErrorBudgetCriticallyLow` | budget `< 10%` and `> 0` (1h) | warning | `/slo/error-budget-low` |
+
+*Plus* the kube-prometheus-stack `defaultRules` bundle (alertmanager, k8s apps/resources/
+storage/system, node-exporter, network, prometheus, kubeApiserver SLOs). `etcd`,
+`kubeScheduler`, `kubeProxy` histogram/scheduler rules are **disabled** for EKS.
+
+### 9.2 ML drift / accuracy alerts (`ml-monitoring/…/ml-drift-alerts.yaml`)
+
+| Alert | Condition | Severity | Route |
+|---|---|---|---|
+| `MLDatasetDriftWarning` / `Critical` | `dataset_drift_score >` 0.20 / 0.40 (30m/15m) | warning / critical | Slack / +PagerDuty+retrain |
+| `MLFeaturePSIWarning` / `Critical` | `feature_psi_score >` 0.10 / 0.25 | warning / critical | Slack / +retrain |
+| `MLDriftDetected` | `drift_detected == 1` (15m) | critical | PagerDuty + retrain |
+| `MLModelAccuracyWarning` / `Critical` | `model_accuracy <` 0.85 / 0.75 | warning / critical | Slack / +retrain |
+| `MLModelF1Warning` / `Critical` | `model_f1_score <` 0.80 / 0.65 | warning / critical | Slack / — |
+| `MLDriftExporterDown` | `up{job=~"ml-drift-exporter-.*"} == 0` (5m) | critical | PagerDuty |
+| `MLRetrainTriggerFailures` | `rate(retrain_triggers_total{outcome!="success"}[15m]) > 0.1` (10m) | warning | Slack |
+
+### 9.3 GPU / EFA / ML-pipeline alerts (self-serve AWS, `aws-gpu-prometheusrule.yaml`)
+
+| Alert (team-prefixed) | Condition | Severity | For |
+|---|---|---|---|
+| `{{SLUG}}_GPULowUtilisation` | `avg DCGM_FI_DEV_GPU_UTIL/100 < 0.10` | warning | 30m |
+| `{{SLUG}}_GPUMemorySaturation` | `FB_USED/(FB_USED+FB_FREE) > 0.90` | critical | 10m |
+| `{{SLUG}}_GPUXIDError` | `DCGM_FI_DEV_XID_ERRORS > 0` | critical | 0m |
+| `{{SLUG}}_EFAReceiveSaturation` | `rate(node_network_receive_bytes_total{efa}[5m]) > 1e10` (~80% of 100Gbps) | warning | 5m |
+| `{{SLUG}}_AirflowHighTaskFailureRate` | Airflow task failure ratio `> 0.10` (15m) | warning | 5m |
+
+*(GPU-inference in-module VMRule alerts are in §4.5; bare-metal Talos/IB/BGP/Ceph/etcd
+self-serve alerts are catalogued below.)*
+
+### 9.4 Bare-metal substrate alerts (self-serve, `baremetal-prometheusrule.yaml`)
+
+`_TalosNodeDown` (critical), `_TalosVersionSkew`, `_TalosAPIdErrors`, `_IBConstraintErrors`,
+`_NVLinkBandwidthLow`, `_CiliumBGPSessionDown` (critical, `cilium_bgp_peer_state != 3`),
+`_CiliumBGPPrefixCountHigh`, `_CephHealthError` (critical) / `_CephHealthWarn`, `_CephOSDDown`,
+`_CephPGsDegraded`, `_EtcdNoLeader` (critical), `_EtcdHighWALFsyncLatency`,
+`_EtcdLeaderChanges`, `_KubeAPIServerLatencyHigh` — all thresholds Helm-value driven, all
+runbooks `runbooks.{{DOMAIN}}/baremetal/<slug>`.
+
+### 9.5 Self-serve base alerts (`grafana-self-serve/…/prometheusrule.yaml`)
+
+`{{SLUG}}_HighErrorRate` (critical, 5xx ratio > 5%), `{{SLUG}}_ServiceDown` (critical),
+`{{SLUG}}_HighCPUSaturation` / `{{SLUG}}_HighMemorySaturation` (warning, > 80%), and when
+`ml.enabled`: `{{SLUG}}_MLDriftDetected` (warning, > 0.2), `{{SLUG}}_MLAccuracyDegraded`
+(critical, < 0.85). Team RBAC: namespace-scoped Role granting
+`prometheusrules` `[get,list,watch,create,update,patch,delete]`.
+
+### 9.6 DNS-failover alerts (`k8s/monitoring/prometheus-rules.yaml`)
+
+`DNSProviderDown` (critical, health < 20), `DNSFailoverInitiated` (critical),
+`DNSSyncFailed` (critical), `DNSProviderDegraded` (warning, < 70), `DNSHighQueryLatency`
+(warning, p95 > 500ms).
+
+### 9.7 AI-SRE integration surface (SPEC-09 — monitoring integration only)
+
+The AI-SRE orchestrator exposes `:9090/metrics` (scraped by a VictoriaMetrics
+`VMServiceScrape`/scrape-config keyed on `app_kubernetes_io_name` + container port
+`metrics`). Metrics: `ai_sre_investigation_duration_seconds` (histogram),
+`ai_sre_investigation_total`, `ai_sre_tool_calls_total`, `ai_sre_tokens_used_total`,
+`ai_sre_api_cost_dollars`, `ai_sre_daily_cost_usd`, `ai_sre_errors_total`,
+`ai_sre_circuit_breaker_state`, `ai_sre_accuracy_ratio`, `ai_sre_advisories_generated_total`,
+`ai_sre_feedback_total`, `ai_sre_active_investigations`, `ai_sre_system_info`. Alerting
+(`ai-sre/k8s/orchestrator/vmalert-rules.yaml`): `AISRESystemDown` (critical),
+`AISREHighErrorRate` (>30%), `AISRECircuitBreakerOpen` (critical), `AISREHighLatency`
+(p95 > 120s), `AISREDailyCostHigh` (>$80) / `AISREDailyCostExceeded` (>$100, critical),
+`AISRELowAccuracy` (<60%), `AISRESlackAppDown`. Its dashboards (`ai-sre/*.json`) query the
+**ClickHouse-AI-SRE** datasource, not Prometheus. **Boundary:** the agents, MCP servers,
+and analytics store are **SPEC-09**; this spec only guarantees the metrics land in the
+metrics tier and are scraped.
+
+### 9.8 Dashboard catalog
+
+| Dashboard | Covers | Datasource |
+|---|---|---|
+| cluster-overview | EKS single-pane health, top consumers, active alerts | Prometheus |
+| node-health | per-node CPU/mem/disk/net, Karpenter, spot cost | Prometheus |
+| karpenter | provisioning latency P50/95/99, spot vs on-demand, consolidation | Prometheus |
+| service-golden-signals | RED + saturation, data-links to Tempo | Prometheus/Tempo |
+| service-slo | availability/latency SLO, error budget, burn rate | Prometheus |
+| argocd-inventory / argocd-platform-overview | ArgoCD app health, sync, reconcile queue | Prometheus |
+| kubernetes-overview | node/pod/PV from node-exporter+KSM | Prometheus |
+| aws-infra-overview | AWS infra via YACE (NLB/ALB/S3/EBS/RDS/DynamoDB) | Prometheus |
+| platform-system-overview | ADR-0028 unified `$system` taxonomy (EKS+RDS+S3+DynamoDB) | Prometheus |
+| ml-drift-accuracy (+ `-aws`, `-baremetal`) | ML model accuracy + drift per substrate | Prometheus |
+| clustermesh-status / multiregion-overview | Cilium ClusterMesh + multi-region active-active | Prometheus |
+| go-application | Go app RED metrics | Prometheus |
+| cilium-advanced-ebpf (repo `monitoring/`) | Cilium eBPF for gpu-inference; vLLM P99 during NCCL | Prometheus |
+| provider-health (repo `monitoring/`) | DNS/provider health score | Prometheus |
+| ai-sre-{accuracy,agent-usage,cost-roi,findings} | AI-SRE analytics (SPEC-09) | ClickHouse-AI-SRE |
+| *(imported by gnetId)* kubernetes-cluster 7249, node-exporter 1860, prometheus-stats 19105, CoreDNS 14981, Karpenter 20524, EBS-CSI 16924, Cilium 16611, Hubble 16613 | community dashboards | Prometheus |
+
+> **Note:** the grafana-dashboards README advertises `lokiOverview`, `tempoOverview`,
+> `pyroscopeOverview`, and `serviceDeepDive` that are **not** present in the ConfigMap —
+> aspirational, not shipped (§7).
+
+### 9.9 Load-bearing signals
+
+The platform treats these as the signals whose loss = flying blind (page/act on them
+first): **API-server availability + p99 latency**, **CoreDNS success rate**, **node
+Ready ratio**, **error-budget burn**, **GPU XID/ECC/thermal faults** (drive auto-taint),
+**Tempo metrics-generator RED** (feeds Kargo/Rollouts promotion gates + golden-signals),
+**Prometheus/Thanos + VictoriaMetrics up** (the metrics tier itself), **Alertmanager
+quorum + Watchdog** (the alerting pipeline itself), **ML dataset-drift + accuracy** (drive
+retrain), and **AI-SRE daily cost + circuit-breaker** (budget/safety guardrails).
+
+### 9.10 Scaling the stack per cluster count
+
+- **1–2 clusters:** single Prometheus HA pair per cluster + shared Thanos Query reading all
+  sidecars; Grafana points at Thanos for cross-cluster views. Alertmanager per cluster.
+- **10s of clusters:** shard Prometheus (2–4 shards) on high-volume clusters; Thanos Store
+  Gateway + Query scale horizontally; use `externalLabels.cluster`/`region` for dedup;
+  Grafana federates via the single Thanos datasource. KSM sharding once objects > ~10k.
+- **The GPU-inference mega-cluster (up to 5 000 GPU nodes):** do **not** use
+  kube-prometheus-stack — run VictoriaMetrics cluster (scale `vmstorage` replicas + PVC
+  with node count, `replicationFactor 2`), DCGM scrape 15s, auto-taint `*/2`. This is the
+  documented break-point where Prometheus RAM per series stops being economical.
+- **Cost:** OpenCost is per-cluster; aggregate multi-cluster cost views come from CUR/Athena
+  (account-level), not from stitching OpenCost instances.
+
+### 9.11 Client-adaptation notes (self-hosted LGTM vs managed SaaS)
+
+- **This estate deliberately chose self-hosted, OSS, Prometheus-native** (ADR-0026/0038):
+  everything lands in one Grafana pane, no per-host/per-metric SaaS billing, and no data
+  egress — the last point is a hard requirement for the financial-transaction domains (PII
+  risk) and is *the* reason `ADR-0038` rejected managed ML-observability SaaS (Vertex Model
+  Monitoring, Arize, Fiddler).
+- **When a Datadog/New-Relic/Grafana-Cloud client is preferable:** small teams without SRE
+  capacity to operate Thanos/Loki/Tempo/Pyroscope; when time-to-value beats cost; when the
+  client already standardizes on a SaaS pane. The trade the estate accepts by staying
+  self-hosted is **operational surface** (a multi-component stack to pin, upgrade, and
+  scale) in exchange for **cost predictability + data residency + single-pane control**.
+- **Portable adaptation path:** because dashboards, alert rules, and SLOs are all *code*
+  (ConfigMaps, `PrometheusRule`, Pyrra CRDs) and metrics carry a stable taxonomy, a client
+  can point the same instrumentation at a SaaS backend (OTLP export from the OTel gateway,
+  Prometheus remote-write to Grafana Cloud/Datadog) with minimal rework — the collection
+  layer is backend-agnostic; only the storage/query tier swaps.
+
+---
+
+## 10. Dependencies on other specs
+
+- **SPEC-00 — Platform overview:** owns the global placeholder registry (`{{ORG}}`,
+  `{{DOMAIN}}`, `{{PRIMARY_REGION}}`, account IDs). Register the spec-local placeholders
+  introduced here (`{{SECRETS_REGION}}`, `{{CLUSTER_NAME}}`, `{{GCP_PROJECT}}`, `{{TENANT}}`,
+  `{{DOMAIN_SLUG}}`, `{{PD_ROUTING_KEY}}`, `{{SLACK_WEBHOOK}}`, `{{GHCR_REGISTRY}}`).
+- **SPEC-01 — Foundation IaC:** the Terraform modules and state backing the DCGM,
+  VictoriaMetrics, and CUR/Athena resources this spec deploys.
+- **SPEC-02 — Network & DNS:** the Cilium/BGP and DNS-failover signals consumed here
+  (source of the `k8s/monitoring` DNS alerts and the Cilium dashboards).
+- **SPEC-04 — Delivery & GitOps:** owns ArgoCD sync-wave ordering (obs wave 10,
+  ml-monitoring wave 20, self-serve wave 30), app-of-apps, and the Kargo/Argo-Rollouts
+  analysis templates that read the Tempo-generator RED metrics as promotion gates
+  (`ADR-0021`).
+- **SPEC-05 — Security:** External Secrets Operator + secret stores deliver every
+  observability secret (Thanos objstore, Grafana admin/OAuth, Alertmanager Slack/PagerDuty,
+  Tempo/Pyroscope S3, Airflow API creds, ML retrain token); the Kyverno
+  `require-platform-labels` policy enforces the taxonomy self-serve depends on; the SOC2
+  matrix (`ADR-0040`) treats this observability plane as the runtime evidence store.
+- **SPEC-06 — CI/CD & quality:** owns the CI framework the `ml-monitoring-baremetal-validate`
+  workflow and terraform/helm validation loops run within.
+- **SPEC-09 — AI-SRE:** the AI-SRE system, ClickHouse analytics store, and agents. This spec
+  consumes only its `ai_sre_*` metric surface + alerting; observability *scrapes and pages
+  on* AI-SRE while AI-SRE *reads* this plane (metrics MCP) — but AI-SRE internals are SPEC-09.
+- **SPEC-03 — Compute/GPU day-2:** provisions GPU node pools, the GPU operator, Karpenter,
+  EFA/IB fabric, and Talos; the DCGM exporter and auto-taint CronJob attach to their signals.
+- **SPEC-10 — ML / GPU-inference surface:** owns the model-serving (vLLM), the training
+  pipeline (Airflow `train_domain_adapter`), and the GPU-inference cluster whose signals this
+  spec collects — DCGM telemetry, drift/accuracy metrics, vLLM HPA metrics, and the retrain
+  trigger all attach to SPEC-10's workloads.
+
+---
+
+*Source ADRs cited: ADR-0019 (OBI/Beyla→Tempo), ADR-0021 (Prometheus analysis gates),
+ADR-0026 (observability target architecture), ADR-0027 (OpenCost + CUR/Athena),
+ADR-0028 (platform taxonomy), ADR-0034 (Backstage deferred), ADR-0038 (ML drift),
+ADR-0039 (self-serve observability), ADR-0040 (SOC2 posture + ML on-call),
+ADR-0044/0045 (AWS GPU/EFA), ADR-0048 (AWS ML CI/CD), ADR-0049/0050 (bare-metal GPU/Talos).*

--- a/specs/SPEC-08-resilience-data.md
+++ b/specs/SPEC-08-resilience-data.md
@@ -1,0 +1,651 @@
+# SPEC-08 — Resilience, Disaster Recovery & Stateful Services
+
+> Portable reverse-engineering of this platform's resilience estate. A senior platform team
+> can rebuild the same failover, DR, and data-durability design for a new client from this
+> document alone. Follows `specs/CONVENTIONS.md`. All identifiers are placeholders (see §5).
+
+---
+
+## 1. Scope & non-goals
+
+This spec covers everything the platform does to **survive failure and never lose data**:
+(a) the in-repo **`failover-controller`** — a Go control loop that fails a domain's DNS between
+providers at the registrar; (b) the **DR account** design (a pre-provisioned warm-standby AWS
+account for production); (c) **stateful services** — RDS PostgreSQL HA, Kubernetes persistent
+storage, and schema-migration handling; (d) **object/artifact storage** durability — the MLflow
+artifact store, the centralized **log-archive** immutability design, and Terraform-state DR;
+(e) **cross-region / cross-cloud federation** — the two-cluster active/active-standby topology
+(AWS EKS, Azure AKS, GKE) and the AWS Global Accelerator active-active transaction plane; and
+(f) the **failure-mode matrix**, **DR runbook shape**, **data-classification → storage mapping**,
+and the **RTO/RPO tiers** a client must decide (§5.1, §6.x tables).
+
+**Non-goals.** DNS record synchronisation and provider health *measurement* mechanics belong to
+**SPEC-02** (`dns-monitor` / `dns-sync`) — this spec consumes their health scores and references
+their zone-of-truth. Network fabric (Transit Gateway, Cilium, VPC CIDRs) is also **SPEC-02**;
+IAM/org guardrails are **SPEC-05**. GPU-fabric and ML-serving internals are **SPEC-10**;
+here they appear only as *stateful-service* and *federation* consumers.
+
+---
+
+## 2. Architecture
+
+The estate has **three independent resilience layers**, each with its own detector, actuator,
+and blast radius. They are deliberately decoupled: a failure in one does not disable the others.
+
+```
+                          RESILIENCE LAYER MAP
+
+  L1  DNS-PROVIDER FAILOVER (registrar nameserver swap)   ── this spec, core
+  ┌───────────────────────────────────────────────────────────────────────┐
+  │  dns-monitor (SPEC-02)          failover-controller (Go)                │
+  │  probes NS via DNS TXT   ──►  Postgres  ──►  5-state machine, 30s tick  │
+  │  score=0.6·succ+0.3·lat+0.1·cons   health_check_results                 │
+  │                                          │                             │
+  │                                          ▼  RegistrarClient            │
+  │                              {{REGISTRAR}} API: swap NS records         │
+  │  primary ({{PRIMARY_DNS_PROVIDER}}) ⇄ secondary ({{SECONDARY_DNS_PROVIDER}})           │
+  └───────────────────────────────────────────────────────────────────────┘
+
+  L2  MULTI-REGION APP FAILOVER (anycast, no DNS change)  ── transaction plane
+  ┌───────────────────────────────────────────────────────────────────────┐
+  │        AWS Global Accelerator (anycast, TCP/443 health, ~30s)          │
+  │              │ traffic_dial=100/100 (true active-active)               │
+  │        ┌─────┴─────┐                                                    │
+  │     NLB euw1     NLB euc1                                               │
+  │     EKS euw1  ⇄  EKS euc1     Cilium ClusterMesh (WireGuard, east-west) │
+  └───────────────────────────────────────────────────────────────────────┘
+
+  L3  DR ACCOUNT / REGION (warm standby, IaC re-provision)  ── prod DR
+  ┌───────────────────────────────────────────────────────────────────────┐
+  │  dr account ({{DR_ACCOUNT_ID}}) — full platform stack as Terragrunt,   │
+  │  scaled down (no GPU), applied/scaled-up on invocation.                │
+  │  Data restored from: RDS automated backups · Velero aws-dr bucket ·    │
+  │  state-backend-dr S3 CRR ({{PRIMARY_REGION}}→{{DR_REGION}}).           │
+  └───────────────────────────────────────────────────────────────────────┘
+```
+
+### 2.1 L1 — the `failover-controller` (fully reverse-engineered)
+
+A single Go binary (`failover-controller/`, module `failover-controller`, `go 1.23`). It does
+**not** measure health itself; it reads scores that `dns-monitor` (SPEC-02) writes to a shared
+PostgreSQL database, decides whether to fail over, and actuates by rewriting the domain's
+**nameserver records at the registrar**. This is *provider-level* failover (swap the whole DNS
+provider), distinct from record-level DNS.
+
+**Control loop** (`main.go`): a 30-second `time.Ticker`; one immediate evaluation on startup;
+graceful shutdown on SIGINT/SIGTERM. An HTTP server on `:8080` exposes `/metrics` (Prometheus),
+`/healthz` (liveness), `/readyz` (loads persisted state), and `/state` (current JSON state).
+
+**State machine** (`statemachine.go`) — five states (consolidated from an original eight; the
+removed MONITORING/PREPARING/RESTORING added ceremony without distinct behaviour):
+
+```
+  HEALTHY ──score<0.5──► DEGRADED ──3 consecutive degraded──► FAILING_OVER
+     ▲                      │                                      │
+     │                 score≥0.5                              swap NS ok
+     │                      ▼                                      ▼
+     └──cooldown 10m──── RECOVERING ◄──score>0.7──── FAILED_OVER (serve on secondary)
+        failback NS          │  (abort back to FAILED_OVER if score<0.5 during cooldown)
+```
+
+| State | Handler behaviour |
+|---|---|
+| `HEALTHY` | Query provider scores; if primary `< DegradeThreshold (0.5)` → set `DegradedCheckCount=1`, go `DEGRADED`. |
+| `DEGRADED` | If primary recovers (`≥0.5`) → reset, back to `HEALTHY`. Else increment counter; at `ConsecutiveDegradedChecksRequired (3)` → `FAILING_OVER`. |
+| `FAILING_OVER` | Read current NS (audit), resolve secondary NS, `UpdateNameservers`, `VerifyPropagation`; record `LastFailoverTime`, `DailyFailoverCount++`; → `FAILED_OVER`. On any error, abort → `DEGRADED` (not a tight retry loop). |
+| `FAILED_OVER` | Serve on secondary; watch primary; when primary `> RecoveryThreshold (0.7)` → set `RecoveryStartTime`, go `RECOVERING`. |
+| `RECOVERING` | Primary must stay healthy for `RecoveryCooldown (10m)`; if it degrades again → abort to `FAILED_OVER`; after cooldown → failback NS to primary → `HEALTHY`. |
+
+**Thresholds** (`statemachine.go`): `DegradeThreshold=0.5`, `ConsecutiveDegradedChecksRequired=3`,
+`RecoveryThreshold=0.7`, `HealthScoreWindow=5m`.
+
+**Safety guard-rails** (`safety.go`, `DefaultSafetyParams`) — every transition passes
+`ValidateTransition` before it is applied:
+
+```go
+MinTimeInState    = 5 * time.Minute   // anti-flap: min dwell in any state
+FailoverCooldown  = 1 * time.Hour     // min gap between failovers
+MaxDailyFailovers = 1                 // hard cap per calendar day (day-of-year)
+RequireManualAuth = false             // set TRUE in prod initially (human-gates FAILING_OVER)
+RecoveryCooldown  = 10 * time.Minute  // primary must be stable this long before failback
+```
+
+`ValidateTransition` enforces, in order: (1) the transition is in the `validTransitions`
+adjacency map (anything else rejected); (2) `MinTimeInState` elapsed; (3) for `→ FAILING_OVER`,
+`FailoverCooldown` elapsed **and** `DailyFailoverCount < MaxDailyFailovers`; (4) if
+`RequireManualAuth`, block `→ FAILING_OVER` entirely (out-of-band human action required).
+
+**Health scoring** (`healthstore.go`, `PostgresHealthStore`) — the controller re-implements the
+*same* formula `dns-monitor` uses, over `health_check_results` in the shared DB:
+
+```
+score = successRate·0.6 + latencyScore·0.3 + consistency·0.1     (normalized 0.0–1.0)
+latencyScore = 1.0 if avg<50ms ; 0.0 if avg≥1000ms ; linear 1-(avg-50)/950 between
+```
+Providers with `status='failed'` are excluded. `consistency` is a `1.0` placeholder in both
+codebases (a real build measures variance).
+
+**State persistence** (`persistence.go`, `StateStore`) — `ControllerState` is JSON on a
+host/PVC path (`STATE_FILE`, default `/var/lib/failover-controller/state.json`). Writes are
+**atomic** (temp file + `os.Rename`). `DailyFailoverCount` resets when the day-of-year rolls
+over. A missing or corrupt file yields a default `HEALTHY` state rather than a crash. Fields:
+`current_state`, `primary_provider_id`, `secondary_provider_id`, `domain`, `last_transition_time`
+(RFC3339), `last_failover_time`, `daily_failover_count`, `degraded_check_count`,
+`recovery_start_time`, `updated_at`.
+
+**Registrar abstraction** (`registrar.go`) — `RegistrarClient` interface: `GetNameservers`,
+`UpdateNameservers`, `VerifyPropagation` (queries public resolvers, e.g. `8.8.8.8`/`1.1.1.1`, and
+returns true only when all agree). Ships with `MockRegistrarClient` (default, logs only); a real
+build switches on `REGISTRAR_TYPE` (`namecheap`/`godaddy`/…) in `NewRegistrarClient()`.
+
+**Deployment** (`Dockerfile`): multi-stage `golang:1.26-alpine` → `alpine:3.24`, `CGO_ENABLED=0`,
+runs as `nonroot` (uid 65532), exposes `:8080`, state dir owned by the non-root user. Runtime env:
+`DATABASE_URL` (required — fatal if unset), `STATE_FILE`, `PRIMARY_PROVIDER_ID`,
+`SECONDARY_PROVIDER_ID`, `FAILOVER_DOMAIN`. Dependencies: `lib/pq`, `prometheus/client_golang`;
+DB pool capped small (`SetMaxOpenConns(5)`, one query per tick).
+
+### 2.2 L1 data model (`database/migrations/V1__initial_schema.sql`, Flyway)
+
+Shared PostgreSQL between `dns-monitor` (writer) and `failover-controller` (reader). Five tables,
+UUID PKs, JSONB payloads, `TIMESTAMP WITH TIME ZONE`:
+
+| Table | Role |
+|---|---|
+| `dns_providers` | provider registry: `name`, `type IN (active,standby)`, `health_check_endpoints` (JSONB), `status IN (healthy,degraded,failed)`. |
+| `dns_zones` | domain → registrar + `current_ns_records` / `desired_ns_records` (JSONB), `sync_status`. |
+| `health_check_results` | per-probe rows: `provider_id`, `check_timestamp`, `response_time_ms`, `success`, `check_location`. Indexed `(provider_id, check_timestamp DESC)`. |
+| `failover_events` | audit: `event_type`, `old/new_ns_records`, `initiated_by` (`auto`/`manual:user`). |
+| `state_machine_history` | `previous_state`→`current_state`, `transition_reason`. Indexed `(domain_name, timestamp DESC)`. |
+
+### 2.3 L2 — multi-region active-active (transaction plane)
+
+The staging/prod transaction estate runs **true active-active** across `{{PRIMARY_REGION}}`
+(euw1) and a second region (euc1) with **no DNS involvement in failover**:
+
+- **AWS Global Accelerator** (anycast IPs, geo-routing). Both regions `traffic_dial_percentage=100`.
+  Health checks: **TCP/443, 10s interval, 3-consecutive threshold ⇒ ~30s detect and ~30s
+  recover**, `client_affinity=SOURCE_IP`. GA reroutes at the **network layer** — clients need no
+  DNS update. GA is TCP-only: it does **not** fail over on app-level 5xx, partial pod
+  degradation, ClusterMesh disconnect, or latency-without-loss (those use manual traffic-dial failover).
+- **Cilium ClusterMesh** (WireGuard-encrypted) for east-west pod-to-pod service discovery. Global
+  services carry `service.cilium.io/global:"true"`; affinity modes `local` (default; remote
+  failover only when all local endpoints unhealthy), `remote`, `none`.
+- **ApplicationSet matrix generator** (teams × clusters) with `RollingSync` — deploys euw1 first,
+  then euc1 (a natural canary; a failed euw1 sync never reaches euc1).
+
+### 2.4 L2 — GPU-ML two-cluster federation (uniform across clouds)
+
+The GPU-ML platforms mirror one federation shape on all three clouds (AWS two-EKS, Azure two-AKS,
+GKE two-region) — see `docs/architecture/{aws,azure}/*-ml-stack.excalidraw`:
+
+- **Exactly two clusters**: Region A **active**, Region B **active / standby**, each a
+  *self-contained copy* of the per-region stack. **Non-overlapping pod CIDRs 10.10.0.0/16 (A) vs
+  10.20.0.0/16 (B)** — a hard prerequisite for ClusterMesh routability.
+- **North-south failover = anycast + health-probe**: AWS Route 53 + Global Accelerator; Azure
+  Front Door; GCP DNS. **The same in-repo `failover-controller` (Route 53 DNS failover) is the
+  reused serving-failover actuator** (ADR-0044 D5, ADR-0036).
+- **East-west = Cilium ClusterMesh** over cross-region **Transit Gateway peering** (AWS) / Global
+  VNet peering + **Azure Kubernetes Fleet Manager** L4 (Azure).
+- **Serving fails over; batch/training does NOT.** Gang-scheduled GPU jobs are region-pinned and
+  **re-queued**, never migrated. The secondary region is deliberately **asymmetric**: scale-to-zero
+  GPU node pools, spot-first, sized only for *failover-serving headroom* — not a hot training
+  mirror. A **cold-standby (IaC, zero running GPU)** model is left open as a cost-driven revisit.
+- **Cross-region data replication is thin**: only container-image geo-replication (ECR/ACR
+  cross-region replica) is defined; artifact/dataset stores are per-region with no built-in sync.
+  (Bare-metal ADR-0052 is the only estate naming replication tech: CloudNativePG streaming + MinIO
+  site-replication + Ceph 3-replica.)
+
+### 2.5 L3 — DR account (warm standby for production)
+
+`terragrunt/dr/` defines a full, **independent AWS account** (`dr`, OU `Prod`, purpose "Disaster
+recovery for prod") whose region folders (`eu-west-1/2/3`, `eu-central-1`, CIDR block
+`10.30.0.0/16`) each carry the **identical platform stack** (`terragrunt.stack.hcl`: vpc,
+tgw-attachment, secrets, eks, cilium, karpenter{-iam,-controller,-nodepools}, keda, hpa-defaults,
+wpa, rds, monitoring). It is **pilot-light / warm standby**: the IaC exists and is sized, but
+scaled down and not continuously serving —
+
+```hcl
+# terragrunt/dr/account.hcl (sanitized)
+single_nat_gateway = true            eks_public_access = false
+eks_instance_types = ["m6i.xlarge"]  eks_min_size = 1  desired = 2  max = 5
+rds_instance_class = "db.r6g.large"  rds_allocated_storage = 50  rds_multi_az = true
+monitoring_replicas = 1
+enable_tgw_attachment = false        # NOT yet wired to the network hub
+# no GPU node pools; x86+arm64 Karpenter pools at spot_percentage = 50
+```
+
+DR data is **restored, not continuously replicated** into this account: RDS from automated
+backups/snapshots, Kubernetes state from the Velero `aws-dr` bucket, Terraform state from the
+`state-backend-dr` replica. This is the estate's chosen trade: low steady-state cost, RTO paid at
+invocation time (re-apply + scale-up + restore). Today only `dr/_global/iam` is materialized.
+
+### 2.6 Stateful services & durability surfaces
+
+| Surface | Engine / mechanism | HA / DR posture |
+|---|---|---|
+| Platform DB | RDS **PostgreSQL 17.7** (registry module `terraform-aws-modules/rds/aws` v7.1.0). **Vanilla, single-instance + Multi-AZ standby. No Aurora, no read replicas.** | Multi-AZ = single-region AZ failover. `backup_retention_period` prod 30d / others 7d. **No cross-region snapshot copy or read replica.** |
+| DB schema | ADR-0032: migrations as **ArgoCD PreSync Jobs** (Flyway `V1__` naming in-repo). | `backoffLimit:0`, `activeDeadlineSeconds:300`, ESO creds; no auto-rollback. |
+| K8s persistent volumes | EBS CSI `gp3` StorageClasses (`WaitForFirstConsumer`); large per-chain StatefulSets, VictoriaMetrics, RabbitMQ. | Velero daily/weekly + EBS volume snapshots; cross-region `aws-dr` copy. |
+| K8s app/PV backup | **Velero** (plugin-for-aws v1.11.0, CSI v0.8.0, `EnableCSI`). | Dual `backupStorageLocation` (`aws-primary` + `aws-dr`), **SSE-KMS required** (`alias/velero`), EBS snapshots primary + DR. Schedules: `daily-full` 02:00 UTC / 30d TTL, `weekly-full` Sun 03:00 / 90d TTL. |
+| MLflow artifact store | S3 (`aws-ml-artifact-store`), GCS mirror, MinIO/Ceph-RGW mirror. | Versioning on; **no Object Lock, no replication**; SSE-KMS *or AES256 fallback*. |
+| Immutable log archive | `centralized-logging` S3 bucket + org CloudTrail bucket. | **Object Lock** (GOVERNANCE 365d / CloudTrail **COMPLIANCE** WORM), SSE-KMS, cross-region CRR. |
+| Terraform state | S3 `tfstate-<account>-<region>` + DynamoDB locks. | `state-backend-dr`: S3 CRR + DynamoDB **Global Tables v2** (active-active locks). |
+| Bare-metal (UK DC, ADR-0052) | Rook-Ceph (RBD/CephFS/RGW, ≥3 replicas) + CloudNativePG streaming + MinIO site-replication. | Cross-DC: CNPG streaming (relational) + Ceph/MinIO site-replication (object). |
+
+### 2.7 Data-at-rest immutability (object storage)
+
+- **`aws-ml-artifact-store`** (`terraform/modules/aws-ml-artifact-store`, ADR-0048/0018/0028):
+  `object_ownership=BucketOwnerEnforced`, all-four public-access-block, `prevent_destroy`,
+  versioning **on by default**, a `DenyInsecureTransport` (`aws:SecureTransport=false`) bucket
+  policy applied **after** the public-access-block, lifecycle `STANDARD_IA@90d → GLACIER_IR@365d →
+  expire@730d`, **ABAC IAM** (grant conditioned on `aws:PrincipalTag/platform:system ==
+  aws:ResourceTag/platform:system`), EKS **Pod Identity** trust scoped to the caller account.
+  **Caveat**: when `kms_key_arn` is empty (the default) it silently falls back to **AES256
+  (SSE-S3), not SSE-KMS**; and it carries **no Object Lock and no replication**.
+- **`centralized-logging`** (the log-archive sink; `_envcommon/centralized-logging.hcl`): versioning
+  hardcoded on, SSE-KMS always, **Object Lock GOVERNANCE, 365-day** default retention, cross-account
+  write policy for CloudTrail/Config/VPC-Flow/EKS-audit, lifecycle to Glacier + expire **2555d
+  (~7yr, PCI-DSS)**, and a **DR replica bucket** (`${bucket}-dr`) with S3 replication
+  `{{PRIMARY_REGION}}→{{DR_REGION}}` including `delete_marker_replication`. The org **CloudTrail**
+  bucket is stricter: **Object Lock COMPLIANCE** (true, non-overridable WORM), 365d.
+- **KMS** (`_envcommon/kms.hcl`): a per-region CMK inventory (cloudtrail, aws-config, s3-data,
+  eks-secrets, ebs, rds, sns, sqs, logs, backup), **rotation on**, `deletion_window=30`, ABAC key
+  policy, `prevent_destroy` on protected keys. `common.hcl` declares
+  `default_compliance_frameworks = "pci-dss,soc2,iso27001"`.
+
+### 2.8 Terraform-state DR (deploy-capability continuity)
+
+State lives in `tfstate-<account>-<region>` (SSE-KMS, versioning, `prevent_destroy`,
+`DenyUnencryptedTransport` + `DenyDeleteBucket` policies) with a DynamoDB lock table
+(`terraform-locks-<account>`, PAY_PER_REQUEST, **PITR on**, `prevent_destroy`). `root.hcl` sets
+`retry_max_attempts=3`. The `state-backend-dr` module adds **one-way S3 CRR**
+`{{PRIMARY_REGION}}→{{DR_REGION}}` plus a **DynamoDB Global Table v2** replica (bidirectional,
+active-active locks; requires `stream_enabled` on the source). Failover is a **PR that repoints
+`bucket`+`region`** in `root.hcl` to the DR region; `init -reconfigure` regenerates `backend.tf`.
+Writes made to the replica during an outage are **not auto-replicated back** — recovery does an
+explicit `aws s3 sync` before failing back. (Sandbox is the exception: it uses S3 native
+`use_lockfile` instead of DynamoDB.)
+
+---
+
+## 3. Decision record
+
+| Decision | Rationale | Trade-off accepted | Source |
+|---|---|---|---|
+| DNS-provider failover as a **stateful Go control loop with a 5-state machine**, not a cron script | Explicit states + persisted transitions make failover auditable, resumable after restart, and safe against flapping | Extra service to run and monitor; a shared DB dependency | `failover-controller/` (this spec) |
+| **Hard safety caps**: `MaxDailyFailovers=1`, `FailoverCooldown=1h`, `MinTimeInState=5m`, optional `RequireManualAuth` | Failover is high-blast-radius (whole domain moves); caps prevent oscillation and runaway automation | A genuine second incident the same day needs manual override | `safety.go` |
+| **3 consecutive degraded checks** before failover; **10-min recovery cooldown** before failback | Debounce transient provider blips; avoid ping-ponging back to a still-flaky primary | Adds ~90s (3×30s) detection latency and 10-min failback latency | `statemachine.go` |
+| **Atomic JSON file** for controller state (not the DB) | Controller must know its own state even if the DB is the thing that failed; temp+rename is crash-safe | State is node-local; needs a PVC or restore on reschedule | `persistence.go` |
+| **Registrar behind an interface**, mock by default, real impl via `REGISTRAR_TYPE` | Portable across Namecheap/GoDaddy/Cloudflare Registrar; testable without touching production DNS | A misconfigured build silently no-ops (mock) | `registrar.go` |
+| **DR = warm-standby account re-provisioned by IaC**, data restored from backups; **not** continuous cross-region replication for RDS | Lowest steady-state cost; the full stack is already codified per region and re-appliable | Higher RTO (apply + scale-up + restore); RPO bounded by backup cadence | `terragrunt/dr/`, ADR-0032 |
+| **Vanilla RDS Multi-AZ, no Aurora / no read replica** | Simplicity; Multi-AZ covers the common AZ-failure case; PITR + snapshots cover data loss | No sub-minute cross-region DB failover; regional RDS outage needs snapshot restore | `catalog/units/rds`, ADR-0032 |
+| **Migrations as ArgoCD PreSync Jobs** (`backoffLimit:0`) | Runs once per sync, strictly before rollout; a failure blocks the sync and leaves current pods serving | No automatic down-migration; teams must ship idempotent, expand/contract migrations | ADR-0032 |
+| **Immutable log archive**: Object Lock (GOVERNANCE for ops logs, **COMPLIANCE for CloudTrail**) + SSE-KMS + cross-region CRR | Tamper-evident audit trail for PCI-DSS/SOC2/ISO27001; survives a region loss | COMPLIANCE objects cannot be deleted before retention even by admins; storage cost | ADR-0002, `centralized-logging` |
+| **Terraform-state DR**: S3 CRR + DynamoDB Global Tables, PR-driven region flip | Deploy capability survives a primary-region outage; locks stay consistent | Manual PR to flip; replica-side writes need manual sync-back | ADR-0002, `state-backend-dr` |
+| **Break-glass IAM users protected with `prevent_destroy` + `force_destroy=false`** | Emergency access must survive `terraform destroy`, stray `moved` blocks, and SSO outages | `destroy` on such an account always fails until the lifecycle block is removed (intentional friction) | **ADR-0011** |
+| **Serving fails over cross-region; batch/training is region-pinned + re-queued** | GPU jobs are gang-scheduled and stateful-in-flight; migrating them mid-run is unsafe | A region loss loses in-flight training progress (re-queued, not migrated) | ADR-0044, ADR-0036 |
+| **Global Accelerator anycast for the transaction plane** (no DNS change on failover) | ~30s network-layer reroute; no client DNS-cache dependency | TCP-only health — app-level failures need manual traffic-dial failover | `docs/multi-region/`, ADR-0043 |
+
+Additional cited ADRs: **ADR-0035** (Control Tower + AFT is the *intended* account-vending
+substrate under which the `dr`/`log-archive` accounts are enrolled — planning-only today);
+**ADR-0043** (cross-cluster ClusterMesh substrate the federation rides); **ADR-0052** (bare-metal
+Rook-Ceph + CloudNativePG streaming DR); **ADR-0037/0048** (ML artifact-store lineage).
+
+---
+
+## 4. Implementation blueprint
+
+### 4.1 Directory layout (load-bearing paths)
+
+```
+failover-controller/            # L1 Go control loop
+├── main.go            # 30s ticker, HTTP :8080 (/metrics /healthz /readyz /state), signal handling
+├── statemachine.go    # 5 states, thresholds, transition handlers
+├── safety.go          # SafetyParams, validTransitions map, ValidateTransition
+├── persistence.go     # ControllerState, atomic file StateStore
+├── healthstore.go     # PostgresHealthStore, score formula (0.6/0.3/0.1)
+├── registrar.go       # RegistrarClient interface + MockRegistrarClient
+├── storage.go         # *sql.DB pool (lib/pq), MaxOpenConns=5
+└── Dockerfile         # golang:1.26-alpine → alpine:3.24, nonroot uid 65532
+database/migrations/V1__initial_schema.sql   # 5 tables (Flyway)
+
+terragrunt/
+├── root.hcl           # remote_state (S3+DynamoDB / sandbox use_lockfile), retry_max_attempts=3
+├── dr/account.hcl     # DR sizing knobs (warm standby); regions eu-west-1/2/3, eu-central-1
+├── dr/<region>/platform/terragrunt.stack.hcl   # full stack, identical to prod, scaled down
+├── log-archive/account.hcl                      # immutable log sink account
+└── _envcommon/{centralized-logging,kms}.hcl     # Object Lock, CRR, CMK inventory
+
+terraform/modules/
+├── aws-ml-artifact-store/     # S3 + TLS-deny + ABAC + Pod Identity + lifecycle
+├── centralized-logging/       # Object Lock GOVERNANCE + SSE-KMS + DR CRR
+├── cloudtrail/                # Object Lock COMPLIANCE (WORM)
+├── state-backend{,-dr}/       # state S3+DynamoDB, cross-region replica + Global Table
+├── rds{,-postgres}/           # RDS wrappers (legacy + service-owned)
+└── break-glass-user/          # prevent_destroy + MFA policy (ADR-0011)
+apps/infra/velero/values.yaml  # dual backupStorageLocation, schedules, SSE-KMS
+docs/runbooks/                 # DISASTER_RECOVERY.md, state-backend-failover.md, velero-restore.md, DNS_*
+docs/multi-region/runbooks/    # failover-auto.md, failover-manual.md, region-recovery.md
+```
+
+### 4.2 Load-bearing snippets (sanitized)
+
+**RDS live unit** (`catalog/units/rds/terragrunt.hcl`) — sizing flows from `account.hcl`:
+
+```hcl
+terraform { source = "tfr:///terraform-aws-modules/rds/aws?version=7.1.0" }
+inputs = {
+  engine = "postgres"  engine_version = "17.7"  family = "postgres17"
+  instance_class          = local.account_vars.locals.rds_instance_class      # per-env
+  allocated_storage       = local.account_vars.locals.rds_allocated_storage
+  multi_az                = local.account_vars.locals.rds_multi_az
+  backup_retention_period = local.environment == "prod" ? 30 : 7              # 30d prod / 7d rest
+  deletion_protection     = contains(["prod", "staging"], local.environment)  # NOT dr/dev
+  storage_encrypted = true
+  kms_key_id        = dependency.kms.outputs.key_arns["rds"]                  # customer CMK
+  manage_master_user_password = true                                         # RDS-managed secret
+  # rds.force_ssl=1 parameter group (apply_method = pending-reboot)
+}
+```
+
+**Immutable log archive** (`_envcommon/centralized-logging.hcl` inputs → `centralized-logging`):
+
+```hcl
+enable_object_lock = true   object_lock_mode = "GOVERNANCE"  object_lock_retention_days = 365
+use_kms_encryption = true   enable_replication = true         enable_cross_account_writes = true
+lifecycle_standard_days = 90  lifecycle_glacier_days = 365    lifecycle_expiration_days = 2555 # ~7yr
+# DR replica: ${bucket}-dr in {{DR_REGION}}, delete_marker_replication = Enabled
+```
+
+**TLS-deny bucket policy** (identical shape on every state/log/artifact bucket — CIS/FSBP):
+
+```json
+{ "Sid": "DenyInsecureTransport", "Effect": "Deny", "Principal": "*",
+  "Action": "s3:*", "Resource": ["<bucket-arn>", "<bucket-arn>/*"],
+  "Condition": { "Bool": { "aws:SecureTransport": "false" } } }
+```
+
+**Velero DR** (`apps/infra/velero/values.yaml`, excerpt): two `backupStorageLocation`s
+(`aws-primary` default + `aws-dr`, `kmsKeyId` **required**), EBS `volumeSnapshotLocation`s
+primary+DR, `defaultBackupTTL: 720h`, `schedules.daily-full "0 2 * * *"` (ttl 720h),
+`weekly-full "0 3 * * 0"` (ttl 2160h), `features: EnableCSI`, `deployNodeAgent: true`.
+
+**State backend** (`root.hcl`, sanitized) — note the sandbox branch uses S3 native locking:
+
+```hcl
+config = merge(
+  { bucket  = "tfstate-${account_name}-${aws_region}"
+    key     = "${environment}/${path_relative_to_include()}/terraform.tfstate"
+    region  = state_bucket_region  encrypt = true },
+  is_sandbox
+    ? { use_lockfile = true  dynamodb_table = null }                 # S3 native lock (TF ≥ 1.10)
+    : { use_lockfile = false dynamodb_table = "terraform-locks-${account_name}" } )
+```
+
+### 4.3 Ordering / dependencies (what must exist before what)
+
+1. **State backend** (`bootstrap/state-backend/` via plain `terraform apply`, local state) → then
+   `state-backend-dr` (needs source DynamoDB streams; gated by `enable_dynamodb_streams`).
+2. **KMS CMK inventory** (`_envcommon/kms.hcl`) → before any SSE-KMS bucket/RDS/Velero (they
+   reference `key_arns[...]` / `alias/velero` / `alias/log-archive`).
+3. **Per-region platform stack** dependency chain (Terragrunt-managed): `vpc, secrets` →
+   `eks` → `karpenter, monitoring, rds`. `rds` depends on `vpc, eks, secrets, kms`.
+4. **L1 controller**: `database/migrations` applied → `dns-monitor` populating
+   `health_check_results` → **then** `failover-controller` (empty scores otherwise no-op).
+5. **Log archive**: `log-archive` account + `_envcommon/centralized-logging.hcl` unit wired before
+   producer accounts point CloudTrail/Config/VPC-Flow/EKS-audit at it (see §7 pitfall — not yet
+   instantiated in the reference estate).
+
+---
+
+## 5. Parameterization table
+
+Global placeholders are defined in `SPEC-00-overview.md`. Spec-local placeholders below.
+
+| Placeholder | Meaning | Example shape |
+|---|---|---|
+| `{{PRIMARY_REGION}}` / `{{DR_REGION}}` | primary + DR AWS regions | `eu-west-1` / `eu-central-1` |
+| `{{DR_ACCOUNT_ID}}` | DR (warm-standby) account ID | `444444444444` |
+| `{{LOG_ARCHIVE_ACCOUNT_ID}}` | immutable log-sink account ID | `888888888888` |
+| `{{DOMAIN}}` | domain the controller fails over | `platform.example.com` |
+| `{{REGISTRAR}}` | domain registrar (drives `REGISTRAR_TYPE`) | `namecheap` \| `godaddy` |
+| `{{PRIMARY_DNS_PROVIDER}}` / `{{SECONDARY_DNS_PROVIDER}}` | active / standby DNS providers | `cloudflare` / `route53` |
+| `{{STATE_BUCKET}}` | Terraform state bucket | `tfstate-{{ORG}}-{{PRIMARY_REGION}}` |
+| `{{SANDBOX_ACCOUNT_ID}}` | personal/sandbox account (S3-native-lock path) | `123456789012` |
+
+**Sizing knobs** (defaults observed here; resize per client):
+
+| Knob | Where | Default (this estate) | Resize guidance |
+|---|---|---|---|
+| `DegradeThreshold` / `RecoveryThreshold` | `statemachine.go` | 0.5 / 0.7 | Lower degrade for eager failover; widen the gap to add hysteresis. |
+| `ConsecutiveDegradedChecksRequired` | `statemachine.go` | 3 (×30s ≈ 90s) | Raise for noisier providers; lower to cut detection latency. |
+| `MaxDailyFailovers` / `FailoverCooldown` | `safety.go` | 1 / 1h | Raise cap only with strong anti-flap confidence. |
+| `RequireManualAuth` | `safety.go` | `false` (→ `true` in prod initially) | Keep `true` until failover is trusted end-to-end. |
+| tick interval | `main.go` | 30s | Trades detection latency vs DB/registrar load. |
+| `rds_instance_class` / `_allocated_storage` / `_multi_az` | `account.hcl` | prod `db.r6g.xlarge`/100/true · dr+staging `db.r6g.large`/50/true · dev `db.t4g.medium`/20/false | Match prod IOPS; keep DR ≥ the tier you must serve on. |
+| `backup_retention_period` | `catalog/units/rds` | prod 30d / others 7d | Set to your RPO tier (see §5.1). |
+| Velero `daily/weekly TTL` | `velero/values.yaml` | 720h / 2160h | Align with retention + restore SLA. |
+| `object_lock_retention_days` | `centralized-logging.hcl` | 365 (GOVERNANCE); CloudTrail COMPLIANCE 365 | Set to the longest regulatory hold; COMPLIANCE is irreversible. |
+| `lifecycle_expiration_days` | log buckets | 2555 (~7yr) | Match audit-retention regulation. |
+| DR pod CIDRs | federation | A `10.10.0.0/16` / B `10.20.0.0/16` | Must be non-overlapping for ClusterMesh. |
+
+### 5.1 What the client must decide — RTO/RPO tiers
+
+The reference estate **does not publish numeric RTO/RPO for the GPU-ML federation** (it relies on
+health-check detection windows). Numeric targets exist only in adjacent estates and are the shape a
+client should adopt and tune:
+
+| Tier | Example workload | RTO | RPO | Knobs that set it |
+|---|---|---|---|---|
+| **T0 tx/critical** | trading / UK-DC | < 15m planned, < 30m unplanned | < 60s | streaming replication (CNPG), Global Accelerator ~30s, MinIO site-replication |
+| **T1 relational DB** | platform Postgres | ~1h (snapshot restore) | 5m (PITR) | RDS Multi-AZ + PITR; add cross-region snapshot copy for regional DR |
+| **T2 observability** | metrics/logs in S3 | 2h | 0 (data in S3) | re-deploy stack; data already durable in object store |
+| **T3 GPU serving** | inference | health-detect (~30s) + failover | stateless | `failover-controller` DNS failover + scale-to-zero standby pools |
+| **T3 GPU batch** | training | re-queue, not migrated | last checkpoint | checkpoint cadence to durable store |
+
+A client picks a tier per service, then sets: RDS `backup_retention_period` + optional
+cross-region snapshot copy (RPO), DR account sizing + whether it is warm vs cold (RTO), Velero
+schedule/TTL, Object Lock mode + retention, and the controller thresholds/caps.
+
+### 5.2 Failure-mode matrix (failure · blast radius · detection · response · automated?)
+
+| Failure | Blast radius | Detection | Response | Automated? |
+|---|---|---|---|---|
+| Primary DNS provider degrades | Domain resolution slows/fails globally | `dns-monitor` score `< 0.5`, 3× (~90s) | `failover-controller` swaps NS to secondary at registrar | ✅ (capped: 1/day, 1h cooldown; `RequireManualAuth` can gate) |
+| Both DNS providers down | Total resolution outage | Both scores low; controller cannot pick a healthy target | Manual: activate 3rd emergency provider, upload octoDNS zone (`DISASTER_RECOVERY.md` Scenario B) | ❌ manual |
+| Failover-controller / EKS control plane down | No automated DNS failover | Missing `/healthz`, absent metrics, alerts | Manual registrar override (bypasses safety checks); restore control plane | ❌ manual |
+| Shared Postgres corrupt/down | Controller & monitor blind (no fresh scores) | Query errors; stale `check_timestamp` | Restore from RDS snapshot/AWS Backup; repoint `database-url` secret; restart pods (Scenario C) | ❌ manual (restore) |
+| Single AZ failure (RDS) | One AZ of the DB | RDS Multi-AZ health | Automatic Multi-AZ standby promotion | ✅ (Multi-AZ, prod/staging/dr) |
+| Regional RDS outage | Whole DB in a region | RDS/region alarms | Restore latest snapshot into `{{DR_REGION}}` / DR account; repoint secret | ❌ manual (no cross-region replica) |
+| Region-level app outage (transaction plane) | All traffic to that region | Global Accelerator TCP/443 health, 3× (~30s) | GA reroutes anycast to healthy region; no DNS change | ✅ (network-layer) |
+| App-level degradation (5xx, healthy TCP) | Users on that region get errors | Dashboards/alerts (GA won't catch it) | Manual traffic-dial → 0% for the region (`failover-manual.md`) | ❌ manual |
+| Primary-region Terraform-state outage | Deploy capability (not prod traffic) | `terragrunt init/plan` fails > 15m; AWS Health | PR repoints backend to DR replica; force-unlock stale locks (`state-backend-failover.md`) | ❌ manual (PR) |
+| EKS node / PV loss | Stateful pods on that node | Pod/PVC alerts | Velero restore (PV from EBS snapshot); Karpenter re-provisions nodes | ⚠️ semi (Velero restore is manual) |
+| GPU region loss (serving) | Inference in that region | Health-probe / DNS failover | `failover-controller` shifts serving to standby region (scale-to-zero pools spin up) | ✅ serving only |
+| GPU region loss (training) | In-flight batch jobs | Job/scheduler alerts | Jobs re-queued in healthy region from last checkpoint (NOT migrated) | ⚠️ re-queue, not migrate |
+
+### 5.3 DR runbook shape (the estate's runbook library)
+
+The estate keeps a runbook per failure class; a rebuild should mirror this shape. Every runbook is:
+**trigger → decision tree → action steps → verification → recovery/failback → post-incident review**.
+
+| Runbook | Scenario | Core action |
+|---|---|---|
+| `docs/runbooks/DISASTER_RECOVERY.md` | Region outage / total DNS outage / DB corruption | A: manual registrar override + deploy stack to secondary region + restore DB snapshot. B: emergency 3rd DNS provider + upload zone. C: restore DB from AWS Backup + repoint secret + restart pods. |
+| `docs/multi-region/runbooks/failover-auto.md` | NLB/region loss (transaction plane) | GA auto-reroute (~30s); TCP-only; documents what does/doesn't trigger it. |
+| `docs/multi-region/runbooks/failover-manual.md` | App-level degradation | Traffic-dial → 0% for the region; gradual 10→50→100% ramp on recovery; rollback to 0% if it re-fails. |
+| `docs/multi-region/runbooks/region-recovery.md` | Bringing a failed region back | Verify EKS/nodes/Cilium/ClusterMesh; GA ramp 10→50→100% with 5-min soaks; post-incident review ≤ 48h. |
+| `docs/runbooks/state-backend-failover.md` | Primary state-region outage | PR repoints `bucket`+`region` to DR replica; force-unlock orphaned locks; `aws s3 sync` back on failback. |
+| `docs/runbooks/velero-restore.md` | K8s app/PV loss or whole-cluster DR | `velero restore create` (namespace, resource, or whole-cluster); cross-region restore from `aws-dr` label. |
+| `docs/runbooks/DNS_*` (SPEC-02) | DNS failover initiated / provider degraded / sync failure | Operator-facing detail for each L1 event. |
+
+**Drill cadence:** quarterly — practice the "controller down → manual registrar override" and the
+region-recovery traffic ramp; schedule failover tests (scale a region's deployments to 0).
+
+### 5.4 Data classification → storage mapping
+
+| Class | Examples | Store | Durability controls |
+|---|---|---|---|
+| **Regulated audit / immutable** | CloudTrail, Config, VPC Flow, EKS audit | `centralized-logging` S3 (log-archive account) | Object Lock (CloudTrail **COMPLIANCE** / ops **GOVERNANCE**) 365d, SSE-KMS, cross-region CRR, expire ~7yr |
+| **Relational transactional** | platform DB, tenant metadata, `dns_failover` schema | RDS PostgreSQL Multi-AZ | SSE-KMS CMK, `force_ssl`, backups 30d(prod)/7d, PITR; DR = snapshot restore |
+| **ML artifacts / datasets** | MLflow artifacts, models, datasets | S3 (`aws-ml-artifact-store`) / GCS / MinIO-Ceph | Versioning, SSE-KMS (⚠ AES256 fallback), lifecycle IA→Glacier→expire; per-region (no CRR) |
+| **Kubernetes app + PV state** | StatefulSets (chains, VictoriaMetrics, RabbitMQ) | EBS `gp3` + Velero | Velero daily/weekly, EBS snapshots, cross-region `aws-dr` bucket, SSE-KMS |
+| **Infra state / locks** | Terraform state, lock table | S3 `tfstate-*` + DynamoDB | Versioning, SSE-KMS, `prevent_destroy`, PITR; DR = CRR + Global Tables |
+| **Secrets** | DB creds, provider tokens | AWS Secrets Manager / Vault via ESO | RDS-managed master password; ESO refresh; SSE-KMS; never in TF state/`.tfvars` |
+| **Ephemeral scratch** | build temp, non-durable caches | `emptyDir` / local-path | None — must not hold stateful ML data (ADR-0052 D5) |
+
+---
+
+## 6. Best practices distilled
+
+1. **Separate the detector from the actuator.** `dns-monitor` measures; `failover-controller`
+   decides and acts. A bug in scoring cannot directly move DNS, and the actuator can be reasoned
+   about (and safety-capped) independently. *Why:* smaller blast radius, testable in isolation.
+2. **Persist controller state atomically and locally, not in the database you might be failing over
+   from.** Temp-file + rename survives a crash mid-write; a corrupt file degrades to a safe default.
+   *Why:* the controller must remain deterministic even when its data plane is the thing that broke.
+3. **Guard-rail every automated failover with hard caps.** `MaxDailyFailovers`, a cooldown, a
+   minimum dwell time, and a manual-auth kill-switch. *Why:* the worst failover automation failure
+   is oscillation; caps convert "runaway" into "one action, then a human".
+4. **Debounce before you act, cool down before you revert.** 3 consecutive bad checks in; a 10-min
+   stability window before failback. *Why:* transient provider blips must not trigger a real,
+   costly provider swap, and a flaky primary must not be trusted the instant it looks up.
+5. **Prefer network-layer failover (anycast) where you can.** Global Accelerator reroutes in ~30s
+   with no client DNS-cache dependency; DNS-provider failover is the fallback for when the whole
+   provider is the failure. *Why:* DNS TTLs make DNS failover slow and uneven.
+6. **Make DR an *account*, defined as IaC, sized down — not a second live environment.** The `dr`
+   account carries the same stack, so recovery is `apply` + scale-up + restore, reviewed like any
+   change. *Why:* a warm standby you can rebuild beats a hot mirror you pay for and let drift.
+7. **Encrypt in transit *and* deny plaintext at the bucket.** Every state/log/artifact bucket
+   carries `DenyInsecureTransport` on top of SSE-KMS. *Why:* defence in depth; a missing
+   client-side flag fails closed, not open.
+8. **Use Object Lock for audit data — COMPLIANCE where regulation demands true WORM.** CloudTrail
+   is COMPLIANCE (no one, including admins, deletes before retention); ops logs are GOVERNANCE.
+   *Why:* tamper-evidence for PCI-DSS/SOC2/ISO27001; pick the strictest mode you can operate.
+9. **Replicate the things you cannot recreate — state and audit logs — cross-region.** Terraform
+   state (CRR + DynamoDB Global Tables) and the log archive (CRR) both survive a region loss.
+   *Why:* you can re-apply infrastructure, but you cannot re-derive lost state or lost audit trail.
+10. **Run schema migrations as a pre-deploy gate, not per-pod.** ArgoCD PreSync Jobs run once,
+    strictly before rollout, `backoffLimit:0`; a failure blocks the sync and leaves current pods
+    serving. *Why:* eliminates the multi-replica migration race and the "neither version available"
+    window of init-container migrations.
+11. **Protect break-glass identities with `prevent_destroy`.** Plan-time protection beats
+    apply-time (`force_destroy=false`) because it stops a destroy from even being *planned*.
+    *Why:* emergency access must survive a stray `terraform destroy` or `moved` block (ADR-0011).
+12. **Drill quarterly and ramp traffic back gradually.** Practise the manual registrar override and
+    the region recovery (10% → 50% → 100% traffic dial). *Why:* an untested runbook is a hypothesis;
+    a thundering-herd restore causes a second outage.
+13. **Classify data first, then map storage + durability to the class.** Each class (audit, tx,
+    artifacts, PV, state, secrets, scratch — §5.4) has one home and one durability contract.
+    *Why:* prevents regulated data landing in a non-immutable bucket or secrets in Terraform state.
+
+---
+
+## 7. Known pitfalls
+
+1. **As-built divergence — the log-archive design is not wired.** `terragrunt/log-archive/<region>/` contains only
+   `region.hcl` — no unit includes `_envcommon/centralized-logging.hcl`. Object Lock, KMS,
+   cross-account policy, and DR replication are **designed but not instantiated**. A rebuild must
+   actually create the unit; do not assume immutability is live because the module exists.
+2. **As-built divergence — ML artifact store silently downgrades encryption.** `aws-ml-artifact-store` defaults
+   `kms_key_arn=""` → **AES256 (SSE-S3), not SSE-KMS**. Pass a CMK explicitly for any regulated
+   data. It also has **no Object Lock and no replication** — it is not a durable-of-record store.
+3. **As-built divergence — lifecycle wiring mismatch in `centralized-logging`.** `_envcommon` passes
+   `lifecycle_glacier_days=365`, but the module transitions to GLACIER on the *unset*
+   `lifecycle_ia_days` (default **90**); `lifecycle_glacier_days` is defined-but-unused there. Audit
+   the actual transition, don't trust the input name.
+4. **As-built divergence (confirm intent) — Object Lock mode divergence (GOVERNANCE vs COMPLIANCE).** Only the **CloudTrail** bucket is true WORM (COMPLIANCE); the
+   general log archive is **GOVERNANCE** (an admin with the bypass permission *can* delete). If a
+   client needs regulator-grade immutability for all logs, promote to COMPLIANCE knowingly.
+5. **As-built divergence — RDS has no cross-region DR.** Multi-AZ covers AZ failure only; there is **no read replica and
+   no cross-region snapshot copy**. A regional RDS outage means restore-from-snapshot into the DR
+   region (T1 RTO ~1h). The DR account's RDS is a *fresh* instance, not a replica.
+6. **As-built divergence — DR account is a warm standby, and `deletion_protection=false` there.** DR RDS retention is 7d
+   (only prod gets 30d + deletion protection), and `enable_tgw_attachment=false` means DR is not yet
+   connected to the network hub. Treat DR as "codified, needs finishing", not "hot".
+7. **As-built divergence — three divergent RDS code paths.** `catalog/units/rds` (registry `7.1.0`, PG 17.7) vs
+   `terraform/modules/rds` (`~>6.0`, PG "17", `db_name=dns_failover`) vs `rds-postgres` (raw
+   `aws_db_instance`, PG "16"). Only the catalog unit is wired into platform stacks; do not copy the
+   legacy wrappers by mistake.
+8. **As-built divergence — `RequireManualAuth=false` by default.** The failover safety default ships permissive; the code
+   comment says set it `true` for production initially. A rebuild that skips this gives fully
+   automated DNS failover on day one.
+9. **`MaxDailyFailovers=1` can strand you.** A legitimate second incident the same calendar day
+   cannot auto-fail-over — it needs the manual registrar-override runbook. This is intentional but
+   must be operationally understood.
+10. **State-backend failback is not automatic.** S3 CRR is one-way; writes to the DR replica during
+    an outage must be `aws s3 sync`'d back before failback, or state diverges. Both buckets carry
+    `prevent_destroy` — never `aws s3 rb` / `delete-table` during an incident.
+11. **Batch/training does not fail over.** In-flight GPU jobs are region-pinned and re-queued.
+    Clients must checkpoint to a durable store; a region loss loses uncheckpointed progress.
+12. **Sanitize the sandbox path.** The reference `root.hcl` embeds a real sandbox account ID and a
+    real pre-existing bucket name; replace with `{{SANDBOX_ACCOUNT_ID}}` / `{{STATE_BUCKET}}` and
+    do not carry the hard-coded personal-account carve-out into a client build.
+
+---
+
+## 8. Acceptance checklist
+
+A rebuild passes when:
+
+- [ ] `failover-controller` starts, loads (or defaults) persisted state, exposes `/healthz`,
+      `/readyz`, `/state`, `/metrics`, and logs an initial evaluation within one tick.
+- [ ] With a synthetic primary score `< 0.5` sustained for 3 checks, the controller transitions
+      `HEALTHY→DEGRADED→FAILING_OVER`, calls `UpdateNameservers` to the secondary, and lands in
+      `FAILED_OVER`; a `< 0.5` blip that recovers before 3 checks returns to `HEALTHY`.
+- [ ] `ValidateTransition` **blocks** a second failover within `FailoverCooldown`, a failover once
+      `DailyFailoverCount ≥ MaxDailyFailovers`, and (when `RequireManualAuth=true`) any
+      `→ FAILING_OVER`.
+- [ ] Killing the controller mid-run and restarting resumes from the persisted state file (no
+      re-failover), and a corrupted state file degrades to `HEALTHY` without crashing.
+- [ ] `terragrunt run --all plan` is clean for the `dr` account from an empty account; the DR stack
+      composes the same units as prod at DR sizing.
+- [ ] RDS comes up Multi-AZ (prod/staging/dr), `storage_encrypted=true` with the `rds` CMK,
+      `rds.force_ssl=1` enforced, `backup_retention_period` = 30 (prod) / 7 (others),
+      `deletion_protection` on for prod+staging.
+- [ ] A DB migration ships as an ArgoCD **PreSync** Job (`hook-delete-policy: HookSucceeded`,
+      `backoffLimit:0`); a failing migration marks the Application `Failed` and does **not** start
+      the new rollout.
+- [ ] Velero has two `backupStorageLocation`s (`aws-primary` + `aws-dr`), both SSE-KMS; `daily-full`
+      and `weekly-full` schedules exist; a `velero restore` of one namespace succeeds and binds PVCs
+      from EBS snapshots.
+- [ ] Every state/log/artifact bucket denies `aws:SecureTransport=false`, blocks public access, and
+      carries `prevent_destroy`; the CloudTrail bucket is Object-Lock **COMPLIANCE**.
+- [ ] `state-backend-dr` replicates state `{{PRIMARY_REGION}}→{{DR_REGION}}` and the DynamoDB lock
+      table shows both regions as Global-Table replicas; the state-backend-failover runbook flips
+      the backend via a PR and `terragrunt plan` succeeds against the replica.
+- [ ] Global Accelerator health checks are TCP/443, 10s/3-threshold, both endpoint groups
+      `traffic_dial=100`; scaling a region's workloads to 0 shifts traffic within ~30s.
+- [ ] A quarterly DR drill (manual registrar override + region-recovery ramp 10→50→100%) is
+      scheduled and documented.
+
+---
+
+## 9. Dependencies on other specs
+
+- **SPEC-00** — global placeholders (`{{ORG}}`, `{{PRIMARY_REGION}}`, `{{DR_REGION}}`,
+  `{{STATE_BUCKET}}`, account IDs).
+- **SPEC-01 (Foundation IaC)** — the Terragrunt root/`_envcommon` skeleton, `versions.hcl`
+  (Terraform `1.14.8`, Terragrunt `1.0.8`, `aws ~> 6.0`), and the account/region hierarchy this
+  spec's DR account and state backend build on.
+- **SPEC-02 (Network & DNS)** — **tight coupling**: `dns-monitor` writes the
+  `health_check_results` this controller reads and owns the health-score formula; `dns-sync`
+  (octoDNS, YAML zone-of-truth, Cloudflare + Route53 targets, IRSA for Route53) is the zone source
+  used by the DR "upload zone to emergency provider" runbook. SPEC-02 also owns the **network
+  fabric** the L2 federation rides — Transit Gateway peering, Cilium ClusterMesh (WireGuard), VPC
+  CIDR allocation, and the DR account's `enable_tgw_attachment` wiring. The L1 failover here is the
+  actuator on top of SPEC-02's detection.
+- **SPEC-03 (Compute / EKS / Karpenter / KEDA)** — the platform stack the DR account re-provisions;
+  scale-to-zero standby GPU node pools.
+- **SPEC-04 (Delivery / GitOps)** — ArgoCD ApplicationSets, the PreSync-Job DB migration mechanism
+  (ADR-0032), and Velero delivery (`SPEC-04-delivery-gitops.md`).
+- **SPEC-05 (Security / IAM / Org)** — KMS CMK inventory, ABAC tag conditions, break-glass
+  (ADR-0011), and Control Tower/AFT account vending (ADR-0035) that governs the `dr` and
+  `log-archive` accounts.
+- **SPEC-07 (Observability)** — Grafana `multiregion-overview` / `clustermesh-status` dashboards,
+  the GA/CloudWatch alarms, and the Velero `ServiceMonitor` that make failover observable.
+- **SPEC-09 (AI-SRE)** — the advisory SRE layer that consumes these failover/DR signals
+  (`specs/SPEC-09-ai-sre.md`).
+- **SPEC-10 (ML Workloads)** — the GPU-ML federation whose serving-failover / batch-re-queue
+  semantics this spec documents at the resilience layer.
+```

--- a/specs/SPEC-09-ai-sre.md
+++ b/specs/SPEC-09-ai-sre.md
@@ -1,0 +1,525 @@
+# SPEC-09 — Advisory AI-SRE System ("Platform Brain SRE" / PB-SRE)
+
+> Portable blueprint for an **advisory-only, multi-agent AI Site-Reliability system** that
+> observes a multi-cluster Kubernetes/GPU platform, investigates alerts with LLM agents, and
+> posts human-actionable recommendations to Slack. It **never mutates infrastructure
+> autonomously**; every write is gated behind a human approval. This spec captures the
+> architecture, the defense-in-depth model that makes "advisory-only" an enforced property
+> (not a promise), the knowledge/memory design, the MCP tool surface, the deployment shape,
+> and the maturity ladder from advisory → gated execution.
+
+---
+
+## 1. Scope & non-goals
+
+**In scope.** A Python service (`claude-agent-sdk` + FastAPI + MCP) that: ingests alerts from
+Alertmanager/CloudWatch/Slack; deduplicates and enriches them; routes each to a specialized
+LLM agent (incident, GPU-health, scaling, cost, capacity, chaos, on-call copilot,
+runbook-automation, AWS-cloud) coordinated by an **Orchestrator** over a shared **Blackboard**;
+consults a topology/knowledge graph ("Omniscience") and a ClickHouse incident memory; and emits
+a structured advisory to Slack with approve/escalate/ack/snooze buttons. Includes the guardrail
+stack, the runbook engine with approval workflow, meta-observability (self-SLOs, cost, accuracy
+feedback), and the Kubernetes deployment manifests.
+
+**Non-goals.** This spec does not define the underlying platform's observability stack
+(VictoriaMetrics/ClickHouse/Grafana — see **SPEC-07**), the GitOps delivery machinery it opens
+PRs against (see **SPEC-04**), or the cluster/network foundation it reads. It does not describe
+building the Omniscience knowledge-graph service itself — PB-SRE is a *client* of that graph.
+
+**Honesty boundary (read before building).** In this estate the system is a **faithfully
+architected scaffold, partially simulated**. What is production-grade and real: routing,
+deduplication, the guardrail classes, MCP server registry/config, Slack Block Kit + approval
+handlers, all ClickHouse schemas, and every Kubernetes manifest (RBAC, NetworkPolicy,
+ExternalSecret, hardened Deployments, meta-alerts). What is **stubbed/simulated** and must be
+completed for a real deployment is called out explicitly in §4.7 and §7 — the actual Claude
+Agent SDK tool-calling loop, embedding-based retrieval, live runbook execution, and the push to
+the Omniscience graph (an in-process HTTP **mock** / dry-run today). Build the real loop into the
+seams the scaffold already defines; do not assume the agents currently reason over live tools.
+
+---
+
+## 2. Architecture
+
+### 2.1 The advisory loop: signal → enrich → advise → human
+
+```
+                      ┌──────────────────────── SIGNAL ───────────────────────┐
+  Alertmanager/VMAlert │  CloudWatch alarms │  Slack /sre command or @mention  │
+                      └───────────────┬────────────────────────────────────────┘
+                                      ▼
+                        ┌───────────────────────────┐   rate-limit 100/min
+                        │  Ingestion API (FastAPI)   │   dedup 5-min window
+                        │  /api/v1/alerts            │   (alertname:cluster:ns)
+                        └───────────────┬────────────┘
+                                        ▼  EnrichedAlert  ────────────── ENRICH
+                        ┌───────────────────────────┐   resource utilization,
+                        │  Orchestrator (Claude Opus)│   recent similar alerts,
+                        │  route_alert() → role      │   topology subgraph
+                        └───────────────┬────────────┘
+                    writes Alert signal ▼            reads/writes findings
+                        ┌───────────────────────────┐
+                        │  Shared Blackboard         │◀──────────────┐
+                        │  signals + subgraph +      │               │
+                        │  findings(Advisory[])      │               │ ADVISE
+                        └───────────────┬────────────┘               │
+             ┌──────────────┬───────────┼───────────┬───────────┐    │
+             ▼              ▼           ▼           ▼           ▼    │
+        Incident       GPU-Health   Scaling     Cost/Cap    AWS-Cloud│  (Claude Sonnet workers)
+        Response        agent       agent       agent        agent   │
+             │  each agent calls MCP tools (READ-ONLY) through guardrails
+             ▼
+        ┌──────────────────────────────── MCP TOOL SURFACE ──────────────────────────────┐
+        │ kubernetes-mcp(ro) │ aws-mcp(ro) │ metrics-mcp(ro) │ git-mcp(ro) │ runbook-mcp   │
+        │ slack-mcp(rw, output-only) │  Omniscience graph API (topology/RAG, read)        │
+        └────────────────────────────────────────────────────────────────────────────────┘
+                                        ▼  aggregate_advisories()
+                        ┌───────────────────────────┐
+                        │  Slack Advisory (BlockKit) │   ──────────────────── HUMAN
+                        │  Summary · RootCause(conf) │   [Approve Runbook]
+                        │  Recommended actions       │   [Escalate][Ack][Snooze]
+                        └───────────────┬────────────┘
+                                        ▼ human clicks Approve
+                        ┌───────────────────────────┐   15-min approval expiry
+                        │  Runbook engine            │   auto steps: [DRY RUN]
+                        │  approval_required → gate  │   privileged steps: human
+                        └────────────────────────────┘
+   Every hop is written immutably to ClickHouse `ai_sre.audit_log` / `ai_sre.agent_usage`.
+```
+
+The loop stops at **HUMAN** by design. No specialized agent writes to the cluster, cloud, or
+Git without a human clicking Approve on a specific runbook step; the "GitOps remediation"
+path (§4.6) produces a *Pull Request*, never a direct apply.
+
+### 2.2 Component roles
+
+| Component | Tech | Responsibility |
+|---|---|---|
+| **Ingestion API** | FastAPI, `ingestion/` | Accept Alertmanager/VMAlertmanager webhooks; rate-limit; dedup; enrich; route. |
+| **Orchestrator** | Claude Opus, `agents/orchestrator/` | Label-based routing to a specialist; run agents on the Blackboard; aggregate advisories; cross-layer AWS enrichment. |
+| **Blackboard** | dataclass, in-orchestrator | Shared canvas: `incident_signals`, `infrastructure_subgraph`, `findings: Advisory[]`. |
+| **Specialist agents** | Claude Sonnet, `agents/{incident,gpu-health,scaling,cost,ops,cloud}/` | Domain RCA / recommendation; write `Advisory` back to the Blackboard. |
+| **AWS-Cloud agent + collector** | `agents/cloud/` | Cross-layer EC2/EBS/TGW/GuardDuty correlation; background topology collector → Omniscience graph. |
+| **MCP servers** | `mcp-servers/`, external | `metrics-mcp` (VictoriaMetrics/ClickHouse), `runbook-mcp` (runbook engine), plus stdio servers for k8s/aws/git/slack. |
+| **Guardrails** | `guardrails/` | Tool allowlists + write-verb blocking, per-agent rate limits, circuit breaker, secret scanner, immutable audit. |
+| **Memory** | ClickHouse, `memory/` | `incident_store` (history/RAG), `topology_store` (static YAML or Omniscience), `slo_store`. |
+| **Omniscience** | Neo4j + Postgres + Qdrant (external) | Graph-of-record for platform topology + document/vector RAG. PB-SRE reads it; the collector writes it. |
+| **Slack app** | slack-bolt, `slack/` | Deliver advisories; run approval button workflow; `/sre` slash commands; feedback reactions. |
+| **Analytics/Observability** | ClickHouse + Prometheus, `analytics/`, `observability/` | Per-invocation usage/cost/findings; self-SLOs; human-accuracy feedback loop. |
+
+### 2.3 Model tiering
+
+`AgentModel.ORCHESTRATOR = claude-opus-4-*` (routing + synthesis, deeper reasoning, extended
+thinking tokens tracked separately); `AgentModel.WORKER = claude-sonnet-4-*` (specialist
+investigations). Temperature `0.0`, `max_tokens 4096` per agent definition.
+
+---
+
+## 3. Decision record
+
+| Decision | Rationale | Trade-off accepted | Source |
+|---|---|---|---|
+| **Advisory-only** (agents never mutate; humans approve every write) | Trust, blast-radius control, auditability while LLM reliability matures | Slower MTTR than closed-loop automation; a human must be in the loop | System-wide invariant enforced by §4.2 defense-in-depth; on-call integration governed by `ADR-0040 SOC2 posture + ML on-call` |
+| **Defense in depth, 4 layers** (MCP read-only → RBAC → NetworkPolicy → SDK guardrails) | No single control is trusted; the app-layer guardrail is the *last* line, not the only one | Redundant config to maintain across YAML + Python | `guardrails/read_only.py` header; `ADR-0011 break-glass / destroy protection` (least-privilege lineage) |
+| **Orchestrator + specialists over a shared Blackboard** | Divide domain expertise; let the Opus orchestrator synthesize; keep worker context small/cheap | Coordination complexity; blackboard is in-memory per investigation | `agents/orchestrator/agent.py` |
+| **Label-prefix routing** (e.g. `gpu_*`,`dcgm_*`→GPU-Health) | Deterministic, debuggable, zero-cost routing before spending tokens | Brittle to alert-name drift; unknown alerts fall to on-call copilot | `route_alert()` |
+| **Cross-layer AWS enrichment by default** | Most K8s symptoms (pod crash, node NotReady) have an EC2/EBS/TGW root cause | Extra read calls per investigation | `AGENT_TOOL_PERMISSIONS` (most agents hold read-only `aws-mcp`) |
+| **Omniscience graph-of-record for topology/RAG** (Neo4j+Qdrant), collector pushes state | One source of truth for dependencies + semantic runbook/incident retrieval | External dependency; **mocked in this estate** (§4.7) | `memory/topology_store.py`, `agents/cloud/collector.py`; graph model per `ADR-0055 logical-units: graph-of-record vs tag-projection` (see §9 caveat) |
+| **ClickHouse for audit/analytics/incidents** | High-ingest, columnar, cheap TTL'd retention; already in platform observability stack | Eventually-consistent; SQL string-building needs escaping discipline | `analytics/`, `memory/incident_store.py`; **SPEC-07** |
+| **Runbooks as Markdown + YAML frontmatter** with `auto_executable_steps` / `approval_required_steps` | Human-readable, Git-reviewable, powers a skills registry reused elsewhere | Parser must stay in lockstep with the doc format | `mcp-servers/runbooks/server.py`, `runbooks/*.md` |
+| **Remediation via GitOps PR, never direct apply** | Keeps the declarative Git source of truth authoritative; review gate | Even approved fixes wait for PR merge/sync | `agents/ops/gitops_remediation.py`; **SPEC-04** |
+| **Meta-monitoring: the AI-SRE has its own SLOs + circuit breaker + cost cap** | An observer that fails silently or runs away on cost is worse than none | Extra alert rules and daily cost ceiling to tune | `observability/slos.py`, `guardrails/rate_limiter.py`, `k8s/orchestrator/vmalert-rules.yaml` |
+
+---
+
+## 4. Implementation blueprint
+
+### 4.1 Directory layout
+
+```
+ai-sre/
+├── pyproject.toml            # py>=3.12, claude-agent-sdk>=0.1.56, fastapi, slack-bolt, clickhouse-connect
+├── Dockerfile               # python:3.12-slim, non-root 'aisre', uvicorn orchestrator.main:app
+├── agents/
+│   ├── orchestrator/        # agent.py (routing+blackboard), config.py (roles/prompts/perms), mcp_registry.py, main.py (FastAPI)
+│   ├── incident/            # multi-signal RCA specialist (+ investigation.py)
+│   ├── gpu-health/  scaling/  cost/  capacity(ops/)  chaos(ops/)  oncall(ops/)  runbook(ops/)
+│   └── cloud/               # agent.py, collector.py (topology→Omniscience), correlation.py, iam_policy.py
+├── guardrails/              # read_only.py, rate_limiter.py, audit.py, secret_scanner.py, migrations/
+├── ingestion/              # api.py, dedup.py, enrichment.py, router.py, models.py, migrations/
+├── knowledge/              # cilium-bgp-issues.md, eks-upgrade-checklist.md, gpu-driver-updates.md, nccl-troubleshooting.md
+├── memory/                 # incident_store.py, topology_store.py, slo_store.py, topology.yaml, models/, migrations/
+├── mcp-servers/            # metrics/server.py, runbooks/server.py
+├── observability/          # slos.py, feedback.py, cost_tracker.py, health.py, metrics.py, migrations/
+├── analytics/              # tracker.py, client.py, slack_feedback.py, migrations/001_create_analytics_schema.sql
+├── slack/                  # app.py, blocks.py, interactions.py, commands.py, channels.py, listeners.py
+├── runbooks/               # <slug>.md with YAML frontmatter (symptoms + step gating)
+└── k8s/                    # orchestrator/, slack-app/, ingestion/, mcp-servers/, clickhouse/
+```
+
+**Build order (what must exist before what):** ClickHouse DB + schemas (`analytics`, `guardrails`,
+`memory`, `ingestion`, `observability` migrations) → MCP servers reachable → secrets in the
+cloud secret manager → orchestrator/ingestion/slack Deployments → VMAlert meta-rules. The
+topology collector and Omniscience are optional at first (static `memory/topology.yaml` is the
+fallback).
+
+### 4.2 The crown jewel — how "advisory-only" is *enforced*, layer by layer
+
+Advisory-only is not a single flag; it is four independent controls, any one of which blocks a
+write. From the module header of `guardrails/read_only.py`:
+
+- **Layer 1 — MCP server config.** The Kubernetes MCP server runs with
+  `KUBERNETES_MCP_READ_ONLY=true` and `KUBERNETES_MCP_REDACT_SECRETS=true`; the AWS MCP server is
+  launched read-only. Servers refuse mutating calls before the agent's request reaches a cluster.
+
+  ```python
+  # agents/orchestrator/mcp_registry.py — DEFAULT_MCP_SERVERS (excerpt)
+  "kubernetes-mcp": MCPServerConfig(
+      name="kubernetes-mcp", transport=MCPTransport.STDIO, command="kubernetes-mcp-server",
+      env={"KUBERNETES_MCP_READ_ONLY": "true", "KUBERNETES_MCP_REDACT_SECRETS": "true"},
+      read_only=True),
+  # slack-mcp and runbook-mcp are the only read_only=False servers (output + gated execution)
+  ```
+
+- **Layer 2 — Kubernetes RBAC.** Every agent runs under its own ServiceAccount, all bound to a
+  single **read-only** ClusterRole. There is no Role anywhere that grants a write verb.
+
+  ```yaml
+  # k8s/orchestrator/rbac-per-agent.yaml — the ONLY ClusterRole, shared by all 9 agent SAs
+  kind: ClusterRole
+  metadata: { name: ai-sre-readonly }
+  rules:
+    - apiGroups: ["*"], resources: ["*"], verbs: ["get", "list", "watch"]
+    - apiGroups: [""],  resources: ["pods/log"], verbs: ["get"]
+  ```
+
+- **Layer 3 — NetworkPolicy egress allowlist.** Orchestrator egress is pinned to the K8s API
+  (443), VictoriaMetrics vmselect (8481), ClickHouse (8123), in-namespace MCP servers (8080/8081)
+  and DNS. There is no open egress path to arbitrary cloud control-plane endpoints.
+
+- **Layer 4 — Agent SDK guardrails (application, last line).** `ToolCallGuard.validate()` runs
+  before every tool call and enforces three things: (a) the tool is in the agent-role allowlist;
+  (b) the per-agent `max_tool_calls` budget is not exhausted; (c) in `read_only` mode, the call is
+  not a write. Write detection scans both the **tool name** and **every string value in the tool
+  input** for a verb in `WRITE_VERBS`:
+
+  ```python
+  # guardrails/read_only.py
+  WRITE_VERBS = frozenset({"create","update","patch","delete","apply","cordon","uncordon",
+      "drain","taint","scale","rollout","restart","insert","alter","drop","truncate"})
+
+  def _is_write_operation(tool_name, tool_input=None) -> bool:
+      if any(v in tool_name.lower() for v in WRITE_VERBS): return True
+      for value in (tool_input or {}).values():
+          if isinstance(value, str) and any(v in value.lower() for v in WRITE_VERBS):
+              return True
+      return False
+  ```
+
+  Per-role guardrails apply least privilege: `gpu-health` gets 6 read tools / 30 calls / 180s;
+  the orchestrator and `oncall-copilot` get `["*"]`; **`runbook-automation` is the single role
+  with `read_only=False`** (max 50 calls) — and even it can only reach the runbook engine, which
+  itself gates privileged steps behind human approval (§4.5).
+
+- **Prompt-level reinforcement.** Every system prompt restates the invariant (Orchestrator:
+  *"Enforce advisory-only mode: you NEVER take autonomous actions… All write operations require
+  explicit human approval via Slack"*; Chaos: *"You NEVER execute chaos experiments
+  autonomously"*). Prompts are defense-in-depth reinforcement, **not** the enforcement — the four
+  layers above hold even if the model is jailbroken.
+
+- **Cross-cutting — audit + secret hygiene.** `AuditLogger` writes every tool call, Slack message,
+  and approval/denial immutably to `ai_sre.audit_log` (input sanitized of `password/token/secret/…`
+  keys first). `secret_scanner.scan_text()` redacts AWS keys, bearer/JWT/Slack/GitHub tokens,
+  private keys, etc. from any agent output **before** it is posted to Slack or logged.
+
+### 4.3 Ingestion, dedup, routing
+
+`POST /api/v1/alerts` accepts Alertmanager/VMAlertmanager webhooks. Pipeline per alert:
+rate-limit (sliding window, default 100/min → HTTP 429) → **dedup** (`AlertDeduplicator`,
+key = `alertname:cluster:namespace`, 5-min window; increments a count and suppresses re-investigation
+within the window; groups GC'd at 2× window) → enrich → `route_alert()`. Routing is prefix-based:
+
+```
+gpu_*, dcgm_*            → gpu-health          kube_pod_*, container_* → incident-response
+node_*, kubelet_*        → capacity-planning   cilium_*, network_*     → incident-response
+vllm_*                   → predictive-scaling  cost_*                  → cost-optimization
+ec2_*|ebs_*|spot_*|guardduty_*|securityhub_*|aws_quota_*|cloudwatch_* → aws-cloud
+(no match)               → oncall-copilot
+```
+
+For most K8s-layer alerts the orchestrator *also* runs the AWS-Cloud agent on the same Blackboard
+(`_needs_aws_enrichment`) to rule out an infrastructure root cause.
+
+### 4.4 Blackboard & advisory aggregation
+
+`InvestigationContext` seeds a `Blackboard` with the alert signal, links `blackboard.findings`
+to `context.advisories`, runs the routed specialist (and optionally AWS-Cloud) which read signals
++ `infrastructure_subgraph` and append `Advisory(agent_role, summary, root_cause, confidence,
+recommended_actions[], severity)`. `aggregate_advisories()` synthesizes them into
+`{status, advisories[], infrastructure_subgraph, aws_enrichment, timestamp}` for Slack.
+
+### 4.5 Runbook engine & approval workflow
+
+Runbooks are Markdown with YAML frontmatter; steps are gated in the frontmatter, not the body:
+
+```markdown
+---
+id: gpu-node-unhealthy
+category: gpu-health
+severity: high
+clusters: [gpu-inference, gpu-analysis]
+auto_executable_steps: [1, 2, 3]      # diagnostics only
+approval_required_steps: [4, 5]       # cordon / drain — human must click Approve
+---
+## Symptoms
+- DCGM XID errors detected
+## Steps
+### Step 1: Gather GPU diagnostics (auto)
+### Step 4: Cordon node (requires approval)
+```
+
+`runbook-mcp` `execute_runbook_step` returns `pending_approval` for approval-required steps, and
+`[DRY RUN] Would execute: <cmd>` for auto steps (real execution is a seam to implement, §4.7).
+The Slack side (`slack/blocks.build_runbook_approval_blocks` + `slack/interactions.py`) posts
+Approve/Deny buttons; approvals **expire after 15 minutes** (`APPROVAL_EXPIRY_SECONDS = 900`) and
+are logged with user id + timestamp. `suggest_runbook()` matches symptoms by keyword overlap
+today (embedding search is the documented upgrade).
+
+### 4.6 GitOps remediation (PR, not apply)
+
+`agents/ops/gitops_remediation.py` proposes config fixes by: checkout `-B <branch>` → string-replace
+in the target file → commit → optionally `git push` + `gh pr create` → restore original branch.
+It **opens a PR for human review**; it never merges or applies. This is the only write path to the
+platform and it flows through the same review gate as any human change (**SPEC-04**).
+
+### 4.7 What is simulated (build these seams for a real deployment)
+
+| Seam | Current state in estate | To productionize |
+|---|---|---|
+| Agent tool-calling loop | `orchestrator._run_agent` and `incident/agent.py` steps 2–6 **simulate** findings/subgraph; comments read *"In production, this would invoke the Claude Agent SDK"* | Wire `claude-agent-sdk` with `mcp_registry.to_sdk_config()` + per-role `AGENT_TOOL_PERMISSIONS`, run the real tool loop through `ToolCallGuard`. |
+| Omniscience push | `collector.py` uses an in-process `httpx.MockTransport`; a "live" token `sk_live_mock_token` / `OMNISCIENCE_DRY_RUN` **forces dry-run**, writing the graph payload to a local JSON artifact instead of Neo4j | Point `OMNISCIENCE_URL`/`OMNISCIENCE_TOKEN` at the real graph service; remove the mock transport; the real `push_to_omniscience()` POST `/api/v1/graph/sync` already exists. |
+| Retrieval | `incident_store.search_similar` and `runbook.suggest_runbook` use keyword matching; `similarity_score` is a placeholder `1.0` | Replace with Qdrant embedding search (GraphRAG). |
+| Runbook execution | auto steps return `[DRY RUN] Would execute` | Implement the executor service behind the approval gate; keep audit logging. |
+
+**Sanitization note (do not copy verbatim from the estate):** the mock handler in `collector.py`
+writes its artifact to a hard-coded developer path containing a personal home directory and a
+conversation UUID. That is an authoring leak — a real build MUST write to a configurable
+`{{ARTIFACT_DIR}}` (or nothing) and must not embed any personal path or ID.
+
+### 4.8 Data model (ClickHouse, `ai_sre` database)
+
+MergeTree, monthly `PARTITION BY toYYYYMM(timestamp)`, **365-day TTL** across the board:
+
+- `audit_log` — every tool call/message/approval (agent_id, agent_role, action, tool_name,
+  sanitized tool_input, cluster, namespace, approved_by, tokens_used, duration_ms, error).
+- `agent_usage` — one row per invocation: model, trigger_type, tokens_{input,output,thinking},
+  `cost_usd`, tool_calls_count, `mcp_servers_used Array`, outcome, `finding_id` FK.
+- `findings` — one row per discovered issue: finding_type, severity, category, affected_resource,
+  root_cause_summary, confidence, recommendations[], `is_cross_layer` (K8s+AWS both present).
+- `incidents` — history/RAG memory: symptoms[], root_cause(_category), resolution_steps[],
+  `resolution_source`, TTD/TTM/TTR seconds. `capture_resolution()` back-fills human resolutions so
+  agents can cite "how similar incidents were resolved" (the learning loop).
+- `feedback` — human reaction → advisory quality (helpful / unhelpful / root_cause_correct/wrong).
+
+### 4.9 Deployment (Kubernetes, namespace `ai-sre-system`)
+
+- **Orchestrator Deployment**: `replicas: 2`; `runAsNonRoot`, `readOnlyRootFilesystem: true`,
+  `allowPrivilegeEscalation: false`, `capabilities.drop:[ALL]`, `seccompProfile: RuntimeDefault`;
+  `emptyDir` `/tmp` (100Mi); requests `1 CPU / 2Gi`, limits `2 CPU / 4Gi`; `ADVISORY_ONLY="true"`;
+  `/healthz` liveness, `/readyz` readiness; Prometheus `/metrics` on 9090.
+- **Secrets** via External Secrets Operator: `ExternalSecret` pulls `ANTHROPIC_API_KEY`,
+  `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN` from the cloud secret manager (`ClusterSecretStore
+  aws-secrets-manager`, `refreshInterval: 1h`). No secret is ever committed.
+- **NetworkPolicy** (§4.2 Layer 3) constrains ingress (only in-namespace + monitoring) and egress
+  (443/8481/8123/8080/8081/53 only).
+- **Meta-monitoring** (`vmalert-rules.yaml`): `AISRESystemDown` (up==0 5m, critical),
+  `AISREHighErrorRate` (>30% 5m), `AISRECircuitBreakerOpen`, `AISREHighLatency` (p95>120s),
+  `AISREDailyCostHigh` (>$80) / `AISREDailyCostExceeded` (>$100, critical), `AISRELowAccuracy`
+  (<60% for 24h), plus recorded 30-day availability/latency error-budget series.
+- **Image** from `python:3.12-slim`, non-root `aisre` user, `uvicorn agents.orchestrator.main:app`.
+
+### 4.10 Guardrail runtime limits (defaults)
+
+`RateLimitConfig`: 10 investigations/agent/hour, 50 API calls/min, **$100/day cost cap**;
+circuit breaker trips at 30% error rate over a 300s window (min 5 samples) → OPEN for 600s →
+HALF_OPEN test. `can_proceed()` checks breaker → api rate → cost cap → per-agent rate in order.
+
+---
+
+## 5. Parameterization table
+
+| Placeholder / knob | Meaning | Default in this estate | Resize guidance |
+|---|---|---|---|
+| `{{AGENT_NAMESPACE}}` | K8s namespace | `ai-sre-system` | Keep one namespace; NetworkPolicies assume it. |
+| `{{PRIMARY_REGION}}` | region for clusters/secret store | `us-east-1` | Per SPEC-00. |
+| `{{HUB_CLUSTER}}` / spoke clusters | monitored clusters | `platform` (hub); `gpu-inference`, `blockchain`, `gpu-analysis` (spokes) | Edit `memory/topology.yaml`; routing/prompts reference these names. |
+| `{{ANTHROPIC_API_KEY}}` | LLM credential | secret `ai-sre/anthropic-api-key` | Rotate via secret manager; never inline. |
+| `{{SLACK_BOT_TOKEN}}` / `{{SLACK_APP_TOKEN}}` | Slack app creds | secret `ai-sre/slack-credentials` | Socket-mode app token + bot token. |
+| `{{OMNISCIENCE_URL}}` / `{{OMNISCIENCE_TOKEN}}` | knowledge-graph endpoint | `http://localhost:8000` / mock `sk_live_mock_token` | Point at real Neo4j+Qdrant service; unset token or `OMNISCIENCE_DRY_RUN=true` → mock. |
+| `{{CLICKHOUSE_URL}}` | audit/analytics/incident store | `http://clickhouse.monitoring.svc.cluster.local:8123` | Shared with SPEC-07 stack. |
+| `{{METRICS_MCP_URL}}` / `{{RUNBOOK_MCP_URL}}` | MCP HTTP servers | `…svc.cluster.local:8080` / `:8081` | In-namespace; NetworkPolicy pins these ports. |
+| `{{ARTIFACT_DIR}}` | collector mock output dir | *(hard-coded dev path — sanitize!)* | Set explicitly or disable; must contain no PII (§4.7). |
+| Orchestrator `replicas` | HA | `2` | Scale with alert volume; agents are stateless per investigation. |
+| Resources | cpu/mem | req `1/2Gi`, lim `2/4Gi` | Opus context is memory-light; scale for concurrency. |
+| `max_daily_cost_usd` | LLM cost cap | `100.0` | Primary cost lever; drives $80/$100 meta-alerts. |
+| `max_investigations_per_hour` / `max_api_calls_per_minute` | rate limits | `10` / `50` | Raise carefully; watch circuit breaker. |
+| Circuit breaker | threshold / window / cooldown | `0.30` / `300s` / `600s` | Lower threshold = more conservative auto-pause. |
+| Dedup / approval windows | suppression / approval TTL | `300s` / `900s` | Approval TTL must exceed on-call human response time. |
+| `max_tool_calls` per role | tool budget | 20–50 | Least privilege; unknown roles default to 20. |
+| ClickHouse TTL | retention | `365 DAY` | Compliance-driven; shorten to cut storage. |
+
+---
+
+## 6. Best practices distilled
+
+1. **Make "advisory-only" an enforced property, not a prompt.** Stack four independent controls
+   (MCP read-only config → read-only RBAC → egress NetworkPolicy → app-layer `ToolCallGuard`).
+   *Why:* a jailbroken or buggy model must still be physically unable to mutate; any single layer
+   holding is sufficient.
+2. **Scan tool *inputs*, not just tool *names*, for write verbs.** `_is_write_operation` inspects
+   every string argument. *Why:* a read-named tool (`run_query`, `exec`) can still carry
+   `DROP TABLE` or `kubectl delete` in its payload.
+3. **Least privilege per agent role.** Give each role the *minimum* tool allowlist, call budget,
+   and timeout; only `runbook-automation` is non-read-only, and only it reaches the gated engine.
+   *Why:* compromise of one specialist cannot escalate across the platform.
+4. **One ServiceAccount per agent, one shared read-only ClusterRole.** *Why:* per-SA identity gives
+   you audit granularity in K8s API logs while a single Role guarantees no write verb exists to grant.
+5. **Gate privileged runbook steps in frontmatter, with expiring approvals.** `auto_executable_steps`
+   vs `approval_required_steps` + a 15-minute Slack approval TTL. *Why:* diagnostics run freely;
+   destructive ops (cordon/drain) always need a fresh, attributable human click.
+6. **Remediate through Git PRs, never direct apply.** *Why:* the declarative Git state stays the
+   source of truth, and every fix — human or agent-proposed — passes the same review/sync gate.
+7. **Give the observer its own SLOs, cost cap, and circuit breaker.** Self-SLOs (99% within 5 min,
+   p95 first-advisory < 2 min, 80% helpful) + `$100/day` cap + auto-pause at 30% error rate.
+   *Why:* an SRE bot that runs away on cost or fails silently is a liability; it must fail safe.
+8. **Deduplicate before you spend a token.** 5-min `alertname:cluster:namespace` grouping stops an
+   alert storm from launching N parallel investigations. *Why:* cost and rate-limit protection.
+9. **Route deterministically before invoking a model.** Cheap label-prefix routing picks the
+   specialist; unknown alerts fall back to the on-call copilot. *Why:* debuggable, free, and it
+   keeps worker context tight.
+10. **Correlate cross-layer by default.** Most K8s symptoms have an EC2/EBS/TGW/GuardDuty root
+    cause; grant read-only `aws-mcp` to most agents and run the AWS-Cloud agent alongside. *Why:*
+    "pod CrashLoopBackOff + EBS impaired → root cause is storage, not the app."
+11. **Redact secrets on the way *out*.** `secret_scanner` runs on agent output before Slack/logs;
+    `audit._sanitize_input` redacts sensitive keys before storage. *Why:* an LLM can echo a secret
+    it read; stop it at the boundary.
+12. **Audit everything immutably with TTL.** Every tool call/approval to `ai_sre.audit_log`
+    (MergeTree, 365-day TTL). *Why:* post-incident forensics and compliance evidence.
+13. **Close the accuracy loop with humans.** Map Slack reactions → helpful / root_cause_correct,
+    emit per-agent `ai_sre_accuracy_ratio`, alert when <60%. *Why:* measured trust is the gate for
+    advancing maturity (§7 ladder).
+14. **Track thinking tokens and cost per invocation.** `agent_usage.tokens_thinking` + `cost_usd`.
+    *Why:* Opus extended-thinking is a real cost driver; you cannot cap what you do not measure.
+15. **Harden the pod.** Non-root, `readOnlyRootFilesystem`, drop ALL caps, seccomp RuntimeDefault,
+    secrets via ESO. *Why:* the SRE agent reads the whole fleet — it is a high-value target.
+
+### Maturity ladder (advisory → gated execution)
+
+| Stage | Capability | Gate to advance |
+|---|---|---|
+| **0 Shadow** | Investigate + post advisories; humans act manually | — |
+| **1 Advisory** *(this estate)* | Structured advisory + runbook *suggestions* + Approve/Escalate/Ack/Snooze; all writes manual | Sustained accuracy + audit coverage |
+| **2 Gated execution** | `runbook-automation` executes **auto** steps; privileged steps still human-approved (15-min TTL) | Per-agent accuracy ≥ target; executor + audit hardened |
+| **3 Supervised remediation** | Agent opens GitOps PRs automatically; human merges | PR-quality track record |
+| **4 Closed-loop (out of scope here)** | Auto-apply pre-approved runbooks for narrow, reversible ops | Formal error-budget policy + rollback proof |
+
+Advance a *capability at a time*, measured by the feedback loop — never flip the whole system to
+autonomous.
+
+---
+
+## 7. Known pitfalls
+
+1. **Prompt text is not a control.** Every prompt says "advisory-only," but only §4.2's four
+   layers enforce it. Do not weaken any layer trusting the prompt.
+2. **Write-verb substring matching is coarse.** `_is_write_operation` will flag a benign tool whose
+   name/args merely contain `scale`/`patch`/`drop` (false positives) and could miss an obscure
+   destructive verb (false negatives). Treat it as one layer of four; tune `WRITE_VERBS` per fleet.
+3. **As-built divergence — agents are simulated in this estate.** `_run_agent` and `incident`
+   steps 2–6 fabricate findings; a naïve deploy will post plausible-but-empty advisories. Wire the
+   real SDK loop first (§4.7).
+4. **As-built divergence — Omniscience is a dry-run mock.** With the default `sk_live_mock_token` /
+   `OMNISCIENCE_DRY_RUN`, the collector writes a local JSON artifact and never touches Neo4j.
+   Topology falls back to the static `memory/topology.yaml`. Provision the real graph before relying
+   on dynamic dependencies.
+5. **As-built divergence — authoring leak in `collector.py`.** The mock handler hard-codes a
+   personal home path + a conversation UUID as its artifact directory — must be sanitized to
+   `{{ARTIFACT_DIR}}` and never shipped (§4.7).
+6. **ClickHouse SQL is string-built.** `incident_store` interpolates values with a hand-rolled
+   `_escape`/`_array_str`. Keep inputs constrained and prefer parameter binding; agent-derived
+   strings reach these queries.
+7. **As-built divergence — keyword retrieval ≠ semantic retrieval.** `search_similar` and
+   `suggest_runbook` do keyword overlap and return `similarity_score = 1.0` placeholder. Do not
+   trust "related incidents" ranking until Qdrant embeddings are wired.
+8. **Runbook parser is format-coupled.** `_parse_runbook` keys off exact `### Step N:` / `## Symptoms`
+   headings and fenced code fences; a drifted doc silently yields zero steps. Lint runbooks in CI.
+9. **As-built divergence — in-memory dedup / approval / rate-limit state.** `AlertDeduplicator`,
+   `_pending_approvals`, and the sliding-window counters live in process, yet the Deployment targets
+   `replicas: 2` — so state is per-pod and dedup/cost caps are approximate under HA. Externalize
+   (Redis) before scaling out or tightening caps.
+10. **As-built divergence — daily cost cap resets on a rolling 24h from process start**, not at UTC
+    midnight, and is per-pod. Budgeting is approximate; the meta-alert on `ai_sre_daily_cost_usd` is
+    the real backstop.
+11. **Structlog vs stdlib logging mismatch.** Some modules call `logger.warning(..., key=val)`
+    (structlog kwargs) on a stdlib `logging` logger; verify a single logging config or messages will
+    be malformed. Standardize on structlog across services.
+12. **NetworkPolicy egress `0.0.0.0/0:443`** is required for the K8s API but is broad; pair with the
+    read-only RBAC (Layer 2) so wide egress cannot become a write path.
+13. **As-built divergence — no committed ADR governs this system.** The advisory-only invariant and
+    the Omniscience graph integration are the two most consequential decisions here yet have no
+    dedicated, committed ADR in `docs/adrs/` (only the unverified `ADR-0055` draft, §9). A rebuild
+    should author a committed ADR for both before promoting past Stage 1 of the maturity ladder.
+
+---
+
+## 8. Acceptance checklist
+
+- [ ] `kubectl auth can-i --list` for every `ai-sre-*` ServiceAccount shows **only** `get/list/watch`
+      (+`pods/log:get`); no verb grants create/update/patch/delete anywhere.
+- [ ] With `KUBERNETES_MCP_READ_ONLY=true`, a deliberately requested write tool is refused at the
+      MCP layer **and** blocked by `ToolCallGuard.validate()` (unit test on `_is_write_operation`).
+- [ ] `ToolCallGuard` blocks a tool outside the role allowlist, and blocks once `max_tool_calls` is
+      exceeded (per-role limits from `DEFAULT_GUARDRAILS`).
+- [ ] An Alertmanager webhook storm of identical alerts within 5 min produces exactly **one**
+      investigation (`alerts_deduplicated_total` increments).
+- [ ] `route_alert()` maps each documented prefix to the correct role; an unknown alert routes to
+      `oncall-copilot`.
+- [ ] A runbook `approval_required` step returns `pending_approval` and posts Approve/Deny buttons;
+      an approval older than 15 min is rejected; approve/deny is written to `ai_sre.audit_log` with
+      user id + timestamp.
+- [ ] `secret_scanner.scan_text()` redacts AWS key / bearer / JWT / Slack / GitHub token / private
+      key patterns; advisory output containing a secret is redacted before Slack.
+- [ ] All five migrations apply cleanly; `ai_sre.audit_log`, `agent_usage`, `findings`, `incidents`,
+      `feedback` exist with monthly partitions + 365-day TTL.
+- [ ] Orchestrator pod runs non-root, `readOnlyRootFilesystem`, caps dropped; `ExternalSecret`
+      materializes `ai-sre-secrets`; no secret in any manifest or image.
+- [ ] Meta-alerts fire in test: kill orchestrator → `AISRESystemDown`; force error rate >30% →
+      `AISREHighErrorRate` then `AISRECircuitBreakerOpen`; push cost >$100 → `AISREDailyCostExceeded`.
+- [ ] Self-SLO report renders (availability / p95 latency / accuracy) and `ai_sre_accuracy_ratio`
+      updates from a simulated Slack feedback reaction.
+- [ ] Collector with a real `{{OMNISCIENCE_URL}}`/token performs a live `POST /api/v1/graph/sync`
+      (mock transport disabled); with the mock, it writes only to a sanitized `{{ARTIFACT_DIR}}`.
+- [ ] GitOps remediation opens a **PR** (never a direct apply/merge) and restores the original branch.
+
+---
+
+## 9. Dependencies on other specs
+
+- **SPEC-07 (Observability)** — the AI-SRE **consumes** this stack: VictoriaMetrics (alerts source
+  via VMAlert webhooks + `query_metrics`), ClickHouse (log search + all `ai_sre.*` tables), and it
+  **produces** its own Prometheus metrics + VMAlert meta-rules that live alongside platform alerting.
+  Related: `ADR-0026 observability target architecture`, `ADR-0038 ML observability / drift→PagerDuty`,
+  `ADR-0039 self-serve observability`.
+- **SPEC-04 (Delivery / GitOps)** — the remediation path opens Pull Requests into the GitOps repo;
+  approved fixes reconcile through the platform's ArgoCD/CI, not through the agent.
+- **SPEC-00 (Overview)** — source of `{{ORG}}`, `{{PRIMARY_REGION}}`, and secret-store placeholders;
+  register any recurring placeholder introduced here (`{{OMNISCIENCE_URL}}`, `{{AGENT_NAMESPACE}}`).
+- **On-call governance** — `ADR-0040 SOC2 posture + ML on-call` frames how advisories integrate with
+  the human on-call rotation (PagerDuty/Slack) and the control-to-evidence audit expectation the
+  `audit_log` satisfies.
+
+> **ADR caveat (honesty).** The graph-of-record model behind Omniscience corresponds to
+> `ADR-0055 logical-units: graph-of-record vs tag-projection`, but that ADR is **not present in the
+> `docs/adrs/` snapshot** this spec was reverse-engineered from (it exists only as an untracked
+> draft in the source repo). Its content is therefore **unverified here** — cite it, but confirm
+> against the committed ADR before treating it as authoritative. No other ADR in the committed set
+> is dedicated to the AI-SRE system; the citations above are the governing adjacent decisions.

--- a/specs/SPEC-10-ml-workloads.md
+++ b/specs/SPEC-10-ml-workloads.md
@@ -1,0 +1,682 @@
+# SPEC-10 — ML / GPU Workloads (inference serving, model lifecycle, multi-cloud GPU ML)
+
+> Portable reverse-engineering of the platform's ML/GPU workload surface. A senior platform team
+> can rebuild the same model-serving stack, GPU capacity strategy, ML CI/CD, and multi-cloud
+> pattern for a new client from this document alone. Placeholders follow `SPEC-00-overview.md`.
+
+---
+
+## 1. Scope & non-goals
+
+**Scope.** The workloads the GPU platform exists to run: (a) the **model-serving reference
+architecture** — the OpenAI-compatible request path `client → WAF → Gateway API → InferencePool →
+Endpoint Picker (EPP) → vLLM pods on DRA-claimed GPUs`; (b) the **GPU capacity strategy** that feeds
+it — per-machine-family RDMA fabric, provisioner split, gang-scheduling queues, scale-to-zero; (c)
+the **model lifecycle** — Airflow training DAGs → MLflow registry → SBOM+signature → Kargo promotion
+→ ArgoCD deploy → drift-driven retrain; (d) the **multi-cloud ML pattern** expressing the same
+operating model on GKE (etalon), AWS/EKS, Azure/AKS, and owned bare-metal/Talos, including the
+Azure two-AKS cross-region federation and its three CI/CD pipelines; (e) **client-adaptation knobs**
+(GPU SKUs, model sizes, tensor-parallelism, latency/criticality tiers).
+
+**Non-goals.** This spec does not re-derive: the GPU-cluster **day-2 infra install** (NVIDIA GPU
+Operator, DCGM exporter, Volcano, DRA driver), the **node lifecycle / Karpenter / bare-metal
+re-imaging** capacity plane, and the **Cilium CNI + Gateway-API data-plane install** — all
+→ **SPEC-03 (Compute / Kubernetes)**; **cross-region DNS/failover, VPC/VNet peering & cross-cluster
+connectivity** → **SPEC-02 (Network & DNS)**; the **ArgoCD app-of-apps bootstrap + Kargo machinery**
+→ **SPEC-04 (Delivery & GitOps)**; the **ADR-0028 tagging taxonomy + Terraform/Terragrunt module &
+state conventions** → **SPEC-01 (Foundation/IaC)**; the **metrics/alerting backends**
+(VictoriaMetrics/Prometheus/Thanos/Grafana/Alertmanager) → **SPEC-07 (Observability)**; **supply-chain
+signing, secrets, and pod identity** → **SPEC-05 (Security)**. This spec references those by contract,
+not content, and covers only the ML-specific knobs on each.
+
+**Status of the estate.** Every ML/GPU ADR (0036–0054) is **Proposed / plan-and-validate-only /
+apply-gated**: modules default `enabled = false`, workflows are illustrative scaffolds. Rebuild
+these as design targets, not as already-wired production.
+
+---
+
+## 2. Architecture
+
+### 2.1 Model-serving reference architecture (the request path)
+
+The serving front is **model-aware and KV-cache-aware**, not an L4 round-robin load balancer. It is
+the [Gateway API Inference Extension](https://gateway-api-inference-extension.sigs.k8s.io/) layered
+on whatever Gateway API data plane the cloud provides.
+
+```
+                          OpenAI-compatible clients  (POST /v1/chat/completions {"model": "..."})
+                                       │
+                              ┌────────▼─────────┐   WAF / DDoS / rate-limit / TLS
+                              │   WAF layer      │   AWS WAF · Cloud Armor · Azure App-GW WAF · on-prem WAF
+                              └────────┬─────────┘
+                              ┌────────▼─────────┐   Gateway API data plane (per cloud):
+                              │  Gateway (L7)    │   Envoy Gateway (AWS default) · GKE Inference Gateway ·
+                              │  GatewayClass    │   App Gateway for Containers (Azure) · Cilium/Envoy (bare-metal)
+                              └────────┬─────────┘
+                              ┌────────▼─────────┐   Body-Based Router: reads body {"model":X} → header
+                              │   HTTPRoute      │   host/path + model-header match → backendRef=InferencePool
+                              └────────┬─────────┘
+                    ┌──────────────────▼───────────────────┐
+                    │  InferencePool  (set of replicas that │   spec.selector {app: vllm}
+                    │  share one accelerator + base model)  │   spec.targetPortNumber: 8000
+                    │  spec.extensionRef → <pool>-epp       │   spec.extensionRef → EPP service
+                    └──────────────────┬───────────────────┘
+                              ┌─────────▼────────┐  ext-proc gRPC :9002. Scores every replica on
+                              │ Endpoint Picker  │  KV-cache hit affinity · queue depth · running-req /
+                              │ (EPP, ext-proc)  │  GPU+KV util · LoRA-adapter affinity; picks best.
+                              └─────────┬────────┘
+        InferenceObjective (per model) │  criticality Critical>Standard>Sheddable · poolRef ·
+        modelName→targetModels (LoRA)  │  targetModels weights → canary/A-B (v3=90% / v4=10%)
+                    ┌──────────────────▼───────────────────┐
+                    │  vLLM replicas (3×)  :8000            │  Deployment, schedulerName: volcano,
+                    │  DRA GPU claim · TP=8 · LoRA · /dev/shm│  DRA ResourceClaim (not nvidia.com/gpu limits)
+                    └───────────────────────────────────────┘  NCCL over RDMA fabric (EFA/IB/RoCE/TCPX)
+```
+
+**Data-plane choice is per cloud, the CRD contract is identical** (ADR-0047 frames the decision as
+"not *inference gateway yes/no* — yes everywhere — but *which Gateway API data plane* hosts it, and
+*which WAF*"):
+
+| Cloud | Data plane | WAF | Source ADR |
+|---|---|---|---|
+| GCP/GKE | GKE Inference Gateway (managed) + Body-Based Router | Cloud Armor (+ optional Model Armor) | ADR-0042 |
+| AWS/EKS | Envoy Gateway (default) · ALB+Gateway API (fallback); **VPC Lattice explicitly NOT the inference front** | AWS WAF (`aws_wafv2_web_acl`) | ADR-0047 |
+| Azure/AKS | Application Gateway for Containers (Gateway API) + ALB controller | App Gateway WAF policy (regional OWASP) + Front Door WAF | diagram-only (no ADR) |
+| Bare-metal/Talos | Cilium L7 / Envoy Gateway (VIP via Cilium LB-IPAM+BGP, ADR-0051) | on-prem `baremetal-ingress-waf` (Cilium L7 or Envoy) | ADR-0053 |
+
+### 2.2 The inference CRD model and the v1 GA rename (ADR-0042/0047/0053)
+
+Pin CRD group **`inference.networking.k8s.io/v1` (v1 GA)** and `gateway.networking.k8s.io/v1`.
+
+- **`InferencePool`** — the set of model-server replicas sharing one accelerator + base model.
+  Graduated to **v1/stable** at GA (optional `InferencePoolImport` for cross-cluster). Attached to
+  the gateway via **`HTTPRoute`** (`backendRefs[].group: inference.networking.k8s.io`, `kind:
+  InferencePool`). Carries `spec.extensionRef` → the EPP service.
+- **`InferenceObjective`** — the per-workload **routing + criticality** object. **Renamed from
+  `InferenceModel` (v1alpha2) → `InferenceObjective` at v1 GA.** Maps a public model name →
+  `targetModels` in the pool with traffic-split **weights** (canary/A-B) and a **criticality** tier
+  (`Critical` > `Standard` > `Sheddable`; sheddable is dropped first under saturation). **Multi-LoRA
+  = one `InferenceObjective` per adapter.**
+- **`EPP` (Endpoint Picker)** — an Envoy **ext-proc** external processor (a *separate* Deployment +
+  Service, **not** installed by the gateway). Routes on real serving signals, not round-robin.
+
+> Migration: follow the project v1alpha2→v1 GA guide. The extension is young (v1 GA but evolving —
+> the `InferenceModel`→`InferenceObjective` rename *is* that evolution); the CRD version must be
+> pinned (`inferenceExtension.crdVersion: v1.0.0`), never `latest`.
+
+### 2.3 EPP scoring algorithm (why it beats round-robin)
+
+The EPP scores each candidate replica and picks the best (GKE overview + ADR-0047):
+
+1. **Prefix / KV-cache hit affinity** → route to the replica that already holds the prompt prefix →
+   lower TTFT (time-to-first-token).
+2. **Queue depth** → prefer shorter queues.
+3. **Running requests / GPU & KV-cache utilization** → avoid hot replicas.
+4. **LoRA-adapter affinity** → route to a replica that already has the adapter loaded.
+5. **Tie-break**: least-loaded, then round-robin.
+
+`InferenceObjective` overlays business rules on top: `weights` drive canary/A-B splits; `criticality`
+governs shedding order under saturation; per-client rate-limit lives in the WAF.
+
+### 2.4 vLLM serving pod (the workload)
+
+Serving runtime is **vLLM** (`vllm/vllm-openai`, OpenAI-compatible, port 8000), deployed as a
+**Deployment** (not StatefulSet), 3 replicas, `RollingUpdate maxUnavailable:1 maxSurge:0`,
+`schedulerName: volcano`, priority class `gpu-inference-medium`, Volcano queue
+`gpu-inference-default`. **GPU is allocated via DRA `ResourceClaimTemplate`, not `nvidia.com/gpu`
+limits** — this is the load-bearing modern choice (see §4). Tensor-parallel across 8 GPUs, LoRA
+enabled (`max-loras: 8`), 64Gi `/dev/shm` for NCCL, long `startupProbe` for weight load.
+
+### 2.5 GPU capacity strategy
+
+Three coupled decisions decide GPU capacity: **fabric per machine family**, **provisioner per
+workload class**, and **gang-scheduling queues + scale-to-zero**.
+
+**(a) Per-family high-performance fabric.** The NCCL collective fabric is the bottleneck for large
+models, and each cloud accelerates GPU networking differently *per machine family*, so a single
+fabric config cannot span SKUs. Baseline everywhere: **jumbo frames** + RDMA. Matrix:
+
+| SKU | GCP (ADR-0042) | AWS (ADR-0045) | Bare-metal (ADR-0053) |
+|---|---|---|---|
+| A100 80GB | `a2-ultragpu` gVNIC ~100 Gbps | `p4d`/`p4de` EFA 400 Gbps | A100 pool, IB HDR, MIG-capable |
+| H100 80GB | `a3-highgpu-8g` GPUDirect-**TCPX** (4 NICs) ~800 Gbps | `p5` EFAv2 3.2 Tbps | H100 pool, RoCEv2 200/400G, NVLink |
+| H100-Mega | `a3-megagpu-8g` GPUDirect-**TCPXO** (8 NICs) ~1.8 Tbps | — | — |
+| H200 141GB | `a3-ultragpu-8g` RoCE via **DRANET** 3.2 Tbps | `p5en` EFAv3 3.2 Tbps | H200 pool, IB NDR + SHARP |
+| B200 | `a4-highgpu-8g` RoCE via DRANET 3.2 Tbps | `p6`/P6-B200 EFA 3.2 Tbps | — |
+| cheap inference | — | `g6e`/`g5` (L40S) | L40S pool 48GB |
+
+MTU: GCP 8896, AWS 9001 (VPC max), bare-metal 9000. **Acceptance gate for any fabric: an NCCL
+all-reduce bandwidth test (`nccl-tests`) at the family's line rate** (e.g. ~450 GB/s H100 NVLink).
+
+**(b) Provisioner per workload class (AWS, ADR-0045/0046).** The **EFA DRA driver is NOT supported
+with Karpenter or EKS Auto Mode.** This forces a split, not a cluster-wide either/or:
+
+- **Karpenter (default)** GPU pools → EFA via **device plugin** (`vpc.amazonaws.com/efa`); serving +
+  bursty training; spot-first + scale-to-zero + consolidation.
+- **EKS managed node groups (reserved)** → EFA via **DRA driver** (topology-aware `netdev`
+  ResourceClaim composed with the GPU claim under Volcano); large reserved distributed training.
+- **EFA training is never spot** (a spot reclaim kills the gang). Scarce SKUs via **EC2 Capacity
+  Blocks for ML**. No EKS Auto Mode for GPU pools. (Capacity plane details → SPEC-03.)
+
+**(c) Gang scheduling + queues.** **Volcano (not Kueue)** — Kueue does not do native gang
+scheduling. Queues carry weights and GPU caps (e.g. `gpu-inference` weight 10 / cap 64 GPU;
+`gpu-training` weight 5 / cap 32). DRA device classes give typed GPU requests. On bare metal there
+is **no node autoscaler** — elasticity is *workload* scale-to-zero (KEDA/HPA free GPUs back to the
+pool) + Volcano queue reservation + Cluster-API/Sidero re-imaging for physical capacity (ADR-0054).
+
+### 2.6 Model lifecycle (build → registry → promote → serve → monitor)
+
+```
+ git push (models/** adapters/**)                     drift breach
+        │                                                  │  Alertmanager webhook
+        ▼  GitHub Actions (ml-pipeline*.yml)               ▼  → ml-retrain-trigger proxy
+ ┌──────────────┐  POST Airflow REST /dags/<dag>/dagRuns   → Airflow REST dagRuns
+ │ train (DAG)  │  train_domain_adapter: SFT+LoRA on Qwen 2.5 3B,
+ └──────┬───────┘  DeepSpeed ZeRO-3, 8×H100 Volcano gang job
+        ▼  poll (40×30s = 20 min bound)
+ ┌──────────────┐  eval_adapter_debate — LLM-as-judge debate gate.
+ │ eval / gate  │  Quality gate: fail if win_rate < 0.55 OR p95_distance_regression > 0
+ └──────┬───────┘
+        ▼
+ ┌──────────────┐  mlflow models create-version → Staging.  Syft SBOM + cosign keyless (OIDC) sign.
+ │ register     │  Artifact store per substrate: GCS · S3 · Azure Blob/ADLS · MinIO/Ceph-RGW.
+ └──────┬───────┘
+        ▼
+ ┌──────────────┐  promote_to_edge: merge LoRA→base · quantize fp8 · compile TRT-LLM engine ·
+ │ promote      │  build+sign OCI · register Kargo Freight (dev auto / staging reviewer / prod manual)
+ └──────┬───────┘  MLflow Staging→Production on prod promotion (Kargo WebhookPromotion)
+        ▼
+ ┌──────────────┐  Kargo promotion = argocd-tag-bump opens a PR in the ArgoCD config repo bumping
+ │ deploy       │  image.tag + image.digest → ArgoCD syncs → vLLM rollout → InferenceObjective weights
+ └──────┬───────┘
+        ▼
+ ┌──────────────┐  Evidently (drift-exporter Deployment) = accuracy/quality; whylogs (inline) =
+ │ monitor      │  feature drift. ServiceMonitor → Prometheus/VM → Alertmanager → PagerDuty + retrain
+ └──────────────┘  namespace-per-model isolation (ml-<tenant>-<domain>); metrics prefixed ml_monitoring_
+```
+
+Orchestration is **Apache Airflow 2.9 self-hosted (not Kubeflow Pipelines)** — DAGs are already
+Airflow DAGs, Airflow is ~2 GiB vs Kubeflow >8 GiB, and the retrain path targets Airflow REST
+(ADR-0037). Registry is **MLflow** (`ghcr.io/mlflow/mlflow:v2.21.3`, 2 replicas + PDB) with a
+dedicated Postgres backend + object artifact store. Promotion is **Kargo** progressive delivery
+(`oci://ghcr.io/akuity/kargo-charts`). Signing is **cosign keyless + Syft SBOM**. GPU training runs
+inside the DAGs on Volcano gang jobs — the GitHub Actions jobs themselves are CPU-only control/gate
+plane (`ubuntu-latest`).
+
+### 2.7 Multi-cloud ML pattern (one operating model, cloud-native substitutions)
+
+| Layer | GCP (etalon, ADR-0036/0042) | AWS (ADR-0044/0048) | Azure (diagram-only) | Bare-metal (ADR-0049–54) |
+|---|---|---|---|---|
+| Kubernetes | GKE Standard | EKS (managed CP) | AKS (managed CP) | Talos (self-operated CP) |
+| CNI | Cilium/Dataplane V2 | Cilium (ENI/native) | Azure CNI **Powered by Cilium** | Cilium LB-IPAM+BGP |
+| GPU day-2 | GPU Operator+DCGM+DRA+**Volcano** | same | same | same (driver-less via Talos ext) |
+| Fabric | TCPX/TCPXO / RoCE-DRANET | **EFA** | **InfiniBand** (NDR/HDR) | RoCEv2/IB/SR-IOV+DRANET |
+| GPU SKUs | a2/a3/a4 | P5/P4de/G6e | **ND H100 v5 / NDm A100 v4 / NC H100 v5** | H200/H100/A100/L40S |
+| Serving | vLLM + GKE IGW | vLLM + Envoy/ALB | vLLM + App-GW for Containers | vLLM + Cilium/Envoy GW |
+| Registry | MLflow (Postgres+**GCS**) | MLflow (**RDS+S3**) + SageMaker-adjacent | **Azure ML/MLflow** (Blob/ADLS)+ACR | MLflow (**MinIO/Ceph-RGW**) |
+| Image registry | GCP AR | **ECR** (pull-through, cosign) | **ACR** (cosign, geo-replica) | registry + cosign |
+| Pod identity | GKE Workload Identity→GSA | **IRSA / EKS Pod Identity**+ABAC | **Entra Workload Identity**→User-Assigned MI | Talos mTLS / K8s SA |
+| Parallel FS | GCS + local | **FSx for Lustre** | **Azure Managed Lustre (AMLFS)** | CephFS / Rook-Ceph |
+| Elasticity | GKE autoscale+spot+scale-to-zero | **Karpenter**+spot | autoscaler+spot+scale-to-zero | **no autoscaler**; workload scale-to-zero + CAPI re-image |
+| Observability | VictoriaMetrics+LGTM | CloudWatch+**AMP/AMG**+ADOT+X-Ray | **Azure Monitor mgd Prometheus**+Log Analytics+App Insights+Mgd Grafana | Prometheus/Thanos+Grafana+Loki/Tempo |
+| Multi-region | eu-west9+us-c1, Global LB | 2 regions, **ClusterMesh+Route53/GA+TGW** | **W.Europe+N.Europe, Fleet Mgr+ClusterMesh+Front Door** | 2 UK DCs, GeoDNS, no shared CP |
+
+**Invariants across all clouds.** OpenAI ingress → WAF → Gateway API → InferencePool/EPP/
+InferenceObjective → vLLM on DRA GPUs with NCCL over RDMA; three-pipeline CI/CD; MLflow registry +
+drift → retrain webhook; ADR-0028 `platform.system/component/owner` tags mandatory; **serving fails
+over cross-region but gang-scheduled training/batch is always region/DC-pinned**; secondary region
+cost-bounded (scale-to-zero + spot).
+
+### 2.8 Azure two-AKS cross-region federation + three CI/CD pipelines (diagram-only pattern)
+
+Azure has **no ADR or written plan** — the design lives only in the architecture diagram and is a
+field-for-field mirror of the AWS diagram. Capture it as a portable pattern:
+
+- **Topology.** Two active AKS clusters — **Region A (West Europe)** primary, pod CIDR
+  `10.10.0.0/16`; **Region B (North Europe)** active/standby, pod CIDR `10.20.0.0/16` (non-overlapping,
+  ClusterMesh-ready). **Azure Kubernetes Fleet Manager** = multi-cluster L4 LB + resource propagation
+  + policy. East-west = **managed Cilium Cluster Mesh** (direct pod-to-pod, no gateways). North-south
+  = **Azure Front Door (anycast) + WAF + health-probe A↔B failover**. Backbone = **Global VNet
+  peering** (or VNet-to-VNet VPN).
+- **Per-region stack (identical A/B).** App Gateway for Containers (Gateway API) + WAF; InferencePool/
+  EPP; vLLM on N-series GPU pools over InfiniBand; GPU Operator+DCGM+Volcano+DRA; Entra Workload
+  Identity (secretless federated credential → User-Assigned Managed Identity); Azure Monitor managed
+  Prometheus + Log Analytics + App Insights + Managed Grafana.
+- **GPU pools.** ND H100 v5 (8×H100, NDR IB 3.2 Tbps) training; NDm A100 v4 (8×A100, HDR IB 1.6 Tbps);
+  NC H100 v5 (1–2×H100) inference. Spot + scale-to-zero + autoscaler.
+- **The three CI/CD pipelines** (GitHub Actions → ACR → Flux/ArgoCD GitOps):
+  1. **Backend apps** — build/test/lint → ACR (buildx + cosign) → Defender/Trivy + SBOM → Flux/ArgoCD
+     → rolling/canary AKS Deployment.
+  2. **ML workers (Airflow/Volcano)** — build worker image (CUDA/torch base) → ACR → Flux syncs
+     Airflow DAGs + Volcano Job manifests → Volcano gang-scheduled GPU job → artifacts to MLflow/Blob.
+  3. **Inference (model, e.g. Qwen3)** — model-registry trigger → build vLLM serving image (weights
+     from Blob/Lustre → ACR) → **eval gate (accuracy/TTFT canary)** → Flux/ArgoCD → vLLM Deployment +
+     InferencePool → **canary via App Gateway / Front Door (shadow → % traffic)** → SLO-gated
+     promote/auto-rollback.
+
+---
+
+## 3. Decision record
+
+Cite as `ADR-NNNN <title>` (this estate's `docs/adrs/`). All Proposed/apply-gated.
+
+| Decision | Rationale | Trade-off accepted | Source ADR |
+|---|---|---|---|
+| Serving front = Gateway API Inference Extension (InferencePool/InferenceObjective/EPP), not L4 LB | Model-blind, cache-blind round-robin wastes GPUs; EPP routes on KV-cache + queue + load | EPP is a separate moving part that must be deployed & wired explicitly | ADR-0042, 0047, 0053 |
+| Pin CRD `inference.networking.k8s.io/v1` (v1 GA); `InferenceModel`→`InferenceObjective` | Extension reached v1 GA, vLLM-integrated via llm-d; vendor-neutral | Young API still evolving — version must be pinned, migration guide followed | ADR-0047 |
+| EPP data plane = Envoy Gateway default on AWS (ALB fallback); VPC Lattice NOT the inference front | The extension's reference data plane is Envoy; EPP is an Envoy ext-proc | Two-data-plane story; WAF-on-Envoy indirection (two hops) | ADR-0047 |
+| GPU via DRA `ResourceClaim`, not `nvidia.com/gpu` limits | DRA is the typed, topology-aware modern path; composes GPU + RDMA claims | DRA GA floor (EKS 1.33 / GKE 1.32.1) raises version requirement | ADR-0044, 0036 |
+| NVIDIA GPU Operator (not standalone device plugin / managed driver) | The Operator is the only path that unlocks DRA | Sharp driver coupling: double-driver or no-driver failure modes | ADR-0036, 0044, 0050 |
+| Gang scheduler = Volcano, not Kueue | Volcano does native gang scheduling; Kueue only approximates it | Extra scheduler to operate alongside default | ADR-0036, 0044 |
+| Per-machine-family RDMA fabric (TCPX/TCPXO/RoCE/EFA/IB) with NCCL bandwidth gate | Fabric is the NCCL bottleneck; each family accelerates differently | Per-family node-pool/network complexity; more VPCs | ADR-0042, 0045, 0053 |
+| AWS provisioner split: Karpenter default + managed node groups for EFA-DRA training | EFA DRA driver unsupported under Karpenter/Auto Mode | Two provisioners; fabric mode coupled to provisioner | ADR-0045, 0046 |
+| EFA training never spot; scarce SKUs via Capacity Blocks | A spot reclaim kills the gang | Capacity Block lifecycle (time-boxed, must renew) | ADR-0046 |
+| Orchestrator = self-hosted Airflow 2.9, not Kubeflow Pipelines | DAGs already Airflow; lighter; retrain path targets Airflow REST | Self-hosted Airflow patch/upgrade burden | ADR-0037 |
+| Registry = MLflow (dedicated Postgres backend + object artifact store) | Standard registry; Staging→Production stage gates | New DB baseline cost; object-store IAM per cloud | ADR-0037, 0048, 0052 |
+| Fold cluster-agnostic ML layer by reference; per-cloud swap only backends | ML layer is cluster-agnostic by design; avoid duplicating ADRs | Cross-ADR coupling; N× backend modules in-repo | ADR-0048 |
+| Drift = Evidently (accuracy) + whylogs (feature) → Alertmanager → retrain proxy → Airflow | Platform owns Grafana/Thanos/Alertmanager; needs PromQL-native metrics | Two tools; reference-dataset mgmt; retrain-storm risk | ADR-0038 |
+| Promotion = Kargo Freight (dev auto / staging reviewer / prod manual) via ArgoCD tag bump | Progressive delivery with staged gates + GitOps audit trail | Extra controller; PR-bump indirection | ADR-0037, 0021 |
+| Sign every artifact: cosign keyless (OIDC) + Syft SBOM | Supply-chain provenance; SOC2 reproducibility invariants | Signing/SBOM step in every pipeline | ADR-0037, 0048 |
+| Bare-metal: Talos immutable OS, driver-less Operator (driver via system extension) | No `apt`/DKMS/writable `/usr`; driver change = image change + A/B reboot | Coupled Talos+driver upgrades; inverse-default footgun | ADR-0049, 0050 |
+| Bare-metal: no node autoscaler; workload scale-to-zero + CAPI re-image | Autoscaling a finite owned rack is a category error | No fast burst; capacity is capex | ADR-0054 |
+| Cross-region: serving fails over (DNS/health), training/batch region-pinned | Gang training can't tolerate cross-region reschedule | No cross-region GPU pooling | ADR-0044, 0043 |
+
+---
+
+## 4. Implementation blueprint
+
+### 4.1 Directory layout (load-bearing paths)
+
+```
+apps/infra/                              # Helm charts, ArgoCD-delivered (day-2)
+  gpu-operator/         values.yaml + values-gpu-inference.yaml   # NVIDIA GPU Operator (DRA on)
+  volcano/              values.yaml                               # gang scheduler + queues (comments)
+  dcgm-exporter/        values.yaml                               # GPU health metrics + auto-taint
+  aws-eks-inference-gateway/   templates/{inferencepool,inferenceobjective,httproute,endpoint-picker}.yaml
+  baremetal-inference-gateway/ values.yaml                        # mirror (values-only)
+  mlflow/ mlflow-aws/ mlflow-baremetal/  values.yaml             # registry, one per substrate
+  ml-monitoring/        values.yaml + values-{aws,baremetal}.yaml # Evidently/whylogs drift
+  airflow/ airflow-baremetal/  dags/*.py                          # orchestrator + training DAGs
+  kargo/                                                          # promotion engine
+  cilium/               values-gpu-inference.yaml                 # CNI overlay (WireGuard, BGP)
+k8s/gpu-inference/                       # raw manifests (the actual serving workload)
+  vllm/       deployment.yaml service.yaml configmap.yaml hpa.yaml
+  scheduling/ priority-class-*.yaml podgroup-*.yaml
+terraform/modules/                       # plan-time twins of the above
+  gpu-inference-vllm/ gpu-inference-volcano/ aws-eks-inference-gateway/
+  gke-inference-gateway/ aws-ml-artifact-store/ baremetal-ml-artifact-store/ ...
+catalog/units/                           # Terragrunt units (thin wrappers)
+  gpu-inference-{vllm,volcano,dra,dcgm,gpu-operator,eks,hpa}/ aws-eks-inference-gateway/ ...
+  baremetal-ml-monitoring/ ml-artifact-store/
+argocd/  applicationset-gpu-inference.yaml   # dedicated ApplicationSet for cluster-type: gpu-inference
+.github/workflows/  ml-pipeline.yml  ml-pipeline-aws.yml  ml-pipeline-baremetal.yml
+                    ml-monitoring-baremetal-validate.yml
+.github/actions/    harden-runner/ syft-sbom/ cosign-sign/ argocd-tag-bump/   # composite actions
+docs/architecture/  {azure,aws}/*-ml-stack.excalidraw  baremetal-ml-stack.excalidraw  gcp-ml-*.excalidraw
+```
+
+### 4.2 Dedicated GPU-inference ApplicationSet (matrix generator)
+
+The gpu-inference cluster diverges enough (VictoriaMetrics not Prometheus, Cilium native+BGP+
+WireGuard, GPU charts) that it gets its **own** ApplicationSet; the standard one excludes it via
+`matchExpressions: cluster-type NotIn [gpu-inference]`. Charts get a `values-gpu-inference.yaml`
+delta on top of `values.yaml`; `observability/*` is excluded (VictoriaMetrics replaces it).
+
+```yaml
+# argocd/applicationset-gpu-inference.yaml (sanitized)
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - matrix:
+        generators:
+          - git:
+              repoURL: git@github.com:{{VCS_ORG}}/platform-design.git
+              directories:
+                - path: apps/infra/*
+                - { path: apps/infra/observability/*, exclude: true }   # VM, not Prometheus
+          - clusters:
+              selector: { matchLabels: { cluster-type: gpu-inference } }
+  template:
+    spec:
+      source:
+        helm:
+          ignoreMissingValueFiles: true
+          valueFiles: [values.yaml, values-gpu-inference.yaml,
+                       '../../../envs/{{ .values.env }}/values/infra/{{ .path.basename }}.yaml']
+      syncPolicy: { automated: { prune: true, selfHeal: true },
+                    syncOptions: [CreateNamespace=true, ServerSideApply=true] }
+```
+
+### 4.3 Serving CRDs (InferencePool + InferenceObjective + EPP)
+
+```yaml
+# InferencePool: the replica set sharing one accelerator + base model
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+spec:
+  selector: { app: vllm }
+  targetPortNumber: 8000
+  extensionRef: { name: vllm-pool-epp }        # → the EPP ext-proc service
+---
+# InferenceObjective: one per model/LoRA; criticality + weights drive shed order & canary
+apiVersion: inference.networking.k8s.io/v1
+kind: InferenceObjective
+spec:
+  criticality: Critical                         # Critical > Standard > Sheddable
+  poolRef: { name: vllm-pool }
+  targetModels: [ { name: fraud-scorer-v3 } ]   # multi-LoRA → multiple objectives
+```
+
+**EPP hardening** — the recent fix bounds the ext-proc so it cannot OOM-pressure the node.
+Deliberate shape: **CPU request-only (no limit) to avoid throttling latency-sensitive routing;
+memory request + hard limit; non-root UID 65534; read-only rootfs; drop ALL caps.**
+
+```yaml
+# apps/infra/aws-eks-inference-gateway/values.yaml (EPP block, verbatim shape)
+epp:
+  image: registry.k8s.io/gateway-api-inference-extension/epp:v1.0.0
+  replicas: 2
+  resources:
+    requests: { cpu: 100m, memory: 128Mi }
+    limits:   { memory: 256Mi }                 # memory-only limit (hard cap)
+  podSecurityContext:       { runAsNonRoot: true, runAsUser: 65534 }
+  containerSecurityContext: { allowPrivilegeEscalation: false, readOnlyRootFilesystem: true,
+                              capabilities: { drop: [ALL] } }
+```
+EPP container port 9002 (`grpc-ext-proc`), args `--pool-name` / `--pool-namespace`, env
+`INFERENCE_CRD_VERSION`. Terraform twin gates it `count = enabled && deploy_epp`.
+
+### 4.4 vLLM Deployment with DRA GPU claim
+
+```yaml
+# k8s/gpu-inference/vllm/deployment.yaml (DRA claim, verbatim shape)
+apiVersion: resource.k8s.io/v1beta1
+kind: ResourceClaimTemplate
+metadata: { name: single-gpu-inference, namespace: gpu-inference }
+spec:
+  spec:
+    devices:
+      requests: [ { name: gpu, deviceClassName: gpu.nvidia.com, count: 8 } ]   # TP=8
+      config:
+        - requests: [gpu]
+          opaque:
+            driver: gpu.nvidia.com
+            parameters: { apiVersion: gpu.nvidia.com/v1alpha1, kind: GpuClaimParameters,
+                          sharing: { strategy: None } }
+---
+# Deployment pod spec (excerpt)
+spec:
+  schedulerName: volcano
+  priorityClassName: gpu-inference-medium
+  affinity: { nodeAffinity: { requiredDuringSchedulingIgnoredDuringExecution:
+    { nodeSelectorTerms: [ { matchExpressions: [
+      { key: gpu-inference, operator: In, values: ["true"] },
+      { key: nvidia.com/gpu.product, operator: In, values: ["H100-SXM5"] } ] } ] } } }
+  tolerations: [ { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule } ]
+  resourceClaims: [ { name: gpu-claim, resourceClaimTemplateName: single-gpu-inference } ]
+  containers:
+    - name: vllm
+      resources:
+        requests: { cpu: "16", memory: "128Gi" }
+        limits:   { cpu: "32", memory: "256Gi" }
+        claims:   [ { name: gpu-claim } ]
+```
+`configmap.yaml` carries the model config: `tensor-parallel-size: 8`, `max-model-len: 131072`,
+`gpu-memory-utilization: 0.92`, `dtype: bfloat16`, `enable-lora: true`, `max-loras: 8`, plus LoRA
+adapters. **Replace the `busybox` `model-loader` init container** with a real weight pull (from
+object store / Lustre); HF token from optional secret `vllm-secrets/hf-token`. `/dev/shm` = 64Gi
+Memory emptyDir for NCCL. Terraform twin also emits a VMServiceScrape keeping `vllm:.+` metrics.
+
+### 4.5 GPU Operator + Volcano knobs
+
+```yaml
+# apps/infra/gpu-operator/values.yaml (load-bearing)
+driver:    { enabled: false }                   # cloud AMI ships driver; TRUE only on AL2023
+toolkit:   { version: "v1.17.5-ubuntu22.04" }
+draDriver: { enabled: true }                    # backs the vLLM ResourceClaims
+migManager:{ default: all-disabled }            # migStrategy: none (full-GPU); mixed for MIG slices
+```
+```yaml
+# apps/infra/volcano/values.yaml — plugin order is load-bearing
+plugins: [gang, dra, predicates, proportion, priority, nodeorder, binpack]
+# binpack weighted toward GPU packing: binpack.weight 10, binpack.resources nvidia.com/gpu 10
+```
+> **Known discrepancy to reconcile:** `gang.enablePreemptable` is `true` in the chart values but
+> `false` in `terraform/modules/gpu-inference-volcano/main.tf`. Queue CRDs (`training`/`inference`/
+> `batch`) are created in Terraform, not the chart — two sources of truth. Pick one.
+
+### 4.6 ML CI/CD workflow (four-job DAG)
+
+All three variants share the topology `train → eval → register → deploy`, all `ubuntu-latest`
+(GPU work is delegated to Airflow inside the cluster). Only auth + registry + artifact store differ.
+
+```yaml
+# .github/workflows/ml-pipeline.yml (GKE variant, sanitized skeleton)
+on:
+  workflow_dispatch: { inputs: { model: {required: true}, environment: {default: dev} } }
+  push: { branches: [main], paths: [models/**, adapters/**] }
+permissions: { contents: read, id-token: write }        # WIF/OIDC + cosign keyless
+concurrency: { group: ml-pipeline-${{ github.ref }}-${{ inputs.model }}, cancel-in-progress: false }
+jobs:
+  train:    # harden-runner → checkout → cloud auth → POST Airflow /dags/train_domain_adapter/dagRuns
+  eval:     # needs train; poll /dagRuns/${RUN_ID} 40×30s (20 min); success→pass failed→fail
+  register: # needs eval; mlflow models create-version → Staging; syft-sbom + cosign-sign
+  deploy:   # needs register; environment gate; argocd-tag-bump app=mlflow-serving-${MODEL_ID}
+```
+
+Per-substrate deltas: **AWS** adds `aws-actions/configure-aws-credentials@v4` +
+`amazon-ecr-login@v2`, `ECR_REGISTRY: {{AWS_ACCOUNT_ID}}.dkr.ecr.{{PRIMARY_REGION}}.amazonaws.com`.
+**Bare-metal** drops cloud auth, uses Airflow bearer token + S3 static keys, DAG
+`train_domain_adapter_baremetal`, artifact `s3://mlflow-artifacts/${MODEL_ID}/${SHA}` via
+`MLFLOW_S3_ENDPOINT_URL` (MinIO/Ceph-RGW), env choices `staging`/`prod` (no `dev`).
+
+```yaml
+# ml-monitoring-baremetal-validate.yml — PR gate, NO APPLY (plan/validate only)
+env: { HELM_VERSION: 3.17.0, TF_VERSION: 1.14.8, TG_VERSION: 1.0.8 }
+jobs: [helm-lint, yamllint, terragrunt-validate, summary]   # helm template + verify ADR-0028 labels
+```
+
+Composite `argocd-tag-bump` = the "Kargo promotion" deploy step: opens a PR in the ArgoCD config
+repo bumping `image.tag`+`image.digest` (via `yq`), commits as the CI bot, labels `auto-merge` for
+non-prod. **Sanitize its defaults:** repo `{{VCS_ORG}}/argocd`, committer `{{ORG}}-platform-ci[bot]`
+/ `ci@{{DOMAIN}}`.
+
+### 4.7 MLflow registry per substrate
+
+| Substrate | Backend DB | Artifact store | Pod identity |
+|---|---|---|---|
+| GKE | Cloud SQL PG16 | `gs://mlflow-artifacts-{env}-{{GCP_PROJECT_ID}}` | Workload Identity SA `mlflow` (`roles/storage.objectAdmin`) |
+| AWS | RDS PG | `s3://mlflow-artifacts-{env}-{{AWS_ACCOUNT_ID}}` (versioning, SSE-KMS, lifecycle) | EKS Pod Identity + ABAC (`platform:system=ml-pipeline`) |
+| Bare-metal | CloudNativePG (`mlflow-pg-rw`) | `s3://mlflow-artifacts` on MinIO/Ceph-RGW | ESO/Vault Secret `mlflow-s3-credentials` |
+
+Artifact-store lifecycle (AWS): Standard-IA 90d → Glacier IR 365d → expire 730d. Bucket IAM uses
+**EKS Pod Identity trust + ABAC** (`aws:PrincipalTag/platform:system == aws:ResourceTag/platform:system`).
+All artifact-store modules default `create_resources = false` (apply-gated).
+
+### 4.8 Ordering / dependencies (what must exist before what)
+
+1. **GPU cluster infra** (GPU Operator + DRA driver, DCGM, Volcano, VictoriaMetrics) — via the
+   dedicated ApplicationSet — before any vLLM pod can claim a GPU.
+2. **Gateway API CRDs + inference-extension CRDs (pinned v1)** + a **GatewayClass** (Envoy/Cilium/
+   AppGW/GKE-IGW) before InferencePool/HTTPRoute apply.
+3. **EPP Deployment+Service** before the InferencePool `extensionRef` resolves (gateway alone is
+   insufficient — ADR-0047 D2).
+4. **MLflow (DB + object store + pod identity)** and **Airflow** before any pipeline run.
+5. **Kargo project + Freight + ArgoCD config repo** before the `deploy` job's tag bump merges.
+6. **WAF web ACL** attached to the fronting LB before exposing the Gateway publicly.
+
+---
+
+## 5. Parameterization table
+
+| Placeholder | Meaning | Default in this estate | Resize guidance |
+|---|---|---|---|
+| `{{VCS_ORG}}` | Git hosting org | — | your VCS org; owns the platform + GitOps-config repos |
+| `{{ORG}}` / `{{DOMAIN}}` | org slug / DNS zone (CI bot email) | — | see SPEC-00 |
+| `{{PRIMARY_REGION}}` / `{{DR_REGION}}` | serving + DR regions | GCP eu-west9/us-c1 · AWS us-east-1/us-west-2 · Azure W.Europe/N.Europe | ≥2 regions; training region-pinned |
+| `{{AWS_ACCOUNT_ID}}` / `{{GCP_PROJECT_ID}}` / `{{AZURE_SUBSCRIPTION_ID}}` | cloud identity | — | injected via CI `vars.*`, never hardcoded |
+| `{{ML_IMAGE_REPO}}` / `{{ECR_REGISTRY}}` | model image registry | `{{AWS_ACCOUNT_ID}}.dkr.ecr.{{PRIMARY_REGION}}.amazonaws.com/ml` | ECR/ACR/AR/registry per cloud |
+| `{{MLFLOW_TRACKING_URI}}` / `{{AIRFLOW_BASE_URL}}` / `{{MLFLOW_S3_ENDPOINT_URL}}` | ML control-plane endpoints | CI `vars.*` | per-substrate; bare-metal points at MinIO/Ceph-RGW |
+| `{{ARGOCD_CONFIG_REPO}}` / `{{CI_BOT_NAME}}` / `{{CI_BOT_EMAIL}}` | promotion PR target + committer | `{{VCS_ORG}}/argocd` · `{{ORG}}-platform-ci[bot]` · `ci@{{DOMAIN}}` | your GitOps config repo + bot |
+| `{{MODEL_ID}}` / `{{BASE_MODEL}}` | served model + base | e.g. `fraud-uk` / Qwen 2.5 3B / Llama-3-70B-Instruct | any HF/local model |
+
+**Sizing knobs** (default → resize):
+
+| Knob | Default | Resize guidance |
+|---|---|---|
+| GPU SKU / instance family | H100-SXM5 (`p5`/`a3-highgpu-8g`/ND H100 v5) | A100/L40S for cheaper inference; H200/B200 for largest models |
+| `tensor-parallel-size` / DRA `count` | 8 | match GPUs per node; smaller models → 1–2 (use `g6e`/NC) |
+| vLLM `replicas` | 3 | scale to QPS; HPA/KEDA scale-to-zero on idle |
+| `max-model-len` / `gpu-memory-utilization` | 131072 / 0.92 | lower ctx for memory headroom |
+| `max-loras` | 8 | per-tenant adapter count |
+| EPP `replicas` / resources | 2 / cpu 100m req, mem 128Mi req / 256Mi limit | raise mem limit for very large pools |
+| InferenceObjective `criticality` | Critical / Standard / Sheddable | tag latency-critical models Critical |
+| WAF `rate_limit` (AWS) | 2000 / 5-min | tune per client SLA |
+| Volcano queue caps | inference 64 GPU / training 32 GPU | size to fleet |
+| MLflow artifact lifecycle | IA 90d / Glacier 365d / expire 730d | per retention policy |
+| Quality gate | `win_rate ≥ 0.55` AND `p95_distance_regression ≤ 0` | tighten per model risk |
+| Drift thresholds | dataset_drift warn 0.2/crit 0.4; PSI 0.1/0.25; accuracy 0.85/0.75; F1 0.80/0.65 | per model |
+
+---
+
+## 6. Best practices distilled
+
+1. **Route on serving signals, not connections.** Put an EPP in front of vLLM and score replicas on
+   KV-cache/prefix affinity, queue depth, and GPU/KV utilization — a plain L4 LB is model-blind and
+   cache-blind and silently wastes accelerator time and TTFT.
+2. **Pin the inference CRD version explicitly** (`crdVersion: v1.0.0`, never `latest`). The extension
+   is v1 GA but still moving (the `InferenceModel`→`InferenceObjective` rename proves it); an
+   unpinned CRD is a self-inflicted outage on the next upstream release.
+3. **Deploy the EPP as a first-class object.** Installing the gateway + CRDs is *not* enough — the
+   EPP is a separate ext-proc Deployment+Service that must be wired via `InferencePool.extensionRef`.
+   Treat "gateway is green but EPP is missing" as a specific failure mode.
+4. **Bound the EPP: memory request+limit, CPU request-only.** A hard memory cap stops it
+   OOM-pressuring the node; leaving CPU unlimited avoids throttling latency-sensitive routing. Run it
+   non-root (UID 65534), read-only rootfs, drop ALL caps.
+5. **Allocate GPUs with DRA `ResourceClaimTemplate`, not `nvidia.com/gpu` limits.** DRA is typed and
+   topology-aware and composes the GPU claim with an RDMA `netdev` claim — the only clean way to pin
+   both accelerator and fabric to a pod.
+6. **Make the NCCL all-reduce bandwidth test a hard acceptance gate for every fabric.** A silent
+   AMI/NCCL-plugin mismatch degrades EFA/RoCE to TCP with no error; only a measured line-rate
+   all-reduce catches it before training runs cost money.
+7. **Match the fabric to the machine family, one config per family.** TCPX≠TCPXO≠RoCE≠EFA≠IB; a
+   single fabric config cannot span SKUs. Drive selection off a `fabric_mode` node label.
+8. **Split the provisioner by workload class on AWS.** Karpenter (serving + bursty, EFA device
+   plugin) vs managed node groups (reserved distributed training, EFA-DRA) — because the EFA DRA
+   driver is unsupported under Karpenter/Auto Mode. Provisioner is a property of the workload.
+9. **Never run gang-scheduled training on spot.** One reclaimed node kills the whole gang; reserve
+   scarce SKUs with Capacity Blocks and keep spot for scale-to-zero serving only.
+10. **Use Volcano for gang scheduling.** Kueue only approximates it; distributed training needs
+    all-or-nothing placement or it deadlocks on partial gangs.
+11. **Keep the ML lifecycle layer cluster-agnostic; swap only backends per cloud.** Airflow + MLflow
+    + Evidently/whylogs + Kargo + cosign/syft are identical everywhere; only DB, object store, image
+    registry, and pod-identity mechanism change. This is what makes multi-cloud tractable.
+12. **Gate promotions on an eval, not a green build.** `win_rate ≥ 0.55` and no p95 regression before
+    Staging; staged Kargo Freight (dev auto → staging reviewer → prod manual + smoke) before Prod.
+13. **Sign and SBOM every model image** (cosign keyless OIDC + Syft) and record reproducibility
+    invariants (dataset snapshot id, base-model hash, training-config hash) for SOC2.
+14. **Fail serving over cross-region; pin training/batch.** DNS/health failover for the request path;
+    never try to reschedule a gang across regions — re-queue it in-region.
+15. **Isolate models by namespace** (`ml-<tenant>-<domain>`) with one ServiceMonitor each and
+    `platform.system` label filtering, so drift metrics and retrain triggers stay per-tenant.
+16. **Secretless pod identity everywhere** — GKE Workload Identity, EKS Pod Identity/IRSA+ABAC, Entra
+    Workload Identity federated credential, Talos mTLS. No static cloud keys on serving/training pods.
+
+---
+
+## 7. Known pitfalls
+
+1. **Double-driver / no-driver GPU Operator footgun.** `driver.enabled` must be `false` where the
+   node AMI/system-extension already ships the driver (cloud GPU AMIs, Talos extension) and `true`
+   only on AL2023-style images. The bare-metal default is the *inverse* of the cloud default — get
+   it wrong and you get either a driver conflict or no working GPU driver.
+2. **DRA requires the Operator, and a version floor.** DRA needs the GPU Operator (not the managed
+   driver) plus EKS ≥1.33 / GKE ≥1.32.1 (DRANET GA raises GKE to `1.35.2-gke.1842000+`). Provisioning
+   DRA claims on an older cluster silently fails to schedule.
+3. **EFA DRA ≠ Karpenter.** The EFA DRA driver does not work under Karpenter or EKS Auto Mode. Putting
+   reserved EFA training on Karpenter pools yields TCP-degraded NCCL, not an error.
+4. **Gateway green but EPP absent.** The gateway and CRDs can be healthy while the `extensionRef`
+   points at a non-existent EPP; requests then fail model-aware routing. Deploy the EPP explicitly.
+5. **As-built divergence — two sources of truth for Volcano.** Chart values and the Terraform module
+   disagree on `gang.enablePreemptable` (true vs false) and on where Queue CRDs are created.
+   Reconcile to one.
+6. **As-built divergence — CI/CD composite-action interface drift.** The scaffold ML workflows call
+   `syft-sbom`/`cosign-sign` with `image:` but the actions declare `image-ref:`, and `argocd-tag-bump`
+   requires `image-digest`/`values-path`/`bot-token` the workflows don't pass. Treat the workflows as
+   illustrative until wired through — do not assume they run end-to-end as-is.
+7. **As-built divergence — hardcoded identifiers in scaffold defaults.** The real VCS-org name, the
+   CI-bot identity, and the CI-bot email are hardcoded in the `argocd-tag-bump` action defaults, and
+   placeholder-shaped tokens (project/account-id strings, well-known test account IDs) appear in
+   manifests, actions, and `.tftest.hcl`. A rebuild must scrub and re-parameterize every one before
+   sharing — the sanitization rule applies to config defaults, not just copied snippets.
+8. **Retrain storms.** A drift breach can fire repeatedly; the retrain proxy must de-dup (15-min) and
+   respect a `repeat_interval` (6h) or a flapping model floods the GPU training queue.
+9. **`/dev/shm` too small for NCCL.** vLLM tensor-parallel needs a large shared-memory emptyDir
+   (64Gi here); the default 64Mi silently kills multi-GPU NCCL init.
+10. **Bare-metal kernel-module coupling.** Talos won't mount Ceph RBD until `rbd`+`ceph` are in
+    `machine.kernel.modules` (else `csi-rbdplugin` crash-loops), and GPU needs `nvidia*` modules —
+    all baked in the immutable image, not installed at runtime.
+11. **Azure is undocumented.** The two-AKS federation + three pipelines exist only in an Excalidraw
+    diagram with no ADR or plan. Treat §2.8 as the authoritative capture and write the missing ADR.
+12. **As-built divergence — `busybox` model-loader stub.** The vLLM init container is a placeholder
+    stub; ship a real weight-pull (object store / Lustre) or pods start with no model.
+
+---
+
+## 8. Acceptance checklist
+
+A rebuild passes when:
+
+- [ ] The dedicated `gpu-inference` ApplicationSet syncs GPU charts (GPU Operator w/ DRA, DCGM,
+      Volcano, VictoriaMetrics) to `cluster-type: gpu-inference` clusters and the standard
+      ApplicationSet excludes them — zero manual steps.
+- [ ] `InferencePool`, `InferenceObjective`, and a running EPP (2 replicas, memory-capped, non-root,
+      read-only rootfs) exist; CRD group is `inference.networking.k8s.io/v1` pinned to a fixed tag.
+- [ ] A `POST /v1/chat/completions {"model":...}` traverses WAF → Gateway → HTTPRoute → InferencePool
+      → EPP → a vLLM replica and returns tokens; EPP demonstrably prefers a KV-cache-warm replica.
+- [ ] vLLM pods schedule via `volcano`, claim GPUs through a DRA `ResourceClaimTemplate` (not
+      `nvidia.com/gpu`), and pass a startup probe under load.
+- [ ] An `nccl-tests` all-reduce hits the family's line rate on every GPU pool (no TCP fallback).
+- [ ] `ml-pipeline*.yml` runs `train → eval → register → deploy`: Airflow DAG launches a Volcano gang
+      job; the eval gate blocks on `win_rate < 0.55` or a p95 regression; MLflow gets a Staging
+      version; the image is cosign-signed with an SBOM; Kargo promotes dev→staging→prod.
+- [ ] MLflow registry is reachable with the correct per-substrate backend (Cloud SQL / RDS /
+      CloudNativePG) and object store (GCS / S3 / MinIO-Ceph) via secretless pod identity.
+- [ ] Drift metrics (`ml_monitoring_*`) scrape per model namespace; a synthetic drift breach fires an
+      Alertmanager route that (de-duped) POSTs an Airflow retrain `dagRuns`.
+- [ ] `ml-monitoring-baremetal-validate.yml` is plan/validate-only (helm lint/template + terragrunt
+      validate, no apply) and verifies ADR-0028 `platform.system` labels render.
+- [ ] Serving fails over to `{{DR_REGION}}` on health loss; training/batch stays region-pinned.
+- [ ] No real account IDs, ARNs, org names, bot emails, or registry hostnames remain — all
+      placeholders resolve from SPEC-00 / CI `vars`.
+
+---
+
+## 9. Dependencies on other specs
+
+- **SPEC-01 (Foundation: IaC, Account Topology & State)** — Terraform/Terragrunt module + remote-state
+  conventions and account topology the ML modules plug into, plus the ADR-0028
+  `platform.system/component/owner` tagging taxonomy that is mandatory on every GPU/ML resource.
+- **SPEC-02 (Network Topology & DNS)** — cross-region DNS/failover (Route 53 / Front Door / GeoDNS),
+  VPC/VNet peering + Transit Gateway, and Cilium ClusterMesh / Azure Fleet Manager cross-cluster
+  east-west, plus the per-family RDMA VPC/fabric plumbing the GPU pools sit on.
+- **SPEC-03 (Compute / Kubernetes)** — GPU node pools, Karpenter GPU NodePools, EKS managed node
+  groups for EFA-DRA training, Capacity Blocks, bare-metal fixed pools + Cluster-API/Sidero re-image,
+  the Cilium CNI + Gateway API **data-plane install**, and the GPU day-2 stack (GPU Operator, DCGM,
+  Volcano, DRA). This spec consumes those; SPEC-03 provisions them.
+- **SPEC-04 (Delivery & GitOps Machinery)** — ArgoCD app-of-apps, ApplicationSet mechanics, and the
+  Kargo project/Freight wiring + the ArgoCD config repo that the `argocd-tag-bump` promotion targets.
+- **SPEC-05 (Security)** — cosign keyless + Syft SBOM supply-chain signing, ESO/Vault credential
+  materialization, the secretless pod-identity mechanisms per cloud, and the Gatekeeper/Kyverno ML
+  policies (`ml-policy`, block-privileged).
+- **SPEC-07 (Observability)** — VictoriaMetrics / Prometheus / Thanos / Grafana / Alertmanager that
+  DCGM, vLLM, and the drift exporters feed; the retrain-trigger Alertmanager route lives on that
+  stack.
+
+> Spec-local placeholders introduced here (`{{VCS_ORG}}`, `{{ML_IMAGE_REPO}}`, `{{ECR_REGISTRY}}`,
+> `{{MLFLOW_TRACKING_URI}}`, `{{AIRFLOW_BASE_URL}}`, `{{MLFLOW_S3_ENDPOINT_URL}}`,
+> `{{ARGOCD_CONFIG_REPO}}`, `{{CI_BOT_NAME}}`, `{{CI_BOT_EMAIL}}`, `{{GCP_PROJECT_ID}}`,
+> `{{AZURE_SUBSCRIPTION_ID}}`, `{{MODEL_ID}}`, `{{BASE_MODEL}}`) should be promoted into
+> `SPEC-00-overview.md` if reused by sibling specs.
+```

--- a/specs/SPEC-INDEX.md
+++ b/specs/SPEC-INDEX.md
@@ -1,0 +1,52 @@
+# SPEC-INDEX — Platform Specs
+
+Portable, reverse-engineered specs for an AWS-primary multi-account IaC + Kubernetes/GPU
+platform. A senior platform team can rebuild the estate for a new client from these files
+alone. **Start with `SPEC-00-overview.md`** (owns the canonical placeholder registry + the
+cross-spec divergence/recommendation registers), then read in the order below.
+
+## Files
+
+| File | Description | Lines |
+|---|---|---|
+| `CONVENTIONS.md` | Authoring rules: audience, parameterization, sanitization, per-spec structure | 68 |
+| `SPEC-00-overview.md` | **Start here** — platform overview, canonical placeholder registry, as-built divergence register (45), recommendations register, sanitization statement, client-build protocol | 390 |
+| `SPEC-01-foundation-iac.md` | Foundation: AWS Org + 8-OU tree, ~11-account topology, Terragrunt/`_envcommon`/`catalog`, TF-only state bootstrap, version pins, ADR-0028 tagging | 523 |
+| `SPEC-02-network-dns.md` | Network & DNS: hub-spoke Transit Gateway, deterministic VPC CIDRs, deny-by-default segmentation, Route 53 Resolver, dual-provider octoDNS + health monitor + registrar failover | 608 |
+| `SPEC-03-compute-clusters.md` | Compute: EKS + Cilium (eBPF/ENI) + Karpenter on Bottlerocket + KEDA/HPA, Pod Identity, per-workload cluster split | 657 |
+| `SPEC-04-delivery-gitops.md` | Delivery: ArgoCD app-of-apps + ApplicationSets, Kargo promotion graph, the generic `helm/app` chart, PreSync migrations | 610 |
+| `SPEC-05-security.md` | Security: SCP/RCP/EC2-declarative guardrails, audit/logging accounts, Pod-Identity ABAC, ESO+KMS+rotation, admission control, supply-chain gates | 551 |
+| `SPEC-06-cicd-quality.md` | CI/CD: GitHub Actions estate (34 wf + 10 actions), IaC loop as CI, keyless OIDC, supply chain, drift detection, Infracost, GitLab port | 604 |
+| `SPEC-07-observability.md` | Observability: LGTM (Prom+Thanos/Loki/Tempo/Pyroscope), VictoriaMetrics GPU variant, DCGM + auto-taint, ML drift, Pyrra SLOs, Alertmanager, OpenCost | 783 |
+| `SPEC-08-resilience-data.md` | Resilience/DR: `failover-controller`, warm-standby DR account, RDS HA, Velero, immutable log archive, state DR, failure-mode matrix, RTO/RPO tiers | 651 |
+| `SPEC-09-ai-sre.md` | Advisory AI-SRE: multi-agent system, four-layer advisory-only enforcement, runbook/approval engine, ClickHouse memory, MCP surface, meta-observability | 525 |
+| `SPEC-10-ml-workloads.md` | ML/GPU: inference serving (Gateway API Inference Extension + EPP + vLLM on DRA), GPU capacity strategy, Airflow→MLflow→Kargo lifecycle, multi-cloud pattern | 682 |
+
+## Reading / execution order
+
+```
+SPEC-00 → 01 → 02 → 03 → 05 → 04 → 06 → 07 → 08 → 10 → 09
+overview  found. net  comp  sec  deliv ci/cd obs  resil ml   ai-sre
+```
+
+Foundation first; network before compute; **security before delivery** (secrets/admission are
+prerequisites delivery references); CI/CD guards it all; observability is delivered via GitOps;
+resilience layers on the running stack; ML reuses everything; the advisory AI-SRE is last
+(consumes signals, mutates nothing). Full justification in `SPEC-00-overview.md` §2. Use each
+spec's **§8 acceptance checklist** as the gate before moving to the next.
+
+## Placeholder aliases (resolved in `SPEC-00-overview.md` §3.9)
+
+The domain specs are not edited; where two specs named the same thing differently, the canonical
+name and its alias are:
+
+| Canonical | Alias | Alias used by |
+|---|---|---|
+| `{{LOG_ARCHIVE_ACCOUNT_ID}}` | `{{LOGARCHIVE_ACCOUNT_ID}}` | SPEC-01, SPEC-02 |
+| `{{PRIMARY_DNS_PROVIDER}}` | `{{PRIMARY_DNS}}` | SPEC-02 |
+| `{{SECONDARY_DNS_PROVIDER}}` | `{{SECONDARY_DNS}}` | SPEC-02 |
+| `{{GCP_PROJECT_ID}}` | `{{GCP_PROJECT}}` | SPEC-07 |
+| `{{PROJECT}}` | `{{REPO}}` | SPEC-01 |
+
+> Unresolved inconsistency (a decision, not a clean alias): `{{GITOPS_REPO}}` (SPEC-04 mono-repo
+> model) vs `{{ARGOCD_CONFIG_REPO}}` (SPEC-06/10 separate-config-repo model) — see SPEC-00 §3.9 / D-INC.


### PR DESCRIPTION
Adds `specs/` — a 13-file, ~6700-line portable specification of the whole platform, reverse-engineered from this estate so the same platform can be rebuilt for a client.

## Contents
- **CONVENTIONS.md** — format contract: 9-section spec structure, {{placeholder}} parameterization, hard sanitization rule.
- **SPEC-00-overview.md** — platform overview, spec map + reading order (01→02→03→05→04→06→07→08→10→09), canonical placeholder registry (~80 tokens, 5 alias mappings), **46-item as-built divergence register**, 15 recommendations, sanitization statement, client-build protocol.
- **SPEC-INDEX.md** — front door.
- **SPEC-01..10** — foundation IaC · network/DNS · compute/EKS · delivery/GitOps · security · CI/CD quality gates · observability · resilience/data · AI-SRE (advisory) · ML/GPU workloads. Each: architecture, decision record with ADR citations, implementation blueprint, parameterization table, best practices, known pitfalls, acceptance checklist.

## Notable findings captured in the divergence register
- Family-B ApplicationSets (workloads/Kargo plane) not wired into bootstrap — clean rebuild never brings them up
- Cilium deployed 1.19.4 vs TF default 1.17.1 vs catalog 1.16.5; cluster versions 1.29/1.32/1.34 spread
- Log-archive immutability designed but unwired; lifecycle policy input defined-but-unused
- No cross-region RDS DR; GPU-ML federation has no numeric RTO/RPO targets
- ADR-0026 contradicted twice by the running observability stack
- Istio unit declared but nothing ships — plane is sidecarless by design

## Review
Independent full-folder review: **zero sanitization leaks** (no real account IDs, org identifiers, personal data), cross-refs and registers verified; the review's M1/L1/L3 fixes are applied. Known cosmetic leftovers (SPEC-07 section numbering, two heading levels in SPEC-09) deliberately left.

Sources: the estate itself (terragrunt/, terraform/, argocd/, apps/, kargo/, ai-sre/, monitoring/, .github/workflows/, 56 ADRs).