### PR TITLE
feat(contracts): define signed HTTP probe evidence

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,5 @@
 /platform-contracts/ @100rd
 /docs/adrs/0056-machine-readable-platform-contracts.md @100rd
 /.github/workflows/platform-contracts-validate.yml @100rd
+/scripts/http_probe_contract_validation.py @100rd
 /scripts/validate-platform-contracts.py @100rd

--- a/.github/workflows/platform-contracts-validate.yml
+++ b/.github/workflows/platform-contracts-validate.yml
@@ -5,12 +5,14 @@ on:
     branches: [main]
     paths:
       - "platform-contracts/**"
+      - "scripts/http_probe_contract_validation.py"
       - "scripts/validate-platform-contracts.py"
       - "scripts/requirements-platform-contracts.txt"
       - ".github/workflows/platform-contracts-validate.yml"
   pull_request:
     paths:
       - "platform-contracts/**"
+      - "scripts/http_probe_contract_validation.py"
       - "scripts/validate-platform-contracts.py"
       - "scripts/requirements-platform-contracts.txt"
       - ".github/workflows/platform-contracts-validate.yml"

--- a/docs/adrs/0058-precommitted-http-probe-evidence.md
+++ b/docs/adrs/0058-precommitted-http-probe-evidence.md
@@ -1,0 +1,91 @@
+# ADR-0058: Precommit HTTP completion and verify every delivered backend
+
+- Status: **Proposed**
+- Date: 2026-07-14
+- Authors: platform-team
+- Related issues: genai-enablement ADR-0014; 100rd/omnius draft HTTP verifier work
+- Supersedes: (none)
+- Superseded by: (none)
+
+## Context
+
+The draft `standard-http-service/v3` path names health, readiness, and request-contract Conditions of
+Done but only registers symbolic probe and evidence identifiers. It does not yet define the frozen
+probe semantics, target attribution, four-state reduction, signed result shape, or replay boundary.
+Implementing a network client against those symbols would let the executor choose its own oracle and
+would not prove that responses came from the delivered image.
+
+## Decision
+
+1. The platform publishes one closed `http-preview-service/v1` probe profile. It fixes origin-form
+   `GET` paths, status/body comparison, one-through-three ready backends, attempt limits, deadlines,
+   response bounds, four result states, aggregation, canonicalization, and external verifier trust.
+2. Request acceptance is frozen before mutation in the execution envelope. After independently
+   verified delivery, a closed run subject binds that envelope and acceptance digest to WorkOrder,
+   cluster, Realm, Namespace, Service routing spec, merge commit, image digest, fresh delivery
+   evidence, and the exact profile revision.
+3. The verifier derives the complete EndpointSlice backend set. Every endpoint must identify an
+   admitted Pod UID running the frozen image digest. Each attempt directly probes every backend in
+   deterministic stable backend order and records pre/post Service and backend snapshots. Empty, excess,
+   external, unready, mixed-image, changed, or recreated targets are `probe-error`.
+4. Caller input is limited to a strict ASCII origin path: exactly one leading slash, non-empty
+   unreserved segments, and no repeated slash, dot segment, percent encoding, backslash, query,
+   fragment, authority, header, credential, proxy, redirect, or alternate method.
+5. Backend, batch, and condition results use exactly `pass`, `fail`, `inconclusive`, or
+   `probe-error`. A batch passes only when all unchanged backends pass. Three consecutive passing
+   batches are required; every non-pass resets the streak and remains in evidence.
+6. Signed evidence binds unique run/attempt identity and order, subject and delivery digests,
+   pre/post target snapshots, per-backend status/content digests, bounded oracle projections,
+   aggregate results, time, expiry, verifier profile, and signing key. Duplicate, stale, reordered,
+   cross-cluster, cross-run, or worker-signed evidence cannot satisfy a condition.
+7. The probe profile is attached only to draft delivery profile
+   `argocd-preview-http-service/v2`. This candidate revision remains outside Realm admission and
+   readiness. Existing v1/v2 executable bundles are unchanged.
+
+## Alternatives considered
+
+### Accept one caller-supplied URL
+
+Rejected because URL resolution, redirects, proxy inheritance, and credentials create SSRF and
+cross-Realm authority channels.
+
+### Probe only the logical Service
+
+Rejected because a Service UID can retain a changed selector and one load-balanced response does not
+attribute success to every ready backend or the frozen image digest.
+
+### Store complete response bodies
+
+Rejected because bounded canonical projections and digests are sufficient to audit deterministic
+comparisons without retaining arbitrary application data.
+
+## Consequences
+
+### Positive
+
+- Conditions are fixed before implementation and checked by an external oracle.
+- Runtime success is tied to every stable delivered backend, not a worker assertion.
+- Failure, insufficient evidence, and verifier failure remain distinct and fail closed.
+
+### Negative
+
+- Runtime verification requires fresh Kubernetes reads and direct Realm-network reachability.
+- A rollout or backend restart during the short run invalidates the run and requires a retry.
+- The preview profile intentionally excludes TLS, authentication, write methods, streaming, deep
+  JSON, SLO claims, and production use.
+
+## Implementation notes
+
+- Authority: indexed profile plus closed subject/result schemas under `platform-contracts/`.
+- Validation: positive examples and semantic mutations cover target drift, empty backend sets,
+  mixed results, duplicate attempts, stale delivery, cross-run replay, path injection, and untrusted
+  verifier identity.
+- Omnius must first implement transport-neutral comparison and evidence verification. Network
+  transport qualification is a separate step and cannot create Realm admission by itself.
+
+## References
+
+- `genai-enablement/docs/decisions/0014-precommitted-http-condition-evidence.md`
+- `platform-contracts/paths/standard-http-service/v3/`
+- ADR-0056
+- ADR-0057

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -101,6 +101,7 @@ decision.
 | [0054](0054-baremetal-elasticity-node-lifecycle.md) | Bare-metal elasticity & node lifecycle without a cloud autoscaler — Cluster-API/Sidero vs Metal³ vs robot-API vs static pools; workload scale-to-zero | Proposed | pending | WS-A of Bare-Metal ML platform plan; replaces GKE/Karpenter autoscaling; design 2026-06-15 |
 | [0056](0056-machine-readable-platform-contracts.md) | Machine-readable platform contracts for organizational automation | Accepted | contract published; execution pending | native · Omnius P0 vertical |
 | [0057](0057-platform-owned-delivery-observation.md) | Separate platform-owned delivery observation from workload authority | Proposed | draft contract; not admitted | genai ADR-0013 · Omnius ADR-0020/SPEC-DO |
+| [0058](0058-precommitted-http-probe-evidence.md) | Precommit HTTP completion and verify every delivered backend | Proposed | draft contract; not admitted | genai ADR-0014 · Omnius HTTP verifier |
 
 
 

--- a/platform-contracts/README.md
+++ b/platform-contracts/README.md
@@ -7,7 +7,8 @@ indexed bundle pinned by exact Git commit and bundle SHA-256.
 ## Layout
 
 - `schemas/v1/` and later version directories define closed Draft 2020-12 schemas.
-- `products/`, `entity-classes/`, `realms/`, `delivery-profiles/`, and `paths/` contain owned instances.
+- `products/`, `entity-classes/`, `realms/`, `delivery-profiles/`, `probe-profiles/`, and `paths/`
+  contain owned instances.
 - `index.yaml` lists every authoritative file, its schema, and its content digest.
 - `fixtures/` contains requests that must pass or fail validation.
 
@@ -22,6 +23,12 @@ The proposed observer-access design is published as the separate draft
 `argocd-preview-http-service/v2`. It names `preview/v2` as a compatibility target but is not in that
 Realm's admission list, so the bundle cannot authorize its execution. Acceptance, qualification, and
 admission require later human-owned revisions.
+
+The draft now also binds `http-preview-service/v1`. Its Conditions of Done are frozen before
+authoring. After fresh delivery observation, a separately signed subject derives one Service and its
+complete one-through-three ready EndpointSlice/Pod backend set. Every backend must run the delivered
+image digest and pass three consecutive bounded attempts. The signed result uses four states and
+cannot accept an empty backend set, caller URL, worker self-report, stale subject, or changed target.
 
 ## Publication and pinning
 
@@ -62,6 +69,13 @@ reaping are closed contract fields. Runtime schemas bind the resolved observatio
 collection snapshots, delivery evidence, and cleanup evidence to the same WorkOrder-derived identity,
 adapter configuration, object UIDs, and semantic verifiers. Each collection keeps its own
 resourceVersion; the contract makes no cross-kind atomic-snapshot claim.
+
+For runtime verification the same WorkOrder-specific read-only observer identity gains only
+EndpointSlice list authority in addition to its existing bounded inventory reads. The control plane
+issues a separate five-minute probe credential and a four-minute signed subject after delivery
+evidence is stored. The verifier network source and port 8080 ingress are adapter- and
+NetworkPolicy-derived; requests cannot nominate a destination. Access is revoked after the probes,
+and normal or terminal compensation still proves cleanup.
 
 Kubernetes built-in bindings may grant `/api` and `/apis` discovery to authenticated principals. The
 platform-owned rules grant no `nonResourceURLs`, the observer transport exposes no discovery method,

--- a/platform-contracts/delivery-profiles/argocd-preview-http-service/v2/profile.yaml
+++ b/platform-contracts/delivery-profiles/argocd-preview-http-service/v2/profile.yaml
@@ -62,6 +62,7 @@ resourceEnvelope:
     - dedicated-namespace
     - default-deny-network
     - digest-pinned-image
+    - http-verifier-ingress-only
     - no-persistent-volumes
     - no-runtime-secrets
     - no-service-account-token
@@ -139,7 +140,7 @@ observerAccess:
       nameFrom: observerAccess.serviceAccount.nameTemplate
       namespaceFrom: observerAccess.observerNamespace
   inventoryClusterRole:
-    name: darkfactory-preview-delivery-list-v1
+    name: darkfactory-preview-delivery-list-v2
     shared: true
     rules:
       - apiGroups: [""]
@@ -147,6 +148,9 @@ observerAccess:
         verbs: [list]
       - apiGroups: [apps]
         resources: [deployments, replicasets]
+        verbs: [list]
+      - apiGroups: [discovery.k8s.io]
+        resources: [endpointslices]
         verbs: [list]
       - apiGroups: [networking.k8s.io]
         resources: [ingresses, networkpolicies]
@@ -189,6 +193,7 @@ observerAccess:
     kindIds:
       - apps/v1/Deployment
       - apps/v1/ReplicaSet
+      - discovery.k8s.io/v1/EndpointSlice
       - networking.k8s.io/v1/Ingress
       - networking.k8s.io/v1/NetworkPolicy
       - rbac.authorization.k8s.io/v1/Role
@@ -396,6 +401,41 @@ observerAccess:
     tokenExpiryIsCleanup: false
     onAmbiguous: park-and-escalate
     triggers: [cancelled, completed, expired, failed]
+runtimeVerification:
+  action: verification.run-http-probes/v1
+  profile: http-preview-service/v1
+  profileSchema: urn:darkfactory:platform-contract:http-probe-profile:v1
+  subjectSchema: urn:darkfactory:platform-contract:http-probe-subject:v1
+  resultSchema: urn:darkfactory:platform-contract:http-probe-result:v1
+  evidenceType: http.probe-result/v1
+  deliveryObservationSchemaFrom: observations.evidenceSchema
+  credential:
+    authority: platform-control-plane
+    serviceAccountFrom: observerAccess.serviceAccount.nameTemplate
+    issueAction: verification.issue-http-probe-credential/v1
+    audienceFrom: adapter.destination.tokenAudience
+    apiServerFrom: adapter.destination.apiServer
+    caSha256From: adapter.destination.caSha256
+    maxLifetime: PT5M
+    absoluteDeadline: PT4M
+    maxResponseBytes: 1048576
+    operations: [deployments.list, endpointslices.list, namespace.get, networkpolicies.list, pods.list, replicasets.list, services.list]
+    kindIds: [apps/v1/Deployment, apps/v1/ReplicaSet, discovery.k8s.io/v1/EndpointSlice, networking.k8s.io/v1/NetworkPolicy, v1/Namespace, v1/Pod, v1/Service]
+    subjectIssuerProfileFrom: adapter.httpVerification.subjectIssuerProfile
+  network:
+    sourceNamespaceFrom: adapter.httpVerification.namespace
+    sourcePodSelectorFrom: adapter.httpVerification.podSelector
+    destinationNamespaceFrom: destination.namespaceTemplate
+    destinationPodSelectorFrom: application.requiredLabels
+    destinationPort: 8080
+    protocol: TCP
+    policyTypes: [Ingress]
+    allowRuleCount: 1
+    denyOtherIngress: true
+    desiredPolicyDigestFrom: workflow.validate-change.httpVerifierNetworkPolicyDigest
+    observedPolicySnapshotFrom: evidence.kubernetes.delivery-observation.finalCollectionSnapshots.networking-v1-networkpolicies
+    requiredAssertion: http-verifier-ingress-only
+    callerNetworkTargetAccepted: false
 compensation:
   action: delivery.revert-prune-and-revoke-preview/v2
   verifier: realm.preview-and-observer-pruned/v1

--- a/platform-contracts/index.yaml
+++ b/platform-contracts/index.yaml
@@ -5,7 +5,7 @@ metadata:
   version: v1
 spec:
   digestAlgorithm: sha256-path-nul-bytes-v1
-  bundleDigest: f4fa3aaafa3217a4beb231b52aa1184486addff026841f92bb2380a2d095c611
+  bundleDigest: 1c86f50f9463c4d71383663e7dfd450aa10d63b603ebda2a19aac52037167c87
   artifacts:
     - path: delivery-profiles/argocd-preview-http-service/v1/profile.yaml
       kind: PlatformDeliveryProfile
@@ -14,7 +14,7 @@ spec:
     - path: delivery-profiles/argocd-preview-http-service/v2/profile.yaml
       kind: PlatformDeliveryProfile
       schema: urn:darkfactory:platform-contract:delivery-profile:v2
-      sha256: ba87e6c63cb1d7dd99435c7fd625c1fa00b5e7513f10d1656e655c6a968954ee
+      sha256: 19e1fce6de041974c44a2be9f4ad09f5ead3a0a28eb413ff0ef53f986334964e
     - path: entity-classes/environment/v1/entity-class.yaml
       kind: EntityClass
       schema: urn:darkfactory:platform-contract:entity-class:v1
@@ -58,11 +58,15 @@ spec:
     - path: paths/standard-http-service/v3/path.yaml
       kind: PlatformPath
       schema: urn:darkfactory:platform-contract:platform-path:v2
-      sha256: 920ace687d3422b1adddbe69c807f7f0c051a9c51ad8039f96c80143fb455add
+      sha256: 86e8fbd0839809d6dd00d3ea120daa6a750b1218e0455440f07d4e6c394343e8
     - path: paths/standard-http-service/v3/request.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
-      sha256: 57ddd5d7e9c57b9bd403233252fffff63ef72dd56f6afb59000960bd6c90ad82
+      sha256: c3a0c5085f9a384ad93216d89154d094de079fe63c4f37c2c83d9bbc33e1565d
+    - path: probe-profiles/http-preview-service/v1/profile.yaml
+      kind: HttpProbeProfile
+      schema: urn:darkfactory:platform-contract:http-probe-profile:v1
+      sha256: 9a3070e7f537438fc96966766336c3d0125b86e41e8ac38826f5b5c59d63abea
     - path: products/standard-service/v1/product.yaml
       kind: PlatformProduct
       schema: urn:darkfactory:platform-contract:platform-product:v1
@@ -86,7 +90,7 @@ spec:
     - path: schemas/v1/delivery-observation-evidence.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
-      sha256: 1aaeab8995b906a4f212d098df846353db39d24674b0ce6cfa2918c36acb29b5
+      sha256: 860763a4ac37a2c38e386221f3c13d38e3be8460f0f2660bdb12c1ca60bb81fe
     - path: schemas/v1/delivery-profile.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
@@ -95,26 +99,38 @@ spec:
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
       sha256: 745c089840975f2a363b9cfc09312259a50a667c2345fc5ebac9ab2550a75bc2
+    - path: schemas/v1/http-probe-profile.schema.json
+      kind: Schema
+      schema: https://json-schema.org/draft/2020-12/schema
+      sha256: f3338cfe11accb2e450afc807f1c5ab77896bd45795c0a111d1cd5d845c55bc6
+    - path: schemas/v1/http-probe-result.schema.json
+      kind: Schema
+      schema: https://json-schema.org/draft/2020-12/schema
+      sha256: a69d38924f3ffc3c4253fb4e0eb1a6df4f1aa13a71299194ecbf01bfe072db66
+    - path: schemas/v1/http-probe-subject.schema.json
+      kind: Schema
+      schema: https://json-schema.org/draft/2020-12/schema
+      sha256: 19e9b88af6a18fe661bf26e3dee3baca685579cbe3911e4b2702e08f31dcf2ce
     - path: schemas/v1/namespaced-resource-snapshot.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
-      sha256: bab8fe6654562bf470b86b057ca0db4b482bdef5f04294ab8fe16bc939f55af9
+      sha256: 7af87737f4b782e8c8cc48d3554c8998b20a904bd6dbcaa419e335cd9830e515
     - path: schemas/v1/observation-scope.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
-      sha256: e7836c9b510fd73f293e0813d85303e15f6b35cb7b105d479a46ba308e7a399c
+      sha256: 6d879434cc27d897cc4cf664cb6dd8d81ef3cfc06a7be205b5891669691aed6d
     - path: schemas/v1/observer-access-attestation.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
-      sha256: 992cefd863874e1f4ba288e55cf556ae235adedc893beaa6052c68ec74c2505e
+      sha256: 9f6644383a0c1728f5333ad84050012019e5559815e9e39c1bf0f525bb7a5c53
     - path: schemas/v1/observer-access-cleanup-evidence.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
-      sha256: c3e43cbcc827c0cbefaea910f1fe17339c68138c0e866cd009c0f3dabc1936b3
+      sha256: 88d69a02de3e0e5c65d1c11213c2b224ab62358c11bb38a062122e8695083f84
     - path: schemas/v1/observer-access-profile.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
-      sha256: a4760fcd1aaf70bed85851e2f5e1cb2d8b15b8292cd7a5fa4facee4fe85909fb
+      sha256: 9d55e8292ad715ac298049c6f09411d1fd3df6f73233188e89918868dfccbaeb
     - path: schemas/v1/platform-path.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
@@ -134,7 +150,7 @@ spec:
     - path: schemas/v2/delivery-profile.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
-      sha256: 5c279a75cc1479d393e077523f05a8960dfecbb1a7d09a49db1fba0c604780fd
+      sha256: 9d965697935dc47b854709b6c7656d996a2c931bc6e013341b8c64b3725dc896
     - path: schemas/v2/platform-path.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
@@ -159,6 +175,8 @@ spec:
       - realm.resolve-preview/v1
       - source.author-http-service-change/v1
       - source.inspect-existing-repository/v1
+      - verification.freeze-http-conditions/v1
+      - verification.issue-http-probe-credential/v1
       - verification.run-http-probes/v1
       - verification.run-source-gates/v1
     capabilities:

--- a/platform-contracts/paths/standard-http-service/v3/README.md
+++ b/platform-contracts/paths/standard-http-service/v3/README.md
@@ -7,8 +7,10 @@ already implements every registered action or probe.
 ## Request boundary
 
 The request names one existing GitHub repository and a safe relative source subpath. Runtime,
-exposure, port, and resource size are fixed. Acceptance probes are bounded `GET` requests with
-HTTP 200 and either exact text or a shallow JSON subset. Unknown fields fail validation.
+exposure, port, and resource size are fixed. Acceptance probes are bounded origin-form `GET`
+requests with HTTP 200, a fixed media type, and either exact text or a shallow JSON subset. Paths
+cannot contain an authority, empty/repeated segment, dot segment, percent encoding, query, fragment,
+or backslash. Unknown fields and duplicate paths fail validation.
 
 The request cannot supply commands, scripts, environment variables, secrets, image tags, Helm
 values, policy overrides, namespaces, clusters, accounts, or production targets. Identity and
@@ -32,8 +34,11 @@ The workload desired inventory remains the same closed six-kind set as v2. Obser
 separate platform control inventory: one shared versioned list-only ClusterRole and six exact
 WorkOrder objects. Workers cannot author those objects. The control plane registers cleanup before
 creation, obtains signed independent live-RBAC evidence, issues an issuer-signed WorkOrder and
-adapter-bound short-lived scope, stores schema-bound observation evidence, and removes the access
-bundle before runtime probes continue.
+adapter-bound short-lived scope, and stores schema-bound observation evidence. It then issues a
+separate five-minute runtime credential to the same WorkOrder-specific read-only identity. That
+identity can additionally list EndpointSlices; it remains unable to read Secrets or ConfigMaps,
+watch, proxy, execute, mint tokens, or mutate anything. The access bundle is removed immediately
+after runtime verification and is also covered by terminal compensation.
 
 The observer transport has no discovery operation and platform-owned rules contain no
 `nonResourceURLs`. Kubernetes may still grant `/api` and `/apis` through its built-in
@@ -56,15 +61,18 @@ actions, probes, expected responses, compensation, and evidence TTL. Completion 
 6. Independent authority evidence binds the exact platform control inventory, negative checks,
    inherited authority, credential scope, transport recording, and live RBAC digests.
 7. Two complete bounded inventory passes prove stable exact-revision delivery and Realm containment.
-8. Observer access is revoked through attested UID and resourceVersion DELETE preconditions; signed
-   cleanup evidence proves six exact WorkOrder objects absent, the credential lease revoked, and the
-   shared ClusterRole preserved before runtime probing continues.
+8. A fresh signed HTTP subject binds the frozen acceptance digest, exact bundle/profile, WorkOrder,
+   cluster, Namespace/Service identity, delivery evidence, merge commit, image digest, and deadline.
 9. A dedicated quota-bound, default-deny preview namespace has no production credentials,
    shared-state access, data mutation, or cross-Realm authority.
-10. `/healthz`, `/readyz`, and every requested route pass three consecutive bounded probes
-   from a verifier outside the worker identity and writable environment.
-11. The evidence manifest is immutable and no older than `PT24H`.
-12. Registered compensation can close an unmerged PR or revert the landed change, revoke observer
+10. `/healthz`, `/readyz`, and every requested route pass three consecutive all-backend batches.
+    Every batch directly probes the complete one-through-three ready Pod set in deterministic order;
+    pre/post Service, EndpointSlice, Pod UID/address, readiness, and image snapshots must match.
+11. Observer access is revoked through attested UID and resourceVersion DELETE preconditions; signed
+    cleanup evidence proves six exact WorkOrder objects absent, the credential lease revoked, and the
+    shared versioned ClusterRole preserved after runtime verification.
+12. The evidence manifest is immutable and no older than `PT24H`.
+13. Registered compensation can close an unmerged PR or revert the landed change, revoke observer
    access, and prune the preview Realm; the verifier proves absence of WorkOrder-owned resources.
 
 Any missing, expired, conflicting, or unverifiable result prevents verified completion.

--- a/platform-contracts/paths/standard-http-service/v3/path.yaml
+++ b/platform-contracts/paths/standard-http-service/v3/path.yaml
@@ -17,9 +17,12 @@ workflow:
   - id: inspect-source
     action: source.inspect-existing-repository/v1
     needs: []
+  - id: freeze-http-conditions
+    action: verification.freeze-http-conditions/v1
+    needs: [inspect-source]
   - id: author-change
     action: source.author-http-service-change/v1
-    needs: [inspect-source]
+    needs: [freeze-http-conditions]
   - id: validate-change
     action: verification.run-source-gates/v1
     needs: [author-change]
@@ -50,12 +53,15 @@ workflow:
   - id: store-observation-evidence
     action: evidence.store-delivery-observation/v1
     needs: [observe-gitops]
-  - id: revoke-observer-access
-    action: delivery.revoke-observer-access/v1
+  - id: issue-http-probe-credential
+    action: verification.issue-http-probe-credential/v1
     needs: [store-observation-evidence]
   - id: verify-runtime
     action: verification.run-http-probes/v1
-    needs: [revoke-observer-access]
+    needs: [issue-http-probe-credential]
+  - id: revoke-observer-access
+    action: delivery.revoke-observer-access/v1
+    needs: [verify-runtime]
 policies:
   - delivery.platform-observer-access/v1
   - global.no-main-push/v1

--- a/platform-contracts/paths/standard-http-service/v3/request.schema.json
+++ b/platform-contracts/paths/standard-http-service/v3/request.schema.json
@@ -29,23 +29,34 @@
         "required": ["method", "path", "expected"],
         "properties": {
           "method": {"const": "GET"},
-          "path": {"type": "string", "pattern": "^/[a-zA-Z0-9/_-]{0,127}$"},
+          "path": {"type": "string", "minLength": 2, "maxLength": 128, "pattern": "^/[A-Za-z0-9_~-]+(?:/[A-Za-z0-9_~-]+)*$"},
           "expected": {
             "type": "object",
             "additionalProperties": false,
             "required": ["status"],
             "properties": {
               "status": {"const": 200},
+              "mediaType": {"enum": ["text/plain", "text/plain; charset=utf-8", "application/json", "application/json; charset=utf-8"]},
               "exactText": {"type": "string", "maxLength": 512},
               "jsonSubset": {
                 "type": "object",
                 "maxProperties": 10,
-                "additionalProperties": {"type": ["string", "number", "integer", "boolean", "null"]}
+                "minProperties": 1,
+                "propertyNames": {"type": "string", "pattern": "^[A-Za-z0-9_.-]{1,64}$"},
+                "additionalProperties": {
+                  "anyOf": [
+                    {"type": "string", "maxLength": 512},
+                    {"type": "integer"},
+                    {"type": "number"},
+                    {"type": "boolean"},
+                    {"type": "null"}
+                  ]
+                }
               }
             },
             "oneOf": [
-              {"required": ["exactText"]},
-              {"required": ["jsonSubset"]}
+              {"required": ["mediaType", "exactText"], "properties": {"mediaType": {"enum": ["text/plain", "text/plain; charset=utf-8"]}}},
+              {"required": ["mediaType", "jsonSubset"], "properties": {"mediaType": {"enum": ["application/json", "application/json; charset=utf-8"]}}}
             ]
           }
         }

--- a/platform-contracts/probe-profiles/http-preview-service/v1/profile.yaml
+++ b/platform-contracts/probe-profiles/http-preview-service/v1/profile.yaml
@@ -1,0 +1,96 @@
+schemaVersion: platform/http-probe-profile/v1
+kind: HttpProbeProfile
+metadata:
+  name: http-preview-service
+  version: v1
+  owner: platform-team
+  state: draft
+appliesTo:
+  path: standard-http-service/v3
+  deliveryProfile: argocd-preview-http-service/v2
+  realm: preview/v2
+conditionPlan:
+  freezeAction: verification.freeze-http-conditions/v1
+  freezeBefore: workflow.author-change
+  acceptanceFrom: request.inputs.acceptance
+  acceptanceDigestFrom: executionEnvelope.httpAcceptanceDigest
+  method: GET
+  pathPattern: ^/[A-Za-z0-9_~-]+(?:/[A-Za-z0-9_~-]+)*$
+  fixedConditions:
+    - id: runtime.health
+      probe: http.healthz/v1
+      path: /healthz
+      status: 200
+      assertion: status-only
+    - id: runtime.readiness
+      probe: http.readyz/v1
+      path: /readyz
+      status: 200
+      assertion: status-only
+  requestContract:
+    conditionId: runtime.request-contract
+    probe: http.request-contract/v1
+    minItems: 1
+    maxItems: 5
+    status: 200
+    assertions: [exact-text, json-subset]
+targetResolution:
+  deliveryEvidenceFrom: evidence.kubernetes.delivery-observation
+  deliveryEvidenceMaxAge: PT5M
+  clusterRefFrom: destination.clusterRef
+  namespaceFrom: destination.namespaceTemplate
+  namespaceSnapshotFields: [resourceVersion, uid]
+  serviceNameFrom: request.inputs.serviceName
+  servicePort: 8080
+  serviceSnapshotFields: [clusterIP, ports, resourceVersion, selector, type, uid]
+  backendChain: [apps/v1/Deployment, apps/v1/ReplicaSet, v1/Pod, discovery.k8s.io/v1/EndpointSlice, status.containerStatuses.imageID]
+  servingContainerRule: exactly-one-container-serving-port-8080
+  minReadyBackends: 1
+  maxReadyBackends: 3
+  backendOrder: stable-pod-or-endpoint-key-ascending
+  probeMode: each-ready-backend-direct
+  snapshotTiming: before-and-after-each-attempt
+  invalidTargetReasons: [empty-backend-set, excess-backend-set, invalid-backend, mixed-image, target-drift]
+  onInvalidTarget: probe-error
+transport:
+  scheme: http
+  method: GET
+  pathMode: prevalidated-origin-form
+  urlJoin: false
+  trustEnvironment: false
+  redirects: false
+  authentication: none
+  hostHeaderFrom: derivedTarget.serviceDnsName
+  backendExecution: concurrent-bounded-3-results-pod-uid-ordered
+  textMediaTypes: [text/plain, "text/plain; charset=utf-8"]
+  jsonMediaTypes: [application/json, "application/json; charset=utf-8"]
+limits:
+  maxAttemptsPerConditionRun: 5
+  consecutivePasses: 3
+  delayBetweenAttempts: PT1S
+  perBackendDeadline: PT5S
+  attemptBatchDeadline: PT30S
+  overallRunDeadline: PT4M
+  maxResponseBytesPerBackend: 65536
+  maxOracleEntries: 10
+  onAssertionFailure: continue-until-five-or-success
+  onProbeError: stop
+aggregation:
+  states: [fail, inconclusive, pass, probe-error]
+  batchPass: all-backends-pass-and-snapshots-identical
+  batchPrecedence: [probe-error, fail, inconclusive, pass]
+  conditionPass: three-consecutive-pass-batches
+  nonPassResetsStreak: true
+  requestContractPass: all-acceptance-condition-runs-pass
+  pathPass: all-three-path-conditions-pass
+evidence:
+  subjectSchema: urn:darkfactory:platform-contract:http-probe-subject:v1
+  resultSchema: urn:darkfactory:platform-contract:http-probe-result:v1
+  evidenceType: http.probe-result/v1
+  canonicalization: rfc8785-json-canonicalization/v1
+  digestAlgorithm: sha256
+  signatureAlgorithm: Ed25519
+  verifierProfileFrom: adapter.httpVerification.verifierProfile
+  signingKeyFrom: adapter.httpVerification.signingKey
+  workerEvidenceAccepted: false
+  rawResponseStored: false

--- a/platform-contracts/schemas/v1/delivery-observation-evidence.schema.json
+++ b/platform-contracts/schemas/v1/delivery-observation-evidence.schema.json
@@ -79,6 +79,7 @@
       "required": [
         "apps-v1-deployments",
         "apps-v1-replicasets",
+        "discovery-v1-endpointslices",
         "networking-v1-ingresses",
         "networking-v1-networkpolicies",
         "rbac-v1-rolebindings",
@@ -92,6 +93,7 @@
       "properties": {
         "apps-v1-deployments": {"$ref": "#/$defs/appsDeployment"},
         "apps-v1-replicasets": {"$ref": "#/$defs/appsReplicaSet"},
+        "discovery-v1-endpointslices": {"$ref": "#/$defs/discoveryEndpointSlice"},
         "networking-v1-ingresses": {"$ref": "#/$defs/networkingIngress"},
         "networking-v1-networkpolicies": {"$ref": "#/$defs/networkingNetworkPolicy"},
         "rbac-v1-rolebindings": {"$ref": "#/$defs/rbacRoleBinding"},
@@ -125,6 +127,7 @@
     "digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     "appsDeployment": {"$ref": "urn:darkfactory:platform-contract:namespaced-resource-snapshot:v1", "properties": {"kindId": {"const": "apps/v1/Deployment"}}},
     "appsReplicaSet": {"$ref": "urn:darkfactory:platform-contract:namespaced-resource-snapshot:v1", "properties": {"kindId": {"const": "apps/v1/ReplicaSet"}}},
+    "discoveryEndpointSlice": {"$ref": "urn:darkfactory:platform-contract:namespaced-resource-snapshot:v1", "properties": {"kindId": {"const": "discovery.k8s.io/v1/EndpointSlice"}}},
     "networkingIngress": {"$ref": "urn:darkfactory:platform-contract:namespaced-resource-snapshot:v1", "properties": {"kindId": {"const": "networking.k8s.io/v1/Ingress"}}},
     "networkingNetworkPolicy": {"$ref": "urn:darkfactory:platform-contract:namespaced-resource-snapshot:v1", "properties": {"kindId": {"const": "networking.k8s.io/v1/NetworkPolicy"}}},
     "rbacRoleBinding": {"$ref": "urn:darkfactory:platform-contract:namespaced-resource-snapshot:v1", "properties": {"kindId": {"const": "rbac.authorization.k8s.io/v1/RoleBinding"}}},

--- a/platform-contracts/schemas/v1/http-probe-profile.schema.json
+++ b/platform-contracts/schemas/v1/http-probe-profile.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:darkfactory:platform-contract:http-probe-profile:v1",
+  "title": "HttpProbeProfile v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "kind", "metadata", "appliesTo", "conditionPlan", "targetResolution", "transport", "limits", "aggregation", "evidence"],
+  "properties": {
+    "schemaVersion": {"const": "platform/http-probe-profile/v1"},
+    "kind": {"const": "HttpProbeProfile"},
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "owner", "state"],
+      "properties": {
+        "name": {"const": "http-preview-service"},
+        "version": {"const": "v1"},
+        "owner": {"const": "platform-team"},
+        "state": {"const": "draft"}
+      }
+    },
+    "appliesTo": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "deliveryProfile", "realm"],
+      "properties": {
+        "path": {"const": "standard-http-service/v3"},
+        "deliveryProfile": {"const": "argocd-preview-http-service/v2"},
+        "realm": {"const": "preview/v2"}
+      }
+    },
+    "conditionPlan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["freezeAction", "freezeBefore", "acceptanceFrom", "acceptanceDigestFrom", "method", "pathPattern", "fixedConditions", "requestContract"],
+      "properties": {
+        "freezeAction": {"const": "verification.freeze-http-conditions/v1"},
+        "freezeBefore": {"const": "workflow.author-change"},
+        "acceptanceFrom": {"const": "request.inputs.acceptance"},
+        "acceptanceDigestFrom": {"const": "executionEnvelope.httpAcceptanceDigest"},
+        "method": {"const": "GET"},
+        "pathPattern": {"const": "^/[A-Za-z0-9_~-]+(?:/[A-Za-z0-9_~-]+)*$"},
+        "fixedConditions": {
+          "const": [
+            {"id": "runtime.health", "probe": "http.healthz/v1", "path": "/healthz", "status": 200, "assertion": "status-only"},
+            {"id": "runtime.readiness", "probe": "http.readyz/v1", "path": "/readyz", "status": 200, "assertion": "status-only"}
+          ]
+        },
+        "requestContract": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["conditionId", "probe", "minItems", "maxItems", "status", "assertions"],
+          "properties": {
+            "conditionId": {"const": "runtime.request-contract"},
+            "probe": {"const": "http.request-contract/v1"},
+            "minItems": {"const": 1},
+            "maxItems": {"const": 5},
+            "status": {"const": 200},
+            "assertions": {"const": ["exact-text", "json-subset"]}
+          }
+        }
+      }
+    },
+    "targetResolution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["deliveryEvidenceFrom", "deliveryEvidenceMaxAge", "clusterRefFrom", "namespaceFrom", "namespaceSnapshotFields", "serviceNameFrom", "servicePort", "serviceSnapshotFields", "backendChain", "servingContainerRule", "minReadyBackends", "maxReadyBackends", "backendOrder", "probeMode", "snapshotTiming", "invalidTargetReasons", "onInvalidTarget"],
+      "properties": {
+        "deliveryEvidenceFrom": {"const": "evidence.kubernetes.delivery-observation"},
+        "deliveryEvidenceMaxAge": {"const": "PT5M"},
+        "clusterRefFrom": {"const": "destination.clusterRef"},
+        "namespaceFrom": {"const": "destination.namespaceTemplate"},
+        "namespaceSnapshotFields": {"const": ["resourceVersion", "uid"]},
+        "serviceNameFrom": {"const": "request.inputs.serviceName"},
+        "servicePort": {"const": 8080},
+        "serviceSnapshotFields": {"const": ["clusterIP", "ports", "resourceVersion", "selector", "type", "uid"]},
+        "backendChain": {"const": ["apps/v1/Deployment", "apps/v1/ReplicaSet", "v1/Pod", "discovery.k8s.io/v1/EndpointSlice", "status.containerStatuses.imageID"]},
+        "servingContainerRule": {"const": "exactly-one-container-serving-port-8080"},
+        "minReadyBackends": {"const": 1},
+        "maxReadyBackends": {"const": 3},
+        "backendOrder": {"const": "stable-pod-or-endpoint-key-ascending"},
+        "probeMode": {"const": "each-ready-backend-direct"},
+        "snapshotTiming": {"const": "before-and-after-each-attempt"},
+        "invalidTargetReasons": {"const": ["empty-backend-set", "excess-backend-set", "invalid-backend", "mixed-image", "target-drift"]},
+        "onInvalidTarget": {"const": "probe-error"}
+      }
+    },
+    "transport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scheme", "method", "pathMode", "urlJoin", "trustEnvironment", "redirects", "authentication", "hostHeaderFrom", "backendExecution", "textMediaTypes", "jsonMediaTypes"],
+      "properties": {
+        "scheme": {"const": "http"},
+        "method": {"const": "GET"},
+        "pathMode": {"const": "prevalidated-origin-form"},
+        "urlJoin": {"const": false},
+        "trustEnvironment": {"const": false},
+        "redirects": {"const": false},
+        "authentication": {"const": "none"},
+        "hostHeaderFrom": {"const": "derivedTarget.serviceDnsName"},
+        "backendExecution": {"const": "concurrent-bounded-3-results-pod-uid-ordered"},
+        "textMediaTypes": {"const": ["text/plain", "text/plain; charset=utf-8"]},
+        "jsonMediaTypes": {"const": ["application/json", "application/json; charset=utf-8"]}
+      }
+    },
+    "limits": {
+      "const": {
+        "maxAttemptsPerConditionRun": 5,
+        "consecutivePasses": 3,
+        "delayBetweenAttempts": "PT1S",
+        "perBackendDeadline": "PT5S",
+        "attemptBatchDeadline": "PT30S",
+        "overallRunDeadline": "PT4M",
+        "maxResponseBytesPerBackend": 65536,
+        "maxOracleEntries": 10,
+        "onAssertionFailure": "continue-until-five-or-success",
+        "onProbeError": "stop"
+      }
+    },
+    "aggregation": {
+      "const": {
+        "states": ["fail", "inconclusive", "pass", "probe-error"],
+        "batchPass": "all-backends-pass-and-snapshots-identical",
+        "batchPrecedence": ["probe-error", "fail", "inconclusive", "pass"],
+        "conditionPass": "three-consecutive-pass-batches",
+        "nonPassResetsStreak": true,
+        "requestContractPass": "all-acceptance-condition-runs-pass",
+        "pathPass": "all-three-path-conditions-pass"
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["subjectSchema", "resultSchema", "evidenceType", "canonicalization", "digestAlgorithm", "signatureAlgorithm", "verifierProfileFrom", "signingKeyFrom", "workerEvidenceAccepted", "rawResponseStored"],
+      "properties": {
+        "subjectSchema": {"const": "urn:darkfactory:platform-contract:http-probe-subject:v1"},
+        "resultSchema": {"const": "urn:darkfactory:platform-contract:http-probe-result:v1"},
+        "evidenceType": {"const": "http.probe-result/v1"},
+        "canonicalization": {"const": "rfc8785-json-canonicalization/v1"},
+        "digestAlgorithm": {"const": "sha256"},
+        "signatureAlgorithm": {"const": "Ed25519"},
+        "verifierProfileFrom": {"const": "adapter.httpVerification.verifierProfile"},
+        "signingKeyFrom": {"const": "adapter.httpVerification.signingKey"},
+        "workerEvidenceAccepted": {"const": false},
+        "rawResponseStored": {"const": false}
+      }
+    }
+  }
+}

--- a/platform-contracts/schemas/v1/http-probe-result.schema.json
+++ b/platform-contracts/schemas/v1/http-probe-result.schema.json
@@ -1,0 +1,254 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:darkfactory:platform-contract:http-probe-result:v1",
+  "title": "HttpProbeResult v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "evidenceType", "workOrderId", "runId", "subject", "subjectSha256", "conditionRuns", "pathConditionResults", "aggregateState", "satisfied", "startedAt", "completedAt", "expiresAt", "canonicalization", "digestPayloadExcludes", "evidenceSha256", "verifier"],
+  "properties": {
+    "schemaVersion": {"const": "verification/http-probe-result/v1"},
+    "evidenceType": {"const": "http.probe-result/v1"},
+    "workOrderId": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]{7,52}$"},
+    "runId": {"$ref": "#/$defs/runId"},
+    "subject": {"$ref": "urn:darkfactory:platform-contract:http-probe-subject:v1"},
+    "subjectSha256": {"$ref": "#/$defs/digest"},
+    "conditionRuns": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 7,
+      "items": {"$ref": "#/$defs/conditionRun"}
+    },
+    "pathConditionResults": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "prefixItems": [
+        {"$ref": "#/$defs/pathResult", "properties": {"id": {"const": "runtime.health"}}},
+        {"$ref": "#/$defs/pathResult", "properties": {"id": {"const": "runtime.readiness"}}},
+        {"$ref": "#/$defs/pathResult", "properties": {"id": {"const": "runtime.request-contract"}}}
+      ],
+      "items": false
+    },
+    "aggregateState": {"$ref": "#/$defs/state"},
+    "satisfied": {"type": "boolean"},
+    "startedAt": {"type": "string", "format": "date-time"},
+    "completedAt": {"type": "string", "format": "date-time"},
+    "expiresAt": {"type": "string", "format": "date-time"},
+    "canonicalization": {"const": "rfc8785-json-canonicalization/v1"},
+    "digestPayloadExcludes": {"const": ["evidenceSha256", "verifier.signature"]},
+    "evidenceSha256": {"$ref": "#/$defs/digest"},
+    "verifier": {"$ref": "#/$defs/signer"}
+  },
+  "$defs": {
+    "digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "runId": {"type": "string", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"},
+    "state": {"enum": ["pass", "fail", "inconclusive", "probe-error"]},
+    "pathResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "state", "satisfied"],
+      "properties": {
+        "id": {"enum": ["runtime.health", "runtime.readiness", "runtime.request-contract"]},
+        "state": {"$ref": "#/$defs/state"},
+        "satisfied": {"type": "boolean"}
+      }
+    },
+    "conditionRun": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "pathConditionId", "probe", "expectationOrdinal", "path", "expectationDigest", "attempts", "achievedConsecutivePasses", "state", "termination"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^(health|readiness|acceptance-[1-5])$"},
+        "pathConditionId": {"enum": ["runtime.health", "runtime.readiness", "runtime.request-contract"]},
+        "probe": {"enum": ["http.healthz/v1", "http.readyz/v1", "http.request-contract/v1"]},
+        "expectationOrdinal": {"type": "integer", "minimum": 0, "maximum": 5},
+        "path": {"type": "string", "minLength": 2, "maxLength": 128, "pattern": "^/[A-Za-z0-9_~-]+(?:/[A-Za-z0-9_~-]+)*$"},
+        "expectationDigest": {"$ref": "#/$defs/digest"},
+        "attempts": {
+          "type": "array",
+          "minItems": 0,
+          "maxItems": 5,
+          "items": {"$ref": "#/$defs/attempt"}
+        },
+        "achievedConsecutivePasses": {"type": "integer", "minimum": 0, "maximum": 3},
+        "state": {"$ref": "#/$defs/state"},
+        "termination": {"enum": ["condition-satisfied", "attempts-exhausted", "run-deadline", "probe-error"]}
+      }
+    },
+    "attempt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["attemptId", "ordinal", "startedAt", "completedAt", "durationMs", "preTarget", "targetErrorCode", "backendResults", "postTarget", "state"],
+      "properties": {
+        "attemptId": {"$ref": "#/$defs/runId"},
+        "ordinal": {"type": "integer", "minimum": 1, "maximum": 5},
+        "startedAt": {"type": "string", "format": "date-time"},
+        "completedAt": {"type": "string", "format": "date-time"},
+        "durationMs": {"type": "integer", "minimum": 0, "maximum": 30000},
+        "preTarget": {"$ref": "#/$defs/targetSnapshot"},
+        "targetErrorCode": {"type": ["string", "null"], "enum": [null, "empty-backend-set", "excess-backend-set", "invalid-backend", "mixed-image", "target-drift"]},
+        "backendResults": {
+          "type": "array",
+          "minItems": 0,
+          "maxItems": 3,
+          "items": {"$ref": "#/$defs/backendResult"}
+        },
+        "postTarget": {"$ref": "#/$defs/targetSnapshot"},
+        "state": {"$ref": "#/$defs/state"}
+      }
+    },
+    "targetSnapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["namespaceUid", "namespaceResourceVersion", "serviceUid", "serviceResourceVersion", "serviceRoutingSpecDigest", "networkPolicySetDigest", "endpointSliceSetDigest", "backendSetDigest", "observedBackendCount", "backends"],
+      "properties": {
+        "namespaceUid": {"type": "string", "minLength": 1, "maxLength": 128},
+        "namespaceResourceVersion": {"type": "string", "minLength": 1, "maxLength": 128},
+        "serviceUid": {"type": "string", "minLength": 1, "maxLength": 128},
+        "serviceResourceVersion": {"type": "string", "minLength": 1, "maxLength": 128},
+        "serviceRoutingSpecDigest": {"$ref": "#/$defs/digest"},
+        "networkPolicySetDigest": {"$ref": "#/$defs/digest"},
+        "endpointSliceSetDigest": {"$ref": "#/$defs/digest"},
+        "backendSetDigest": {"$ref": "#/$defs/digest"},
+        "observedBackendCount": {"type": "integer", "minimum": 0, "maximum": 100},
+        "backends": {
+          "type": "array",
+          "minItems": 0,
+          "maxItems": 100,
+          "items": {"$ref": "#/$defs/backendSnapshot"}
+        }
+      }
+    },
+    "backendSnapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["endpointSliceName", "endpointSliceUid", "endpointSliceResourceVersion", "endpointSliceDigest", "endpointSliceServiceName", "endpointSliceManagedBy", "addressType", "address", "targetRefKind", "targetRefName", "targetRefUid", "podNamespace", "podName", "podUid", "podResourceVersion", "podSpecDigest", "podStatusDigest", "podIp", "podOwnerKind", "podOwnerName", "podOwnerUid", "replicaSetName", "replicaSetUid", "replicaSetResourceVersion", "replicaSetOwnerKind", "replicaSetOwnerName", "replicaSetOwnerUid", "deploymentName", "deploymentUid", "deploymentResourceVersion", "renderedPodTemplateDigest", "ownershipWorkOrderId", "selectorMatches", "ready", "serving", "terminating", "hostNetwork", "containerName", "containersServingPort", "containerPort", "serviceTargetPort", "containerReady", "imageId", "imageDigest"],
+      "properties": {
+        "endpointSliceName": {"type": "string", "minLength": 1, "maxLength": 253},
+        "endpointSliceUid": {"type": "string", "minLength": 1, "maxLength": 128},
+        "endpointSliceResourceVersion": {"type": "string", "minLength": 1, "maxLength": 128},
+        "endpointSliceDigest": {"$ref": "#/$defs/digest"},
+        "endpointSliceServiceName": {"type": "string", "minLength": 1, "maxLength": 63},
+        "endpointSliceManagedBy": {"type": "string", "minLength": 1, "maxLength": 253},
+        "addressType": {"enum": ["IPv4", "IPv6"]},
+        "address": {"type": "string", "minLength": 2, "maxLength": 45},
+        "targetRefKind": {"type": ["string", "null"], "maxLength": 63},
+        "targetRefName": {"type": ["string", "null"], "minLength": 1, "maxLength": 253},
+        "targetRefUid": {"type": ["string", "null"], "minLength": 1, "maxLength": 128},
+        "podNamespace": {"type": ["string", "null"], "maxLength": 63},
+        "podName": {"type": ["string", "null"], "minLength": 1, "maxLength": 253},
+        "podUid": {"type": ["string", "null"], "minLength": 1, "maxLength": 128},
+        "podResourceVersion": {"type": ["string", "null"], "minLength": 1, "maxLength": 128},
+        "podSpecDigest": {"oneOf": [{"$ref": "#/$defs/digest"}, {"type": "null"}]},
+        "podStatusDigest": {"oneOf": [{"$ref": "#/$defs/digest"}, {"type": "null"}]},
+        "podIp": {"type": ["string", "null"], "minLength": 2, "maxLength": 45},
+        "podOwnerKind": {"type": ["string", "null"], "maxLength": 63},
+        "podOwnerName": {"type": ["string", "null"], "minLength": 1, "maxLength": 253},
+        "podOwnerUid": {"type": ["string", "null"], "minLength": 1, "maxLength": 128},
+        "replicaSetName": {"type": ["string", "null"], "minLength": 1, "maxLength": 253},
+        "replicaSetUid": {"type": ["string", "null"], "minLength": 1, "maxLength": 128},
+        "replicaSetResourceVersion": {"type": ["string", "null"], "minLength": 1, "maxLength": 128},
+        "replicaSetOwnerKind": {"type": ["string", "null"], "maxLength": 63},
+        "replicaSetOwnerName": {"type": ["string", "null"], "minLength": 1, "maxLength": 253},
+        "replicaSetOwnerUid": {"type": ["string", "null"], "minLength": 1, "maxLength": 128},
+        "deploymentName": {"type": ["string", "null"], "minLength": 1, "maxLength": 253},
+        "deploymentUid": {"type": ["string", "null"], "minLength": 1, "maxLength": 128},
+        "deploymentResourceVersion": {"type": ["string", "null"], "minLength": 1, "maxLength": 128},
+        "renderedPodTemplateDigest": {"oneOf": [{"$ref": "#/$defs/digest"}, {"type": "null"}]},
+        "ownershipWorkOrderId": {"type": ["string", "null"], "maxLength": 53},
+        "selectorMatches": {"type": "boolean"},
+        "ready": {"type": "boolean"},
+        "serving": {"type": "boolean"},
+        "terminating": {"type": "boolean"},
+        "hostNetwork": {"type": "boolean"},
+        "containerName": {"type": ["string", "null"], "minLength": 1, "maxLength": 63},
+        "containersServingPort": {"type": "integer", "minimum": 0, "maximum": 100},
+        "containerPort": {"type": ["integer", "null"], "minimum": 1, "maximum": 65535},
+        "serviceTargetPort": {"type": ["integer", "null"], "minimum": 1, "maximum": 65535},
+        "containerReady": {"type": "boolean"},
+        "imageId": {"type": ["string", "null"], "maxLength": 512},
+        "imageDigest": {"oneOf": [{"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}, {"type": "null"}]}
+      }
+    },
+    "backendResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["podUid", "state", "durationMs", "status", "mediaType", "responseBytes", "responseTruncated", "contentSha256", "errorCode", "oracle"],
+      "properties": {
+        "podUid": {"type": "string", "minLength": 1, "maxLength": 128},
+        "state": {"$ref": "#/$defs/state"},
+        "durationMs": {"type": "integer", "minimum": 0, "maximum": 5000},
+        "status": {"type": ["integer", "null"], "minimum": 100, "maximum": 599},
+        "mediaType": {"type": ["string", "null"], "maxLength": 80},
+        "responseBytes": {"type": "integer", "minimum": 0, "maximum": 65536},
+        "responseTruncated": {"type": "boolean"},
+        "contentSha256": {"oneOf": [{"$ref": "#/$defs/digest"}, {"type": "null"}]},
+        "errorCode": {"type": ["string", "null"], "enum": [null, "connection", "deadline", "target-drift", "target-invalid", "run-deadline", "verifier"]},
+        "oracle": {
+          "oneOf": [
+            {"$ref": "#/$defs/statusOracle"},
+            {"$ref": "#/$defs/textOracle"},
+            {"$ref": "#/$defs/jsonOracle"}
+          ]
+        }
+      }
+    },
+    "statusOracle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "expectedStatus", "observedStatus"],
+      "properties": {
+        "kind": {"const": "status-only"},
+        "expectedStatus": {"const": 200},
+        "observedStatus": {"type": ["integer", "null"], "minimum": 100, "maximum": 599}
+      }
+    },
+    "textOracle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "expectedByteDigest", "observedByteDigest"],
+      "properties": {
+        "kind": {"const": "exact-text"},
+        "expectedByteDigest": {"$ref": "#/$defs/digest"},
+        "observedByteDigest": {"oneOf": [{"$ref": "#/$defs/digest"}, {"type": "null"}]}
+      }
+    },
+    "jsonOracle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "entries"],
+      "properties": {
+        "kind": {"const": "json-subset"},
+        "entries": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 10,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["key", "expectedType", "expectedValueDigest", "observedPresent", "observedType", "observedValueDigest"],
+            "properties": {
+              "key": {"type": "string", "minLength": 1, "maxLength": 64},
+              "expectedType": {"enum": ["boolean", "integer", "null", "number", "string"]},
+              "expectedValueDigest": {"$ref": "#/$defs/digest"},
+              "observedPresent": {"type": "boolean"},
+              "observedType": {"type": ["string", "null"], "enum": [null, "boolean", "integer", "null", "number", "string"]},
+              "observedValueDigest": {"oneOf": [{"$ref": "#/$defs/digest"}, {"type": "null"}]}
+            }
+          }
+        }
+      }
+    },
+    "signer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profileDigest", "signingKeyId", "algorithm", "signature"],
+      "properties": {
+        "profileDigest": {"$ref": "#/$defs/digest"},
+        "signingKeyId": {"type": "string", "minLength": 1, "maxLength": 253},
+        "algorithm": {"const": "Ed25519"},
+        "signature": {"type": "string", "pattern": "^[A-Za-z0-9_-]{43,4096}$"}
+      }
+    }
+  }
+}

--- a/platform-contracts/schemas/v1/http-probe-subject.schema.json
+++ b/platform-contracts/schemas/v1/http-probe-subject.schema.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:darkfactory:platform-contract:http-probe-subject:v1",
+  "title": "HttpProbeSubject v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "workOrderId", "runId", "executionEnvelopeDigest", "platformPath", "platformCommitSha", "platformBundleDigest", "probeProfile", "acceptance", "acceptanceDigest", "cluster", "realm", "service", "delivery", "issuedAt", "deadline", "canonicalization", "digestPayloadExcludes", "subjectSha256", "issuer"],
+  "properties": {
+    "schemaVersion": {"const": "verification/http-probe-subject/v1"},
+    "workOrderId": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]{7,52}$"},
+    "runId": {"type": "string", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"},
+    "executionEnvelopeDigest": {"$ref": "#/$defs/digest"},
+    "platformPath": {"const": "standard-http-service/v3"},
+    "platformCommitSha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "platformBundleDigest": {"$ref": "#/$defs/digest"},
+    "probeProfile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "digest"],
+      "properties": {
+        "id": {"const": "http-preview-service/v1"},
+        "digest": {"$ref": "#/$defs/digest"}
+      }
+    },
+    "acceptance": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 5,
+      "items": {"$ref": "#/$defs/acceptance"}
+    },
+    "acceptanceDigest": {"$ref": "#/$defs/digest"},
+    "cluster": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ref", "identityDigest", "apiServerDigest", "caSha256"],
+      "properties": {
+        "ref": {"const": "kubernetes:preview-primary"},
+        "identityDigest": {"$ref": "#/$defs/digest"},
+        "apiServerDigest": {"$ref": "#/$defs/digest"},
+        "caSha256": {"$ref": "#/$defs/digest"}
+      }
+    },
+    "realm": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "namespaceName", "namespaceUid", "namespaceResourceVersion"],
+      "properties": {
+        "id": {"const": "preview/v2"},
+        "name": {"type": "string", "pattern": "^preview-[a-z0-9][a-z0-9-]{7,52}$"},
+        "namespaceName": {"type": "string", "pattern": "^preview-[a-z0-9][a-z0-9-]{7,52}$"},
+        "namespaceUid": {"type": "string", "minLength": 1, "maxLength": 128},
+        "namespaceResourceVersion": {"type": "string", "minLength": 1, "maxLength": 128}
+      }
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "uid", "resourceVersion", "routingSpecDigest", "dnsName", "port"],
+      "properties": {
+        "name": {"type": "string", "pattern": "^[a-z][a-z0-9-]{2,40}[a-z0-9]$"},
+        "uid": {"type": "string", "minLength": 1, "maxLength": 128},
+        "resourceVersion": {"type": "string", "minLength": 1, "maxLength": 128},
+        "routingSpecDigest": {"$ref": "#/$defs/digest"},
+        "dnsName": {"type": "string", "pattern": "^[a-z][a-z0-9-]{2,40}[a-z0-9]\\.preview-[a-z0-9][a-z0-9-]{7,52}\\.svc$"},
+        "port": {"const": 8080}
+      }
+    },
+    "delivery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidenceDigest", "observedAt", "expiresAt", "mergeCommitSha", "imageDigest", "renderedInventoryDigest", "renderedPodTemplateDigest", "networkPolicySetDigest"],
+      "properties": {
+        "evidenceDigest": {"$ref": "#/$defs/digest"},
+        "observedAt": {"type": "string", "format": "date-time"},
+        "expiresAt": {"type": "string", "format": "date-time"},
+        "mergeCommitSha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "imageDigest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+        "renderedInventoryDigest": {"$ref": "#/$defs/digest"},
+        "renderedPodTemplateDigest": {"$ref": "#/$defs/digest"},
+        "networkPolicySetDigest": {"$ref": "#/$defs/digest"}
+      }
+    },
+    "issuedAt": {"type": "string", "format": "date-time"},
+    "deadline": {"type": "string", "format": "date-time"},
+    "canonicalization": {"const": "rfc8785-json-canonicalization/v1"},
+    "digestPayloadExcludes": {"const": ["subjectSha256", "issuer.signature"]},
+    "subjectSha256": {"$ref": "#/$defs/digest"},
+    "issuer": {"$ref": "#/$defs/signer"}
+  },
+  "$defs": {
+    "digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "acceptance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ordinal", "method", "path", "expected"],
+      "properties": {
+        "ordinal": {"type": "integer", "minimum": 1, "maximum": 5},
+        "method": {"const": "GET"},
+        "path": {"type": "string", "minLength": 2, "maxLength": 128, "pattern": "^/[A-Za-z0-9_~-]+(?:/[A-Za-z0-9_~-]+)*$"},
+        "expected": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["status", "kind", "mediaType", "exactText"],
+              "properties": {
+                "status": {"const": 200},
+                "kind": {"const": "exact-text"},
+                "mediaType": {"enum": ["text/plain", "text/plain; charset=utf-8"]},
+                "exactText": {"type": "string", "maxLength": 512}
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["status", "kind", "mediaType", "jsonSubset"],
+              "properties": {
+                "status": {"const": 200},
+                "kind": {"const": "json-subset"},
+                "mediaType": {"enum": ["application/json", "application/json; charset=utf-8"]},
+                "jsonSubset": {
+                  "type": "object",
+                  "minProperties": 1,
+                  "maxProperties": 10,
+                  "propertyNames": {"type": "string", "pattern": "^[A-Za-z0-9_.-]{1,64}$"},
+                  "additionalProperties": {
+                    "anyOf": [
+                      {"type": "string", "maxLength": 512},
+                      {"type": "integer"},
+                      {"type": "number"},
+                      {"type": "boolean"},
+                      {"type": "null"}
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "signer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profileDigest", "signingKeyId", "algorithm", "signature"],
+      "properties": {
+        "profileDigest": {"$ref": "#/$defs/digest"},
+        "signingKeyId": {"type": "string", "minLength": 1, "maxLength": 253},
+        "algorithm": {"const": "Ed25519"},
+        "signature": {"type": "string", "pattern": "^[A-Za-z0-9_-]{43,4096}$"}
+      }
+    }
+  }
+}

--- a/platform-contracts/schemas/v1/namespaced-resource-snapshot.schema.json
+++ b/platform-contracts/schemas/v1/namespaced-resource-snapshot.schema.json
@@ -11,6 +11,7 @@
       "enum": [
         "apps/v1/Deployment",
         "apps/v1/ReplicaSet",
+        "discovery.k8s.io/v1/EndpointSlice",
         "networking.k8s.io/v1/Ingress",
         "networking.k8s.io/v1/NetworkPolicy",
         "rbac.authorization.k8s.io/v1/Role",

--- a/platform-contracts/schemas/v1/observation-scope.schema.json
+++ b/platform-contracts/schemas/v1/observation-scope.schema.json
@@ -50,6 +50,7 @@
       "const": [
         "apps/v1/Deployment",
         "apps/v1/ReplicaSet",
+        "discovery.k8s.io/v1/EndpointSlice",
         "networking.k8s.io/v1/Ingress",
         "networking.k8s.io/v1/NetworkPolicy",
         "rbac.authorization.k8s.io/v1/Role",

--- a/platform-contracts/schemas/v1/observer-access-attestation.schema.json
+++ b/platform-contracts/schemas/v1/observer-access-attestation.schema.json
@@ -234,7 +234,7 @@
     },
     "applicationRole": {"$ref": "#/$defs/namespacedObject", "properties": {"apiVersion": {"const": "rbac.authorization.k8s.io/v1"}, "kind": {"const": "Role"}, "namespace": {"const": "argocd"}}},
     "applicationRoleBinding": {"$ref": "#/$defs/namespacedObject", "properties": {"apiVersion": {"const": "rbac.authorization.k8s.io/v1"}, "kind": {"const": "RoleBinding"}, "namespace": {"const": "argocd"}}},
-    "inventoryClusterRole": {"$ref": "#/$defs/clusterObject", "properties": {"kind": {"const": "ClusterRole"}, "name": {"const": "darkfactory-preview-delivery-list-v1"}}},
+    "inventoryClusterRole": {"$ref": "#/$defs/clusterObject", "properties": {"kind": {"const": "ClusterRole"}, "name": {"const": "darkfactory-preview-delivery-list-v2"}}},
     "namespaceClusterRole": {"$ref": "#/$defs/clusterObject", "properties": {"kind": {"const": "ClusterRole"}, "name": {"pattern": "^obs-[a-z0-9][a-z0-9-]{7,52}$"}}},
     "namespaceClusterRoleBinding": {"$ref": "#/$defs/clusterObject", "properties": {"kind": {"const": "ClusterRoleBinding"}, "name": {"pattern": "^obs-[a-z0-9][a-z0-9-]{7,52}$"}}},
     "realmRoleBinding": {"$ref": "#/$defs/namespacedObject", "properties": {"apiVersion": {"const": "rbac.authorization.k8s.io/v1"}, "kind": {"const": "RoleBinding"}, "namespace": {"pattern": "^preview-[a-z0-9][a-z0-9-]{7,52}$"}}},

--- a/platform-contracts/schemas/v1/observer-access-cleanup-evidence.schema.json
+++ b/platform-contracts/schemas/v1/observer-access-cleanup-evidence.schema.json
@@ -100,7 +100,7 @@
       "additionalProperties": false,
       "required": ["name", "status", "canonicalDigest"],
       "properties": {
-        "name": {"const": "darkfactory-preview-delivery-list-v1"},
+        "name": {"const": "darkfactory-preview-delivery-list-v2"},
         "status": {"const": "preserved"},
         "canonicalDigest": {"$ref": "#/$defs/digest"}
       }

--- a/platform-contracts/schemas/v1/observer-access-profile.schema.json
+++ b/platform-contracts/schemas/v1/observer-access-profile.schema.json
@@ -80,7 +80,7 @@
       "additionalProperties": false,
       "required": ["name", "shared", "rules"],
       "properties": {
-        "name": {"const": "darkfactory-preview-delivery-list-v1"},
+        "name": {"const": "darkfactory-preview-delivery-list-v2"},
         "shared": {"const": true},
         "rules": {
           "const": [
@@ -92,6 +92,11 @@
             {
               "apiGroups": ["apps"],
               "resources": ["deployments", "replicasets"],
+              "verbs": ["list"]
+            },
+            {
+              "apiGroups": ["discovery.k8s.io"],
+              "resources": ["endpointslices"],
               "verbs": ["list"]
             },
             {
@@ -158,6 +163,7 @@
           "const": [
             "apps/v1/Deployment",
             "apps/v1/ReplicaSet",
+            "discovery.k8s.io/v1/EndpointSlice",
             "networking.k8s.io/v1/Ingress",
             "networking.k8s.io/v1/NetworkPolicy",
             "rbac.authorization.k8s.io/v1/Role",

--- a/platform-contracts/schemas/v2/delivery-profile.schema.json
+++ b/platform-contracts/schemas/v2/delivery-profile.schema.json
@@ -4,7 +4,7 @@
   "title": "PlatformDeliveryProfile v2",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schemaVersion", "kind", "metadata", "path", "mechanism", "templateBindings", "source", "application", "destination", "resourceEnvelope", "observations", "observerAccess", "compensation"],
+  "required": ["schemaVersion", "kind", "metadata", "path", "mechanism", "templateBindings", "source", "application", "destination", "resourceEnvelope", "observations", "observerAccess", "runtimeVerification", "compensation"],
   "properties": {
     "schemaVersion": {"const": "platform/delivery-profile/v2"},
     "kind": {"const": "PlatformDeliveryProfile"},
@@ -152,6 +152,7 @@
               "dedicated-namespace",
               "default-deny-network",
               "digest-pinned-image",
+              "http-verifier-ingress-only",
               "no-workload-rbac",
               "no-persistent-volumes",
               "no-runtime-secrets",
@@ -200,6 +201,59 @@
     },
     "observerAccess": {
       "$ref": "urn:darkfactory:platform-contract:observer-access-profile:v1"
+    },
+    "runtimeVerification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action", "profile", "profileSchema", "subjectSchema", "resultSchema", "evidenceType", "deliveryObservationSchemaFrom", "credential", "network"],
+      "properties": {
+        "action": {"const": "verification.run-http-probes/v1"},
+        "profile": {"const": "http-preview-service/v1"},
+        "profileSchema": {"const": "urn:darkfactory:platform-contract:http-probe-profile:v1"},
+        "subjectSchema": {"const": "urn:darkfactory:platform-contract:http-probe-subject:v1"},
+        "resultSchema": {"const": "urn:darkfactory:platform-contract:http-probe-result:v1"},
+        "evidenceType": {"const": "http.probe-result/v1"},
+        "deliveryObservationSchemaFrom": {"const": "observations.evidenceSchema"},
+        "credential": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["authority", "serviceAccountFrom", "issueAction", "audienceFrom", "apiServerFrom", "caSha256From", "maxLifetime", "absoluteDeadline", "maxResponseBytes", "operations", "kindIds", "subjectIssuerProfileFrom"],
+          "properties": {
+            "authority": {"const": "platform-control-plane"},
+            "serviceAccountFrom": {"const": "observerAccess.serviceAccount.nameTemplate"},
+            "issueAction": {"const": "verification.issue-http-probe-credential/v1"},
+            "audienceFrom": {"const": "adapter.destination.tokenAudience"},
+            "apiServerFrom": {"const": "adapter.destination.apiServer"},
+            "caSha256From": {"const": "adapter.destination.caSha256"},
+            "maxLifetime": {"const": "PT5M"},
+            "absoluteDeadline": {"const": "PT4M"},
+            "maxResponseBytes": {"const": 1048576},
+            "operations": {"const": ["deployments.list", "endpointslices.list", "namespace.get", "networkpolicies.list", "pods.list", "replicasets.list", "services.list"]},
+            "kindIds": {"const": ["apps/v1/Deployment", "apps/v1/ReplicaSet", "discovery.k8s.io/v1/EndpointSlice", "networking.k8s.io/v1/NetworkPolicy", "v1/Namespace", "v1/Pod", "v1/Service"]},
+            "subjectIssuerProfileFrom": {"const": "adapter.httpVerification.subjectIssuerProfile"}
+          }
+        },
+        "network": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["sourceNamespaceFrom", "sourcePodSelectorFrom", "destinationNamespaceFrom", "destinationPodSelectorFrom", "destinationPort", "protocol", "policyTypes", "allowRuleCount", "denyOtherIngress", "desiredPolicyDigestFrom", "observedPolicySnapshotFrom", "requiredAssertion", "callerNetworkTargetAccepted"],
+          "properties": {
+            "sourceNamespaceFrom": {"const": "adapter.httpVerification.namespace"},
+            "sourcePodSelectorFrom": {"const": "adapter.httpVerification.podSelector"},
+            "destinationNamespaceFrom": {"const": "destination.namespaceTemplate"},
+            "destinationPodSelectorFrom": {"const": "application.requiredLabels"},
+            "destinationPort": {"const": 8080},
+            "protocol": {"const": "TCP"},
+            "policyTypes": {"const": ["Ingress"]},
+            "allowRuleCount": {"const": 1},
+            "denyOtherIngress": {"const": true},
+            "desiredPolicyDigestFrom": {"const": "workflow.validate-change.httpVerifierNetworkPolicyDigest"},
+            "observedPolicySnapshotFrom": {"const": "evidence.kubernetes.delivery-observation.finalCollectionSnapshots.networking-v1-networkpolicies"},
+            "requiredAssertion": {"const": "http-verifier-ingress-only"},
+            "callerNetworkTargetAccepted": {"const": false}
+          }
+        }
+      }
     },
     "compensation": {
       "type": "object",

--- a/scripts/http_probe_contract_validation.py
+++ b/scripts/http_probe_contract_validation.py
@@ -1,0 +1,1800 @@
+"""Positive and adversarial qualification for the draft HTTP probe contracts."""
+
+from __future__ import annotations
+
+import base64
+import copy
+import hashlib
+import ipaddress
+import math
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import rfc8785
+import yaml
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from jsonschema import Draft202012Validator, FormatChecker, ValidationError
+from referencing import Registry, Resource
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROFILE_PATH = (
+    ROOT / "platform-contracts/probe-profiles/http-preview-service/v1/profile.yaml"
+)
+STATE_PRECEDENCE = ("probe-error", "fail", "inconclusive", "pass")
+
+
+class HttpProbeContractError(Exception):
+    pass
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    try:
+        return rfc8785.dumps(value)
+    except Exception as error:
+        raise HttpProbeContractError(f"value is not canonically serializable: {error}") from error
+
+
+def _digest(value: Any) -> str:
+    if isinstance(value, bytes):
+        payload = value
+    elif isinstance(value, str):
+        payload = value.encode("utf-8")
+    else:
+        payload = _canonical_bytes(value)
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _canonical_digest(value: Any) -> str:
+    return hashlib.sha256(_canonical_bytes(value)).hexdigest()
+
+
+def _without(value: dict[str, Any], dotted_paths: tuple[str, ...]) -> dict[str, Any]:
+    result = copy.deepcopy(value)
+    for dotted in dotted_paths:
+        parent: Any = result
+        parts = dotted.split(".")
+        for part in parts[:-1]:
+            parent = parent[part]
+        del parent[parts[-1]]
+    return result
+
+
+def _private_key(label: str) -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.from_private_bytes(hashlib.sha256(label.encode()).digest())
+
+
+def _encode_signature(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _decode_signature(value: str) -> bytes:
+    return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+
+
+def _sign(
+    value: dict[str, Any],
+    private_key: Ed25519PrivateKey,
+    excluded: tuple[str, ...],
+    signature_path: tuple[str, str],
+) -> None:
+    payload = _canonical_bytes(_without(value, excluded))
+    value[signature_path[0]][signature_path[1]] = _encode_signature(
+        private_key.sign(payload)
+    )
+
+
+def _verify_signature(
+    value: dict[str, Any],
+    signer: dict[str, Any],
+    public_key: Ed25519PublicKey,
+    expected_profile: str,
+    expected_key_id: str,
+    excluded: tuple[str, ...],
+) -> None:
+    if signer["profileDigest"] != expected_profile or signer["signingKeyId"] != expected_key_id:
+        raise HttpProbeContractError("signer is not an adapter-owned trust anchor")
+    try:
+        public_key.verify(
+            _decode_signature(signer["signature"]),
+            _canonical_bytes(_without(value, excluded)),
+        )
+    except (InvalidSignature, ValueError) as error:
+        raise HttpProbeContractError("cryptographic signature verification failed") from error
+
+
+def _parse(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _timestamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _json_type(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise HttpProbeContractError("non-finite JSON number")
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    raise HttpProbeContractError("JSON subset values must be shallow scalars")
+
+
+def _validate_json_scalar(value: Any) -> str:
+    value_type = _json_type(value)
+    _canonical_bytes(value)
+    return value_type
+
+
+def _validate_exact_text(value: str) -> None:
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError as error:
+        raise HttpProbeContractError("exact text is not valid UTF-8") from error
+
+
+def _validate_acceptance(acceptance: list[dict[str, Any]]) -> None:
+    paths = [item["path"] for item in acceptance]
+    if len(paths) != len(set(paths)):
+        raise HttpProbeContractError("acceptance paths must be unique")
+    if [item["ordinal"] for item in acceptance] != list(range(1, len(acceptance) + 1)):
+        raise HttpProbeContractError("acceptance ordinals must be contiguous")
+    for item in acceptance:
+        expected = item["expected"]
+        if expected["kind"] == "json-subset":
+            for value in expected["jsonSubset"].values():
+                _validate_json_scalar(value)
+        elif expected["kind"] == "exact-text":
+            _validate_exact_text(expected["exactText"])
+
+
+def validate_http_request_inputs(inputs: dict[str, Any]) -> None:
+    paths = [item["path"] for item in inputs["acceptance"]]
+    if len(paths) != len(set(paths)):
+        raise HttpProbeContractError("request acceptance paths must be unique")
+    for item in inputs["acceptance"]:
+        expected = item["expected"]
+        if "jsonSubset" in expected:
+            for value in expected["jsonSubset"].values():
+                _validate_json_scalar(value)
+        elif "exactText" in expected:
+            _validate_exact_text(expected["exactText"])
+
+
+def _target_snapshot(subject: dict[str, Any]) -> dict[str, Any]:
+    service = subject["service"]
+    image_digest = subject["delivery"]["imageDigest"]
+    pod_name = "payments-api-6d9f7c8b9c-2lmnp"
+    pod_uid = "uid-pod-payments-api-1"
+    backend = {
+        "endpointSliceName": "payments-api-4z2mk",
+        "endpointSliceUid": "uid-slice-payments-api",
+        "endpointSliceResourceVersion": "401",
+        "endpointSliceDigest": _digest("slice-payments-api-401"),
+        "endpointSliceServiceName": service["name"],
+        "endpointSliceManagedBy": "endpointslice-controller.k8s.io",
+        "addressType": "IPv4",
+        "address": "10.244.1.9",
+        "targetRefKind": "Pod",
+        "targetRefName": pod_name,
+        "targetRefUid": pod_uid,
+        "podNamespace": subject["realm"]["namespaceName"],
+        "podName": pod_name,
+        "podUid": pod_uid,
+        "podResourceVersion": "501",
+        "podSpecDigest": _digest("pod-spec-payments-api-1"),
+        "podStatusDigest": _digest("pod-status-payments-api-1"),
+        "podIp": "10.244.1.9",
+        "podOwnerKind": "ReplicaSet",
+        "podOwnerName": "payments-api-6d9f7c8b9c",
+        "podOwnerUid": "uid-rs-payments-api",
+        "replicaSetName": "payments-api-6d9f7c8b9c",
+        "replicaSetUid": "uid-rs-payments-api",
+        "replicaSetResourceVersion": "601",
+        "replicaSetOwnerKind": "Deployment",
+        "replicaSetOwnerName": "payments-api",
+        "replicaSetOwnerUid": "uid-deployment-payments-api",
+        "deploymentName": "payments-api",
+        "deploymentUid": "uid-deployment-payments-api",
+        "deploymentResourceVersion": "701",
+        "renderedPodTemplateDigest": subject["delivery"]["renderedPodTemplateDigest"],
+        "ownershipWorkOrderId": subject["workOrderId"],
+        "selectorMatches": True,
+        "ready": True,
+        "serving": True,
+        "terminating": False,
+        "hostNetwork": False,
+        "containerName": "service",
+        "containersServingPort": 1,
+        "containerPort": 8080,
+        "serviceTargetPort": 8080,
+        "containerReady": True,
+        "imageId": f"containerd://{image_digest}",
+        "imageDigest": image_digest,
+    }
+    endpoint_projection = [
+        {
+            key: backend[key]
+            for key in (
+                "endpointSliceName",
+                "endpointSliceUid",
+                "endpointSliceResourceVersion",
+                "endpointSliceDigest",
+                "endpointSliceServiceName",
+                "endpointSliceManagedBy",
+            )
+        }
+    ]
+    return {
+        "namespaceUid": subject["realm"]["namespaceUid"],
+        "namespaceResourceVersion": subject["realm"]["namespaceResourceVersion"],
+        "serviceUid": service["uid"],
+        "serviceResourceVersion": service["resourceVersion"],
+        "serviceRoutingSpecDigest": service["routingSpecDigest"],
+        "networkPolicySetDigest": subject["delivery"]["networkPolicySetDigest"],
+        "endpointSliceSetDigest": _digest(endpoint_projection),
+        "backendSetDigest": _digest([backend]),
+        "observedBackendCount": 1,
+        "backends": [backend],
+    }
+
+
+def _refresh_target_digests(target: dict[str, Any]) -> None:
+    endpoint_slices: dict[str, dict[str, Any]] = {}
+    for backend in target["backends"]:
+        endpoint_slices[backend["endpointSliceUid"]] = {
+            key: backend[key]
+            for key in (
+                "endpointSliceName",
+                "endpointSliceUid",
+                "endpointSliceResourceVersion",
+                "endpointSliceDigest",
+                "endpointSliceServiceName",
+                "endpointSliceManagedBy",
+            )
+        }
+    endpoint_projection = [endpoint_slices[key] for key in sorted(endpoint_slices)]
+    target["observedBackendCount"] = len(target["backends"])
+    target["endpointSliceSetDigest"] = _digest(endpoint_projection)
+    target["backendSetDigest"] = _digest(target["backends"])
+
+
+def _oracle_for(expected: dict[str, Any]) -> dict[str, Any]:
+    if expected["kind"] == "status-only":
+        return {"kind": "status-only", "expectedStatus": 200, "observedStatus": 200}
+    if expected["kind"] == "exact-text":
+        value_digest = _digest(expected["exactText"].encode("utf-8"))
+        return {
+            "kind": "exact-text",
+            "expectedByteDigest": value_digest,
+            "observedByteDigest": value_digest,
+        }
+    entries = []
+    for key in sorted(expected["jsonSubset"]):
+        value = expected["jsonSubset"][key]
+        value_type = _validate_json_scalar(value)
+        value_digest = _canonical_digest(value)
+        entries.append(
+            {
+                "key": key,
+                "expectedType": value_type,
+                "expectedValueDigest": value_digest,
+                "observedPresent": True,
+                "observedType": value_type,
+                "observedValueDigest": value_digest,
+            }
+        )
+    return {"kind": "json-subset", "entries": entries}
+
+
+def _build_example(
+    index: dict[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    subject_private_key = _private_key("http-subject-issuer-v1")
+    verifier_private_key = _private_key("http-verifier-v1")
+    work_order_id = "httpprobe1"
+    run_id = "10000000-0000-4000-8000-000000000001"
+    realm_name = f"preview-{work_order_id}"
+    image_digest = f"sha256:{_digest('image')}"
+    issued_at = datetime(2026, 7, 14, 0, 1, tzinfo=timezone.utc)
+    acceptance = [
+        {
+            "ordinal": 1,
+            "method": "GET",
+            "path": "/api/v2/payments",
+            "expected": {
+                "status": 200,
+                "kind": "exact-text",
+                "mediaType": "text/plain; charset=utf-8",
+                "exactText": "ready",
+            },
+        },
+        {
+            "ordinal": 2,
+            "method": "GET",
+            "path": "/api/v2/summary",
+            "expected": {
+                "status": 200,
+                "kind": "json-subset",
+                "mediaType": "application/json",
+                "jsonSubset": {"count": 2, "status": "ready"},
+            },
+        },
+    ]
+    service = {
+        "name": "payments-api",
+        "uid": "uid-service-payments-api",
+        "resourceVersion": "301",
+        "routingSpecDigest": _digest("service-routing-spec"),
+        "dnsName": f"payments-api.{realm_name}.svc",
+        "port": 8080,
+    }
+    subject = {
+        "schemaVersion": "verification/http-probe-subject/v1",
+        "workOrderId": work_order_id,
+        "runId": run_id,
+        "executionEnvelopeDigest": _digest("execution-envelope"),
+        "platformPath": "standard-http-service/v3",
+        "platformCommitSha": "a" * 40,
+        "platformBundleDigest": index["spec"]["bundleDigest"],
+        "probeProfile": {
+            "id": "http-preview-service/v1",
+            "digest": hashlib.sha256(PROFILE_PATH.read_bytes()).hexdigest(),
+        },
+        "acceptance": acceptance,
+        "acceptanceDigest": _digest(acceptance),
+        "cluster": {
+            "ref": "kubernetes:preview-primary",
+            "identityDigest": _digest("preview-cluster-identity"),
+            "apiServerDigest": _digest("https://127.0.0.1:6443"),
+            "caSha256": _digest("preview-cluster-ca"),
+        },
+        "realm": {
+            "id": "preview/v2",
+            "name": realm_name,
+            "namespaceName": realm_name,
+            "namespaceUid": "uid-namespace-httpprobe1",
+            "namespaceResourceVersion": "201",
+        },
+        "service": service,
+        "delivery": {
+            "evidenceDigest": _digest("delivery-observation"),
+            "observedAt": "2026-07-14T00:00:00Z",
+            "expiresAt": "2026-07-15T00:00:00Z",
+            "mergeCommitSha": "b" * 40,
+            "imageDigest": image_digest,
+            "renderedInventoryDigest": _digest("rendered-inventory"),
+            "renderedPodTemplateDigest": _digest("rendered-pod-template"),
+            "networkPolicySetDigest": _digest("http-verifier-network-policy-set"),
+        },
+        "issuedAt": _timestamp(issued_at),
+        "deadline": _timestamp(issued_at + timedelta(minutes=4)),
+        "canonicalization": "rfc8785-json-canonicalization/v1",
+        "digestPayloadExcludes": ["subjectSha256", "issuer.signature"],
+        "subjectSha256": "0" * 64,
+        "issuer": {
+            "profileDigest": _digest("http-subject-issuer-profile"),
+            "signingKeyId": "kms:http-subject-v1",
+            "algorithm": "Ed25519",
+            "signature": "0" * 86,
+        },
+    }
+    subject["subjectSha256"] = _digest(
+        _without(subject, ("subjectSha256", "issuer.signature"))
+    )
+    _sign(
+        subject,
+        subject_private_key,
+        ("subjectSha256", "issuer.signature"),
+        ("issuer", "signature"),
+    )
+
+    descriptors = [
+        (
+            "health",
+            "runtime.health",
+            "http.healthz/v1",
+            0,
+            "/healthz",
+            {"kind": "status-only", "status": 200},
+        ),
+        (
+            "readiness",
+            "runtime.readiness",
+            "http.readyz/v1",
+            0,
+            "/readyz",
+            {"kind": "status-only", "status": 200},
+        ),
+    ]
+    descriptors.extend(
+        (
+            f"acceptance-{item['ordinal']}",
+            "runtime.request-contract",
+            "http.request-contract/v1",
+            item["ordinal"],
+            item["path"],
+            item["expected"],
+        )
+        for item in acceptance
+    )
+    condition_runs = []
+    attempt_sequence = 1
+    target = _target_snapshot(subject)
+    for condition_id, path_id, probe, expectation_ordinal, path, expected in descriptors:
+        attempts = []
+        for ordinal in range(1, 4):
+            started = issued_at + timedelta(seconds=attempt_sequence * 2)
+            completed = started + timedelta(seconds=1)
+            oracle = _oracle_for(expected)
+            media_type = expected.get("mediaType")
+            if expected["kind"] == "exact-text":
+                response_payload = expected["exactText"].encode("utf-8")
+            elif expected["kind"] == "json-subset":
+                response_payload = _canonical_bytes(expected["jsonSubset"])
+            else:
+                response_payload = b""
+            attempts.append(
+                {
+                    "attemptId": (
+                        f"{attempt_sequence:08x}-0000-4000-8000-"
+                        f"{attempt_sequence:012x}"
+                    ),
+                    "ordinal": ordinal,
+                    "startedAt": _timestamp(started),
+                    "completedAt": _timestamp(completed),
+                    "durationMs": 1000,
+                    "preTarget": copy.deepcopy(target),
+                    "targetErrorCode": None,
+                    "backendResults": [
+                        {
+                            "podUid": target["backends"][0]["podUid"],
+                            "state": "pass",
+                            "durationMs": 500,
+                            "status": 200,
+                            "mediaType": media_type,
+                            "responseBytes": len(response_payload),
+                            "responseTruncated": False,
+                            "contentSha256": _digest(response_payload),
+                            "errorCode": None,
+                            "oracle": oracle,
+                        }
+                    ],
+                    "postTarget": copy.deepcopy(target),
+                    "state": "pass",
+                }
+            )
+            attempt_sequence += 1
+        condition_runs.append(
+            {
+                "id": condition_id,
+                "pathConditionId": path_id,
+                "probe": probe,
+                "expectationOrdinal": expectation_ordinal,
+                "path": path,
+                "expectationDigest": _digest(expected),
+                "attempts": attempts,
+                "achievedConsecutivePasses": 3,
+                "state": "pass",
+                "termination": "condition-satisfied",
+            }
+        )
+    result = {
+        "schemaVersion": "verification/http-probe-result/v1",
+        "evidenceType": "http.probe-result/v1",
+        "workOrderId": work_order_id,
+        "runId": run_id,
+        "subject": subject,
+        "subjectSha256": subject["subjectSha256"],
+        "conditionRuns": condition_runs,
+        "pathConditionResults": [
+            {"id": "runtime.health", "state": "pass", "satisfied": True},
+            {"id": "runtime.readiness", "state": "pass", "satisfied": True},
+            {"id": "runtime.request-contract", "state": "pass", "satisfied": True},
+        ],
+        "aggregateState": "pass",
+        "satisfied": True,
+        "startedAt": condition_runs[0]["attempts"][0]["startedAt"],
+        "completedAt": condition_runs[-1]["attempts"][-1]["completedAt"],
+        "expiresAt": "2026-07-14T01:00:00Z",
+        "canonicalization": "rfc8785-json-canonicalization/v1",
+        "digestPayloadExcludes": ["evidenceSha256", "verifier.signature"],
+        "evidenceSha256": "0" * 64,
+        "verifier": {
+            "profileDigest": _digest("http-verifier-profile"),
+            "signingKeyId": "kms:http-verifier-v1",
+            "algorithm": "Ed25519",
+            "signature": "0" * 86,
+        },
+    }
+    result["evidenceSha256"] = _digest(
+        _without(result, ("evidenceSha256", "verifier.signature"))
+    )
+    _sign(
+        result,
+        verifier_private_key,
+        ("evidenceSha256", "verifier.signature"),
+        ("verifier", "signature"),
+    )
+    trusted = {
+        "executionEnvelope": {
+            "digest": subject["executionEnvelopeDigest"],
+            "workOrderId": work_order_id,
+            "serviceName": service["name"],
+            "httpAcceptanceDigest": subject["acceptanceDigest"],
+            "platformPath": subject["platformPath"],
+            "platformCommitSha": subject["platformCommitSha"],
+            "platformBundleDigest": subject["platformBundleDigest"],
+        },
+        "deliveryEvidence": copy.deepcopy(subject["delivery"]),
+        "cluster": copy.deepcopy(subject["cluster"]),
+        "realm": copy.deepcopy(subject["realm"]),
+        "service": copy.deepcopy(subject["service"]),
+        "subjectIssuer": {
+            "profileDigest": subject["issuer"]["profileDigest"],
+            "signingKeyId": subject["issuer"]["signingKeyId"],
+            "publicKey": subject_private_key.public_key(),
+            "privateKey": subject_private_key,
+        },
+        "verifier": {
+            "profileDigest": result["verifier"]["profileDigest"],
+            "signingKeyId": result["verifier"]["signingKeyId"],
+            "publicKey": verifier_private_key.public_key(),
+            "privateKey": verifier_private_key,
+        },
+    }
+    return subject, result, trusted
+
+
+def _state_from(values: list[str]) -> str:
+    if not values:
+        return "inconclusive"
+    for state in STATE_PRECEDENCE:
+        if state in values:
+            return state
+    raise HttpProbeContractError("unknown result state")
+
+
+def _backend_state(result: dict[str, Any], expected: dict[str, Any]) -> str:
+    error = result["errorCode"]
+    if error is not None:
+        return "inconclusive" if error == "run-deadline" else "probe-error"
+    if (
+        result["status"] != 200
+        or result["responseBytes"] > 65536
+        or result["responseTruncated"]
+    ):
+        return "fail"
+    oracle = result["oracle"]
+    if expected["kind"] == "status-only":
+        return "pass" if oracle == {
+            "kind": "status-only",
+            "expectedStatus": 200,
+            "observedStatus": 200,
+        } else "fail"
+    if result["mediaType"] != expected["mediaType"]:
+        return "fail"
+    if expected["kind"] == "exact-text":
+        expected_digest = _digest(expected["exactText"].encode("utf-8"))
+        if (
+            result["contentSha256"] != expected_digest
+            or result["responseBytes"] != len(expected["exactText"].encode("utf-8"))
+        ):
+            return "fail"
+        return "pass" if oracle == {
+            "kind": "exact-text",
+            "expectedByteDigest": expected_digest,
+            "observedByteDigest": expected_digest,
+        } else "fail"
+    expected_entries = _oracle_for(expected)["entries"]
+    if result["contentSha256"] is None or result["responseBytes"] == 0:
+        return "fail"
+    return "pass" if oracle == {
+        "kind": "json-subset",
+        "entries": expected_entries,
+    } else "fail"
+
+
+def _validate_target(
+    target: dict[str, Any], subject: dict[str, Any]
+) -> tuple[list[str], str | None]:
+    service = subject["service"]
+    realm = subject["realm"]
+    target_error: str | None = None
+    if (
+        target["namespaceUid"] != realm["namespaceUid"]
+        or target["namespaceResourceVersion"] != realm["namespaceResourceVersion"]
+    ):
+        target_error = "invalid-backend"
+    if (
+        target["serviceUid"] != service["uid"]
+        or target["serviceResourceVersion"] != service["resourceVersion"]
+        or target["serviceRoutingSpecDigest"] != service["routingSpecDigest"]
+    ):
+        target_error = "invalid-backend"
+    if target["networkPolicySetDigest"] != subject["delivery"]["networkPolicySetDigest"]:
+        target_error = "invalid-backend"
+    backends = target["backends"]
+    if target["observedBackendCount"] != len(backends):
+        raise HttpProbeContractError("observed backend count is false")
+    if not backends:
+        target_error = "empty-backend-set"
+    elif len(backends) > 3:
+        target_error = "excess-backend-set"
+    backend_order_keys = [
+        (
+            "pod",
+            backend["podUid"],
+            backend["endpointSliceUid"],
+            backend["address"],
+        )
+        if backend["podUid"] is not None
+        else (
+            "endpoint",
+            backend["endpointSliceUid"],
+            backend["address"],
+            backend["targetRefUid"] or "",
+        )
+        for backend in backends
+    ]
+    if backend_order_keys != sorted(set(backend_order_keys)):
+        target_error = "invalid-backend"
+    pod_uids = [
+        backend["podUid"] for backend in backends if backend["podUid"] is not None
+    ]
+    if len(pod_uids) != len(backends) or pod_uids != sorted(set(pod_uids)):
+        target_error = "invalid-backend"
+    endpoint_slices: dict[str, dict[str, Any]] = {}
+    for backend in backends:
+        required_identity_fields = (
+            "targetRefName",
+            "targetRefUid",
+            "podNamespace",
+            "podName",
+            "podUid",
+            "podOwnerName",
+            "podOwnerUid",
+            "replicaSetName",
+            "replicaSetUid",
+            "replicaSetOwnerName",
+            "replicaSetOwnerUid",
+            "deploymentName",
+            "deploymentUid",
+            "containerName",
+        )
+        if any(backend[field] is None for field in required_identity_fields):
+            target_error = "invalid-backend"
+        try:
+            address = ipaddress.ip_address(backend["address"])
+        except ValueError:
+            target_error = "invalid-backend"
+            address = None
+        expected_address_type = (
+            "IPv4" if address is not None and address.version == 4 else "IPv6"
+        )
+        if (
+            backend["address"] != backend["podIp"]
+            or backend["addressType"] != expected_address_type
+            or backend["endpointSliceServiceName"] != service["name"]
+            or backend["endpointSliceManagedBy"]
+            != "endpointslice-controller.k8s.io"
+            or backend["targetRefKind"] != "Pod"
+            or backend["targetRefName"] != backend["podName"]
+            or backend["targetRefUid"] != backend["podUid"]
+            or backend["podNamespace"] != realm["namespaceName"]
+            or backend["podResourceVersion"] is None
+            or backend["podSpecDigest"] is None
+            or backend["podStatusDigest"] is None
+            or backend["podOwnerKind"] != "ReplicaSet"
+            or backend["podOwnerName"] != backend["replicaSetName"]
+            or backend["podOwnerUid"] != backend["replicaSetUid"]
+            or backend["replicaSetResourceVersion"] is None
+            or backend["replicaSetOwnerKind"] != "Deployment"
+            or backend["replicaSetOwnerName"] != backend["deploymentName"]
+            or backend["replicaSetOwnerUid"] != backend["deploymentUid"]
+            or backend["deploymentName"] != service["name"]
+            or backend["deploymentResourceVersion"] is None
+            or backend["renderedPodTemplateDigest"]
+            != subject["delivery"]["renderedPodTemplateDigest"]
+            or backend["ownershipWorkOrderId"] != subject["workOrderId"]
+            or not backend["selectorMatches"]
+            or not backend["ready"]
+            or not backend["serving"]
+            or backend["terminating"]
+            or backend["hostNetwork"]
+            or backend["containersServingPort"] != 1
+            or backend["containerPort"] != service["port"]
+            or backend["serviceTargetPort"] != service["port"]
+            or not backend["containerReady"]
+        ):
+            target_error = "invalid-backend"
+        if backend["imageDigest"] is None:
+            target_error = "invalid-backend"
+        elif backend["imageDigest"] != subject["delivery"]["imageDigest"]:
+            target_error = "mixed-image"
+        if (
+            backend["imageId"] is None
+            or backend["imageDigest"] is None
+            or backend["imageId"]
+            not in {
+                f"containerd://{backend['imageDigest']}",
+                f"docker-pullable://{backend['imageDigest']}",
+            }
+        ):
+            target_error = "invalid-backend"
+        projection = {
+            key: backend[key]
+            for key in (
+                "endpointSliceName",
+                "endpointSliceUid",
+                "endpointSliceResourceVersion",
+                "endpointSliceDigest",
+                "endpointSliceServiceName",
+                "endpointSliceManagedBy",
+            )
+        }
+        existing = endpoint_slices.setdefault(backend["endpointSliceUid"], projection)
+        if existing != projection:
+            raise HttpProbeContractError("EndpointSlice identity is internally inconsistent")
+    endpoint_projection = [endpoint_slices[key] for key in sorted(endpoint_slices)]
+    if target["endpointSliceSetDigest"] != _digest(endpoint_projection):
+        raise HttpProbeContractError("EndpointSlice set digest is false")
+    if target["backendSetDigest"] != _digest(backends):
+        raise HttpProbeContractError("backend set digest is false")
+    return pod_uids, target_error
+
+
+def _validate_semantics(
+    subject: dict[str, Any],
+    result: dict[str, Any],
+    index: dict[str, Any],
+    trusted: dict[str, Any],
+) -> None:
+    if subject["platformBundleDigest"] != index["spec"]["bundleDigest"]:
+        raise HttpProbeContractError("subject is bound to another platform bundle")
+    profile_digest = hashlib.sha256(PROFILE_PATH.read_bytes()).hexdigest()
+    if subject["probeProfile"] != {
+        "id": "http-preview-service/v1",
+        "digest": profile_digest,
+    }:
+        raise HttpProbeContractError("subject is bound to another probe profile")
+    _verify_signature(
+        subject,
+        subject["issuer"],
+        trusted["subjectIssuer"]["publicKey"],
+        trusted["subjectIssuer"]["profileDigest"],
+        trusted["subjectIssuer"]["signingKeyId"],
+        ("subjectSha256", "issuer.signature"),
+    )
+    envelope = trusted["executionEnvelope"]
+    expected_envelope = {
+        "digest": subject["executionEnvelopeDigest"],
+        "workOrderId": subject["workOrderId"],
+        "serviceName": subject["service"]["name"],
+        "httpAcceptanceDigest": subject["acceptanceDigest"],
+        "platformPath": subject["platformPath"],
+        "platformCommitSha": subject["platformCommitSha"],
+        "platformBundleDigest": subject["platformBundleDigest"],
+    }
+    if envelope != expected_envelope:
+        raise HttpProbeContractError("subject does not join the trusted execution envelope")
+    if subject["delivery"] != trusted["deliveryEvidence"]:
+        raise HttpProbeContractError("subject does not join trusted delivery evidence")
+    if subject["cluster"] != trusted["cluster"]:
+        raise HttpProbeContractError("subject does not join the adapter cluster identity")
+    if subject["realm"] != trusted["realm"] or subject["service"] != trusted["service"]:
+        raise HttpProbeContractError("subject target does not join trusted delivery identity")
+    _validate_acceptance(subject["acceptance"])
+    if subject["acceptanceDigest"] != _digest(subject["acceptance"]):
+        raise HttpProbeContractError("acceptance digest is false")
+    expected_subject_digest = _digest(
+        _without(subject, ("subjectSha256", "issuer.signature"))
+    )
+    if subject["subjectSha256"] != expected_subject_digest:
+        raise HttpProbeContractError("subject digest is false")
+    observed_at = _parse(subject["delivery"]["observedAt"])
+    delivery_expiry = _parse(subject["delivery"]["expiresAt"])
+    issued_at = _parse(subject["issuedAt"])
+    deadline = _parse(subject["deadline"])
+    if not observed_at <= issued_at <= observed_at + timedelta(minutes=5):
+        raise HttpProbeContractError("delivery observation is stale")
+    if not issued_at < deadline <= issued_at + timedelta(minutes=4):
+        raise HttpProbeContractError("subject deadline is outside the profile")
+    if deadline > delivery_expiry:
+        raise HttpProbeContractError("subject outlives delivery evidence")
+    if subject["realm"]["name"] != subject["realm"]["namespaceName"]:
+        raise HttpProbeContractError("Realm and Namespace identity differ")
+    expected_dns = f"{subject['service']['name']}.{subject['realm']['namespaceName']}.svc"
+    if subject["service"]["dnsName"] != expected_dns:
+        raise HttpProbeContractError("Service DNS name is not derived")
+    expected_realm = f"preview-{subject['workOrderId']}"
+    if subject["realm"]["name"] != expected_realm:
+        raise HttpProbeContractError("Realm is not derived from WorkOrder")
+
+    if result["subject"] != subject or result["subjectSha256"] != subject["subjectSha256"]:
+        raise HttpProbeContractError("result is not bound to its signed subject")
+    if result["workOrderId"] != subject["workOrderId"]:
+        raise HttpProbeContractError("cross-WorkOrder result")
+    if result["runId"] != subject["runId"]:
+        raise HttpProbeContractError("cross-run result")
+    _verify_signature(
+        result,
+        result["verifier"],
+        trusted["verifier"]["publicKey"],
+        trusted["verifier"]["profileDigest"],
+        trusted["verifier"]["signingKeyId"],
+        ("evidenceSha256", "verifier.signature"),
+    )
+
+    descriptors = [
+        (
+            "health",
+            "runtime.health",
+            "http.healthz/v1",
+            0,
+            "/healthz",
+            {"kind": "status-only", "status": 200},
+        ),
+        (
+            "readiness",
+            "runtime.readiness",
+            "http.readyz/v1",
+            0,
+            "/readyz",
+            {"kind": "status-only", "status": 200},
+        ),
+    ]
+    descriptors.extend(
+        (
+            f"acceptance-{item['ordinal']}",
+            "runtime.request-contract",
+            "http.request-contract/v1",
+            item["ordinal"],
+            item["path"],
+            item["expected"],
+        )
+        for item in subject["acceptance"]
+    )
+    if len(result["conditionRuns"]) != len(descriptors):
+        raise HttpProbeContractError("condition run set is incomplete")
+
+    global_attempt_ids: set[str] = set()
+    derived_condition_states: dict[str, list[str]] = {
+        "runtime.health": [],
+        "runtime.readiness": [],
+        "runtime.request-contract": [],
+    }
+    all_attempt_times: list[tuple[datetime, datetime]] = []
+    previous_global_completion: datetime | None = None
+    run_deadline_reached = False
+    for condition, descriptor in zip(result["conditionRuns"], descriptors, strict=True):
+        condition_id, path_id, probe, expectation_ordinal, path, expected = descriptor
+        if (
+            condition["id"],
+            condition["pathConditionId"],
+            condition["probe"],
+            condition["expectationOrdinal"],
+            condition["path"],
+            condition["expectationDigest"],
+        ) != (condition_id, path_id, probe, expectation_ordinal, path, _digest(expected)):
+            raise HttpProbeContractError("condition expansion differs from frozen expectations")
+        attempt_states: list[str] = []
+        streak = 0
+        achieved = 0
+        attempts = condition["attempts"]
+        if run_deadline_reached and attempts:
+            raise HttpProbeContractError("attempt recorded after the global run deadline")
+        previous_condition_completion: datetime | None = None
+        if [attempt["ordinal"] for attempt in attempts] != list(range(1, len(attempts) + 1)):
+            raise HttpProbeContractError("attempt ordinals must be contiguous")
+        for attempt in attempts:
+            if attempt["attemptId"] in global_attempt_ids:
+                raise HttpProbeContractError("attempt ID is reused")
+            global_attempt_ids.add(attempt["attemptId"])
+            started = _parse(attempt["startedAt"])
+            completed = _parse(attempt["completedAt"])
+            actual_duration = int((completed - started).total_seconds() * 1000)
+            if actual_duration != attempt["durationMs"] or not issued_at <= started < completed:
+                raise HttpProbeContractError("attempt time or duration is false")
+            if completed > deadline or attempt["durationMs"] > 30000:
+                raise HttpProbeContractError("attempt exceeds signed deadline")
+            if previous_global_completion is not None and started < previous_global_completion:
+                raise HttpProbeContractError("condition attempts overlap or are reordered")
+            if (
+                previous_condition_completion is not None
+                and started < previous_condition_completion + timedelta(seconds=1)
+            ):
+                raise HttpProbeContractError("PT1S attempt delay is not satisfied")
+            previous_condition_completion = completed
+            previous_global_completion = completed
+            all_attempt_times.append((started, completed))
+
+            pre_uids, pre_error = _validate_target(attempt["preTarget"], subject)
+            post_uids, post_error = _validate_target(attempt["postTarget"], subject)
+            target_error = pre_error or post_error
+            if attempt["preTarget"] != attempt["postTarget"] or pre_uids != post_uids:
+                target_error = "target-drift"
+            if attempt["targetErrorCode"] != target_error:
+                raise HttpProbeContractError("target error is falsely classified")
+            if target_error is not None:
+                if attempt["backendResults"]:
+                    raise HttpProbeContractError("invalid target must not be probed")
+                batch_state = "probe-error"
+            else:
+                result_uids = [item["podUid"] for item in attempt["backendResults"]]
+                if result_uids != pre_uids:
+                    raise HttpProbeContractError("backend result set differs from target snapshot")
+                backend_states = []
+                for item in attempt["backendResults"]:
+                    if item["durationMs"] > 5000 or item["durationMs"] > attempt["durationMs"]:
+                        raise HttpProbeContractError("backend request exceeds PT5S deadline")
+                    derived_backend_state = _backend_state(item, expected)
+                    if item["state"] != derived_backend_state:
+                        raise HttpProbeContractError("backend state is falsely asserted")
+                    backend_states.append(derived_backend_state)
+                batch_state = _state_from(backend_states)
+            if attempt["state"] != batch_state:
+                raise HttpProbeContractError("attempt batch state is falsely reduced")
+            attempt_states.append(batch_state)
+            streak = streak + 1 if batch_state == "pass" else 0
+            achieved = max(achieved, min(streak, 3))
+            if achieved == 3 and attempt["ordinal"] != len(attempts):
+                raise HttpProbeContractError(
+                    "condition continued after three consecutive passes"
+                )
+        if (
+            "probe-error" in attempt_states
+            and attempt_states.index("probe-error") != len(attempt_states) - 1
+        ):
+            raise HttpProbeContractError("probe-error did not stop the condition run")
+        non_pass_states = [state for state in attempt_states if state != "pass"]
+        final_state = (
+            "pass"
+            if achieved == 3
+            else _state_from(non_pass_states)
+            if non_pass_states
+            else "inconclusive"
+        )
+        if condition["state"] != final_state:
+            raise HttpProbeContractError("condition state is falsely reduced")
+        if condition["achievedConsecutivePasses"] != achieved:
+            raise HttpProbeContractError("consecutive-pass count is false")
+        expected_termination = (
+            "condition-satisfied"
+            if final_state == "pass"
+            else "probe-error"
+            if final_state == "probe-error"
+            else "attempts-exhausted"
+            if len(attempts) == 5
+            else "run-deadline"
+        )
+        if condition["termination"] != expected_termination:
+            raise HttpProbeContractError("condition termination is false")
+        if expected_termination == "run-deadline":
+            run_deadline_reached = True
+        derived_condition_states[path_id].append(final_state)
+
+    path_states = {
+        path_id: _state_from(states)
+        for path_id, states in derived_condition_states.items()
+    }
+    expected_path_results = [
+        {
+            "id": path_id,
+            "state": path_states[path_id],
+            "satisfied": path_states[path_id] == "pass",
+        }
+        for path_id in (
+            "runtime.health",
+            "runtime.readiness",
+            "runtime.request-contract",
+        )
+    ]
+    if result["pathConditionResults"] != expected_path_results:
+        raise HttpProbeContractError("path Condition of Done reduction is false")
+    aggregate = _state_from(list(path_states.values()))
+    if result["aggregateState"] != aggregate or result["satisfied"] != (aggregate == "pass"):
+        raise HttpProbeContractError("overall HTTP result reduction is false")
+    started_at = _parse(result["startedAt"])
+    completed_at = _parse(result["completedAt"])
+    expires_at = _parse(result["expiresAt"])
+    expected_start = all_attempt_times[0][0] if all_attempt_times else issued_at
+    expected_completion = (
+        deadline
+        if run_deadline_reached or not all_attempt_times
+        else all_attempt_times[-1][1]
+    )
+    if started_at != expected_start:
+        raise HttpProbeContractError("run start is false")
+    if completed_at != expected_completion:
+        raise HttpProbeContractError("run completion is false")
+    if not issued_at <= started_at < completed_at <= deadline < expires_at <= delivery_expiry:
+        raise HttpProbeContractError("run evidence time ordering is invalid")
+    expected_evidence_digest = _digest(
+        _without(result, ("evidenceSha256", "verifier.signature"))
+    )
+    if result["evidenceSha256"] != expected_evidence_digest:
+        raise HttpProbeContractError("HTTP evidence digest is false")
+
+
+def _redigest_subject(
+    subject: dict[str, Any], private_key: Ed25519PrivateKey
+) -> None:
+    subject["subjectSha256"] = _digest(
+        _without(subject, ("subjectSha256", "issuer.signature"))
+    )
+    _sign(
+        subject,
+        private_key,
+        ("subjectSha256", "issuer.signature"),
+        ("issuer", "signature"),
+    )
+
+
+def _redigest_result(
+    result: dict[str, Any], private_key: Ed25519PrivateKey
+) -> None:
+    result["subjectSha256"] = result["subject"]["subjectSha256"]
+    result["evidenceSha256"] = _digest(
+        _without(result, ("evidenceSha256", "verifier.signature"))
+    )
+    _sign(
+        result,
+        private_key,
+        ("evidenceSha256", "verifier.signature"),
+        ("verifier", "signature"),
+    )
+
+
+def _make_target_error_result(
+    result: dict[str, Any],
+    target_error: str,
+    private_key: Ed25519PrivateKey,
+    *,
+    pre_target: dict[str, Any] | None = None,
+    post_target: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    mutated = copy.deepcopy(result)
+    condition = mutated["conditionRuns"][0]
+    attempt = condition["attempts"][0]
+    if pre_target is not None:
+        attempt["preTarget"] = pre_target
+    if post_target is not None:
+        attempt["postTarget"] = post_target
+    attempt["targetErrorCode"] = target_error
+    attempt["backendResults"] = []
+    attempt["state"] = "probe-error"
+    condition["attempts"] = [attempt]
+    condition["achievedConsecutivePasses"] = 0
+    condition["state"] = "probe-error"
+    condition["termination"] = "probe-error"
+    mutated["pathConditionResults"][0] = {
+        "id": "runtime.health",
+        "state": "probe-error",
+        "satisfied": False,
+    }
+    mutated["aggregateState"] = "probe-error"
+    mutated["satisfied"] = False
+    _redigest_result(mutated, private_key)
+    return mutated
+
+
+def validate_http_probe_contracts(
+    schemas: dict[str, Any], index: dict[str, Any]
+) -> None:
+    if (
+        _canonical_bytes(1.0) != b"1"
+        or _canonical_bytes({"z": 1, "a": 2}) != b'{"a":2,"z":1}'
+    ):
+        raise HttpProbeContractError("RFC 8785 canonicalization regression")
+    registry = Registry().with_resources(
+        (schema_id, Resource.from_contents(schema))
+        for schema_id, schema in schemas.items()
+    )
+    subject_schema = "urn:darkfactory:platform-contract:http-probe-subject:v1"
+    result_schema = "urn:darkfactory:platform-contract:http-probe-result:v1"
+    subject_validator = Draft202012Validator(
+        schemas[subject_schema], registry=registry, format_checker=FormatChecker()
+    )
+    result_validator = Draft202012Validator(
+        schemas[result_schema], registry=registry, format_checker=FormatChecker()
+    )
+    subject, result, trusted = _build_example(index)
+    subject_private_key = trusted["subjectIssuer"]["privateKey"]
+    verifier_private_key = trusted["verifier"]["privateKey"]
+    subject_validator.validate(subject)
+    result_validator.validate(result)
+    _validate_semantics(subject, result, index, trusted)
+
+    profile_schema = "urn:darkfactory:platform-contract:http-probe-profile:v1"
+    profile_validator = Draft202012Validator(
+        schemas[profile_schema], registry=registry, format_checker=FormatChecker()
+    )
+    with PROFILE_PATH.open(encoding="utf-8") as stream:
+        profile = yaml.safe_load(stream)
+    profile_validator.validate(profile)
+
+    request_schema = schemas[
+        "urn:darkfactory:platform-contract:path-input:standard-http-service:v3"
+    ]
+    request_validator = Draft202012Validator(request_schema)
+    valid_inputs = {
+        "serviceName": "payments-api",
+        "ownerRef": "team:payments",
+        "repositoryRef": "github:100rd/payments-api",
+        "sourceSubpath": "service",
+        "runtime": "go-1.23",
+        "exposure": "internal",
+        "port": 8080,
+        "resourceProfile": "small",
+        "acceptance": [
+            {
+                "method": "GET",
+                "path": "/api/v2/payments",
+                "expected": {
+                    "status": 200,
+                    "mediaType": "text/plain; charset=utf-8",
+                    "exactText": "ready",
+                },
+            },
+            {
+                "method": "GET",
+                "path": "/api/v2/summary",
+                "expected": {
+                    "status": 200,
+                    "mediaType": "application/json",
+                    "jsonSubset": {"count": 2, "status": "ready"},
+                },
+            },
+        ],
+    }
+    request_validator.validate(valid_inputs)
+    validate_http_request_inputs(valid_inputs)
+
+    structural_mutations: list[tuple[str, Draft202012Validator, dict[str, Any]]] = []
+    raw_body = copy.deepcopy(result)
+    raw_body["conditionRuns"][0]["attempts"][0]["backendResults"][0][
+        "rawResponse"
+    ] = "must-not-be-stored"
+    structural_mutations.append(("raw response retention", result_validator, raw_body))
+    bad_path = copy.deepcopy(valid_inputs)
+    bad_path["acceptance"][0]["path"] = "//attacker/path"
+    structural_mutations.append(("network-path acceptance", request_validator, bad_path))
+    bad_media = copy.deepcopy(valid_inputs)
+    bad_media["acceptance"][0]["expected"]["mediaType"] = "application/json"
+    structural_mutations.append(("oracle media mismatch", request_validator, bad_media))
+    redirected = copy.deepcopy(profile)
+    redirected["transport"]["redirects"] = True
+    structural_mutations.append(("redirect-enabled profile", profile_validator, redirected))
+    caller_target = copy.deepcopy(profile)
+    caller_target["targetResolution"]["hostFrom"] = "request.inputs.host"
+    structural_mutations.append(("caller target profile", profile_validator, caller_target))
+    worker_evidence = copy.deepcopy(profile)
+    worker_evidence["evidence"]["workerEvidenceAccepted"] = True
+    structural_mutations.append(("worker evidence profile", profile_validator, worker_evidence))
+    for name, validator, value in structural_mutations:
+        try:
+            validator.validate(value)
+        except ValidationError:
+            continue
+        raise HttpProbeContractError(f"invalid structural mutation passed: {name}")
+
+    duplicate_inputs = copy.deepcopy(valid_inputs)
+    duplicate_inputs["acceptance"].append(copy.deepcopy(duplicate_inputs["acceptance"][0]))
+    try:
+        request_validator.validate(duplicate_inputs)
+        validate_http_request_inputs(duplicate_inputs)
+    except HttpProbeContractError:
+        pass
+    else:
+        raise HttpProbeContractError("invalid request semantic mutation passed: duplicate path")
+
+    noncanonical_inputs = copy.deepcopy(valid_inputs)
+    noncanonical_inputs["acceptance"][1]["expected"]["jsonSubset"]["count"] = 2**53
+    try:
+        request_validator.validate(noncanonical_inputs)
+        validate_http_request_inputs(noncanonical_inputs)
+    except HttpProbeContractError:
+        pass
+    else:
+        raise HttpProbeContractError(
+            "invalid request semantic mutation passed: noncanonical JSON integer"
+        )
+
+    non_utf8_inputs = copy.deepcopy(valid_inputs)
+    non_utf8_inputs["acceptance"][0]["expected"]["exactText"] = "\ud800"
+    try:
+        request_validator.validate(non_utf8_inputs)
+        validate_http_request_inputs(non_utf8_inputs)
+    except HttpProbeContractError:
+        pass
+    else:
+        raise HttpProbeContractError(
+            "invalid request semantic mutation passed: non-UTF-8 exact text"
+        )
+
+    duplicate_subject_acceptance = [
+        {**item, "ordinal": position}
+        for position, item in enumerate(subject["acceptance"] * 2, start=1)
+    ]
+    semantic_input_mutations = [
+        ("duplicate acceptance path", duplicate_subject_acceptance),
+        (
+            "non-finite JSON subset",
+            [
+                {
+                    "ordinal": 1,
+                    "method": "GET",
+                    "path": "/api/value",
+                    "expected": {
+                        "status": 200,
+                        "kind": "json-subset",
+                        "mediaType": "application/json",
+                        "jsonSubset": {"value": float("nan")},
+                    },
+                }
+            ],
+        ),
+        (
+            "noncanonical JSON integer",
+            [
+                {
+                    "ordinal": 1,
+                    "method": "GET",
+                    "path": "/api/value",
+                    "expected": {
+                        "status": 200,
+                        "kind": "json-subset",
+                        "mediaType": "application/json",
+                        "jsonSubset": {"value": 2**53},
+                    },
+                }
+            ],
+        ),
+    ]
+    for name, acceptance in semantic_input_mutations:
+        try:
+            _validate_acceptance(acceptance)
+        except HttpProbeContractError:
+            continue
+        raise HttpProbeContractError(f"invalid request semantic mutation passed: {name}")
+
+    base_target = result["conditionRuns"][0]["attempts"][0]["preTarget"]
+    empty_target = copy.deepcopy(base_target)
+    empty_target["backends"] = []
+    _refresh_target_digests(empty_target)
+
+    excess_target = copy.deepcopy(base_target)
+    excess_target["backends"] = []
+    for ordinal in range(1, 5):
+        backend = copy.deepcopy(base_target["backends"][0])
+        suffix = str(ordinal)
+        pod_name = f"payments-api-6d9f7c8b9c-{suffix}"
+        pod_uid = f"uid-pod-payments-api-{suffix}"
+        pod_ip = f"10.244.1.{8 + ordinal}"
+        backend.update(
+            {
+                "address": pod_ip,
+                "targetRefName": pod_name,
+                "targetRefUid": pod_uid,
+                "podName": pod_name,
+                "podUid": pod_uid,
+                "podResourceVersion": str(500 + ordinal),
+                "podSpecDigest": _digest(f"pod-spec-payments-api-{suffix}"),
+                "podStatusDigest": _digest(f"pod-status-payments-api-{suffix}"),
+                "podIp": pod_ip,
+            }
+        )
+        excess_target["backends"].append(backend)
+    _refresh_target_digests(excess_target)
+
+    mixed_target = copy.deepcopy(base_target)
+    foreign_image = f"sha256:{_digest('foreign-image')}"
+    mixed_target["backends"][0]["imageDigest"] = foreign_image
+    mixed_target["backends"][0]["imageId"] = f"containerd://{foreign_image}"
+    _refresh_target_digests(mixed_target)
+
+    drift_target = copy.deepcopy(base_target)
+    drift_target["serviceResourceVersion"] = "302"
+
+    invalid_target = copy.deepcopy(base_target)
+    invalid_target["networkPolicySetDigest"] = _digest("foreign-network-policy-set")
+
+    unready_target = copy.deepcopy(base_target)
+    unready_backend = unready_target["backends"][0]
+    unready_backend["ready"] = False
+    unready_backend["serving"] = False
+    unready_backend["containerReady"] = False
+    _refresh_target_digests(unready_target)
+
+    external_target = copy.deepcopy(base_target)
+    external_backend = external_target["backends"][0]
+    for field in (
+        "targetRefKind",
+        "targetRefName",
+        "targetRefUid",
+        "podNamespace",
+        "podName",
+        "podUid",
+        "podResourceVersion",
+        "podSpecDigest",
+        "podStatusDigest",
+        "podIp",
+        "podOwnerKind",
+        "podOwnerName",
+        "podOwnerUid",
+        "replicaSetName",
+        "replicaSetUid",
+        "replicaSetResourceVersion",
+        "replicaSetOwnerKind",
+        "replicaSetOwnerName",
+        "replicaSetOwnerUid",
+        "deploymentName",
+        "deploymentUid",
+        "deploymentResourceVersion",
+        "renderedPodTemplateDigest",
+        "ownershipWorkOrderId",
+        "containerName",
+        "containerPort",
+        "imageId",
+        "imageDigest",
+    ):
+        external_backend[field] = None
+    external_backend.update(
+        {
+            "address": "192.0.2.10",
+            "selectorMatches": False,
+            "ready": True,
+            "serving": True,
+            "containersServingPort": 0,
+            "containerReady": False,
+        }
+    )
+    _refresh_target_digests(external_target)
+
+    valid_target_outcomes = [
+        (
+            "empty backend set",
+            _make_target_error_result(
+                result,
+                "empty-backend-set",
+                verifier_private_key,
+                pre_target=copy.deepcopy(empty_target),
+                post_target=copy.deepcopy(empty_target),
+            ),
+        ),
+        (
+            "excess backend set",
+            _make_target_error_result(
+                result,
+                "excess-backend-set",
+                verifier_private_key,
+                pre_target=copy.deepcopy(excess_target),
+                post_target=copy.deepcopy(excess_target),
+            ),
+        ),
+        (
+            "mixed image set",
+            _make_target_error_result(
+                result,
+                "mixed-image",
+                verifier_private_key,
+                pre_target=copy.deepcopy(mixed_target),
+                post_target=copy.deepcopy(mixed_target),
+            ),
+        ),
+        (
+            "target drift",
+            _make_target_error_result(
+                result,
+                "target-drift",
+                verifier_private_key,
+                pre_target=copy.deepcopy(base_target),
+                post_target=drift_target,
+            ),
+        ),
+        (
+            "invalid network target",
+            _make_target_error_result(
+                result,
+                "invalid-backend",
+                verifier_private_key,
+                pre_target=copy.deepcopy(invalid_target),
+                post_target=copy.deepcopy(invalid_target),
+            ),
+        ),
+        (
+            "unready backend",
+            _make_target_error_result(
+                result,
+                "invalid-backend",
+                verifier_private_key,
+                pre_target=copy.deepcopy(unready_target),
+                post_target=copy.deepcopy(unready_target),
+            ),
+        ),
+        (
+            "external endpoint",
+            _make_target_error_result(
+                result,
+                "invalid-backend",
+                verifier_private_key,
+                pre_target=copy.deepcopy(external_target),
+                post_target=copy.deepcopy(external_target),
+            ),
+        ),
+    ]
+    for name, outcome in valid_target_outcomes:
+        try:
+            result_validator.validate(outcome)
+            _validate_semantics(outcome["subject"], outcome, index, trusted)
+        except (HttpProbeContractError, ValidationError) as error:
+            raise HttpProbeContractError(
+                f"valid signed target outcome failed: {name}: {error}"
+            ) from error
+
+    deadline_outcome = copy.deepcopy(result)
+    deadline_condition = deadline_outcome["conditionRuns"][-1]
+    deadline_condition.update(
+        {
+            "attempts": [],
+            "achievedConsecutivePasses": 0,
+            "state": "inconclusive",
+            "termination": "run-deadline",
+        }
+    )
+    deadline_outcome["pathConditionResults"][2] = {
+        "id": "runtime.request-contract",
+        "state": "inconclusive",
+        "satisfied": False,
+    }
+    deadline_outcome["aggregateState"] = "inconclusive"
+    deadline_outcome["satisfied"] = False
+    deadline_outcome["completedAt"] = deadline_outcome["subject"]["deadline"]
+    _redigest_result(deadline_outcome, verifier_private_key)
+    try:
+        result_validator.validate(deadline_outcome)
+        _validate_semantics(deadline_outcome["subject"], deadline_outcome, index, trusted)
+    except (HttpProbeContractError, ValidationError) as error:
+        raise HttpProbeContractError(
+            f"valid zero-attempt deadline outcome failed: {error}"
+        ) from error
+
+    semantic_mutations: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+    missing_response = copy.deepcopy(result)
+    missing_response["conditionRuns"][0]["attempts"][0]["backendResults"] = []
+    _redigest_result(missing_response, verifier_private_key)
+    semantic_mutations.append(
+        ("missing backend response", missing_response["subject"], missing_response)
+    )
+
+    false_target_pass = copy.deepcopy(valid_target_outcomes[0][1])
+    false_target_attempt = false_target_pass["conditionRuns"][0]["attempts"][0]
+    false_target_attempt["targetErrorCode"] = None
+    false_target_attempt["state"] = "pass"
+    false_target_pass["conditionRuns"][0].update(
+        {
+            "achievedConsecutivePasses": 3,
+            "state": "pass",
+            "termination": "condition-satisfied",
+        }
+    )
+    false_target_pass["pathConditionResults"][0] = {
+        "id": "runtime.health",
+        "state": "pass",
+        "satisfied": True,
+    }
+    false_target_pass["aggregateState"] = "pass"
+    false_target_pass["satisfied"] = True
+    _redigest_result(false_target_pass, verifier_private_key)
+    semantic_mutations.append(
+        ("empty target classified pass", false_target_pass["subject"], false_target_pass)
+    )
+
+    network_snapshot = copy.deepcopy(result)
+    target = network_snapshot["conditionRuns"][0]["attempts"][0]["preTarget"]
+    target["networkPolicySetDigest"] = _digest("foreign-network-policy-set")
+    _redigest_result(network_snapshot, verifier_private_key)
+    semantic_mutations.append(
+        ("untrusted NetworkPolicy snapshot", network_snapshot["subject"], network_snapshot)
+    )
+
+    broken_owner_chain = copy.deepcopy(result)
+    owner_backend = broken_owner_chain["conditionRuns"][0]["attempts"][0][
+        "preTarget"
+    ]["backends"][0]
+    owner_backend["replicaSetOwnerUid"] = "uid-other-deployment"
+    _refresh_target_digests(
+        broken_owner_chain["conditionRuns"][0]["attempts"][0]["preTarget"]
+    )
+    _redigest_result(broken_owner_chain, verifier_private_key)
+    semantic_mutations.append(
+        ("broken owner reference chain", broken_owner_chain["subject"], broken_owner_chain)
+    )
+
+    nullable_identity = copy.deepcopy(result)
+    for snapshot_name in ("preTarget", "postTarget"):
+        snapshot = nullable_identity["conditionRuns"][0]["attempts"][0][snapshot_name]
+        nullable_backend = snapshot["backends"][0]
+        for field in (
+            "targetRefName",
+            "podName",
+            "podOwnerName",
+            "replicaSetName",
+            "podOwnerUid",
+            "replicaSetUid",
+            "replicaSetOwnerUid",
+            "deploymentUid",
+            "containerName",
+        ):
+            nullable_backend[field] = None
+        _refresh_target_digests(snapshot)
+    _redigest_result(nullable_identity, verifier_private_key)
+    semantic_mutations.append(
+        ("nullable owner identity pass", nullable_identity["subject"], nullable_identity)
+    )
+
+    invalid_runtime_image_id = copy.deepcopy(result)
+    for snapshot_name in ("preTarget", "postTarget"):
+        snapshot = invalid_runtime_image_id["conditionRuns"][0]["attempts"][0][
+            snapshot_name
+        ]
+        image_backend = snapshot["backends"][0]
+        image_backend["imageId"] = f"invalid/{image_backend['imageDigest']}"
+        _refresh_target_digests(snapshot)
+    _redigest_result(invalid_runtime_image_id, verifier_private_key)
+    semantic_mutations.append(
+        (
+            "invalid runtime image ID pass",
+            invalid_runtime_image_id["subject"],
+            invalid_runtime_image_id,
+        )
+    )
+
+    unsigned_result = copy.deepcopy(result)
+    unsigned_result["verifier"]["signature"] = "A" * 86
+    semantic_mutations.append(
+        ("fabricated verifier signature", unsigned_result["subject"], unsigned_result)
+    )
+
+    cross_run = copy.deepcopy(result)
+    cross_run["runId"] = "20000000-0000-4000-8000-000000000002"
+    _redigest_result(cross_run, verifier_private_key)
+    semantic_mutations.append(("cross-run replay", cross_run["subject"], cross_run))
+
+    cross_work_order = copy.deepcopy(result)
+    cross_work_order["workOrderId"] = "otherwork1"
+    _redigest_result(cross_work_order, verifier_private_key)
+    semantic_mutations.append(
+        ("cross-WorkOrder replay", cross_work_order["subject"], cross_work_order)
+    )
+
+    changed_profile = copy.deepcopy(result)
+    changed_profile["subject"]["probeProfile"]["digest"] = _digest("other-profile")
+    _redigest_subject(changed_profile["subject"], subject_private_key)
+    _redigest_result(changed_profile, verifier_private_key)
+    semantic_mutations.append(
+        ("changed probe profile", changed_profile["subject"], changed_profile)
+    )
+
+    changed_commit = copy.deepcopy(result)
+    changed_commit["subject"]["platformCommitSha"] = "c" * 40
+    _redigest_subject(changed_commit["subject"], subject_private_key)
+    _redigest_result(changed_commit, verifier_private_key)
+    semantic_mutations.append(
+        ("untrusted platform commit", changed_commit["subject"], changed_commit)
+    )
+
+    duplicate_attempt = copy.deepcopy(result)
+    duplicate_attempt["conditionRuns"][1]["attempts"][0]["attemptId"] = (
+        duplicate_attempt["conditionRuns"][0]["attempts"][0]["attemptId"]
+    )
+    _redigest_result(duplicate_attempt, verifier_private_key)
+    semantic_mutations.append(
+        ("duplicate attempt", duplicate_attempt["subject"], duplicate_attempt)
+    )
+
+    no_attempt_delay = copy.deepcopy(result)
+    first_attempt = no_attempt_delay["conditionRuns"][0]["attempts"][0]
+    second_attempt = no_attempt_delay["conditionRuns"][0]["attempts"][1]
+    second_attempt["startedAt"] = first_attempt["completedAt"]
+    second_attempt["completedAt"] = _timestamp(
+        _parse(second_attempt["startedAt"]) + timedelta(seconds=1)
+    )
+    _redigest_result(no_attempt_delay, verifier_private_key)
+    semantic_mutations.append(
+        ("missing PT1S attempt delay", no_attempt_delay["subject"], no_attempt_delay)
+    )
+
+    backend_deadline = copy.deepcopy(result)
+    backend_deadline["conditionRuns"][0]["attempts"][0]["backendResults"][0][
+        "durationMs"
+    ] = 1500
+    _redigest_result(backend_deadline, verifier_private_key)
+    semantic_mutations.append(
+        ("backend exceeds batch time", backend_deadline["subject"], backend_deadline)
+    )
+
+    service_drift = copy.deepcopy(result)
+    service_drift["conditionRuns"][0]["attempts"][0]["postTarget"][
+        "serviceResourceVersion"
+    ] = "302"
+    _redigest_result(service_drift, verifier_private_key)
+    semantic_mutations.append(("Service drift", service_drift["subject"], service_drift))
+
+    endpoint_drift = copy.deepcopy(result)
+    endpoint_drift["conditionRuns"][0]["attempts"][0]["postTarget"][
+        "endpointSliceSetDigest"
+    ] = _digest("changed-slice")
+    _redigest_result(endpoint_drift, verifier_private_key)
+    semantic_mutations.append(("EndpointSlice drift", endpoint_drift["subject"], endpoint_drift))
+
+    mixed_image = copy.deepcopy(result)
+    mixed_image["conditionRuns"][0]["attempts"][0]["preTarget"]["backends"][0][
+        "imageDigest"
+    ] = f"sha256:{_digest('foreign-image')}"
+    _redigest_result(mixed_image, verifier_private_key)
+    semantic_mutations.append(("mixed backend image", mixed_image["subject"], mixed_image))
+
+    false_batch = copy.deepcopy(result)
+    backend = false_batch["conditionRuns"][0]["attempts"][0]["backendResults"][0]
+    backend["status"] = 500
+    backend["oracle"]["observedStatus"] = 500
+    _redigest_result(false_batch, verifier_private_key)
+    semantic_mutations.append(("forged passing batch", false_batch["subject"], false_batch))
+
+    false_text_oracle = copy.deepcopy(result)
+    text_backend = false_text_oracle["conditionRuns"][2]["attempts"][0][
+        "backendResults"
+    ][0]
+    text_backend["oracle"]["observedByteDigest"] = _digest("other-body")
+    _redigest_result(false_text_oracle, verifier_private_key)
+    semantic_mutations.append(
+        ("forged exact-text oracle", false_text_oracle["subject"], false_text_oracle)
+    )
+
+    false_json_oracle = copy.deepcopy(result)
+    json_entry = false_json_oracle["conditionRuns"][3]["attempts"][0][
+        "backendResults"
+    ][0]["oracle"]["entries"][0]
+    json_entry["observedPresent"] = False
+    json_entry["observedType"] = None
+    json_entry["observedValueDigest"] = None
+    _redigest_result(false_json_oracle, verifier_private_key)
+    semantic_mutations.append(
+        ("forged JSON oracle", false_json_oracle["subject"], false_json_oracle)
+    )
+
+    false_streak = copy.deepcopy(result)
+    interrupted = false_streak["conditionRuns"][0]["attempts"][1]
+    interrupted_backend = interrupted["backendResults"][0]
+    interrupted_backend["status"] = 500
+    interrupted_backend["state"] = "fail"
+    interrupted_backend["oracle"]["observedStatus"] = 500
+    interrupted["state"] = "fail"
+    _redigest_result(false_streak, verifier_private_key)
+    semantic_mutations.append(
+        ("non-pass did not reset streak", false_streak["subject"], false_streak)
+    )
+
+    only_two = copy.deepcopy(result)
+    only_two["conditionRuns"][0]["attempts"].pop()
+    only_two["conditionRuns"][0]["achievedConsecutivePasses"] = 2
+    _redigest_result(only_two, verifier_private_key)
+    semantic_mutations.append(("two passes marked complete", only_two["subject"], only_two))
+
+    continued_after_success = copy.deepcopy(result)
+    final_condition = continued_after_success["conditionRuns"][-1]
+    fourth_attempt = copy.deepcopy(final_condition["attempts"][-1])
+    fourth_attempt.update(
+        {
+            "attemptId": "0000000d-0000-4000-8000-00000000000d",
+            "ordinal": 4,
+            "startedAt": _timestamp(
+                _parse(fourth_attempt["completedAt"]) + timedelta(seconds=1)
+            ),
+            "completedAt": _timestamp(
+                _parse(fourth_attempt["completedAt"]) + timedelta(seconds=2)
+            ),
+            "targetErrorCode": "empty-backend-set",
+            "backendResults": [],
+            "state": "probe-error",
+        }
+    )
+    fourth_attempt["preTarget"]["backends"] = []
+    fourth_attempt["postTarget"]["backends"] = []
+    _refresh_target_digests(fourth_attempt["preTarget"])
+    _refresh_target_digests(fourth_attempt["postTarget"])
+    final_condition["attempts"].append(fourth_attempt)
+    continued_after_success["completedAt"] = fourth_attempt["completedAt"]
+    _redigest_result(continued_after_success, verifier_private_key)
+    semantic_mutations.append(
+        (
+            "condition continued after satisfaction",
+            continued_after_success["subject"],
+            continued_after_success,
+        )
+    )
+
+    continued_after_deadline = copy.deepcopy(result)
+    deadline_health = continued_after_deadline["conditionRuns"][0]
+    deadline_attempt = deadline_health["attempts"][0]
+    deadline_backend = deadline_attempt["backendResults"][0]
+    deadline_backend["status"] = 500
+    deadline_backend["oracle"]["observedStatus"] = 500
+    deadline_backend["state"] = "fail"
+    deadline_attempt["state"] = "fail"
+    deadline_health.update(
+        {
+            "attempts": [deadline_attempt],
+            "achievedConsecutivePasses": 0,
+            "state": "fail",
+            "termination": "run-deadline",
+        }
+    )
+    continued_after_deadline["pathConditionResults"][0] = {
+        "id": "runtime.health",
+        "state": "fail",
+        "satisfied": False,
+    }
+    continued_after_deadline["aggregateState"] = "fail"
+    continued_after_deadline["satisfied"] = False
+    continued_after_deadline["completedAt"] = continued_after_deadline["subject"][
+        "deadline"
+    ]
+    _redigest_result(continued_after_deadline, verifier_private_key)
+    semantic_mutations.append(
+        (
+            "attempts continued after run deadline",
+            continued_after_deadline["subject"],
+            continued_after_deadline,
+        )
+    )
+
+    stale = copy.deepcopy(result)
+    stale["subject"]["issuedAt"] = "2026-07-14T00:06:00Z"
+    stale["subject"]["deadline"] = "2026-07-14T00:10:00Z"
+    _redigest_subject(stale["subject"], subject_private_key)
+    _redigest_result(stale, verifier_private_key)
+    semantic_mutations.append(("stale delivery observation", stale["subject"], stale))
+
+    attacker = copy.deepcopy(result)
+    attacker["verifier"]["profileDigest"] = _digest("worker-profile")
+    attacker["verifier"]["signingKeyId"] = "worker:self-signed"
+    attacker_private_key = _private_key("attacker")
+    _redigest_result(attacker, attacker_private_key)
+    semantic_mutations.append(("worker-signed evidence", attacker["subject"], attacker))
+
+    expired = copy.deepcopy(result)
+    expired["expiresAt"] = expired["completedAt"]
+    _redigest_result(expired, verifier_private_key)
+    semantic_mutations.append(("expired evidence", expired["subject"], expired))
+
+    reordered = copy.deepcopy(result)
+    reordered["conditionRuns"][0], reordered["conditionRuns"][1] = (
+        reordered["conditionRuns"][1],
+        reordered["conditionRuns"][0],
+    )
+    _redigest_result(reordered, verifier_private_key)
+    semantic_mutations.append(("reordered conditions", reordered["subject"], reordered))
+
+    for name, mutated_subject, mutated_result in semantic_mutations:
+        try:
+            subject_validator.validate(mutated_subject)
+            result_validator.validate(mutated_result)
+            _validate_semantics(mutated_subject, mutated_result, index, trusted)
+        except (HttpProbeContractError, ValidationError):
+            continue
+        raise HttpProbeContractError(f"invalid HTTP semantic mutation passed: {name}")

--- a/scripts/requirements-platform-contracts.txt
+++ b/scripts/requirements-platform-contracts.txt
@@ -1,2 +1,4 @@
+cryptography==49.0.0
 jsonschema==4.25.1
 PyYAML==6.0.2
+rfc8785==0.1.4

--- a/scripts/validate-platform-contracts.py
+++ b/scripts/validate-platform-contracts.py
@@ -16,6 +16,11 @@ import yaml
 from jsonschema import Draft202012Validator, FormatChecker, ValidationError
 from referencing import Registry, Resource
 
+from http_probe_contract_validation import (
+    validate_http_probe_contracts,
+    validate_http_request_inputs,
+)
+
 
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACT_ROOT = ROOT / "platform-contracts"
@@ -92,6 +97,7 @@ def validate_index(index: dict[str, Any]) -> list[dict[str, str]]:
         "entity-classes",
         "realms",
         "delivery-profiles",
+        "probe-profiles",
         "paths",
     )
     discovered = sorted(
@@ -114,6 +120,7 @@ def validate_index(index: dict[str, Any]) -> list[dict[str, str]]:
         "EntityClass",
         "Realm",
         "PlatformDeliveryProfile",
+        "HttpProbeProfile",
         "PlatformPath",
     }
     for position, artifact in enumerate(artifacts):
@@ -287,6 +294,8 @@ def validate_observer_access(
     } | {
         ("apps", resource, "list") for resource in ("deployments", "replicasets")
     } | {
+        ("discovery.k8s.io", "endpointslices", "list")
+    } | {
         ("networking.k8s.io", resource, "list")
         for resource in ("ingresses", "networkpolicies")
     } | {
@@ -294,8 +303,8 @@ def validate_observer_access(
         for resource in ("rolebindings", "roles")
     }
     if actual_inventory != expected_inventory:
-        raise ContractError(f"{context}: observer inventory rules differ from the closed 11-kind set")
-    if observer["inventoryClusterRole"]["name"] != "darkfactory-preview-delivery-list-v1":
+        raise ContractError(f"{context}: observer inventory rules differ from the closed 12-kind set")
+    if observer["inventoryClusterRole"]["name"] != "darkfactory-preview-delivery-list-v2":
         raise ContractError(f"{context}: shared observer role is not immutable and versioned")
 
     expected_negative_cases = {
@@ -450,6 +459,10 @@ def validate_delivery_profile(
     require_registered(observations["realmEvidenceType"], registries["evidenceTypes"], context)
     if profile["schemaVersion"] == "platform/delivery-profile/v2":
         require_registered(observations["semanticVerifier"], registries["probes"], context)
+        runtime = profile["runtimeVerification"]
+        require_registered(runtime["action"], registries["actions"], context)
+        require_registered(runtime["credential"]["issueAction"], registries["actions"], context)
+        require_registered(runtime["evidenceType"], registries["evidenceTypes"], context)
     compensation = profile["compensation"]
     require_registered(compensation["action"], registries["actions"], context)
     require_registered(compensation["verifier"], registries["probes"], context)
@@ -510,6 +523,7 @@ def validate_delivery_profile(
     if profile["schemaVersion"] == "platform/delivery-profile/v2":
         required_assertions.remove("no-cross-realm-rbac")
         required_assertions.add("no-workload-rbac")
+        required_assertions.add("http-verifier-ingress-only")
     if set(envelope["requiredAssertions"]) != required_assertions:
         raise ContractError(f"{context}: preview containment assertions are incomplete")
     if envelope["requiredAssertions"] != sorted(envelope["requiredAssertions"]):
@@ -542,11 +556,12 @@ def validate_delivery_profile(
 
 def validate_semantics(
     index: dict[str, Any], schemas: dict[str, Any], documents: dict[str, dict[str, Any]]
-) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
     products: dict[str, Any] = {}
     entities: dict[str, Any] = {}
     realms: dict[str, Any] = {}
     delivery_profiles: dict[str, Any] = {}
+    probe_profiles: dict[str, Any] = {}
     paths: dict[str, Any] = {}
     for document in documents.values():
         kind = document.get("kind")
@@ -559,6 +574,8 @@ def validate_semantics(
             target = realms
         elif kind == "PlatformDeliveryProfile":
             target = delivery_profiles
+        elif kind == "HttpProbeProfile":
+            target = probe_profiles
         elif kind == "PlatformPath":
             target = paths
         else:
@@ -570,6 +587,17 @@ def validate_semantics(
     registries = {name: set(values) for name, values in index["spec"]["registries"].items()}
     for profile_id, profile in delivery_profiles.items():
         validate_delivery_profile(profile, registries, profile_id)
+    for probe_profile_id, probe_profile in probe_profiles.items():
+        require_registered(
+            probe_profile["conditionPlan"]["freezeAction"],
+            registries["actions"],
+            probe_profile_id,
+        )
+        require_registered(
+            probe_profile["evidence"]["evidenceType"],
+            registries["evidenceTypes"],
+            probe_profile_id,
+        )
     for entity_id, entity in entities.items():
         for capability in entity["requiredCapabilities"]:
             require_registered(capability, registries["capabilities"], entity_id)
@@ -653,6 +681,26 @@ def validate_semantics(
                     )
             if profile["schemaVersion"] == "platform/delivery-profile/v2":
                 observer = profile["observerAccess"]
+                runtime = profile["runtimeVerification"]
+                runtime_profile_id = runtime["profile"]
+                if runtime_profile_id not in probe_profiles:
+                    raise ContractError(
+                        f"{path_id}: unknown HTTP probe profile {runtime_profile_id}"
+                    )
+                runtime_profile = probe_profiles[runtime_profile_id]
+                expected_applies_to = {
+                    "path": path_id,
+                    "deliveryProfile": profile_id,
+                    "realm": path["supportedRealms"][0],
+                }
+                if runtime_profile["appliesTo"] != expected_applies_to:
+                    raise ContractError(
+                        f"{path_id}: HTTP probe profile applicability is not exact"
+                    )
+                if runtime_profile["metadata"]["state"] != path["metadata"]["state"]:
+                    raise ContractError(
+                        f"{path_id}: HTTP probe profile lifecycle does not match path"
+                    )
                 referenced_runtime_schemas = {
                     profile["observations"]["scopeSchema"],
                     profile["observations"]["snapshotSchema"],
@@ -660,6 +708,9 @@ def validate_semantics(
                     observer["credential"]["scopeSchema"],
                     observer["attestation"]["schema"],
                     observer["cleanup"]["evidenceSchema"],
+                    runtime["profileSchema"],
+                    runtime["subjectSchema"],
+                    runtime["resultSchema"],
                 }
                 unknown_runtime_schemas = referenced_runtime_schemas - set(schemas)
                 if unknown_runtime_schemas:
@@ -675,6 +726,10 @@ def validate_semantics(
                     "register-observer-access-compensation": "execution.register-compensation/v1",
                     "revoke-observer-access": "delivery.revoke-observer-access/v1",
                     "store-observation-evidence": "evidence.store-delivery-observation/v1",
+                    "issue-http-probe-credential": (
+                        "verification.issue-http-probe-credential/v1"
+                    ),
+                    "verify-runtime": "verification.run-http-probes/v1",
                 }
                 for step_id, action in required_observer_steps.items():
                     if step_actions.get(step_id) != action:
@@ -689,8 +744,9 @@ def validate_semantics(
                     "issue-observer-credential": ["attest-observer-access"],
                     "observe-gitops": ["issue-observer-credential"],
                     "store-observation-evidence": ["observe-gitops"],
-                    "revoke-observer-access": ["store-observation-evidence"],
-                    "verify-runtime": ["revoke-observer-access"],
+                    "issue-http-probe-credential": ["store-observation-evidence"],
+                    "verify-runtime": ["issue-http-probe-credential"],
+                    "revoke-observer-access": ["verify-runtime"],
                 }
                 for step_id, needs in observer_chain.items():
                     if step_needs.get(step_id) != needs:
@@ -721,6 +777,17 @@ def validate_semantics(
             if unknown_needs:
                 raise ContractError(f"{path_id}: step {step['id']} has non-prior needs {sorted(unknown_needs)}")
             seen.add(step["id"])
+        if profile and profile["schemaVersion"] == "platform/delivery-profile/v2":
+            step_needs = {step["id"]: step["needs"] for step in path["workflow"]}
+            step_actions = {step["id"]: step["action"] for step in path["workflow"]}
+            if step_actions.get("freeze-http-conditions") != (
+                "verification.freeze-http-conditions/v1"
+            ):
+                raise ContractError(f"{path_id}: HTTP conditions are not frozen")
+            if step_needs.get("freeze-http-conditions") != ["inspect-source"]:
+                raise ContractError(f"{path_id}: HTTP freeze ordering is not closed")
+            if step_needs.get("author-change") != ["freeze-http-conditions"]:
+                raise ContractError(f"{path_id}: mutation can precede HTTP condition freeze")
         for policy in path["policies"]:
             require_registered(policy, registries["policies"], path_id)
         for condition in path["conditionsOfDone"]:
@@ -762,6 +829,27 @@ def validate_semantics(
                     raise ContractError(
                         f"{path_id}: observer authority or cleanup is not a Condition of Done"
                     )
+                runtime = profile["runtimeVerification"]
+                runtime_profile = probe_profiles[runtime["profile"]]
+                expected_http_pairs = {
+                    (
+                        condition["probe"],
+                        runtime_profile["evidence"]["evidenceType"],
+                    )
+                    for condition in runtime_profile["conditionPlan"]["fixedConditions"]
+                }
+                expected_http_pairs.add(
+                    (
+                        runtime_profile["conditionPlan"]["requestContract"]["probe"],
+                        runtime_profile["evidence"]["evidenceType"],
+                    )
+                )
+                if not expected_http_pairs.issubset(condition_pairs):
+                    raise ContractError(
+                        f"{path_id}: HTTP probe profile is not bound to all runtime conditions"
+                    )
+                if runtime["evidenceType"] != runtime_profile["evidence"]["evidenceType"]:
+                    raise ContractError(f"{path_id}: HTTP evidence type binding differs")
         condition_ids = [condition["id"] for condition in path["conditionsOfDone"]]
         if len(condition_ids) != len(set(condition_ids)):
             raise ContractError(f"{path_id}: duplicate Condition of Done id")
@@ -804,7 +892,17 @@ def validate_semantics(
     orphaned_profiles = set(delivery_profiles) - referenced_profiles
     if orphaned_profiles:
         raise ContractError(f"orphaned delivery profiles: {sorted(orphaned_profiles)}")
-    return products, paths, realms, delivery_profiles
+    referenced_probe_profiles = {
+        profile["runtimeVerification"]["profile"]
+        for profile in delivery_profiles.values()
+        if profile["schemaVersion"] == "platform/delivery-profile/v2"
+    }
+    orphaned_probe_profiles = set(probe_profiles) - referenced_probe_profiles
+    if orphaned_probe_profiles:
+        raise ContractError(
+            f"orphaned HTTP probe profiles: {sorted(orphaned_probe_profiles)}"
+        )
+    return products, paths, realms, delivery_profiles, probe_profiles
 
 
 def validate_request(
@@ -836,6 +934,8 @@ def validate_request(
     Draft202012Validator(
         schemas[path["inputSchema"]], format_checker=FORMAT_CHECKER
     ).validate(request["inputs"])
+    if path_id == "standard-http-service/v3":
+        validate_http_request_inputs(request["inputs"])
 
 
 def validate_fixtures(
@@ -1048,7 +1148,7 @@ def validate_runtime_schema_examples(schemas: dict[str, Any]) -> None:
             "inventoryClusterRole": object_evidence(
                 "rbac.authorization.k8s.io/v1",
                 "ClusterRole",
-                "darkfactory-preview-delivery-list-v1",
+                "darkfactory-preview-delivery-list-v2",
             ),
             "namespaceClusterRole": object_evidence(
                 "rbac.authorization.k8s.io/v1", "ClusterRole", observer_name
@@ -1118,6 +1218,7 @@ def validate_runtime_schema_examples(schemas: dict[str, Any]) -> None:
         "kindIds": [
             "apps/v1/Deployment",
             "apps/v1/ReplicaSet",
+            "discovery.k8s.io/v1/EndpointSlice",
             "networking.k8s.io/v1/Ingress",
             "networking.k8s.io/v1/NetworkPolicy",
             "rbac.authorization.k8s.io/v1/Role",
@@ -1148,6 +1249,7 @@ def validate_runtime_schema_examples(schemas: dict[str, Any]) -> None:
     snapshot_kinds = {
         "apps-v1-deployments": "apps/v1/Deployment",
         "apps-v1-replicasets": "apps/v1/ReplicaSet",
+        "discovery-v1-endpointslices": "discovery.k8s.io/v1/EndpointSlice",
         "networking-v1-ingresses": "networking.k8s.io/v1/Ingress",
         "networking-v1-networkpolicies": "networking.k8s.io/v1/NetworkPolicy",
         "rbac-v1-rolebindings": "rbac.authorization.k8s.io/v1/RoleBinding",
@@ -1252,7 +1354,7 @@ def validate_runtime_schema_examples(schemas: dict[str, Any]) -> None:
             for name in cleanup_object_names
         },
         "sharedInventoryClusterRole": {
-            "name": "darkfactory-preview-delivery-list-v1",
+            "name": "darkfactory-preview-delivery-list-v2",
             "status": "preserved",
             "canonicalDigest": attestation["objects"]["inventoryClusterRole"][
                 "canonicalDigest"
@@ -1359,7 +1461,7 @@ def validate_runtime_schema_examples(schemas: dict[str, Any]) -> None:
         expected_control_names = {
             "applicationRole": expected_observer,
             "applicationRoleBinding": expected_observer,
-            "inventoryClusterRole": "darkfactory-preview-delivery-list-v1",
+            "inventoryClusterRole": "darkfactory-preview-delivery-list-v2",
             "namespaceClusterRole": expected_observer,
             "namespaceClusterRoleBinding": expected_observer,
             "realmRoleBinding": expected_observer,
@@ -1793,10 +1895,13 @@ def main() -> int:
         artifacts = validate_index(index)
         validate_digests(index, artifacts)
         schemas, documents = load_and_validate_artifacts(artifacts)
-        products, paths, realms, delivery_profiles = validate_semantics(index, schemas, documents)
+        products, paths, realms, delivery_profiles, probe_profiles = validate_semantics(
+            index, schemas, documents
+        )
         validate_fixtures(schemas, products, paths, realms)
         validate_delivery_profile_fixtures(index, schemas)
         validate_runtime_schema_examples(schemas)
+        validate_http_probe_contracts(schemas, index)
     except Exception as error:
         print(f"platform-contract validation failed: {error}", file=sys.stderr)
         return 1
@@ -1804,7 +1909,8 @@ def main() -> int:
         "platform-contract validation passed: "
         f"{len(artifacts)} indexed artifacts, {len(products)} product, "
         f"{len(paths)} path, {len(realms)} Realm, "
-        f"{len(delivery_profiles)} delivery profile"
+        f"{len(delivery_profiles)} delivery profile, "
+        f"{len(probe_profiles)} HTTP probe profile"
     )
     return 0
 


### PR DESCRIPTION
## Summary
- publish ADR-0058 and a closed draft HTTP probe profile for `standard-http-service/v3`
- bind precommitted acceptance, delivery observation, Kubernetes backend attribution, network policy, deadlines, and Ed25519-signed evidence
- add RFC 8785 semantic qualification with positive error outcomes and regression mutations
- extend the draft observer profile with bounded EndpointSlice/runtime verification access

## Safety
- remains draft and is not admitted by any Realm
- caller URLs, worker evidence, raw bodies, stale/replayed evidence, incomplete targets, and false state reductions fail closed
- independent consistency review: no Critical/P1/P2 findings

## Verification
- `python3 scripts/validate-platform-contracts.py`
- clean `python:3.12-slim` Docker run with pinned requirements
- `python3 -m py_compile scripts/http_probe_contract_validation.py scripts/validate-platform-contracts.py`
- `yamllint` on changed YAML contracts
- `git diff --check`

Bundle digest: `1c86f50f9463c4d71383663e7dfd450aa10d63b603ebda2a19aac52037167c87`
