### PR TITLE
feat: register draft PR close compensator

### DIFF
--- a/platform-contracts/index.yaml
+++ b/platform-contracts/index.yaml
@@ -54,6 +54,7 @@ spec:
   registries:
     actions:
       - delivery.await-human-merge/v1
+      - delivery.close-unmerged-draft-pull-request/v1
       - delivery.observe-argocd-sync/v1
       - delivery.open-draft-pull-request/v1
       - delivery.prune-preview-realm/v1

--- a/platform-contracts/paths/standard-http-service/v1/README.md
+++ b/platform-contracts/paths/standard-http-service/v1/README.md
@@ -34,6 +34,11 @@ actions, probes, expected responses, compensation, and evidence TTL. Completion 
 
 Any missing, expired, conflicting, or unverifiable result prevents verified completion.
 
+The effect-local `delivery.close-unmerged-draft-pull-request/v1` compensator covers only the
+open-PR side effect before human merge. The path-level
+`delivery.revert-and-prune-preview/v1` action remains a separate composite Saga for a landed
+change and its preview resources; closing a Draft PR cannot satisfy the path-level verifier.
+
 ## Current admission
 
 Only `preview/v1` admits this experimental path. Human merge remains mandatory. Promotion to


### PR DESCRIPTION
## Summary
- register an effect-local action for closing one unmerged Draft PR
- keep path-wide revert-and-prune compensation distinct from the PR-only undo
- document that close-PR evidence cannot satisfy the preview-pruned verifier

## Verification
- `python3 scripts/validate-platform-contracts.py`
- `git diff --check`
