### PR TITLE
feat: add versioned platform delivery profile

### DIFF
--- a/docs/adrs/0056-machine-readable-platform-contracts.md
+++ b/docs/adrs/0056-machine-readable-platform-contracts.md
@@ -32,13 +32,23 @@ variables, free-form scripts, and direct apply/deploy are outside this contract.
 3. The bundle digest is calculated over the authoritative files listed in the index, in
    lexical path order, as `path + NUL + bytes`. The index itself is excluded to avoid a
    self-referential digest. Every listed file also has an individual SHA-256.
-4. Platform products, entity classes, Realms, paths, and requests remain distinct artifacts.
+4. Platform products, entity classes, Realms, delivery profiles, paths, and requests remain distinct artifacts.
    JSON Schema Draft 2020-12 with stable `urn:darkfactory:platform-contract:*` identifiers is
    the compatibility boundary. No schema service or GitHub Pages publication is introduced.
 5. `standard-http-service/v1` enters in `experimental` state and is admitted only to the
    `preview/v1` Realm class. Lower-environment evidence is required before any later promotion.
 6. Omnius receives only registered action, policy, and probe identifiers. The path cannot
    contain raw commands or implementation-specific apply authority.
+7. Each executable path references one indexed `PlatformDeliveryProfile`. The platform owner uses
+   that closed artifact to fix trusted source bindings, GitOps naming and topology references,
+   resource envelopes, observation rules, and compensation. Omnius resolves logical endpoint
+   references through separately governed adapter configuration and never accepts delivery targets
+   from a request or model.
+8. Adding the mandatory delivery-profile reference creates `platform/path/v2` and a new immutable
+   `standard-service/v2` → `standard-http-service/v2` → `preview/v2` graph. The complete v1 graph
+   and schema remain byte-compatible with their original contract. The initial delivery profile
+   also requires an authenticated repository-ownership policy decision and binds its sole Namespace
+   and compensation targets to the WorkOrder identity.
 
 ## Alternatives considered
 

--- a/platform-contracts/README.md
+++ b/platform-contracts/README.md
@@ -6,14 +6,16 @@ indexed bundle pinned by exact Git commit and bundle SHA-256.
 
 ## Layout
 
-- `schemas/v1/` defines closed Draft 2020-12 schemas.
-- `products/`, `entity-classes/`, `realms/`, and `paths/` contain owned instances.
+- `schemas/v1/` and later version directories define closed Draft 2020-12 schemas.
+- `products/`, `entity-classes/`, `realms/`, `delivery-profiles/`, and `paths/` contain owned instances.
 - `index.yaml` lists every authoritative file, its schema, and its content digest.
 - `fixtures/` contains requests that must pass or fail validation.
 
-The first vertical is `standard-service/v1` through
-`standard-http-service/v1`. It accepts one existing Go repository, creates an internal HTTP
-service in a disposable `preview-<work-order-id>` Realm, and requires human merge.
+The original `standard-service/v1` and `standard-http-service/v1` graph remains indexed and
+unchanged. The delivery-bound first executable revision is `standard-service/v2` through
+`standard-http-service/v2` in `preview/v2`. It accepts one authorized existing Go repository,
+creates an internal HTTP service in a disposable `preview-<work-order-id>` Realm, and requires
+human merge.
 
 ## Publication and pinning
 
@@ -27,6 +29,29 @@ sha256(path + NUL + file-bytes + path + NUL + file-bytes + ...)
 Each artifact also has an individual SHA-256 in the index. A consumer must verify both and
 record the exact 40-character Git commit. A branch, tag alone, working tree, copied catalog,
 or Omniscience projection is not execution authority.
+
+## Delivery profiles
+
+A `PlatformDeliveryProfile` is the platform-owned bridge from an executable path to a concrete,
+bounded delivery topology. It fixes trusted value sources, GitOps path and naming templates, logical
+Argo CD and Kubernetes destination references, the allowed resource inventory, observation rules,
+and compensation. Requests and agents cannot override those fields. Endpoint and credential lookup
+for a logical reference remains adapter configuration governed outside the request.
+
+The initial profile requires the repository-ownership policy to bind the authenticated WorkOrder
+subject and declared owner to the exact repository before any repository-scoped credential is
+issued. Its inventory kind set is closed, its only cluster-scoped object is one derived Namespace,
+and compensation is bound to the same repository path, Application, namespace, inventory digest,
+and ownership identity. Template variables bind explicitly to `workOrder.id`, the validated service
+name, and the resolved Realm name. Missing authorization or scope evidence denies execution.
+
+The profile does not grant apply authority to Omnius. For the initial path, a human merge lands the
+change and Argo CD reconciles it; Omnius observes exact revision, health, image digest, Realm
+containment, and eventual compensation through scoped read-only adapters.
+
+`PlatformPath` schema v2 adds the required delivery-profile reference. The published v1 schema and
+the complete v1 product/path/entity/Realm graph remain unchanged for consumers of older immutable
+bundles; they are not silently given v2 semantics.
 
 Run validation locally with:
 

--- a/platform-contracts/delivery-profiles/argocd-preview-http-service/v1/profile.yaml
+++ b/platform-contracts/delivery-profiles/argocd-preview-http-service/v1/profile.yaml
@@ -1,0 +1,91 @@
+schemaVersion: platform/delivery-profile/v1
+kind: PlatformDeliveryProfile
+metadata:
+  name: argocd-preview-http-service
+  version: v1
+  owner: platform-team
+  state: experimental
+path: standard-http-service/v2
+mechanism: delivery.argocd/v1
+templateBindings:
+  workOrderIdFrom: workOrder.id
+  serviceNameFrom: request.inputs.serviceName
+  realmNameFrom: realm.effectiveName
+source:
+  repositoryFrom: request.inputs.repositoryRef
+  repositoryAuthorization:
+    policy: source.repository-owner-authorized/v1
+    subjectFrom: workOrder.authenticatedRequester
+    ownerFrom: request.inputs.ownerRef
+    repositoryFrom: request.inputs.repositoryRef
+    credentialScope: exact-repository
+    onMissing: deny
+  gitopsPathTemplate: deploy/preview/{serviceName}/{workOrderId}
+  targetRevisionFrom: workflow.await-human-merge.mergeCommitSha
+  imageDigestFrom: evidence.supply-chain.attested-image
+  desiredInventoryFrom: workflow.validate-change.renderedManifestDigest
+  singleRepository: true
+application:
+  controlPlaneRef: argocd:preview-primary
+  namespace: argocd
+  nameTemplate: preview-{workOrderId}
+  project: preview
+  requiredLabels:
+    darkfactory.platform/path: standard-http-service-v2
+    darkfactory.platform/realm: "{realmName}"
+    darkfactory.platform/work-order: "{workOrderId}"
+destination:
+  clusterRef: kubernetes:preview-primary
+  namespaceTemplate: preview-{workOrderId}
+resourceEnvelope:
+  requiredKinds:
+    - apps/v1/Deployment
+    - networking.k8s.io/v1/Ingress
+    - networking.k8s.io/v1/NetworkPolicy
+    - v1/Namespace
+    - v1/ResourceQuota
+    - v1/Service
+  allowedKinds:
+    - apps/v1/Deployment
+    - networking.k8s.io/v1/Ingress
+    - networking.k8s.io/v1/NetworkPolicy
+    - v1/Namespace
+    - v1/ResourceQuota
+    - v1/Service
+  clusterScopedBindings:
+    - kind: v1/Namespace
+      nameFrom: destination.namespaceTemplate
+      maxCount: 1
+  ownershipLabel: darkfactory.platform/work-order
+  ownershipValueFrom: workOrder.id
+  requiredAssertions:
+    - dedicated-namespace
+    - default-deny-network
+    - digest-pinned-image
+    - no-cross-realm-rbac
+    - no-persistent-volumes
+    - no-runtime-secrets
+    - no-service-account-token
+    - quota-bound
+observations:
+  action: delivery.observe-argocd-sync/v1
+  gitopsProbe: gitops.argocd-synced-healthy/v1
+  gitopsEvidenceType: gitops.revision-status/v1
+  realmProbe: realm.preview-containment/v1
+  realmEvidenceType: kubernetes.realm-boundary/v1
+  requiredSyncStatus: Synced
+  requiredHealthStatus: Healthy
+  exactRevision: true
+  exactImageDigest: true
+compensation:
+  action: delivery.revert-and-prune-preview/v1
+  verifier: realm.preview-pruned/v1
+  evidenceType: compensation.result/v1
+  scope:
+    repositoryFrom: source.repositoryFrom
+    gitopsPathFrom: source.gitopsPathTemplate
+    applicationNameFrom: application.nameTemplate
+    destinationNamespaceFrom: destination.namespaceTemplate
+    inventoryDigestFrom: source.desiredInventoryFrom
+    ownershipLabelFrom: resourceEnvelope.ownershipLabel
+    ownershipValueFrom: resourceEnvelope.ownershipValueFrom

--- a/platform-contracts/entity-classes/environment/v2/entity-class.yaml
+++ b/platform-contracts/entity-classes/environment/v2/entity-class.yaml
@@ -1,0 +1,30 @@
+schemaVersion: platform/entity-class/v1
+kind: EntityClass
+metadata:
+  name: Environment
+  version: v2
+  owner: platform-team
+  state: experimental
+requiredCapabilities:
+  - kubernetes.namespace/v1
+  - kubernetes.resource-quota/v1
+  - kubernetes.default-deny-network-policy/v1
+naming:
+  pattern: ^preview-[a-z0-9][a-z0-9-]{7,52}$
+  maxLength: 63
+lifecycle:
+  - create
+  - observe
+  - delete
+probes:
+  - id: realm.preview-containment/v1
+    phase: preflight
+    required: true
+  - id: realm.preview-pruned/v1
+    phase: compensation
+    required: true
+compensation:
+  action: delivery.prune-preview-realm/v1
+  verifier: realm.preview-pruned/v1
+allowedRealms:
+  - preview/v2

--- a/platform-contracts/entity-classes/http-service/v2/entity-class.yaml
+++ b/platform-contracts/entity-classes/http-service/v2/entity-class.yaml
@@ -1,0 +1,45 @@
+schemaVersion: platform/entity-class/v1
+kind: EntityClass
+metadata:
+  name: HttpService
+  version: v2
+  owner: platform-team
+  state: experimental
+requiredCapabilities:
+  - runtime.go-1.23/v1
+  - delivery.argocd/v1
+  - ingress.internal-http/v1
+  - supply-chain.sbom/v1
+  - supply-chain.signature/v1
+naming:
+  pattern: ^[a-z][a-z0-9-]{2,40}[a-z0-9]$
+  maxLength: 42
+lifecycle:
+  - create
+  - observe
+  - update
+  - delete
+probes:
+  - id: build.unit-tests/v1
+    phase: delivery
+    required: true
+  - id: supply-chain.image-attestation/v1
+    phase: delivery
+    required: true
+  - id: gitops.argocd-synced-healthy/v1
+    phase: runtime
+    required: true
+  - id: http.healthz/v1
+    phase: runtime
+    required: true
+  - id: http.readyz/v1
+    phase: runtime
+    required: true
+  - id: http.request-contract/v1
+    phase: runtime
+    required: true
+compensation:
+  action: delivery.revert-and-prune-preview/v1
+  verifier: realm.preview-pruned/v1
+allowedRealms:
+  - preview/v2

--- a/platform-contracts/fixtures/delivery-profiles/invalid/caller-controlled-target.yaml
+++ b/platform-contracts/fixtures/delivery-profiles/invalid/caller-controlled-target.yaml
@@ -1,0 +1,62 @@
+schemaVersion: platform/delivery-profile/v1
+kind: PlatformDeliveryProfile
+metadata: {name: caller-controlled-target, version: v1, owner: platform-team, state: experimental}
+path: standard-http-service/v1
+mechanism: delivery.argocd/v1
+templateBindings:
+  workOrderIdFrom: workOrder.id
+  serviceNameFrom: request.inputs.serviceName
+  realmNameFrom: realm.effectiveName
+source:
+  repositoryFrom: request.inputs.gitopsRepository
+  repositoryAuthorization:
+    policy: source.repository-owner-authorized/v1
+    subjectFrom: workOrder.authenticatedRequester
+    ownerFrom: request.inputs.ownerRef
+    repositoryFrom: request.inputs.repositoryRef
+    credentialScope: exact-repository
+    onMissing: deny
+  gitopsPathTemplate: deploy/preview/{serviceName}/{workOrderId}
+  targetRevisionFrom: request.inputs.branch
+  imageDigestFrom: request.inputs.image
+  desiredInventoryFrom: workflow.validate-change.renderedManifestDigest
+  singleRepository: true
+application:
+  controlPlaneRef: argocd:preview-primary
+  namespace: argocd
+  nameTemplate: preview-{workOrderId}
+  project: preview
+  requiredLabels:
+    darkfactory.platform/path: standard-http-service-v1
+    darkfactory.platform/realm: "{realmName}"
+    darkfactory.platform/work-order: "{workOrderId}"
+destination: {clusterRef: "kubernetes:preview-primary", namespaceTemplate: "preview-{workOrderId}"}
+resourceEnvelope:
+  requiredKinds: [v1/Namespace]
+  allowedKinds: [v1/Namespace]
+  clusterScopedBindings: [{kind: v1/Namespace, nameFrom: destination.namespaceTemplate, maxCount: 1}]
+  ownershipLabel: darkfactory.platform/work-order
+  ownershipValueFrom: workOrder.id
+  requiredAssertions: [dedicated-namespace]
+observations:
+  action: delivery.observe-argocd-sync/v1
+  gitopsProbe: gitops.argocd-synced-healthy/v1
+  gitopsEvidenceType: gitops.revision-status/v1
+  realmProbe: realm.preview-containment/v1
+  realmEvidenceType: kubernetes.realm-boundary/v1
+  requiredSyncStatus: Synced
+  requiredHealthStatus: Healthy
+  exactRevision: true
+  exactImageDigest: true
+compensation:
+  action: delivery.revert-and-prune-preview/v1
+  verifier: realm.preview-pruned/v1
+  evidenceType: compensation.result/v1
+  scope:
+    repositoryFrom: source.repositoryFrom
+    gitopsPathFrom: source.gitopsPathTemplate
+    applicationNameFrom: application.nameTemplate
+    destinationNamespaceFrom: destination.namespaceTemplate
+    inventoryDigestFrom: source.desiredInventoryFrom
+    ownershipLabelFrom: resourceEnvelope.ownershipLabel
+    ownershipValueFrom: resourceEnvelope.ownershipValueFrom

--- a/platform-contracts/fixtures/delivery-profiles/invalid/resource-envelope-escape.yaml
+++ b/platform-contracts/fixtures/delivery-profiles/invalid/resource-envelope-escape.yaml
@@ -1,0 +1,62 @@
+schemaVersion: platform/delivery-profile/v1
+kind: PlatformDeliveryProfile
+metadata: {name: resource-envelope-escape, version: v1, owner: platform-team, state: experimental}
+path: standard-http-service/v1
+mechanism: delivery.argocd/v1
+templateBindings:
+  workOrderIdFrom: workOrder.id
+  serviceNameFrom: request.inputs.serviceName
+  realmNameFrom: realm.effectiveName
+source:
+  repositoryFrom: request.inputs.repositoryRef
+  repositoryAuthorization:
+    policy: source.repository-owner-authorized/v1
+    subjectFrom: workOrder.authenticatedRequester
+    ownerFrom: request.inputs.ownerRef
+    repositoryFrom: request.inputs.repositoryRef
+    credentialScope: exact-repository
+    onMissing: deny
+  gitopsPathTemplate: deploy/preview/{serviceName}/{workOrderId}
+  targetRevisionFrom: workflow.await-human-merge.mergeCommitSha
+  imageDigestFrom: evidence.supply-chain.attested-image
+  desiredInventoryFrom: workflow.validate-change.renderedManifestDigest
+  singleRepository: true
+application:
+  controlPlaneRef: argocd:preview-primary
+  namespace: argocd
+  nameTemplate: preview-{workOrderId}
+  project: preview
+  requiredLabels:
+    darkfactory.platform/path: standard-http-service-v1
+    darkfactory.platform/realm: "{realmName}"
+    darkfactory.platform/work-order: "{workOrderId}"
+destination: {clusterRef: "kubernetes:preview-primary", namespaceTemplate: "preview-{workOrderId}"}
+resourceEnvelope:
+  requiredKinds: [rbac.authorization.k8s.io/v1/ClusterRole, v1/Namespace]
+  allowedKinds: [v1/Namespace]
+  clusterScopedBindings: [{kind: v1/Namespace, nameFrom: destination.namespaceTemplate, maxCount: 1}]
+  ownershipLabel: darkfactory.platform/work-order
+  ownershipValueFrom: workOrder.id
+  requiredAssertions: [dedicated-namespace]
+observations:
+  action: delivery.observe-argocd-sync/v1
+  gitopsProbe: gitops.argocd-synced-healthy/v1
+  gitopsEvidenceType: gitops.revision-status/v1
+  realmProbe: realm.preview-containment/v1
+  realmEvidenceType: kubernetes.realm-boundary/v1
+  requiredSyncStatus: Synced
+  requiredHealthStatus: Healthy
+  exactRevision: true
+  exactImageDigest: true
+compensation:
+  action: delivery.revert-and-prune-preview/v1
+  verifier: realm.preview-pruned/v1
+  evidenceType: compensation.result/v1
+  scope:
+    repositoryFrom: source.repositoryFrom
+    gitopsPathFrom: source.gitopsPathTemplate
+    applicationNameFrom: application.nameTemplate
+    destinationNamespaceFrom: destination.namespaceTemplate
+    inventoryDigestFrom: source.desiredInventoryFrom
+    ownershipLabelFrom: resourceEnvelope.ownershipLabel
+    ownershipValueFrom: resourceEnvelope.ownershipValueFrom

--- a/platform-contracts/fixtures/valid/standard-http-service-v2-request.yaml
+++ b/platform-contracts/fixtures/valid/standard-http-service-v2-request.yaml
@@ -1,0 +1,23 @@
+schemaVersion: platform/request/v1
+kind: ProductRequest
+metadata:
+  requestId: wo-01j2k3m4n5p6q7r8
+product: standard-service/v2
+path: standard-http-service/v2
+realmClass: preview/v2
+inputs:
+  serviceName: payments-api
+  ownerRef: team:payments
+  repositoryRef: github:example-org/payments-api
+  sourceSubpath: services/payments
+  runtime: go-1.23
+  exposure: internal
+  port: 8080
+  resourceProfile: small
+  acceptance:
+    - method: GET
+      path: /path/v2/payments
+      expected:
+        status: 200
+        jsonSubset:
+          ready: true

--- a/platform-contracts/index.yaml
+++ b/platform-contracts/index.yaml
@@ -5,16 +5,28 @@ metadata:
   version: v1
 spec:
   digestAlgorithm: sha256-path-nul-bytes-v1
-  bundleDigest: 40d837bdc2386e6f4e7031b048d64a4224b8398f9810f7ce98ab981200bd9ed6
+  bundleDigest: 11454cd89172c44a8ddbf021a44f41724e20e3e94180e4450f8f7bc78e2f0697
   artifacts:
+    - path: delivery-profiles/argocd-preview-http-service/v1/profile.yaml
+      kind: PlatformDeliveryProfile
+      schema: urn:darkfactory:platform-contract:delivery-profile:v1
+      sha256: 6eb7e8681331cccff2a1e9e46a59a216dd0e69ec5014589a1212e51bb4afbac8
     - path: entity-classes/environment/v1/entity-class.yaml
       kind: EntityClass
       schema: urn:darkfactory:platform-contract:entity-class:v1
       sha256: 56935e1b40c8d28c6bfde0b17fbd52e6ddbe651ef9c7622fa348d0304e873648
+    - path: entity-classes/environment/v2/entity-class.yaml
+      kind: EntityClass
+      schema: urn:darkfactory:platform-contract:entity-class:v1
+      sha256: 5b1b541df319b408804b79b01b579db150ba9d98299dae307bd6a6567378ecad
     - path: entity-classes/http-service/v1/entity-class.yaml
       kind: EntityClass
       schema: urn:darkfactory:platform-contract:entity-class:v1
       sha256: ba9c8c445ff60417160b2712f4a13356bce8ef2a40636c48f8b0d716c847a162
+    - path: entity-classes/http-service/v2/entity-class.yaml
+      kind: EntityClass
+      schema: urn:darkfactory:platform-contract:entity-class:v1
+      sha256: 13709c261c6b67193f9a7ff02a6f87c0084c425ff5a6fc2608973b8efd4e74d8
     - path: paths/standard-http-service/v1/path.yaml
       kind: PlatformPath
       schema: urn:darkfactory:platform-contract:platform-path:v1
@@ -23,14 +35,34 @@ spec:
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
       sha256: 439432fd6fcb8b876fe7d9d3498910c96c51ed249b857dc1f376482bd4f17f72
+    - path: paths/standard-http-service/v2/path.yaml
+      kind: PlatformPath
+      schema: urn:darkfactory:platform-contract:platform-path:v2
+      sha256: 6c71ce1eb084699aba90ba83611a004747bbb88f611cedf48d1deb12e0cb9209
+    - path: paths/standard-http-service/v2/request.schema.json
+      kind: Schema
+      schema: https://json-schema.org/draft/2020-12/schema
+      sha256: c33cf5edb1926706a1feefe465cbdbd64fa005b6a166c9e7df310d1c427cc078
     - path: products/standard-service/v1/product.yaml
       kind: PlatformProduct
       schema: urn:darkfactory:platform-contract:platform-product:v1
       sha256: 5b6b55edf7b71548b80d4f22a814c9c197b4f4a38c74a7162c120361c9058d84
+    - path: products/standard-service/v2/product.yaml
+      kind: PlatformProduct
+      schema: urn:darkfactory:platform-contract:platform-product:v1
+      sha256: 3871ff2ab767e62e66f409b1955a6ca1579011702b18a8a2179f9e7302e7e431
     - path: realms/preview/v1/realm.yaml
       kind: Realm
       schema: urn:darkfactory:platform-contract:realm:v1
       sha256: af681d9b167ad8503e26fe957752704b6f2ca3c31d6d888c56382f9ce949d29c
+    - path: realms/preview/v2/realm.yaml
+      kind: Realm
+      schema: urn:darkfactory:platform-contract:realm:v1
+      sha256: fdb5f2cebcd0444a6a99cc30e233d9fb60199b66c27d4c1c6fbfb5552f8a7d7d
+    - path: schemas/v1/delivery-profile.schema.json
+      kind: Schema
+      schema: https://json-schema.org/draft/2020-12/schema
+      sha256: c7e8cde98c470a383214e5b0152ada5ae87826b492e64b173cceb919a4439e69
     - path: schemas/v1/entity-class.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
@@ -51,6 +83,10 @@ spec:
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
       sha256: f80e13163bcf41ad5652adc7f772d754c6d308e6c4c3198a01ffc64165119c81
+    - path: schemas/v2/platform-path.schema.json
+      kind: Schema
+      schema: https://json-schema.org/draft/2020-12/schema
+      sha256: c22396e37ddbec21e326b2b5bdf0728b935c8042c680ba29f0c01d82b2e58396
   registries:
     actions:
       - delivery.await-human-merge/v1
@@ -88,6 +124,7 @@ spec:
       - global.no-production-mutation/v1
       - realm.preview-containment/v1
       - realm.preview-no-secrets/v1
+      - source.repository-owner-authorized/v1
       - supply-chain.build-once-by-digest/v1
     probes:
       - build.security-gates/v1

--- a/platform-contracts/paths/standard-http-service/v2/README.md
+++ b/platform-contracts/paths/standard-http-service/v2/README.md
@@ -1,0 +1,60 @@
+# standard-http-service/v2
+
+This experimental path changes one existing Go 1.23 HTTP service and proves it in a
+disposable preview Realm. It is an execution contract, not a claim that the current estate
+already implements every registered action or probe.
+
+## Request boundary
+
+The request names one existing GitHub repository and a safe relative source subpath. Runtime,
+exposure, port, and resource size are fixed. Acceptance probes are bounded `GET` requests with
+HTTP 200 and either exact text or a shallow JSON subset. Unknown fields fail validation.
+
+The request cannot supply commands, scripts, environment variables, secrets, image tags, Helm
+values, policy overrides, namespaces, clusters, accounts, or production targets. Identity and
+the effective `preview-<work-order-id>` Realm are derived by trusted intake and policy code.
+
+The path binds `argocd-preview-http-service/v1` as its platform-owned delivery profile. That
+profile, rather than caller or agent input, fixes the GitOps path template, Argo CD control-plane
+and project references, target cluster reference, Application and namespace names, resource
+envelope, observation rules, and compensation. Logical control-plane and cluster references are
+resolved only through separately governed adapter configuration; they are not network endpoints or
+credentials supplied by a request. The desired inventory digest comes from the deterministic
+source-validation step, not from the authoring worker.
+
+The request repository is not authority by itself. Execution requires
+`source.repository-owner-authorized/v1` to bind the authenticated WorkOrder subject, owner, exact
+repository, and exact-repository credential scope. Compensation reuses the same repository,
+work-order-specific GitOps path, Application, derived namespace, inventory digest, and ownership
+identity; none of those targets can be replaced by compensation input.
+
+## Condition of Done
+
+Before execution, Omnius binds the exact request, path commit, bundle digest, policies,
+actions, probes, expected responses, compensation, and evidence TTL. Completion requires:
+
+1. The source diff stays inside the bound repository and source/GitOps paths.
+2. Unit, build, and security checks pass on the exact commit.
+3. The image is built once; SBOM and signature evidence bind its immutable digest.
+4. A Draft PR is opened idempotently and a human merges it.
+5. Argo CD reports `Synced` and `Healthy` for the exact Git and image revisions.
+6. A dedicated quota-bound, default-deny preview namespace has no production credentials,
+   shared-state access, data mutation, or cross-Realm authority.
+7. `/healthz`, `/readyz`, and every requested route pass three consecutive bounded probes
+   from a verifier outside the worker identity and writable environment.
+8. The evidence manifest is immutable and no older than `PT24H`.
+9. Registered compensation can close an unmerged PR or revert the landed change and prune the
+   preview Realm; the prune verifier proves absence of owned resources.
+
+Any missing, expired, conflicting, or unverifiable result prevents verified completion.
+
+The effect-local `delivery.close-unmerged-draft-pull-request/v1` compensator covers only the
+open-PR side effect before human merge. The path-level
+`delivery.revert-and-prune-preview/v1` action remains a separate composite Saga for a landed
+change and its preview resources; closing a Draft PR cannot satisfy the path-level verifier.
+
+## Current admission
+
+Only `preview/v2` admits this experimental path. Human merge remains mandatory. Promotion to
+another Realm requires a new reviewed contract revision and lower-Realm evidence; Omnius cannot
+widen admission from task input or its own outcome feedback.

--- a/platform-contracts/paths/standard-http-service/v2/path.yaml
+++ b/platform-contracts/paths/standard-http-service/v2/path.yaml
@@ -1,0 +1,103 @@
+schemaVersion: platform/path/v2
+kind: PlatformPath
+metadata:
+  name: standard-http-service
+  version: v2
+  owner: platform-team
+  state: experimental
+product: standard-service/v2
+inputSchema: urn:darkfactory:platform-contract:path-input:standard-http-service:v2
+deliveryProfile: argocd-preview-http-service/v1
+entityClasses:
+  - Environment/v2
+  - HttpService/v2
+supportedRealms:
+  - preview/v2
+workflow:
+  - id: inspect-source
+    action: source.inspect-existing-repository/v1
+    needs: []
+  - id: author-change
+    action: source.author-http-service-change/v1
+    needs: [inspect-source]
+  - id: validate-change
+    action: verification.run-source-gates/v1
+    needs: [author-change]
+  - id: register-compensation
+    action: execution.register-compensation/v1
+    needs: [validate-change]
+  - id: open-draft-pr
+    action: delivery.open-draft-pull-request/v1
+    needs: [register-compensation]
+  - id: await-human-merge
+    action: delivery.await-human-merge/v1
+    needs: [open-draft-pr]
+  - id: observe-gitops
+    action: delivery.observe-argocd-sync/v1
+    needs: [await-human-merge]
+  - id: verify-runtime
+    action: verification.run-http-probes/v1
+    needs: [observe-gitops]
+policies:
+  - global.no-main-push/v1
+  - global.no-direct-apply/v1
+  - global.no-production-mutation/v1
+  - realm.preview-containment/v1
+  - realm.preview-no-secrets/v1
+  - source.repository-owner-authorized/v1
+  - delivery.human-merge-required/v1
+  - supply-chain.build-once-by-digest/v1
+conditionsOfDone:
+  - id: source.unit-tests
+    probe: build.unit-tests/v1
+    evidenceType: ci.check-run/v1
+    required: true
+  - id: source.security-gates
+    probe: build.security-gates/v1
+    evidenceType: ci.check-run/v1
+    required: true
+  - id: supply-chain.attested-image
+    probe: supply-chain.image-attestation/v1
+    evidenceType: supply-chain.attestation/v1
+    required: true
+  - id: delivery.gitops-revision
+    probe: gitops.argocd-synced-healthy/v1
+    evidenceType: gitops.revision-status/v1
+    required: true
+  - id: realm.contained
+    probe: realm.preview-containment/v1
+    evidenceType: kubernetes.realm-boundary/v1
+    required: true
+  - id: runtime.health
+    probe: http.healthz/v1
+    evidenceType: http.probe-result/v1
+    required: true
+    consecutivePasses: 3
+  - id: runtime.readiness
+    probe: http.readyz/v1
+    evidenceType: http.probe-result/v1
+    required: true
+    consecutivePasses: 3
+  - id: runtime.request-contract
+    probe: http.request-contract/v1
+    evidenceType: http.probe-result/v1
+    required: true
+    consecutivePasses: 3
+compensation:
+  action: delivery.revert-and-prune-preview/v1
+  verifier: realm.preview-pruned/v1
+  triggers:
+    - cancelled
+    - failed
+    - expired
+    - completed
+evidence:
+  ttl: PT24H
+  manifestType: darkfactory.evidence-manifest/v1
+  requiredTypes:
+    - ci.check-run/v1
+    - supply-chain.attestation/v1
+    - gitops.revision-status/v1
+    - kubernetes.realm-boundary/v1
+    - http.probe-result/v1
+    - compensation.result/v1

--- a/platform-contracts/paths/standard-http-service/v2/request.schema.json
+++ b/platform-contracts/paths/standard-http-service/v2/request.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:darkfactory:platform-contract:path-input:standard-http-service:v2",
+  "title": "standard-http-service/v2 inputs",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["serviceName", "ownerRef", "repositoryRef", "sourceSubpath", "runtime", "exposure", "port", "resourceProfile", "acceptance"],
+  "properties": {
+    "serviceName": {"type": "string", "pattern": "^[a-z][a-z0-9-]{2,40}[a-z0-9]$"},
+    "ownerRef": {"type": "string", "pattern": "^team:[a-z][a-z0-9-]{2,62}$"},
+    "repositoryRef": {"type": "string", "pattern": "^github:[a-zA-Z0-9_.-]{1,39}/[a-zA-Z0-9_.-]{1,100}$"},
+    "sourceSubpath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))[a-zA-Z0-9_.-]+(?:/[a-zA-Z0-9_.-]+)*$"
+    },
+    "runtime": {"const": "go-1.23"},
+    "exposure": {"const": "internal"},
+    "port": {"const": 8080},
+    "resourceProfile": {"const": "small"},
+    "acceptance": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["method", "path", "expected"],
+        "properties": {
+          "method": {"const": "GET"},
+          "path": {"type": "string", "pattern": "^/[a-zA-Z0-9/_-]{0,127}$"},
+          "expected": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["status"],
+            "properties": {
+              "status": {"const": 200},
+              "exactText": {"type": "string", "maxLength": 512},
+              "jsonSubset": {
+                "type": "object",
+                "maxProperties": 10,
+                "additionalProperties": {"type": ["string", "number", "integer", "boolean", "null"]}
+              }
+            },
+            "oneOf": [
+              {"required": ["exactText"]},
+              {"required": ["jsonSubset"]}
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/platform-contracts/products/standard-service/v2/product.yaml
+++ b/platform-contracts/products/standard-service/v2/product.yaml
@@ -1,0 +1,23 @@
+schemaVersion: platform/product/v1
+kind: PlatformProduct
+metadata:
+  name: standard-service
+  version: v2
+  owner: platform-team
+  lifecycle: experimental
+consumers:
+  - human
+  - agent
+paths:
+  - standard-http-service/v2
+support:
+  slo: platform-gold
+  supportOwner: platform-team
+  lifecyclePolicy: platform-product-lifecycle/v1
+economics:
+  costModel: per-instance
+  budgetProfile: preview-small
+success:
+  adoptionMetric: platform_path.completed_requests
+  outcomeMetric: platform_path.verified_completion_ratio
+  retirementSignal: Retire when the path has no supported consumers for two review periods.

--- a/platform-contracts/realms/preview/v2/realm.yaml
+++ b/platform-contracts/realms/preview/v2/realm.yaml
@@ -1,0 +1,37 @@
+schemaVersion: platform/realm/v1
+kind: Realm
+metadata:
+  name: preview
+  version: v2
+  owner: platform-team
+  state: experimental
+resolution:
+  requestedClass: preview
+  effectiveNameTemplate: preview-{workOrderId}
+  derivedBy: realm.resolve-preview/v1
+admission:
+  pathStates:
+    - experimental
+    - validated
+    - approved
+  paths:
+    - standard-http-service/v2
+namespace:
+  dedicated: true
+  defaultDeny: true
+  quotaProfile: preview-small
+  deleteOnCompletion: true
+boundaries:
+  productionCredentials: deny
+  crossRealmMutation: deny
+  sharedStateMutation: deny
+  dataMutation: deny
+  runtimeSecrets: deny
+  directApply: deny
+policyRefs:
+  - global.no-main-push/v1
+  - global.no-direct-apply/v1
+  - global.no-production-mutation/v1
+  - realm.preview-containment/v1
+  - realm.preview-no-secrets/v1
+  - delivery.human-merge-required/v1

--- a/platform-contracts/schemas/v1/delivery-profile.schema.json
+++ b/platform-contracts/schemas/v1/delivery-profile.schema.json
@@ -1,0 +1,206 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:darkfactory:platform-contract:delivery-profile:v1",
+  "title": "PlatformDeliveryProfile v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "kind", "metadata", "path", "mechanism", "templateBindings", "source", "application", "destination", "resourceEnvelope", "observations", "compensation"],
+  "properties": {
+    "schemaVersion": {"const": "platform/delivery-profile/v1"},
+    "kind": {"const": "PlatformDeliveryProfile"},
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "owner", "state"],
+      "properties": {
+        "name": {"type": "string", "pattern": "^[a-z][a-z0-9-]{2,62}$"},
+        "version": {"type": "string", "pattern": "^v[1-9][0-9]*$"},
+        "owner": {"type": "string", "pattern": "^[a-z][a-z0-9-]{2,62}$"},
+        "state": {"enum": ["draft", "experimental", "validated", "approved", "deprecated"]}
+      }
+    },
+    "path": {"type": "string", "pattern": "^[a-z][a-z0-9-]+/v[1-9][0-9]*$"},
+    "mechanism": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+    "templateBindings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workOrderIdFrom", "serviceNameFrom", "realmNameFrom"],
+      "properties": {
+        "workOrderIdFrom": {"const": "workOrder.id"},
+        "serviceNameFrom": {"const": "request.inputs.serviceName"},
+        "realmNameFrom": {"const": "realm.effectiveName"}
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repositoryFrom", "repositoryAuthorization", "gitopsPathTemplate", "targetRevisionFrom", "imageDigestFrom", "desiredInventoryFrom", "singleRepository"],
+      "properties": {
+        "repositoryFrom": {"const": "request.inputs.repositoryRef"},
+        "repositoryAuthorization": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["policy", "subjectFrom", "ownerFrom", "repositoryFrom", "credentialScope", "onMissing"],
+          "properties": {
+            "policy": {"const": "source.repository-owner-authorized/v1"},
+            "subjectFrom": {"const": "workOrder.authenticatedRequester"},
+            "ownerFrom": {"const": "request.inputs.ownerRef"},
+            "repositoryFrom": {"const": "request.inputs.repositoryRef"},
+            "credentialScope": {"const": "exact-repository"},
+            "onMissing": {"const": "deny"}
+          }
+        },
+        "gitopsPathTemplate": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160,
+          "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))[a-zA-Z0-9_.-]+(?:/[a-zA-Z0-9_.{}-]+)*$"
+        },
+        "targetRevisionFrom": {"const": "workflow.await-human-merge.mergeCommitSha"},
+        "imageDigestFrom": {"const": "evidence.supply-chain.attested-image"},
+        "desiredInventoryFrom": {"const": "workflow.validate-change.renderedManifestDigest"},
+        "singleRepository": {"const": true}
+      }
+    },
+    "application": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["controlPlaneRef", "namespace", "nameTemplate", "project", "requiredLabels"],
+      "properties": {
+        "controlPlaneRef": {"type": "string", "pattern": "^argocd:[a-z][a-z0-9-]{2,62}$"},
+        "namespace": {"type": "string", "pattern": "^[a-z0-9](?:[a-z0-9.-]{0,61}[a-z0-9])?$"},
+        "nameTemplate": {"type": "string", "pattern": "^preview-\\{workOrderId\\}$"},
+        "project": {"type": "string", "pattern": "^[a-z][a-z0-9-]{2,62}$"},
+        "requiredLabels": {
+          "type": "object",
+          "minProperties": 3,
+          "maxProperties": 12,
+          "propertyNames": {"pattern": "^[a-z0-9]([a-z0-9.-]*[a-z0-9])?(?:/[a-zA-Z0-9]([a-zA-Z0-9_.-]*[a-zA-Z0-9])?)?$"},
+          "additionalProperties": {"type": "string", "minLength": 1, "maxLength": 63}
+        }
+      }
+    },
+    "destination": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["clusterRef", "namespaceTemplate"],
+      "properties": {
+        "clusterRef": {"type": "string", "pattern": "^kubernetes:[a-z][a-z0-9-]{2,62}$"},
+        "namespaceTemplate": {"type": "string", "pattern": "^preview-\\{workOrderId\\}$"}
+      }
+    },
+    "resourceEnvelope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requiredKinds", "allowedKinds", "clusterScopedBindings", "ownershipLabel", "ownershipValueFrom", "requiredAssertions"],
+      "properties": {
+        "requiredKinds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "apps/v1/Deployment",
+              "networking.k8s.io/v1/Ingress",
+              "networking.k8s.io/v1/NetworkPolicy",
+              "v1/Namespace",
+              "v1/ResourceQuota",
+              "v1/Service"
+            ]
+          }
+        },
+        "allowedKinds": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "apps/v1/Deployment",
+              "networking.k8s.io/v1/Ingress",
+              "networking.k8s.io/v1/NetworkPolicy",
+              "v1/Namespace",
+              "v1/ResourceQuota",
+              "v1/Service"
+            ]
+          }
+        },
+        "clusterScopedBindings": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["kind", "nameFrom", "maxCount"],
+            "properties": {
+              "kind": {"const": "v1/Namespace"},
+              "nameFrom": {"const": "destination.namespaceTemplate"},
+              "maxCount": {"const": 1}
+            }
+          }
+        },
+        "ownershipLabel": {"const": "darkfactory.platform/work-order"},
+        "ownershipValueFrom": {"const": "workOrder.id"},
+        "requiredAssertions": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "dedicated-namespace",
+              "default-deny-network",
+              "digest-pinned-image",
+              "no-cross-realm-rbac",
+              "no-persistent-volumes",
+              "no-runtime-secrets",
+              "no-service-account-token",
+              "quota-bound"
+            ]
+          }
+        }
+      }
+    },
+    "observations": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action", "gitopsProbe", "gitopsEvidenceType", "realmProbe", "realmEvidenceType", "requiredSyncStatus", "requiredHealthStatus", "exactRevision", "exactImageDigest"],
+      "properties": {
+        "action": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+        "gitopsProbe": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+        "gitopsEvidenceType": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+        "realmProbe": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+        "realmEvidenceType": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+        "requiredSyncStatus": {"const": "Synced"},
+        "requiredHealthStatus": {"const": "Healthy"},
+        "exactRevision": {"const": true},
+        "exactImageDigest": {"const": true}
+      }
+    },
+    "compensation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action", "verifier", "evidenceType", "scope"],
+      "properties": {
+        "action": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+        "verifier": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+        "evidenceType": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+        "scope": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["repositoryFrom", "gitopsPathFrom", "applicationNameFrom", "destinationNamespaceFrom", "inventoryDigestFrom", "ownershipLabelFrom", "ownershipValueFrom"],
+          "properties": {
+            "repositoryFrom": {"const": "source.repositoryFrom"},
+            "gitopsPathFrom": {"const": "source.gitopsPathTemplate"},
+            "applicationNameFrom": {"const": "application.nameTemplate"},
+            "destinationNamespaceFrom": {"const": "destination.namespaceTemplate"},
+            "inventoryDigestFrom": {"const": "source.desiredInventoryFrom"},
+            "ownershipLabelFrom": {"const": "resourceEnvelope.ownershipLabel"},
+            "ownershipValueFrom": {"const": "resourceEnvelope.ownershipValueFrom"}
+          }
+        }
+      }
+    }
+  }
+}

--- a/platform-contracts/schemas/v2/platform-path.schema.json
+++ b/platform-contracts/schemas/v2/platform-path.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:darkfactory:platform-contract:platform-path:v2",
+  "title": "PlatformPath v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "kind", "metadata", "product", "inputSchema", "deliveryProfile", "entityClasses", "supportedRealms", "workflow", "policies", "conditionsOfDone", "compensation", "evidence"],
+  "properties": {
+    "schemaVersion": {"const": "platform/path/v2"},
+    "kind": {"const": "PlatformPath"},
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "owner", "state"],
+      "properties": {
+        "name": {"type": "string", "pattern": "^[a-z][a-z0-9-]{2,62}$"},
+        "version": {"type": "string", "pattern": "^v[1-9][0-9]*$"},
+        "owner": {"type": "string", "pattern": "^[a-z][a-z0-9-]{2,62}$"},
+        "state": {"enum": ["draft", "experimental", "validated", "approved", "deprecated"]}
+      }
+    },
+    "product": {"type": "string", "pattern": "^[a-z][a-z0-9-]+/v[1-9][0-9]*$"},
+    "inputSchema": {"type": "string", "pattern": "^urn:darkfactory:platform-contract:path-input:[a-z][a-z0-9-]+:v[1-9][0-9]*$"},
+    "deliveryProfile": {"type": "string", "pattern": "^[a-z][a-z0-9-]+/v[1-9][0-9]*$"},
+    "entityClasses": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "pattern": "^[A-Z][A-Za-z0-9]+/v[1-9][0-9]*$"}
+    },
+    "supportedRealms": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "pattern": "^[a-z][a-z0-9-]+/v[1-9][0-9]*$"}
+    },
+    "workflow": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "action", "needs"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^[a-z][a-z0-9-]{1,62}$"},
+          "action": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+          "needs": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {"type": "string", "pattern": "^[a-z][a-z0-9-]{1,62}$"}
+          }
+        }
+      }
+    },
+    "policies": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"}
+    },
+    "conditionsOfDone": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "probe", "evidenceType", "required"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+$"},
+          "probe": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+          "evidenceType": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+          "required": {"const": true},
+          "consecutivePasses": {"type": "integer", "minimum": 1, "maximum": 10}
+        }
+      }
+    },
+    "compensation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action", "verifier", "triggers"],
+      "properties": {
+        "action": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+        "verifier": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"},
+        "triggers": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"enum": ["cancelled", "failed", "expired", "completed"]}
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ttl", "manifestType", "requiredTypes"],
+      "properties": {
+        "ttl": {"const": "PT24H"},
+        "manifestType": {"const": "darkfactory.evidence-manifest/v1"},
+        "requiredTypes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+/v[1-9][0-9]*$"}
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate-platform-contracts.py
+++ b/scripts/validate-platform-contracts.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from jsonschema import Draft202012Validator
+from jsonschema import Draft202012Validator, ValidationError
 from referencing import Registry, Resource
 
 
@@ -67,7 +67,14 @@ def validate_index(index: dict[str, Any]) -> list[dict[str, str]]:
     paths = [artifact["path"] for artifact in artifacts]
     if paths != sorted(paths) or len(paths) != len(set(paths)):
         raise ContractError("index: artifact paths must be unique and lexically sorted")
-    authoritative_roots = ("schemas", "products", "entity-classes", "realms", "paths")
+    authoritative_roots = (
+        "schemas",
+        "products",
+        "entity-classes",
+        "realms",
+        "delivery-profiles",
+        "paths",
+    )
     discovered = sorted(
         path.relative_to(CONTRACT_ROOT).as_posix()
         for root in authoritative_roots
@@ -82,7 +89,14 @@ def validate_index(index: dict[str, Any]) -> list[dict[str, str]]:
     digest_pattern = re.compile(r"^[0-9a-f]{64}$")
     if not digest_pattern.fullmatch(index["spec"]["bundleDigest"]):
         raise ContractError("index: bundleDigest must be a lowercase SHA-256")
-    allowed_kinds = {"Schema", "PlatformProduct", "EntityClass", "Realm", "PlatformPath"}
+    allowed_kinds = {
+        "Schema",
+        "PlatformProduct",
+        "EntityClass",
+        "Realm",
+        "PlatformDeliveryProfile",
+        "PlatformPath",
+    }
     for position, artifact in enumerate(artifacts):
         if artifact["kind"] not in allowed_kinds:
             raise ContractError(f"artifact[{position}]: unsupported kind {artifact['kind']}")
@@ -167,12 +181,116 @@ def require_registered(value: str, registry: set[str], context: str) -> None:
         raise ContractError(f"{context}: unregistered identifier {value}")
 
 
+def template_fields(value: str, context: str) -> set[str]:
+    fields = set(re.findall(r"\{([^{}]+)\}", value))
+    residue = re.sub(r"\{[^{}]+\}", "", value)
+    if "{" in residue or "}" in residue:
+        raise ContractError(f"{context}: malformed template")
+    return fields
+
+
+def validate_delivery_profile(
+    profile: dict[str, Any],
+    registries: dict[str, set[str]],
+    context: str,
+) -> None:
+    require_registered(profile["mechanism"], registries["capabilities"], context)
+    expected_template_bindings = {
+        "workOrderIdFrom": "workOrder.id",
+        "serviceNameFrom": "request.inputs.serviceName",
+        "realmNameFrom": "realm.effectiveName",
+    }
+    if profile["templateBindings"] != expected_template_bindings:
+        raise ContractError(f"{context}: template identities are not authority-bound")
+    repository_policy = profile["source"]["repositoryAuthorization"]["policy"]
+    require_registered(repository_policy, registries["policies"], context)
+    observations = profile["observations"]
+    require_registered(observations["action"], registries["actions"], context)
+    require_registered(observations["gitopsProbe"], registries["probes"], context)
+    require_registered(observations["gitopsEvidenceType"], registries["evidenceTypes"], context)
+    require_registered(observations["realmProbe"], registries["probes"], context)
+    require_registered(observations["realmEvidenceType"], registries["evidenceTypes"], context)
+    compensation = profile["compensation"]
+    require_registered(compensation["action"], registries["actions"], context)
+    require_registered(compensation["verifier"], registries["probes"], context)
+    require_registered(compensation["evidenceType"], registries["evidenceTypes"], context)
+
+    source_fields = template_fields(
+        profile["source"]["gitopsPathTemplate"], f"{context}.source.gitopsPathTemplate"
+    )
+    if source_fields != {"serviceName", "workOrderId"}:
+        raise ContractError(
+            f"{context}: GitOps path template must use the trusted serviceName and workOrderId fields"
+        )
+    labels = profile["application"]["requiredLabels"]
+    required_label_values = {
+        "darkfactory.platform/path": profile["path"].replace("/", "-"),
+        "darkfactory.platform/realm": "{realmName}",
+        "darkfactory.platform/work-order": "{workOrderId}",
+    }
+    if labels != required_label_values:
+        raise ContractError(f"{context}: required ownership labels differ from the closed binding")
+
+    envelope = profile["resourceEnvelope"]
+    required_kinds = set(envelope["requiredKinds"])
+    allowed_kinds = set(envelope["allowedKinds"])
+    expected_kinds = {
+        "apps/v1/Deployment",
+        "networking.k8s.io/v1/Ingress",
+        "networking.k8s.io/v1/NetworkPolicy",
+        "v1/Namespace",
+        "v1/ResourceQuota",
+        "v1/Service",
+    }
+    if required_kinds != expected_kinds or allowed_kinds != expected_kinds:
+        raise ContractError(f"{context}: resource kinds differ from the closed P0 envelope")
+    expected_cluster_binding = [
+        {
+            "kind": "v1/Namespace",
+            "nameFrom": "destination.namespaceTemplate",
+            "maxCount": 1,
+        }
+    ]
+    if envelope["clusterScopedBindings"] != expected_cluster_binding:
+        raise ContractError(f"{context}: cluster-scoped binding is not the one derived Namespace")
+    if envelope["requiredKinds"] != sorted(envelope["requiredKinds"]):
+        raise ContractError(f"{context}: requiredKinds must be sorted")
+    if envelope["allowedKinds"] != sorted(envelope["allowedKinds"]):
+        raise ContractError(f"{context}: allowedKinds must be sorted")
+    required_assertions = {
+        "dedicated-namespace",
+        "default-deny-network",
+        "digest-pinned-image",
+        "no-cross-realm-rbac",
+        "no-persistent-volumes",
+        "no-runtime-secrets",
+        "no-service-account-token",
+        "quota-bound",
+    }
+    if set(envelope["requiredAssertions"]) != required_assertions:
+        raise ContractError(f"{context}: preview containment assertions are incomplete")
+    if envelope["requiredAssertions"] != sorted(envelope["requiredAssertions"]):
+        raise ContractError(f"{context}: requiredAssertions must be sorted")
+    expected_compensation_scope = {
+        "repositoryFrom": "source.repositoryFrom",
+        "gitopsPathFrom": "source.gitopsPathTemplate",
+        "applicationNameFrom": "application.nameTemplate",
+        "destinationNamespaceFrom": "destination.namespaceTemplate",
+        "inventoryDigestFrom": "source.desiredInventoryFrom",
+        "ownershipLabelFrom": "resourceEnvelope.ownershipLabel",
+        "ownershipValueFrom": "resourceEnvelope.ownershipValueFrom",
+    }
+    if compensation["scope"] != expected_compensation_scope:
+        raise ContractError(f"{context}: compensation scope is not identity-bound")
+
+
 def validate_semantics(
     index: dict[str, Any], schemas: dict[str, Any], documents: dict[str, dict[str, Any]]
-) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
     products: dict[str, Any] = {}
     entities: dict[str, Any] = {}
     realms: dict[str, Any] = {}
+    delivery_profiles: dict[str, Any] = {}
     paths: dict[str, Any] = {}
     for document in documents.values():
         kind = document.get("kind")
@@ -183,6 +301,8 @@ def validate_semantics(
             target = entities
         elif kind == "Realm":
             target = realms
+        elif kind == "PlatformDeliveryProfile":
+            target = delivery_profiles
         elif kind == "PlatformPath":
             target = paths
         else:
@@ -192,6 +312,8 @@ def validate_semantics(
         target[identifier] = document
 
     registries = {name: set(values) for name, values in index["spec"]["registries"].items()}
+    for profile_id, profile in delivery_profiles.items():
+        validate_delivery_profile(profile, registries, profile_id)
     for entity_id, entity in entities.items():
         for capability in entity["requiredCapabilities"]:
             require_registered(capability, registries["capabilities"], entity_id)
@@ -225,9 +347,45 @@ def validate_semantics(
             raise ContractError(f"{path_id}: product does not publish path")
         if path["inputSchema"] not in schemas:
             raise ContractError(f"{path_id}: unknown input schema {path['inputSchema']}")
+        profile_id = path.get("deliveryProfile")
+        profile = None
+        if path["schemaVersion"] == "platform/path/v2":
+            if not profile_id:
+                raise ContractError(f"{path_id}: v2 delivery profile is required")
+            if profile_id not in delivery_profiles:
+                raise ContractError(f"{path_id}: unknown delivery profile {profile_id}")
+            profile = delivery_profiles[profile_id]
+            if profile["path"] != path_id:
+                raise ContractError(f"{path_id}: delivery profile is bound to {profile['path']}")
+            if profile["metadata"]["state"] != path["metadata"]["state"]:
+                raise ContractError(f"{path_id}: delivery profile lifecycle does not match path")
+            repository_policy = profile["source"]["repositoryAuthorization"]["policy"]
+            if repository_policy not in path["policies"]:
+                raise ContractError(f"{path_id}: repository authorization policy is absent")
+        elif path["schemaVersion"] == "platform/path/v1":
+            if profile_id:
+                raise ContractError(f"{path_id}: v1 path cannot bind a v2 delivery profile")
+        else:
+            raise ContractError(f"{path_id}: unsupported path schema version")
         for entity_id in path["entityClasses"]:
             if entity_id not in entities:
                 raise ContractError(f"{path_id}: unknown EntityClass {entity_id}")
+        if profile:
+            if not any(
+                profile["mechanism"] in entities[entity_id]["requiredCapabilities"]
+                for entity_id in path["entityClasses"]
+            ):
+                raise ContractError(f"{path_id}: no EntityClass requires the delivery mechanism")
+            step_actions = {step["id"]: step["action"] for step in path["workflow"]}
+            required_source_steps = {
+                "await-human-merge": "delivery.await-human-merge/v1",
+                "validate-change": "verification.run-source-gates/v1",
+            }
+            for step_id, action in required_source_steps.items():
+                if step_actions.get(step_id) != action:
+                    raise ContractError(
+                        f"{path_id}: delivery source binding requires {step_id} -> {action}"
+                    )
         for realm_id in path["supportedRealms"]:
             if realm_id not in realms:
                 raise ContractError(f"{path_id}: unknown Realm {realm_id}")
@@ -251,14 +409,62 @@ def validate_semantics(
         for condition in path["conditionsOfDone"]:
             require_registered(condition["probe"], registries["probes"], path_id)
             require_registered(condition["evidenceType"], registries["evidenceTypes"], path_id)
+        condition_pairs = {
+            (condition["probe"], condition["evidenceType"])
+            for condition in path["conditionsOfDone"]
+        }
+        if profile:
+            observations = profile["observations"]
+            if (
+                observations["gitopsProbe"],
+                observations["gitopsEvidenceType"],
+            ) not in condition_pairs:
+                raise ContractError(
+                    f"{path_id}: delivery profile GitOps observation is not a Condition of Done"
+                )
+            if (
+                observations["realmProbe"],
+                observations["realmEvidenceType"],
+            ) not in condition_pairs:
+                raise ContractError(
+                    f"{path_id}: delivery profile Realm observation is not a Condition of Done"
+                )
+            if observations["action"] not in {
+                step["action"] for step in path["workflow"]
+            }:
+                raise ContractError(
+                    f"{path_id}: delivery profile observation action is absent from workflow"
+                )
         condition_ids = [condition["id"] for condition in path["conditionsOfDone"]]
         if len(condition_ids) != len(set(condition_ids)):
             raise ContractError(f"{path_id}: duplicate Condition of Done id")
         require_registered(path["compensation"]["action"], registries["actions"], path_id)
         require_registered(path["compensation"]["verifier"], registries["probes"], path_id)
+        if profile:
+            if profile["compensation"]["action"] != path["compensation"]["action"]:
+                raise ContractError(f"{path_id}: delivery profile compensation action mismatch")
+            if profile["compensation"]["verifier"] != path["compensation"]["verifier"]:
+                raise ContractError(
+                    f"{path_id}: delivery profile compensation verifier mismatch"
+                )
+            if (
+                profile["compensation"]["evidenceType"]
+                not in path["evidence"]["requiredTypes"]
+            ):
+                raise ContractError(
+                    f"{path_id}: delivery profile compensation evidence is not required"
+                )
+        if "supply-chain.attestation/v1" not in path["evidence"]["requiredTypes"]:
+            raise ContractError(f"{path_id}: attested image evidence is not required")
         for evidence_type in path["evidence"]["requiredTypes"]:
             require_registered(evidence_type, registries["evidenceTypes"], path_id)
-    return products, paths, realms
+    referenced_profiles = {
+        path["deliveryProfile"] for path in paths.values() if path.get("deliveryProfile")
+    }
+    orphaned_profiles = set(delivery_profiles) - referenced_profiles
+    if orphaned_profiles:
+        raise ContractError(f"orphaned delivery profiles: {sorted(orphaned_profiles)}")
+    return products, paths, realms, delivery_profiles
 
 
 def validate_request(
@@ -302,7 +508,26 @@ def validate_fixtures(
     for fixture in invalid:
         try:
             validate_request(load_yaml(fixture), schemas, products, paths, realms)
-        except Exception:
+        except (ContractError, ValidationError):
+            continue
+        raise ContractError(f"invalid fixture unexpectedly passed: {fixture.relative_to(ROOT)}")
+
+
+def validate_delivery_profile_fixtures(
+    index: dict[str, Any], schemas: dict[str, Any]
+) -> None:
+    invalid = sorted((CONTRACT_ROOT / "fixtures/delivery-profiles/invalid").glob("*.yaml"))
+    if not invalid:
+        raise ContractError("fixtures: invalid delivery-profile fixtures are required")
+    schema = schemas["urn:darkfactory:platform-contract:delivery-profile:v1"]
+    registry = {name: set(values) for name, values in index["spec"]["registries"].items()}
+    validator = Draft202012Validator(schema)
+    for fixture in invalid:
+        profile = load_yaml(fixture)
+        try:
+            validator.validate(profile)
+            validate_delivery_profile(profile, registry, fixture.relative_to(ROOT).as_posix())
+        except (ContractError, ValidationError):
             continue
         raise ContractError(f"invalid fixture unexpectedly passed: {fixture.relative_to(ROOT)}")
 
@@ -313,15 +538,17 @@ def main() -> int:
         artifacts = validate_index(index)
         validate_digests(index, artifacts)
         schemas, documents = load_and_validate_artifacts(artifacts)
-        products, paths, realms = validate_semantics(index, schemas, documents)
+        products, paths, realms, delivery_profiles = validate_semantics(index, schemas, documents)
         validate_fixtures(schemas, products, paths, realms)
+        validate_delivery_profile_fixtures(index, schemas)
     except Exception as error:
         print(f"platform-contract validation failed: {error}", file=sys.stderr)
         return 1
     print(
         "platform-contract validation passed: "
         f"{len(artifacts)} indexed artifacts, {len(products)} product, "
-        f"{len(paths)} path, {len(realms)} Realm"
+        f"{len(paths)} path, {len(realms)} Realm, "
+        f"{len(delivery_profiles)} delivery profile"
     )
     return 0
 


### PR DESCRIPTION
## Summary
- add a closed `PlatformDeliveryProfile` schema and the first Argo CD preview profile
- publish a complete immutable v2 Product/Path/EntityClass/Realm graph while retaining the v1 graph byte-for-byte
- bind repository authority to an authenticated owner policy and exact-repository credential scope
- close the P0 resource kind set, bind the sole Namespace and all compensation targets to one WorkOrder identity, and source desired inventory from deterministic validation
- extend bundle validation with cross-artifact, registry, source-step, scope, fixture, and digest checks

## Safety boundary
- the profile grants no apply/sync authority to Omnius; delivery observation remains read-only
- caller/model input cannot choose Argo/Kubernetes targets, GitOps path, policy, resource kinds, ownership identity, or compensation scope
- `standard-http-service/v1` and its complete graph remain unchanged; adoption requires an explicit v2 pin

## Verification
- `python3 scripts/validate-platform-contracts.py` (20 indexed artifacts, 2 products, 2 paths, 2 Realms, 1 delivery profile)
- `python3 -m py_compile scripts/validate-platform-contracts.py`
- byte comparison of all tracked v1 graph artifacts against `origin/main`
- `git diff --check`