### PR TITLE
contracts: bind observer attestation to full authority

### DIFF
--- a/docs/adrs/0059-independent-observer-attestor-profiles.md
+++ b/docs/adrs/0059-independent-observer-attestor-profiles.md
@@ -33,9 +33,10 @@ permit self-attestation, cross-cluster replay, and accidental admission of devel
    `ECC_NIST_EDWARDS25519` key with `ED25519_SHA_512`. The private key is never stored in Kubernetes.
    The local profile uses a per-run process-memory Ed25519 key outside the observer identity and is
    non-admissible by construction.
-5. Evidence binds the exact platform commit and bundle, delivery profile, attestor profile, cluster
-   identity, live access-object epochs, inherited authority, positive and negative authorization
-   decisions, WorkOrder identity, and a maximum five-minute validity window.
+5. Evidence binds the exact signed execution-envelope digest, platform commit and bundle, delivery
+   profile, attestor profile, cluster identity, live access-object epochs, every required-positive and
+   forbidden-negative SubjectAccessReview decision, WorkOrder identity, and a maximum five-minute
+   validity window.
 6. The canonical evidence digest excludes `evidenceSha256` and `signature.value`. The signature is
    Ed25519 over the domain-separated payload
    `UTF8("darkfactory.observer-access-attestation/v1") || 0x00 ||
@@ -94,4 +95,3 @@ Rejected because cluster Secret readers could forge the external authority proof
 - `platform-contracts/attestor-profiles/`
 - ADR-0056
 - ADR-0057
-

--- a/platform-contracts/README.md
+++ b/platform-contracts/README.md
@@ -92,7 +92,9 @@ trusted signer.
 The draft attestor catalog separates `kind-development/v1` from `eks-kms-ed25519/v1`. Both remain
 `readinessEligible: false`. Authority evidence binds the exact platform revision and bundle, cluster
 identity, five-minute expiry, trust-profile identity, and a domain-separated Ed25519 payload. The
-local process-memory key can qualify behavior but cannot satisfy a readiness profile.
+signed execution-envelope digest plus closed required-positive and forbidden-negative authorization
+matrices are part of the same evidence. The local process-memory key can qualify behavior but cannot
+satisfy a readiness profile.
 
 Normal cleanup revokes the lease, revalidates and deletes only six exact WorkOrder-owned objects in
 the specified order using attested UID and resourceVersion DELETE preconditions, verifies their

--- a/platform-contracts/index.yaml
+++ b/platform-contracts/index.yaml
@@ -5,7 +5,7 @@ metadata:
   version: v1
 spec:
   digestAlgorithm: sha256-path-nul-bytes-v1
-  bundleDigest: ec63c48e977ceb96240825322f3693cb7b49bdc9ba6a4e3c2acfa6e3ae7bc20f
+  bundleDigest: ff74f28a6b5177990628e3b7994a058fabc6b6db622d1c9f0b8c3154a2f8fd66
   artifacts:
     - path: attestor-profiles/eks-kms-ed25519/v1/profile.yaml
       kind: ObserverAttestorProfile
@@ -130,7 +130,7 @@ spec:
     - path: schemas/v1/observer-access-attestation.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
-      sha256: 92bce914170b6a79cc4d9977e9c7d69a755575c7c94e6602f56f858d06a0622e
+      sha256: e9f65ffdf55a1d97a674a4a016f93a5fff7cae48367143251af8df7fcc8be771
     - path: schemas/v1/observer-access-cleanup-evidence.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema

--- a/platform-contracts/schemas/v1/observer-access-attestation.schema.json
+++ b/platform-contracts/schemas/v1/observer-access-attestation.schema.json
@@ -8,6 +8,7 @@
     "schemaVersion",
     "platformCommitSha",
     "platformBundleDigest",
+    "executionEnvelopeDigest",
     "workOrderId",
     "subject",
     "identityBinding",
@@ -17,6 +18,8 @@
     "controlInventoryDigest",
     "cluster",
     "objects",
+    "positiveAuthorization",
+    "positiveAuthorizationMatrixDigest",
     "negativeAuthorization",
     "negativeAuthorizationMatrixDigest",
     "inheritedAuthority",
@@ -32,6 +35,7 @@
     "schemaVersion": {"const": "delivery/observer-access-attestation/v1"},
     "platformCommitSha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
     "platformBundleDigest": {"$ref": "#/$defs/digest"},
+    "executionEnvelopeDigest": {"$ref": "#/$defs/digest"},
     "workOrderId": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]{7,52}$"},
     "subject": {"type": "string", "pattern": "^system:serviceaccount:darkfactory-observers:obs-[a-z0-9][a-z0-9-]{7,52}$"},
     "identityBinding": {
@@ -80,6 +84,43 @@
         "serviceAccount": {"$ref": "#/$defs/serviceAccount"}
       }
     },
+    "positiveAuthorization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "application-get",
+        "deployment-list",
+        "endpointslice-list",
+        "ingress-list",
+        "namespace-get",
+        "networkpolicy-list",
+        "persistentvolumeclaim-list",
+        "pod-list",
+        "replicaset-list",
+        "resourcequota-list",
+        "role-list",
+        "rolebinding-list",
+        "service-list",
+        "serviceaccount-list"
+      ],
+      "properties": {
+        "application-get": {"$ref": "#/$defs/allowResult"},
+        "deployment-list": {"$ref": "#/$defs/allowResult"},
+        "endpointslice-list": {"$ref": "#/$defs/allowResult"},
+        "ingress-list": {"$ref": "#/$defs/allowResult"},
+        "namespace-get": {"$ref": "#/$defs/allowResult"},
+        "networkpolicy-list": {"$ref": "#/$defs/allowResult"},
+        "persistentvolumeclaim-list": {"$ref": "#/$defs/allowResult"},
+        "pod-list": {"$ref": "#/$defs/allowResult"},
+        "replicaset-list": {"$ref": "#/$defs/allowResult"},
+        "resourcequota-list": {"$ref": "#/$defs/allowResult"},
+        "role-list": {"$ref": "#/$defs/allowResult"},
+        "rolebinding-list": {"$ref": "#/$defs/allowResult"},
+        "service-list": {"$ref": "#/$defs/allowResult"},
+        "serviceaccount-list": {"$ref": "#/$defs/allowResult"}
+      }
+    },
+    "positiveAuthorizationMatrixDigest": {"$ref": "#/$defs/digest"},
     "negativeAuthorization": {
       "type": "object",
       "additionalProperties": false,
@@ -195,6 +236,16 @@
   },
   "$defs": {
     "digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "allowResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["decision", "requestDigest", "responseDigest"],
+      "properties": {
+        "decision": {"const": "allowed"},
+        "requestDigest": {"$ref": "#/$defs/digest"},
+        "responseDigest": {"$ref": "#/$defs/digest"}
+      }
+    },
     "denialResult": {
       "type": "object",
       "additionalProperties": false,

--- a/scripts/validate-platform-contracts.py
+++ b/scripts/validate-platform-contracts.py
@@ -1273,10 +1273,28 @@ def validate_runtime_schema_examples(
         "service-proxy-get",
         "tokenrequest-create",
     )
+    positive_cases = (
+        "application-get",
+        "deployment-list",
+        "endpointslice-list",
+        "ingress-list",
+        "namespace-get",
+        "networkpolicy-list",
+        "persistentvolumeclaim-list",
+        "pod-list",
+        "replicaset-list",
+        "resourcequota-list",
+        "role-list",
+        "rolebinding-list",
+        "service-list",
+        "serviceaccount-list",
+    )
+    execution_envelope_digest = digest_for("execution-envelope")
     attestation = {
         "schemaVersion": "delivery/observer-access-attestation/v1",
         "platformCommitSha": "c" * 40,
         "platformBundleDigest": index["spec"]["bundleDigest"],
+        "executionEnvelopeDigest": execution_envelope_digest,
         "workOrderId": work_order_id,
         "subject": (
             "system:serviceaccount:darkfactory-observers:"
@@ -1321,6 +1339,15 @@ def validate_runtime_schema_examples(
                 "v1", "ServiceAccount", observer_name, "darkfactory-observers"
             ),
         },
+        "positiveAuthorization": {
+            case: {
+                "decision": "allowed",
+                "requestDigest": digest_for(f"request:{case}"),
+                "responseDigest": digest_for(f"response:{case}"),
+            }
+            for case in positive_cases
+        },
+        "positiveAuthorizationMatrixDigest": digest_for("positive-matrix"),
         "negativeAuthorization": {
             case: {
                 "decision": "denied",
@@ -1574,6 +1601,8 @@ def validate_runtime_schema_examples(
         )
         if authority["platformBundleDigest"] != index["spec"]["bundleDigest"]:
             raise ContractError("RBAC attestation is bound to another platform bundle")
+        if authority["executionEnvelopeDigest"] != execution_envelope_digest:
+            raise ContractError("RBAC attestation is bound to another execution envelope")
         if authority["profileDigest"] != delivery_profile_digest:
             raise ContractError("RBAC attestation is bound to another delivery profile")
         work_order_values = {
@@ -1845,6 +1874,16 @@ def validate_runtime_schema_examples(
         )
     )
 
+    denied_positive = copy.deepcopy(attestation)
+    denied_positive["positiveAuthorization"]["application-get"]["decision"] = "denied"
+    invalid_examples.append(
+        (
+            "denied required observer permission",
+            "urn:darkfactory:platform-contract:observer-access-attestation:v1",
+            denied_positive,
+        )
+    )
+
     wrong_snapshot = copy.deepcopy(observation)
     wrong_snapshot["finalCollectionSnapshots"]["v1-pods"]["kindId"] = "v1/Service"
     invalid_examples.append(
@@ -1906,6 +1945,20 @@ def validate_runtime_schema_examples(
         (
             "foreign platform bundle",
             foreign_platform_bundle,
+            scope,
+            observation,
+            cleanup,
+        )
+    )
+
+    foreign_execution_envelope = copy.deepcopy(attestation)
+    foreign_execution_envelope["executionEnvelopeDigest"] = digest_for(
+        "foreign-execution-envelope"
+    )
+    semantic_mutations.append(
+        (
+            "foreign execution envelope",
+            foreign_execution_envelope,
             scope,
             observation,
             cleanup,


### PR DESCRIPTION
## Summary
- bind observer authority evidence to the exact signed execution-envelope digest
- require one closed positive SubjectAccessReview result for every observer permission in addition to the existing forbidden-negative matrix
- add schema and semantic mutations for denied required access and cross-envelope replay

## Why this follows #359
Omnius RED verifier work exposed that the draft schema did not encode two guarantees already required by ADR-0059/genai ADR-0015. Implementing against that gap would accept incomplete authority evidence. This correction keeps the candidate catalog-only and readiness-ineligible.

## Verification
- `python3 scripts/validate-platform-contracts.py`
- Python 3.12 slim container using the CI requirements
- `git diff --check`