### PR TITLE
feat: publish standard HTTP platform contract

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Platform contracts are organizational execution authority. Changes require
+# review by the platform owner before Omnius may consume a new pinned revision.
+/platform-contracts/ @100rd
+/docs/adrs/0056-machine-readable-platform-contracts.md @100rd
+/.github/workflows/platform-contracts-validate.yml @100rd
+/scripts/validate-platform-contracts.py @100rd

--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -28,7 +28,8 @@ jobs:
               -summary \
               -kubernetes-version 1.32.0 \
               -schema-location default \
-              -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'; then
+              -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+              -ignore-missing-schemas; then
               echo "FAILED: $chart"
               FAILED=1
             fi

--- a/.github/workflows/platform-contracts-validate.yml
+++ b/.github/workflows/platform-contracts-validate.yml
@@ -1,0 +1,35 @@
+name: Platform contract validation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "platform-contracts/**"
+      - "scripts/validate-platform-contracts.py"
+      - "scripts/requirements-platform-contracts.txt"
+      - ".github/workflows/platform-contracts-validate.yml"
+  pull_request:
+    paths:
+      - "platform-contracts/**"
+      - "scripts/validate-platform-contracts.py"
+      - "scripts/requirements-platform-contracts.txt"
+      - ".github/workflows/platform-contracts-validate.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: scripts/requirements-platform-contracts.txt
+      - name: Install validator dependencies
+        run: pip install -r scripts/requirements-platform-contracts.txt
+      - name: Validate schemas, digests, references, and fixtures
+        run: python3 scripts/validate-platform-contracts.py

--- a/docs/adrs/0056-machine-readable-platform-contracts.md
+++ b/docs/adrs/0056-machine-readable-platform-contracts.md
@@ -1,0 +1,105 @@
+# ADR-0056: Machine-readable platform contracts for organizational automation
+
+- Status: **Accepted**
+- Date: 2026-07-13
+- Authors: platform-team
+- Related issues: 100rd/omnius#11; genai-enablement ADR-0011 and ADR-0012
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+Platform paths currently exist as documentation, templates, and implementation-specific
+delivery configuration. That is sufficient for a human operator, but it is not a safe
+authority for an organizational executor. Omnius needs a closed, versioned contract that
+separates the product promise, reusable entity classes, Realm constraints, executable
+workflow, Conditions of Done, evidence, and compensation.
+
+The first consumer is the Omnius P0 vertical `standard-http-service/v1`. Its scope is
+deliberately narrow: modify one existing Go service repository, deliver it into a disposable
+preview namespace through a Draft PR and the existing GitOps path, run deterministic HTTP
+probes, and remove or revert the preview instance. Omnius may prepare the change, but a human
+must merge it. Production, shared state, data mutation, secrets, arbitrary environment
+variables, free-form scripts, and direct apply/deploy are outside this contract.
+
+## Decision
+
+1. `platform-contracts/` is the authoritative machine-contract root owned by the platform
+   team. It contains closed JSON Schemas, indexed instances, fixtures, and documentation.
+2. Git is the v1 publication mechanism. A consumer pins an exact 40-character commit and the
+   bundle SHA-256 recorded in `platform-contracts/index.yaml`; mutable branches are not an
+   execution authority.
+3. The bundle digest is calculated over the authoritative files listed in the index, in
+   lexical path order, as `path + NUL + bytes`. The index itself is excluded to avoid a
+   self-referential digest. Every listed file also has an individual SHA-256.
+4. Platform products, entity classes, Realms, paths, and requests remain distinct artifacts.
+   JSON Schema Draft 2020-12 with stable `urn:darkfactory:platform-contract:*` identifiers is
+   the compatibility boundary. No schema service or GitHub Pages publication is introduced.
+5. `standard-http-service/v1` enters in `experimental` state and is admitted only to the
+   `preview/v1` Realm class. Lower-environment evidence is required before any later promotion.
+6. Omnius receives only registered action, policy, and probe identifiers. The path cannot
+   contain raw commands or implementation-specific apply authority.
+
+## Alternatives considered
+
+### Alternative A: Put the contracts in Omnius
+
+This would make the executor own the platform offer it executes.
+Rejected because: platform ownership and execution authority would collapse into one trust
+boundary, and other consumers could not share the same contract independently.
+
+### Alternative B: Publish through a schema service
+
+Operate an API and database as the contract authority.
+Rejected because: it adds availability, identity, migration, and reconciliation failure modes
+before there is evidence that Git publication is insufficient.
+
+### Alternative C: Keep documentation and templates as the contract
+
+Let agents infer the workflow from ADRs, Markdown, Helm values, and repository structure.
+Rejected because: inference cannot prove closed inputs, immutable versions, compensation, or
+referential integrity and therefore cannot safely authorize mutation.
+
+## Consequences
+
+### Positive
+
+- Humans and agents submit one bounded request shape.
+- Contract drift, unknown fields, broken references, and digest changes fail in CI.
+- Platform ownership remains separate from Omnius execution and evidence.
+- The first path can collect preview evidence without claiming production readiness.
+
+### Negative
+
+- Contract changes require coordinated schema/version maintenance.
+- The first path is intentionally less flexible than the existing raw implementation surface.
+- Git revision pinning is completed by the consumer after merge, not embedded recursively in
+  the bundle.
+
+### Risks
+
+- **Contract and implementation diverge.** Mitigation: the path remains experimental until
+  Omnius runs the real delivery and compensation probes against the pinned bundle.
+- **A permissive schema becomes a command channel.** Mitigation: all authority-bearing schemas
+  are closed and the request exposes no shell, arbitrary environment, secret, Helm, or policy
+  fields.
+- **Digest ambiguity.** Mitigation: the byte-level digest algorithm and indexed file set are
+  fixed here and enforced by one repository validator.
+
+## Implementation notes
+
+- Authority: `platform-contracts/index.yaml` and the files it indexes.
+- CI: `scripts/validate-platform-contracts.py` validates schemas, instances, hashes,
+  references, fixtures, and semantic bindings.
+- Rollback: revert the contract PR. Existing WorkOrders continue to use their pinned commit
+  and digest; removing a published version does not retarget them.
+- Promotion requires a new ADR or an amendment with lower-Realm evidence and a new immutable
+  path version when compatibility changes.
+
+## References
+
+- `platform-contracts/README.md`
+- `specs/SPEC-04-delivery-gitops.md`
+- `specs/SPEC-05-security.md`
+- `specs/SPEC-06-cicd-quality.md`
+- ADR-0006, ADR-0014, ADR-0016, ADR-0020, ADR-0024, ADR-0028, ADR-0041

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -99,6 +99,7 @@ decision.
 | [0052](0052-baremetal-storage-rook-ceph.md) | Bare-metal storage for ML artifacts & state — Rook-Ceph (block/FS/RGW S3) vs Mayastor vs local-path; MinIO/Ceph-RGW artifact store; **requires `rbd`+`ceph` kernel modules in Talos MachineConfig** | Proposed | pending | WS-A/WS-B of Bare-Metal ML platform plan; substitutes GCS `ml-artifact-store`; design 2026-06-15 |
 | [0053](0053-baremetal-gpu-fabric-roce-infiniband.md) | Bare-metal high-performance GPU fabric (RoCEv2/InfiniBand + SR-IOV day-0 → DRANET gated) & on-prem serving front (Gateway API: InferencePool/InferenceObjective + WAF) | Proposed | pending | extends WS-A (fabric/serving axis); bare-metal mirror of ADR-0042; design 2026-06-15 |
 | [0054](0054-baremetal-elasticity-node-lifecycle.md) | Bare-metal elasticity & node lifecycle without a cloud autoscaler — Cluster-API/Sidero vs Metal³ vs robot-API vs static pools; workload scale-to-zero | Proposed | pending | WS-A of Bare-Metal ML platform plan; replaces GKE/Karpenter autoscaling; design 2026-06-15 |
+| [0056](0056-machine-readable-platform-contracts.md) | Machine-readable platform contracts for organizational automation | Accepted | contract published; execution pending | native · Omnius P0 vertical |
 
 
 

--- a/platform-contracts/README.md
+++ b/platform-contracts/README.md
@@ -1,0 +1,42 @@
+# Platform contracts
+
+This directory is the machine-readable authority for platform products and executable
+paths. Humans and agents consume the same schemas and instances. Omnius may execute only an
+indexed bundle pinned by exact Git commit and bundle SHA-256.
+
+## Layout
+
+- `schemas/v1/` defines closed Draft 2020-12 schemas.
+- `products/`, `entity-classes/`, `realms/`, and `paths/` contain owned instances.
+- `index.yaml` lists every authoritative file, its schema, and its content digest.
+- `fixtures/` contains requests that must pass or fail validation.
+
+The first vertical is `standard-service/v1` through
+`standard-http-service/v1`. It accepts one existing Go repository, creates an internal HTTP
+service in a disposable `preview-<work-order-id>` Realm, and requires human merge.
+
+## Publication and pinning
+
+The bundle digest excludes `index.yaml` and is computed over the files in
+`index.yaml.spec.artifacts`, sorted by path:
+
+```text
+sha256(path + NUL + file-bytes + path + NUL + file-bytes + ...)
+```
+
+Each artifact also has an individual SHA-256 in the index. A consumer must verify both and
+record the exact 40-character Git commit. A branch, tag alone, working tree, copied catalog,
+or Omniscience projection is not execution authority.
+
+Run validation locally with:
+
+```bash
+python3 scripts/validate-platform-contracts.py
+```
+
+## Lifecycle
+
+Artifacts move through `draft`, `experimental`, `validated`, `approved`, and `deprecated`.
+The initial path is `experimental`: it is usable only where the indexed Realm explicitly
+admits it, and it cannot be promoted without real delivery, probe, compensation, reliability,
+and support evidence.

--- a/platform-contracts/entity-classes/environment/v1/entity-class.yaml
+++ b/platform-contracts/entity-classes/environment/v1/entity-class.yaml
@@ -1,0 +1,30 @@
+schemaVersion: platform/entity-class/v1
+kind: EntityClass
+metadata:
+  name: Environment
+  version: v1
+  owner: platform-team
+  state: experimental
+requiredCapabilities:
+  - kubernetes.namespace/v1
+  - kubernetes.resource-quota/v1
+  - kubernetes.default-deny-network-policy/v1
+naming:
+  pattern: ^preview-[a-z0-9][a-z0-9-]{7,52}$
+  maxLength: 63
+lifecycle:
+  - create
+  - observe
+  - delete
+probes:
+  - id: realm.preview-containment/v1
+    phase: preflight
+    required: true
+  - id: realm.preview-pruned/v1
+    phase: compensation
+    required: true
+compensation:
+  action: delivery.prune-preview-realm/v1
+  verifier: realm.preview-pruned/v1
+allowedRealms:
+  - preview/v1

--- a/platform-contracts/entity-classes/http-service/v1/entity-class.yaml
+++ b/platform-contracts/entity-classes/http-service/v1/entity-class.yaml
@@ -1,0 +1,45 @@
+schemaVersion: platform/entity-class/v1
+kind: EntityClass
+metadata:
+  name: HttpService
+  version: v1
+  owner: platform-team
+  state: experimental
+requiredCapabilities:
+  - runtime.go-1.23/v1
+  - delivery.argocd/v1
+  - ingress.internal-http/v1
+  - supply-chain.sbom/v1
+  - supply-chain.signature/v1
+naming:
+  pattern: ^[a-z][a-z0-9-]{2,40}[a-z0-9]$
+  maxLength: 42
+lifecycle:
+  - create
+  - observe
+  - update
+  - delete
+probes:
+  - id: build.unit-tests/v1
+    phase: delivery
+    required: true
+  - id: supply-chain.image-attestation/v1
+    phase: delivery
+    required: true
+  - id: gitops.argocd-synced-healthy/v1
+    phase: runtime
+    required: true
+  - id: http.healthz/v1
+    phase: runtime
+    required: true
+  - id: http.readyz/v1
+    phase: runtime
+    required: true
+  - id: http.request-contract/v1
+    phase: runtime
+    required: true
+compensation:
+  action: delivery.revert-and-prune-preview/v1
+  verifier: realm.preview-pruned/v1
+allowedRealms:
+  - preview/v1

--- a/platform-contracts/fixtures/invalid/arbitrary-command.yaml
+++ b/platform-contracts/fixtures/invalid/arbitrary-command.yaml
@@ -1,0 +1,23 @@
+schemaVersion: platform/request/v1
+kind: ProductRequest
+metadata:
+  requestId: wo-01j2k3m4n5p6q7r8
+product: standard-service/v1
+path: standard-http-service/v1
+realmClass: preview/v1
+inputs:
+  serviceName: payments-api
+  ownerRef: team:payments
+  repositoryRef: github:example-org/payments-api
+  sourceSubpath: services/payments
+  runtime: go-1.23
+  exposure: internal
+  port: 8080
+  resourceProfile: small
+  command: kubectl delete namespace production
+  acceptance:
+    - method: GET
+      path: /healthz
+      expected:
+        status: 200
+        exactText: ok

--- a/platform-contracts/fixtures/invalid/path-traversal.yaml
+++ b/platform-contracts/fixtures/invalid/path-traversal.yaml
@@ -1,0 +1,22 @@
+schemaVersion: platform/request/v1
+kind: ProductRequest
+metadata:
+  requestId: wo-01j2k3m4n5p6q7r8
+product: standard-service/v1
+path: standard-http-service/v1
+realmClass: preview/v1
+inputs:
+  serviceName: payments-api
+  ownerRef: team:payments
+  repositoryRef: github:example-org/payments-api
+  sourceSubpath: ../../shared
+  runtime: go-1.23
+  exposure: internal
+  port: 8080
+  resourceProfile: small
+  acceptance:
+    - method: GET
+      path: /healthz
+      expected:
+        status: 200
+        exactText: ok

--- a/platform-contracts/fixtures/invalid/production-realm.yaml
+++ b/platform-contracts/fixtures/invalid/production-realm.yaml
@@ -1,0 +1,22 @@
+schemaVersion: platform/request/v1
+kind: ProductRequest
+metadata:
+  requestId: wo-01j2k3m4n5p6q7r8
+product: standard-service/v1
+path: standard-http-service/v1
+realmClass: production/v1
+inputs:
+  serviceName: payments-api
+  ownerRef: team:payments
+  repositoryRef: github:example-org/payments-api
+  sourceSubpath: services/payments
+  runtime: go-1.23
+  exposure: internal
+  port: 8080
+  resourceProfile: small
+  acceptance:
+    - method: GET
+      path: /healthz
+      expected:
+        status: 200
+        exactText: ok

--- a/platform-contracts/fixtures/invalid/unbounded-runtime.yaml
+++ b/platform-contracts/fixtures/invalid/unbounded-runtime.yaml
@@ -1,0 +1,22 @@
+schemaVersion: platform/request/v1
+kind: ProductRequest
+metadata:
+  requestId: wo-01j2k3m4n5p6q7r8
+product: standard-service/v1
+path: standard-http-service/v1
+realmClass: preview/v1
+inputs:
+  serviceName: payments-api
+  ownerRef: team:payments
+  repositoryRef: github:example-org/payments-api
+  sourceSubpath: services/payments
+  runtime: python-latest
+  exposure: public
+  port: 443
+  resourceProfile: unbounded
+  acceptance:
+    - method: POST
+      path: /admin
+      expected:
+        status: 200
+        exactText: ok

--- a/platform-contracts/fixtures/valid/standard-http-service-request.yaml
+++ b/platform-contracts/fixtures/valid/standard-http-service-request.yaml
@@ -1,0 +1,23 @@
+schemaVersion: platform/request/v1
+kind: ProductRequest
+metadata:
+  requestId: wo-01j2k3m4n5p6q7r8
+product: standard-service/v1
+path: standard-http-service/v1
+realmClass: preview/v1
+inputs:
+  serviceName: payments-api
+  ownerRef: team:payments
+  repositoryRef: github:example-org/payments-api
+  sourceSubpath: services/payments
+  runtime: go-1.23
+  exposure: internal
+  port: 8080
+  resourceProfile: small
+  acceptance:
+    - method: GET
+      path: /path/v2/payments
+      expected:
+        status: 200
+        jsonSubset:
+          ready: true

--- a/platform-contracts/index.yaml
+++ b/platform-contracts/index.yaml
@@ -1,0 +1,100 @@
+apiVersion: platform/contracts-index/v1
+kind: PlatformContractIndex
+metadata:
+  owner: platform-team
+  version: v1
+spec:
+  digestAlgorithm: sha256-path-nul-bytes-v1
+  bundleDigest: 40d837bdc2386e6f4e7031b048d64a4224b8398f9810f7ce98ab981200bd9ed6
+  artifacts:
+    - path: entity-classes/environment/v1/entity-class.yaml
+      kind: EntityClass
+      schema: urn:darkfactory:platform-contract:entity-class:v1
+      sha256: 56935e1b40c8d28c6bfde0b17fbd52e6ddbe651ef9c7622fa348d0304e873648
+    - path: entity-classes/http-service/v1/entity-class.yaml
+      kind: EntityClass
+      schema: urn:darkfactory:platform-contract:entity-class:v1
+      sha256: ba9c8c445ff60417160b2712f4a13356bce8ef2a40636c48f8b0d716c847a162
+    - path: paths/standard-http-service/v1/path.yaml
+      kind: PlatformPath
+      schema: urn:darkfactory:platform-contract:platform-path:v1
+      sha256: 5646fbd8a3916216b208c8eb93263a1fa74bc25b9e92b75fc5e522f8549c9ead
+    - path: paths/standard-http-service/v1/request.schema.json
+      kind: Schema
+      schema: https://json-schema.org/draft/2020-12/schema
+      sha256: 439432fd6fcb8b876fe7d9d3498910c96c51ed249b857dc1f376482bd4f17f72
+    - path: products/standard-service/v1/product.yaml
+      kind: PlatformProduct
+      schema: urn:darkfactory:platform-contract:platform-product:v1
+      sha256: 5b6b55edf7b71548b80d4f22a814c9c197b4f4a38c74a7162c120361c9058d84
+    - path: realms/preview/v1/realm.yaml
+      kind: Realm
+      schema: urn:darkfactory:platform-contract:realm:v1
+      sha256: af681d9b167ad8503e26fe957752704b6f2ca3c31d6d888c56382f9ce949d29c
+    - path: schemas/v1/entity-class.schema.json
+      kind: Schema
+      schema: https://json-schema.org/draft/2020-12/schema
+      sha256: 745c089840975f2a363b9cfc09312259a50a667c2345fc5ebac9ab2550a75bc2
+    - path: schemas/v1/platform-path.schema.json
+      kind: Schema
+      schema: https://json-schema.org/draft/2020-12/schema
+      sha256: 37178490442b22c6002887d78d96a638f5ad53cd88d6f3392e7431554236c8a1
+    - path: schemas/v1/platform-product.schema.json
+      kind: Schema
+      schema: https://json-schema.org/draft/2020-12/schema
+      sha256: b66066f71f51531a79528d2fc60a0981440fe5ffa1331abc9ba972c44c9acbea
+    - path: schemas/v1/product-request.schema.json
+      kind: Schema
+      schema: https://json-schema.org/draft/2020-12/schema
+      sha256: af25910db76fdc09a60116ff8456d38e04e0a818960636e5e33bf01e9fc2a8bb
+    - path: schemas/v1/realm.schema.json
+      kind: Schema
+      schema: https://json-schema.org/draft/2020-12/schema
+      sha256: f80e13163bcf41ad5652adc7f772d754c6d308e6c4c3198a01ffc64165119c81
+  registries:
+    actions:
+      - delivery.await-human-merge/v1
+      - delivery.observe-argocd-sync/v1
+      - delivery.open-draft-pull-request/v1
+      - delivery.prune-preview-realm/v1
+      - delivery.revert-and-prune-preview/v1
+      - execution.register-compensation/v1
+      - realm.resolve-preview/v1
+      - source.author-http-service-change/v1
+      - source.inspect-existing-repository/v1
+      - verification.run-http-probes/v1
+      - verification.run-source-gates/v1
+    capabilities:
+      - delivery.argocd/v1
+      - ingress.internal-http/v1
+      - kubernetes.default-deny-network-policy/v1
+      - kubernetes.namespace/v1
+      - kubernetes.resource-quota/v1
+      - runtime.go-1.23/v1
+      - supply-chain.sbom/v1
+      - supply-chain.signature/v1
+    evidenceTypes:
+      - ci.check-run/v1
+      - compensation.result/v1
+      - gitops.revision-status/v1
+      - http.probe-result/v1
+      - kubernetes.realm-boundary/v1
+      - supply-chain.attestation/v1
+    policies:
+      - delivery.human-merge-required/v1
+      - global.no-direct-apply/v1
+      - global.no-main-push/v1
+      - global.no-production-mutation/v1
+      - realm.preview-containment/v1
+      - realm.preview-no-secrets/v1
+      - supply-chain.build-once-by-digest/v1
+    probes:
+      - build.security-gates/v1
+      - build.unit-tests/v1
+      - gitops.argocd-synced-healthy/v1
+      - http.healthz/v1
+      - http.readyz/v1
+      - http.request-contract/v1
+      - realm.preview-containment/v1
+      - realm.preview-pruned/v1
+      - supply-chain.image-attestation/v1

--- a/platform-contracts/paths/standard-http-service/v1/README.md
+++ b/platform-contracts/paths/standard-http-service/v1/README.md
@@ -1,0 +1,41 @@
+# standard-http-service/v1
+
+This experimental path changes one existing Go 1.23 HTTP service and proves it in a
+disposable preview Realm. It is an execution contract, not a claim that the current estate
+already implements every registered action or probe.
+
+## Request boundary
+
+The request names one existing GitHub repository and a safe relative source subpath. Runtime,
+exposure, port, and resource size are fixed. Acceptance probes are bounded `GET` requests with
+HTTP 200 and either exact text or a shallow JSON subset. Unknown fields fail validation.
+
+The request cannot supply commands, scripts, environment variables, secrets, image tags, Helm
+values, policy overrides, namespaces, clusters, accounts, or production targets. Identity and
+the effective `preview-<work-order-id>` Realm are derived by trusted intake and policy code.
+
+## Condition of Done
+
+Before execution, Omnius binds the exact request, path commit, bundle digest, policies,
+actions, probes, expected responses, compensation, and evidence TTL. Completion requires:
+
+1. The source diff stays inside the bound repository and source/GitOps paths.
+2. Unit, build, and security checks pass on the exact commit.
+3. The image is built once; SBOM and signature evidence bind its immutable digest.
+4. A Draft PR is opened idempotently and a human merges it.
+5. Argo CD reports `Synced` and `Healthy` for the exact Git and image revisions.
+6. A dedicated quota-bound, default-deny preview namespace has no production credentials,
+   shared-state access, data mutation, or cross-Realm authority.
+7. `/healthz`, `/readyz`, and every requested route pass three consecutive bounded probes
+   from a verifier outside the worker identity and writable environment.
+8. The evidence manifest is immutable and no older than `PT24H`.
+9. Registered compensation can close an unmerged PR or revert the landed change and prune the
+   preview Realm; the prune verifier proves absence of owned resources.
+
+Any missing, expired, conflicting, or unverifiable result prevents verified completion.
+
+## Current admission
+
+Only `preview/v1` admits this experimental path. Human merge remains mandatory. Promotion to
+another Realm requires a new reviewed contract revision and lower-Realm evidence; Omnius cannot
+widen admission from task input or its own outcome feedback.

--- a/platform-contracts/paths/standard-http-service/v1/path.yaml
+++ b/platform-contracts/paths/standard-http-service/v1/path.yaml
@@ -1,0 +1,101 @@
+schemaVersion: platform/path/v1
+kind: PlatformPath
+metadata:
+  name: standard-http-service
+  version: v1
+  owner: platform-team
+  state: experimental
+product: standard-service/v1
+inputSchema: urn:darkfactory:platform-contract:path-input:standard-http-service:v1
+entityClasses:
+  - Environment/v1
+  - HttpService/v1
+supportedRealms:
+  - preview/v1
+workflow:
+  - id: inspect-source
+    action: source.inspect-existing-repository/v1
+    needs: []
+  - id: author-change
+    action: source.author-http-service-change/v1
+    needs: [inspect-source]
+  - id: validate-change
+    action: verification.run-source-gates/v1
+    needs: [author-change]
+  - id: register-compensation
+    action: execution.register-compensation/v1
+    needs: [validate-change]
+  - id: open-draft-pr
+    action: delivery.open-draft-pull-request/v1
+    needs: [register-compensation]
+  - id: await-human-merge
+    action: delivery.await-human-merge/v1
+    needs: [open-draft-pr]
+  - id: observe-gitops
+    action: delivery.observe-argocd-sync/v1
+    needs: [await-human-merge]
+  - id: verify-runtime
+    action: verification.run-http-probes/v1
+    needs: [observe-gitops]
+policies:
+  - global.no-main-push/v1
+  - global.no-direct-apply/v1
+  - global.no-production-mutation/v1
+  - realm.preview-containment/v1
+  - realm.preview-no-secrets/v1
+  - delivery.human-merge-required/v1
+  - supply-chain.build-once-by-digest/v1
+conditionsOfDone:
+  - id: source.unit-tests
+    probe: build.unit-tests/v1
+    evidenceType: ci.check-run/v1
+    required: true
+  - id: source.security-gates
+    probe: build.security-gates/v1
+    evidenceType: ci.check-run/v1
+    required: true
+  - id: supply-chain.attested-image
+    probe: supply-chain.image-attestation/v1
+    evidenceType: supply-chain.attestation/v1
+    required: true
+  - id: delivery.gitops-revision
+    probe: gitops.argocd-synced-healthy/v1
+    evidenceType: gitops.revision-status/v1
+    required: true
+  - id: realm.contained
+    probe: realm.preview-containment/v1
+    evidenceType: kubernetes.realm-boundary/v1
+    required: true
+  - id: runtime.health
+    probe: http.healthz/v1
+    evidenceType: http.probe-result/v1
+    required: true
+    consecutivePasses: 3
+  - id: runtime.readiness
+    probe: http.readyz/v1
+    evidenceType: http.probe-result/v1
+    required: true
+    consecutivePasses: 3
+  - id: runtime.request-contract
+    probe: http.request-contract/v1
+    evidenceType: http.probe-result/v1
+    required: true
+    consecutivePasses: 3
+compensation:
+  action: delivery.revert-and-prune-preview/v1
+  verifier: realm.preview-pruned/v1
+  triggers:
+    - cancelled
+    - failed
+    - expired
+    - completed
+evidence:
+  ttl: PT24H
+  manifestType: darkfactory.evidence-manifest/v1
+  requiredTypes:
+    - ci.check-run/v1
+    - supply-chain.attestation/v1
+    - gitops.revision-status/v1
+    - kubernetes.realm-boundary/v1
+    - http.probe-result/v1
+    - compensation.result/v1

--- a/platform-contracts/paths/standard-http-service/v1/request.schema.json
+++ b/platform-contracts/paths/standard-http-service/v1/request.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:darkfactory:platform-contract:path-input:standard-http-service:v1",
+  "title": "standard-http-service/v1 inputs",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["serviceName", "ownerRef", "repositoryRef", "sourceSubpath", "runtime", "exposure", "port", "resourceProfile", "acceptance"],
+  "properties": {
+    "serviceName": {"type": "string", "pattern": "^[a-z][a-z0-9-]{2,40}[a-z0-9]$"},
+    "ownerRef": {"type": "string", "pattern": "^team:[a-z][a-z0-9-]{2,62}$"},
+    "repositoryRef": {"type": "string", "pattern": "^github:[a-zA-Z0-9_.-]{1,39}/[a-zA-Z0-9_.-]{1,100}$"},
+    "sourceSubpath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))[a-zA-Z0-9_.-]+(?:/[a-zA-Z0-9_.-]+)*$"
+    },
+    "runtime": {"const": "go-1.23"},
+    "exposure": {"const": "internal"},
+    "port": {"const": 8080},
+    "resourceProfile": {"const": "small"},
+    "acceptance": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["method", "path", "expected"],
+        "properties": {
+          "method": {"const": "GET"},
+          "path": {"type": "string", "pattern": "^/[a-zA-Z0-9/_-]{0,127}$"},
+          "expected": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["status"],
+            "properties": {
+              "status": {"const": 200},
+              "exactText": {"type": "string", "maxLength": 512},
+              "jsonSubset": {
+                "type": "object",
+                "maxProperties": 10,
+                "additionalProperties": {"type": ["string", "number", "integer", "boolean", "null"]}
+              }
+            },
+            "oneOf": [
+              {"required": ["exactText"]},
+              {"required": ["jsonSubset"]}
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/platform-contracts/products/standard-service/v1/product.yaml
+++ b/platform-contracts/products/standard-service/v1/product.yaml
@@ -1,0 +1,23 @@
+schemaVersion: platform/product/v1
+kind: PlatformProduct
+metadata:
+  name: standard-service
+  version: v1
+  owner: platform-team
+  lifecycle: experimental
+consumers:
+  - human
+  - agent
+paths:
+  - standard-http-service/v1
+support:
+  slo: platform-gold
+  supportOwner: platform-team
+  lifecyclePolicy: platform-product-lifecycle/v1
+economics:
+  costModel: per-instance
+  budgetProfile: preview-small
+success:
+  adoptionMetric: platform_path.completed_requests
+  outcomeMetric: platform_path.verified_completion_ratio
+  retirementSignal: Retire when the path has no supported consumers for two review periods.

--- a/platform-contracts/realms/preview/v1/realm.yaml
+++ b/platform-contracts/realms/preview/v1/realm.yaml
@@ -1,0 +1,37 @@
+schemaVersion: platform/realm/v1
+kind: Realm
+metadata:
+  name: preview
+  version: v1
+  owner: platform-team
+  state: experimental
+resolution:
+  requestedClass: preview
+  effectiveNameTemplate: preview-{workOrderId}
+  derivedBy: realm.resolve-preview/v1
+admission:
+  pathStates:
+    - experimental
+    - validated
+    - approved
+  paths:
+    - standard-http-service/v1
+namespace:
+  dedicated: true
+  defaultDeny: true
+  quotaProfile: preview-small
+  deleteOnCompletion: true
+boundaries:
+  productionCredentials: deny
+  crossRealmMutation: deny
+  sharedStateMutation: deny
+  dataMutation: deny
+  runtimeSecrets: deny
+  directApply: deny
+policyRefs:
+  - global.no-main-push/v1
+  - global.no-direct-apply/v1
+  - global.no-production-mutation/v1
+  - realm.preview-containment/v1
+  - realm.preview-no-secrets/v1
+  - delivery.human-merge-required/v1

--- a/platform-contracts/schemas/v1/entity-class.schema.json
+++ b/platform-contracts/schemas/v1/entity-class.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:darkfactory:platform-contract:entity-class:v1",
+  "title": "EntityClass v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "kind", "metadata", "requiredCapabilities", "naming", "lifecycle", "probes", "compensation", "allowedRealms"],
+  "properties": {
+    "schemaVersion": {"const": "platform/entity-class/v1"},
+    "kind": {"const": "EntityClass"},
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "owner", "state"],
+      "properties": {
+        "name": {"type": "string", "pattern": "^[A-Z][A-Za-z0-9]{2,63}$"},
+        "version": {"type": "string", "pattern": "^v[1-9][0-9]*$"},
+        "owner": {"type": "string", "pattern": "^[a-z][a-z0-9-]{2,62}$"},
+        "state": {"enum": ["draft", "experimental", "validated", "approved", "deprecated"]}
+      }
+    },
+    "requiredCapabilities": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"}
+    },
+    "naming": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pattern", "maxLength"],
+      "properties": {
+        "pattern": {"type": "string", "minLength": 3, "maxLength": 160},
+        "maxLength": {"type": "integer", "minimum": 16, "maximum": 253}
+      }
+    },
+    "lifecycle": {
+      "type": "array",
+      "minItems": 2,
+      "uniqueItems": true,
+      "items": {"enum": ["create", "observe", "update", "delete"]}
+    },
+    "probes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "phase", "required"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+          "phase": {"enum": ["preflight", "delivery", "runtime", "compensation"]},
+          "required": {"type": "boolean"}
+        }
+      }
+    },
+    "compensation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action", "verifier"],
+      "properties": {
+        "action": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+        "verifier": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"}
+      }
+    },
+    "allowedRealms": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "pattern": "^[a-z][a-z0-9-]+/v[1-9][0-9]*$"}
+    }
+  }
+}

--- a/platform-contracts/schemas/v1/platform-path.schema.json
+++ b/platform-contracts/schemas/v1/platform-path.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:darkfactory:platform-contract:platform-path:v1",
+  "title": "PlatformPath v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "kind", "metadata", "product", "inputSchema", "entityClasses", "supportedRealms", "workflow", "policies", "conditionsOfDone", "compensation", "evidence"],
+  "properties": {
+    "schemaVersion": {"const": "platform/path/v1"},
+    "kind": {"const": "PlatformPath"},
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "owner", "state"],
+      "properties": {
+        "name": {"type": "string", "pattern": "^[a-z][a-z0-9-]{2,62}$"},
+        "version": {"type": "string", "pattern": "^v[1-9][0-9]*$"},
+        "owner": {"type": "string", "pattern": "^[a-z][a-z0-9-]{2,62}$"},
+        "state": {"enum": ["draft", "experimental", "validated", "approved", "deprecated"]}
+      }
+    },
+    "product": {"type": "string", "pattern": "^[a-z][a-z0-9-]+/v[1-9][0-9]*$"},
+    "inputSchema": {"type": "string", "pattern": "^urn:darkfactory:platform-contract:path-input:[a-z][a-z0-9-]+:v[1-9][0-9]*$"},
+    "entityClasses": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "pattern": "^[A-Z][A-Za-z0-9]+/v[1-9][0-9]*$"}
+    },
+    "supportedRealms": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "pattern": "^[a-z][a-z0-9-]+/v[1-9][0-9]*$"}
+    },
+    "workflow": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "action", "needs"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^[a-z][a-z0-9-]{1,62}$"},
+          "action": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+          "needs": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {"type": "string", "pattern": "^[a-z][a-z0-9-]{1,62}$"}
+          }
+        }
+      }
+    },
+    "policies": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"}
+    },
+    "conditionsOfDone": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "probe", "evidenceType", "required"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+$"},
+          "probe": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+          "evidenceType": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+          "required": {"const": true},
+          "consecutivePasses": {"type": "integer", "minimum": 1, "maximum": 10}
+        }
+      }
+    },
+    "compensation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action", "verifier", "triggers"],
+      "properties": {
+        "action": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+        "verifier": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+        "triggers": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"enum": ["cancelled", "failed", "expired", "completed"]}
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ttl", "manifestType", "requiredTypes"],
+      "properties": {
+        "ttl": {"const": "PT24H"},
+        "manifestType": {"const": "darkfactory.evidence-manifest/v1"},
+        "requiredTypes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"}
+        }
+      }
+    }
+  }
+}

--- a/platform-contracts/schemas/v1/platform-product.schema.json
+++ b/platform-contracts/schemas/v1/platform-product.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:darkfactory:platform-contract:platform-product:v1",
+  "title": "PlatformProduct v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "kind", "metadata", "consumers", "paths", "support", "economics", "success"],
+  "properties": {
+    "schemaVersion": {"const": "platform/product/v1"},
+    "kind": {"const": "PlatformProduct"},
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "owner", "lifecycle"],
+      "properties": {
+        "name": {"type": "string", "pattern": "^[a-z][a-z0-9-]{2,62}$"},
+        "version": {"type": "string", "pattern": "^v[1-9][0-9]*$"},
+        "owner": {"type": "string", "pattern": "^[a-z][a-z0-9-]{2,62}$"},
+        "lifecycle": {"enum": ["draft", "experimental", "validated", "approved", "deprecated"]}
+      }
+    },
+    "consumers": {
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 2,
+      "items": {"enum": ["human", "agent"]}
+    },
+    "paths": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "pattern": "^[a-z][a-z0-9-]+/v[1-9][0-9]*$"}
+    },
+    "support": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["slo", "supportOwner", "lifecyclePolicy"],
+      "properties": {
+        "slo": {"type": "string", "pattern": "^[a-z][a-z0-9-]+$"},
+        "supportOwner": {"type": "string", "pattern": "^[a-z][a-z0-9-]+$"},
+        "lifecyclePolicy": {"type": "string", "pattern": "^[a-z][a-z0-9-]+/v[1-9][0-9]*$"}
+      }
+    },
+    "economics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["costModel", "budgetProfile"],
+      "properties": {
+        "costModel": {"enum": ["per-instance", "per-request", "allocated-shared"]},
+        "budgetProfile": {"type": "string", "pattern": "^[a-z][a-z0-9-]+$"}
+      }
+    },
+    "success": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["adoptionMetric", "outcomeMetric", "retirementSignal"],
+      "properties": {
+        "adoptionMetric": {"type": "string", "pattern": "^[a-z][a-z0-9_.-]+$"},
+        "outcomeMetric": {"type": "string", "pattern": "^[a-z][a-z0-9_.-]+$"},
+        "retirementSignal": {"type": "string", "minLength": 10, "maxLength": 240}
+      }
+    }
+  }
+}

--- a/platform-contracts/schemas/v1/product-request.schema.json
+++ b/platform-contracts/schemas/v1/product-request.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:darkfactory:platform-contract:product-request:v1",
+  "title": "ProductRequest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "kind", "metadata", "product", "path", "realmClass", "inputs"],
+  "properties": {
+    "schemaVersion": {"const": "platform/request/v1"},
+    "kind": {"const": "ProductRequest"},
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requestId"],
+      "properties": {
+        "requestId": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]{7,63}$"}
+      }
+    },
+    "product": {"type": "string", "pattern": "^[a-z][a-z0-9-]+/v[1-9][0-9]*$"},
+    "path": {"type": "string", "pattern": "^[a-z][a-z0-9-]+/v[1-9][0-9]*$"},
+    "realmClass": {"type": "string", "pattern": "^[a-z][a-z0-9-]+/v[1-9][0-9]*$"},
+    "inputs": {"type": "object"}
+  }
+}

--- a/platform-contracts/schemas/v1/realm.schema.json
+++ b/platform-contracts/schemas/v1/realm.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:darkfactory:platform-contract:realm:v1",
+  "title": "Realm v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "kind", "metadata", "resolution", "admission", "namespace", "boundaries", "policyRefs"],
+  "properties": {
+    "schemaVersion": {"const": "platform/realm/v1"},
+    "kind": {"const": "Realm"},
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "owner", "state"],
+      "properties": {
+        "name": {"type": "string", "pattern": "^[a-z][a-z0-9-]{2,62}$"},
+        "version": {"type": "string", "pattern": "^v[1-9][0-9]*$"},
+        "owner": {"type": "string", "pattern": "^[a-z][a-z0-9-]{2,62}$"},
+        "state": {"enum": ["draft", "experimental", "validated", "approved", "deprecated"]}
+      }
+    },
+    "resolution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requestedClass", "effectiveNameTemplate", "derivedBy"],
+      "properties": {
+        "requestedClass": {"type": "string", "pattern": "^[a-z][a-z0-9-]+$"},
+        "effectiveNameTemplate": {"type": "string", "pattern": "^preview-\\{workOrderId\\}$"},
+        "derivedBy": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"}
+      }
+    },
+    "admission": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pathStates", "paths"],
+      "properties": {
+        "pathStates": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"enum": ["experimental", "validated", "approved"]}
+        },
+        "paths": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "pattern": "^[a-z][a-z0-9-]+/v[1-9][0-9]*$"}
+        }
+      }
+    },
+    "namespace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["dedicated", "defaultDeny", "quotaProfile", "deleteOnCompletion"],
+      "properties": {
+        "dedicated": {"const": true},
+        "defaultDeny": {"const": true},
+        "quotaProfile": {"type": "string", "pattern": "^[a-z][a-z0-9-]+$"},
+        "deleteOnCompletion": {"const": true}
+      }
+    },
+    "boundaries": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["productionCredentials", "crossRealmMutation", "sharedStateMutation", "dataMutation", "runtimeSecrets", "directApply"],
+      "properties": {
+        "productionCredentials": {"const": "deny"},
+        "crossRealmMutation": {"const": "deny"},
+        "sharedStateMutation": {"const": "deny"},
+        "dataMutation": {"const": "deny"},
+        "runtimeSecrets": {"const": "deny"},
+        "directApply": {"const": "deny"}
+      }
+    },
+    "policyRefs": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"}
+    }
+  }
+}

--- a/scripts/requirements-platform-contracts.txt
+++ b/scripts/requirements-platform-contracts.txt
@@ -1,0 +1,2 @@
+jsonschema==4.25.1
+PyYAML==6.0.2

--- a/scripts/validate-platform-contracts.py
+++ b/scripts/validate-platform-contracts.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Validate the indexed darkfactory platform-contract bundle."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_ROOT = ROOT / "platform-contracts"
+INDEX_PATH = CONTRACT_ROOT / "index.yaml"
+
+
+class ContractError(Exception):
+    pass
+
+
+def load_yaml(path: Path) -> Any:
+    with path.open(encoding="utf-8") as stream:
+        return yaml.safe_load(stream)
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def require_keys(value: dict[str, Any], expected: set[str], context: str) -> None:
+    actual = set(value)
+    if actual != expected:
+        raise ContractError(
+            f"{context}: expected keys {sorted(expected)}, got {sorted(actual)}"
+        )
+
+
+def artifact_id(document: dict[str, Any]) -> str:
+    metadata = document["metadata"]
+    return f"{metadata['name']}/{metadata['version']}"
+
+
+def validate_index(index: dict[str, Any]) -> list[dict[str, str]]:
+    require_keys(index, {"apiVersion", "kind", "metadata", "spec"}, "index")
+    if index["apiVersion"] != "platform/contracts-index/v1":
+        raise ContractError("index: unsupported apiVersion")
+    if index["kind"] != "PlatformContractIndex":
+        raise ContractError("index: unsupported kind")
+    require_keys(index["metadata"], {"owner", "version"}, "index.metadata")
+    require_keys(
+        index["spec"],
+        {"digestAlgorithm", "bundleDigest", "artifacts", "registries"},
+        "index.spec",
+    )
+    if index["spec"]["digestAlgorithm"] != "sha256-path-nul-bytes-v1":
+        raise ContractError("index: unsupported digest algorithm")
+    artifacts = index["spec"]["artifacts"]
+    if not isinstance(artifacts, list) or not artifacts:
+        raise ContractError("index: artifacts must be a non-empty list")
+    for position, artifact in enumerate(artifacts):
+        require_keys(artifact, {"path", "kind", "schema", "sha256"}, f"artifact[{position}]")
+    paths = [artifact["path"] for artifact in artifacts]
+    if paths != sorted(paths) or len(paths) != len(set(paths)):
+        raise ContractError("index: artifact paths must be unique and lexically sorted")
+    authoritative_roots = ("schemas", "products", "entity-classes", "realms", "paths")
+    discovered = sorted(
+        path.relative_to(CONTRACT_ROOT).as_posix()
+        for root in authoritative_roots
+        for path in (CONTRACT_ROOT / root).rglob("*")
+        if path.is_file() and path.suffix in {".json", ".yaml", ".yml"}
+    )
+    if paths != discovered:
+        raise ContractError(
+            "index: authoritative files and indexed artifacts differ: "
+            f"indexed={paths}, discovered={discovered}"
+        )
+    digest_pattern = re.compile(r"^[0-9a-f]{64}$")
+    if not digest_pattern.fullmatch(index["spec"]["bundleDigest"]):
+        raise ContractError("index: bundleDigest must be a lowercase SHA-256")
+    allowed_kinds = {"Schema", "PlatformProduct", "EntityClass", "Realm", "PlatformPath"}
+    for position, artifact in enumerate(artifacts):
+        if artifact["kind"] not in allowed_kinds:
+            raise ContractError(f"artifact[{position}]: unsupported kind {artifact['kind']}")
+        if not digest_pattern.fullmatch(artifact["sha256"]):
+            raise ContractError(f"artifact[{position}]: sha256 must be a lowercase SHA-256")
+    require_keys(
+        index["spec"]["registries"],
+        {"actions", "capabilities", "evidenceTypes", "policies", "probes"},
+        "index.spec.registries",
+    )
+    for name, identifiers in index["spec"]["registries"].items():
+        if identifiers != sorted(set(identifiers)):
+            raise ContractError(f"registry {name}: identifiers must be unique and sorted")
+    return artifacts
+
+
+def validate_digests(index: dict[str, Any], artifacts: list[dict[str, str]]) -> None:
+    bundle = hashlib.sha256()
+    for artifact in artifacts:
+        relative = Path(artifact["path"])
+        if relative.is_absolute() or ".." in relative.parts:
+            raise ContractError(f"unsafe artifact path: {relative}")
+        path = CONTRACT_ROOT / relative
+        if not path.is_file():
+            raise ContractError(f"missing indexed artifact: {relative}")
+        actual = sha256(path)
+        if actual != artifact["sha256"]:
+            raise ContractError(
+                f"digest mismatch for {relative}: index={artifact['sha256']} actual={actual}"
+            )
+        bundle.update(relative.as_posix().encode("utf-8"))
+        bundle.update(b"\0")
+        bundle.update(path.read_bytes())
+    actual_bundle = bundle.hexdigest()
+    if actual_bundle != index["spec"]["bundleDigest"]:
+        raise ContractError(
+            f"bundle digest mismatch: index={index['spec']['bundleDigest']} actual={actual_bundle}"
+        )
+
+
+def load_and_validate_artifacts(
+    artifacts: list[dict[str, str]],
+) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    schemas: dict[str, Any] = {}
+    documents: dict[str, dict[str, Any]] = {}
+    for artifact in artifacts:
+        path = CONTRACT_ROOT / artifact["path"]
+        document = load_yaml(path)
+        if artifact["kind"] == "Schema":
+            Draft202012Validator.check_schema(document)
+            schema_id = document.get("$id")
+            if not schema_id or schema_id in schemas:
+                raise ContractError(f"schema {path}: missing or duplicate $id")
+            schemas[schema_id] = document
+        else:
+            if document.get("kind") != artifact["kind"]:
+                raise ContractError(
+                    f"{artifact['path']}: index kind {artifact['kind']} "
+                    f"does not match document kind {document.get('kind')}"
+                )
+            documents[artifact["path"]] = document
+
+    registry = Registry().with_resources(
+        (schema_id, Resource.from_contents(schema))
+        for schema_id, schema in schemas.items()
+    )
+    for artifact in artifacts:
+        if artifact["kind"] == "Schema":
+            continue
+        schema_id = artifact["schema"]
+        if schema_id not in schemas:
+            raise ContractError(f"{artifact['path']}: unknown schema {schema_id}")
+        validator = Draft202012Validator(schemas[schema_id], registry=registry)
+        errors = sorted(validator.iter_errors(documents[artifact["path"]]), key=lambda e: list(e.path))
+        if errors:
+            raise ContractError(f"{artifact['path']}: {errors[0].message}")
+    return schemas, documents
+
+
+def require_registered(value: str, registry: set[str], context: str) -> None:
+    if value not in registry:
+        raise ContractError(f"{context}: unregistered identifier {value}")
+
+
+def validate_semantics(
+    index: dict[str, Any], schemas: dict[str, Any], documents: dict[str, dict[str, Any]]
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    products: dict[str, Any] = {}
+    entities: dict[str, Any] = {}
+    realms: dict[str, Any] = {}
+    paths: dict[str, Any] = {}
+    for document in documents.values():
+        kind = document.get("kind")
+        identifier = artifact_id(document)
+        if kind == "PlatformProduct":
+            target = products
+        elif kind == "EntityClass":
+            target = entities
+        elif kind == "Realm":
+            target = realms
+        elif kind == "PlatformPath":
+            target = paths
+        else:
+            raise ContractError(f"unsupported document kind {kind}")
+        if identifier in target:
+            raise ContractError(f"duplicate {kind} identifier {identifier}")
+        target[identifier] = document
+
+    registries = {name: set(values) for name, values in index["spec"]["registries"].items()}
+    for entity_id, entity in entities.items():
+        for capability in entity["requiredCapabilities"]:
+            require_registered(capability, registries["capabilities"], entity_id)
+        for probe in entity["probes"]:
+            require_registered(probe["id"], registries["probes"], entity_id)
+        require_registered(entity["compensation"]["action"], registries["actions"], entity_id)
+        require_registered(entity["compensation"]["verifier"], registries["probes"], entity_id)
+        for realm_id in entity["allowedRealms"]:
+            if realm_id not in realms:
+                raise ContractError(f"{entity_id}: unknown Realm {realm_id}")
+
+    for realm_id, realm in realms.items():
+        require_registered(realm["resolution"]["derivedBy"], registries["actions"], realm_id)
+        for policy in realm["policyRefs"]:
+            require_registered(policy, registries["policies"], realm_id)
+
+    for product_id, product in products.items():
+        for path_id in product["paths"]:
+            if path_id not in paths:
+                raise ContractError(f"{product_id}: publishes unknown path {path_id}")
+
+    for realm_id, realm in realms.items():
+        for path_id in realm["admission"]["paths"]:
+            if path_id not in paths:
+                raise ContractError(f"{realm_id}: admits unknown path {path_id}")
+
+    for path_id, path in paths.items():
+        if path["product"] not in products:
+            raise ContractError(f"{path_id}: unknown product {path['product']}")
+        if path_id not in products[path["product"]]["paths"]:
+            raise ContractError(f"{path_id}: product does not publish path")
+        if path["inputSchema"] not in schemas:
+            raise ContractError(f"{path_id}: unknown input schema {path['inputSchema']}")
+        for entity_id in path["entityClasses"]:
+            if entity_id not in entities:
+                raise ContractError(f"{path_id}: unknown EntityClass {entity_id}")
+        for realm_id in path["supportedRealms"]:
+            if realm_id not in realms:
+                raise ContractError(f"{path_id}: unknown Realm {realm_id}")
+            realm = realms[realm_id]
+            if path_id not in realm["admission"]["paths"]:
+                raise ContractError(f"{path_id}: Realm {realm_id} does not admit path")
+            if path["metadata"]["state"] not in realm["admission"]["pathStates"]:
+                raise ContractError(f"{path_id}: Realm {realm_id} does not admit path state")
+        step_ids = [step["id"] for step in path["workflow"]]
+        if len(step_ids) != len(set(step_ids)):
+            raise ContractError(f"{path_id}: duplicate workflow step id")
+        seen: set[str] = set()
+        for step in path["workflow"]:
+            require_registered(step["action"], registries["actions"], path_id)
+            unknown_needs = set(step["needs"]) - seen
+            if unknown_needs:
+                raise ContractError(f"{path_id}: step {step['id']} has non-prior needs {sorted(unknown_needs)}")
+            seen.add(step["id"])
+        for policy in path["policies"]:
+            require_registered(policy, registries["policies"], path_id)
+        for condition in path["conditionsOfDone"]:
+            require_registered(condition["probe"], registries["probes"], path_id)
+            require_registered(condition["evidenceType"], registries["evidenceTypes"], path_id)
+        condition_ids = [condition["id"] for condition in path["conditionsOfDone"]]
+        if len(condition_ids) != len(set(condition_ids)):
+            raise ContractError(f"{path_id}: duplicate Condition of Done id")
+        require_registered(path["compensation"]["action"], registries["actions"], path_id)
+        require_registered(path["compensation"]["verifier"], registries["probes"], path_id)
+        for evidence_type in path["evidence"]["requiredTypes"]:
+            require_registered(evidence_type, registries["evidenceTypes"], path_id)
+    return products, paths, realms
+
+
+def validate_request(
+    request: dict[str, Any],
+    schemas: dict[str, Any],
+    products: dict[str, Any],
+    paths: dict[str, Any],
+    realms: dict[str, Any],
+) -> None:
+    Draft202012Validator(schemas["urn:darkfactory:platform-contract:product-request:v1"]).validate(request)
+    product_id = request["product"]
+    path_id = request["path"]
+    realm_id = request["realmClass"]
+    if product_id not in products:
+        raise ContractError(f"request: unknown product {product_id}")
+    if path_id not in paths or path_id not in products[product_id]["paths"]:
+        raise ContractError(f"request: path {path_id} is not published by {product_id}")
+    path = paths[path_id]
+    if path["product"] != product_id:
+        raise ContractError("request: product/path mismatch")
+    if realm_id not in realms or realm_id not in path["supportedRealms"]:
+        raise ContractError(f"request: unsupported Realm {realm_id}")
+    realm = realms[realm_id]
+    if path_id not in realm["admission"]["paths"]:
+        raise ContractError(f"request: Realm {realm_id} does not admit {path_id}")
+    Draft202012Validator(schemas[path["inputSchema"]]).validate(request["inputs"])
+
+
+def validate_fixtures(
+    schemas: dict[str, Any],
+    products: dict[str, Any],
+    paths: dict[str, Any],
+    realms: dict[str, Any],
+) -> None:
+    valid = sorted((CONTRACT_ROOT / "fixtures/valid").glob("*.yaml"))
+    invalid = sorted((CONTRACT_ROOT / "fixtures/invalid").glob("*.yaml"))
+    if not valid or not invalid:
+        raise ContractError("fixtures: valid and invalid fixtures are both required")
+    for fixture in valid:
+        validate_request(load_yaml(fixture), schemas, products, paths, realms)
+    for fixture in invalid:
+        try:
+            validate_request(load_yaml(fixture), schemas, products, paths, realms)
+        except Exception:
+            continue
+        raise ContractError(f"invalid fixture unexpectedly passed: {fixture.relative_to(ROOT)}")
+
+
+def main() -> int:
+    try:
+        index = load_yaml(INDEX_PATH)
+        artifacts = validate_index(index)
+        validate_digests(index, artifacts)
+        schemas, documents = load_and_validate_artifacts(artifacts)
+        products, paths, realms = validate_semantics(index, schemas, documents)
+        validate_fixtures(schemas, products, paths, realms)
+    except Exception as error:
+        print(f"platform-contract validation failed: {error}", file=sys.stderr)
+        return 1
+    print(
+        "platform-contract validation passed: "
+        f"{len(artifacts)} indexed artifacts, {len(products)} product, "
+        f"{len(paths)} path, {len(realms)} Realm"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- accept ADR-0056 and make `platform-contracts/` the Git-published authority for machine-readable platform products and paths
- publish the bounded experimental `standard-http-service/v1` product, EntityClasses, preview Realm, request schema, workflow, Conditions of Done, and compensation
- add indexed content and bundle SHA-256 validation, closed Draft 2020-12 schemas, positive/negative fixtures, CODEOWNERS, and CI

## Safety boundary

This does not activate Omnius mutation. The path remains `experimental`, is admitted only to `preview/v1`, requires human merge, forbids direct apply/production/shared/data/secret access, and exposes no arbitrary commands or Helm/environment overrides.

## Verification

- `python3 scripts/validate-platform-contracts.py`
- clean venv with pinned `jsonschema==4.25.1` and `PyYAML==6.0.2`
- `yamllint -c .yamllint platform-contracts .github/workflows/platform-contracts-validate.yml`
- `python3 -m py_compile scripts/validate-platform-contracts.py`
- `git diff --check`
- fail-closed check for an unindexed authority file
