### PR TITLE
Publish HTTP evidence commit and receipt contract

### DIFF
--- a/platform-contracts/README.md
+++ b/platform-contracts/README.md
@@ -72,10 +72,12 @@ resourceVersion; the contract makes no cross-kind atomic-snapshot claim.
 
 For runtime verification the same WorkOrder-specific read-only observer identity gains only
 EndpointSlice list authority in addition to its existing bounded inventory reads. The control plane
-issues a separate five-minute probe credential and a four-minute signed subject after delivery
-evidence is stored. The verifier network source and port 8080 ingress are adapter- and
-NetworkPolicy-derived; requests cannot nominate a destination. Access is revoked after the probes,
-and normal or terminal compensation still proves cleanup.
+issues a separate exact-ten-minute TokenRequest-floor credential and a four-minute signed subject
+after delivery evidence is stored. The verifier network source and port 8080 ingress are adapter- and
+NetworkPolicy-derived; requests cannot nominate a destination. The result signature covers a fixed
+domain plus the canonical evidence digest. A create-only store action reads the exact result back and
+records an immutable receipt before normal revoke. Store failure still triggers fail-safe cleanup but
+cannot satisfy completion; terminal compensation still proves cleanup.
 
 Kubernetes built-in bindings may grant `/api` and `/apis` discovery to authenticated principals. The
 platform-owned rules grant no `nonResourceURLs`, the observer transport exposes no discovery method,

--- a/platform-contracts/delivery-profiles/argocd-preview-http-service/v2/profile.yaml
+++ b/platform-contracts/delivery-profiles/argocd-preview-http-service/v2/profile.yaml
@@ -418,7 +418,9 @@ runtimeVerification:
     audienceFrom: adapter.destination.tokenAudience
     apiServerFrom: adapter.destination.apiServer
     caSha256From: adapter.destination.caSha256
-    maxLifetime: PT5M
+    requestedLifetime: PT10M
+    maxActualLifetime: PT10M
+    minimumRemainingAtStart: PT4M5S
     absoluteDeadline: PT4M
     maxResponseBytes: 1048576
     operations: [deployments.list, endpointslices.list, namespace.get, networkpolicies.list, pods.list, replicasets.list, services.list]
@@ -438,6 +440,18 @@ runtimeVerification:
     observedPolicySnapshotFrom: evidence.kubernetes.delivery-observation.finalCollectionSnapshots.networking-v1-networkpolicies
     requiredAssertion: http-verifier-ingress-only
     callerNetworkTargetAccepted: false
+  evidenceCommit:
+    action: evidence.store-http-probe-result/v1
+    storeProfileFrom: adapter.httpVerification.evidenceStoreProfile
+    storeProfileDigestFrom: executionEnvelope.httpEvidenceStoreProfileDigest
+    objectKeyTemplate: http-probe-result/v1/{workOrderId}/{runId}.json
+    writePrecondition: if-none-match-star-policy-enforced
+    readBack: exact-canonical-bytes-and-evidence-digest
+    identicalReplay: idempotent-committed
+    sameKeyConflict: park-and-escalate
+    receiptSchema: urn:darkfactory:platform-contract:http-evidence-commit-receipt:v1
+    receiptEvidenceType: http.probe-commit-receipt/v1
+    cleanupOnFailure: always-attempt-without-completion
 compensation:
   action: delivery.revert-prune-and-revoke-preview/v2
   verifier: realm.preview-and-observer-pruned/v1

--- a/platform-contracts/index.yaml
+++ b/platform-contracts/index.yaml
@@ -5,7 +5,7 @@ metadata:
   version: v1
 spec:
   digestAlgorithm: sha256-path-nul-bytes-v1
-  bundleDigest: ff74f28a6b5177990628e3b7994a058fabc6b6db622d1c9f0b8c3154a2f8fd66
+  bundleDigest: 96e61c97b74c8565160a56792e9c4e5498341b7a09377a5be898252bb0bf3197
   artifacts:
     - path: attestor-profiles/eks-kms-ed25519/v1/profile.yaml
       kind: ObserverAttestorProfile
@@ -22,7 +22,7 @@ spec:
     - path: delivery-profiles/argocd-preview-http-service/v2/profile.yaml
       kind: PlatformDeliveryProfile
       schema: urn:darkfactory:platform-contract:delivery-profile:v2
-      sha256: b79f1d77d887573f2daffa0ebab40c3c70b9ff64a91b124f68f6a635925f9b7a
+      sha256: 6191861b63c2e030edcf1e5f795704d11a7a03a938411e244b0dfe4417722aec
     - path: entity-classes/environment/v1/entity-class.yaml
       kind: EntityClass
       schema: urn:darkfactory:platform-contract:entity-class:v1
@@ -66,7 +66,7 @@ spec:
     - path: paths/standard-http-service/v3/path.yaml
       kind: PlatformPath
       schema: urn:darkfactory:platform-contract:platform-path:v2
-      sha256: 86e8fbd0839809d6dd00d3ea120daa6a750b1218e0455440f07d4e6c394343e8
+      sha256: 42e01230c13d3bb592e87a75cb456fd6ceea7cdb1bb3f19a643ee8be7a73ba3e
     - path: paths/standard-http-service/v3/request.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
@@ -74,7 +74,7 @@ spec:
     - path: probe-profiles/http-preview-service/v1/profile.yaml
       kind: HttpProbeProfile
       schema: urn:darkfactory:platform-contract:http-probe-profile:v1
-      sha256: 9a3070e7f537438fc96966766336c3d0125b86e41e8ac38826f5b5c59d63abea
+      sha256: 4690af26044fa5fce46a01ab6508226809f51527cbcea2c4133a5d106f0bc733
     - path: products/standard-service/v1/product.yaml
       kind: PlatformProduct
       schema: urn:darkfactory:platform-contract:platform-product:v1
@@ -107,14 +107,18 @@ spec:
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
       sha256: 745c089840975f2a363b9cfc09312259a50a667c2345fc5ebac9ab2550a75bc2
+    - path: schemas/v1/http-evidence-commit-receipt.schema.json
+      kind: Schema
+      schema: https://json-schema.org/draft/2020-12/schema
+      sha256: b8c18a7f87f934d573b9181d29880d138680e0df26bde1fc0b2b7f8021b113e3
     - path: schemas/v1/http-probe-profile.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
-      sha256: f3338cfe11accb2e450afc807f1c5ab77896bd45795c0a111d1cd5d845c55bc6
+      sha256: d9dd89f0b02434d6db4c713c63b01d0ba69539fb6e86e1913a674f25ac57c76b
     - path: schemas/v1/http-probe-result.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
-      sha256: a69d38924f3ffc3c4253fb4e0eb1a6df4f1aa13a71299194ecbf01bfe072db66
+      sha256: e59f3960c7729246517f90d2744fd22895f8748c255cc3cd8efd3d958c7830c9
     - path: schemas/v1/http-probe-subject.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
@@ -162,7 +166,7 @@ spec:
     - path: schemas/v2/delivery-profile.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
-      sha256: 9d965697935dc47b854709b6c7656d996a2c931bc6e013341b8c64b3725dc896
+      sha256: 0bccf65697b621a147dfcd902e3a5b8bb3475dc1ceeaac723e79868d5ae7bc37
     - path: schemas/v2/platform-path.schema.json
       kind: Schema
       schema: https://json-schema.org/draft/2020-12/schema
@@ -183,6 +187,7 @@ spec:
       - delivery.revert-prune-and-revoke-preview/v2
       - delivery.revoke-observer-access/v1
       - evidence.store-delivery-observation/v1
+      - evidence.store-http-probe-result/v1
       - execution.register-compensation/v1
       - realm.resolve-preview/v1
       - source.author-http-service-change/v1
@@ -205,6 +210,7 @@ spec:
       - ci.check-run/v1
       - compensation.result/v1
       - gitops.revision-status/v1
+      - http.probe-commit-receipt/v1
       - http.probe-result/v1
       - kubernetes.delivery-observation/v1
       - kubernetes.inherited-authority/v1

--- a/platform-contracts/paths/standard-http-service/v3/README.md
+++ b/platform-contracts/paths/standard-http-service/v3/README.md
@@ -35,10 +35,14 @@ separate platform control inventory: one shared versioned list-only ClusterRole 
 WorkOrder objects. Workers cannot author those objects. The control plane registers cleanup before
 creation, obtains signed independent live-RBAC evidence, issues an issuer-signed WorkOrder and
 adapter-bound short-lived scope, and stores schema-bound observation evidence. It then issues a
-separate five-minute runtime credential to the same WorkOrder-specific read-only identity. That
+separate exact-ten-minute TokenRequest-floor credential with a four-minute runtime budget to the same
+WorkOrder-specific read-only identity. That
 identity can additionally list EndpointSlices; it remains unable to read Secrets or ConfigMaps,
-watch, proxy, execute, mint tokens, or mutate anything. The access bundle is removed immediately
-after runtime verification and is also covered by terminal compensation.
+watch, proxy, execute, mint tokens, or mutate anything. The signed HTTP result is committed under a
+create-only WorkOrder/run-derived key, read back exactly, and recorded by an immutable commit receipt
+before the normal revoke step. The access bundle is then removed and is also covered by terminal
+compensation. Sign/store failure still drives fail-safe credential and producer cleanup but cannot
+produce completion evidence.
 
 The observer transport has no discovery operation and platform-owned rules contain no
 `nonResourceURLs`. Kubernetes may still grant `/api` and `/apis` through its built-in
@@ -71,7 +75,8 @@ actions, probes, expected responses, compensation, and evidence TTL. Completion 
 11. Observer access is revoked through attested UID and resourceVersion DELETE preconditions; signed
     cleanup evidence proves six exact WorkOrder objects absent, the credential lease revoked, and the
     shared versioned ClusterRole preserved after runtime verification.
-12. The evidence manifest is immutable and no older than `PT24H`.
+12. A create-only commit receipt proves exact read-back of the signed HTTP result before normal revoke;
+    the evidence manifest is immutable and no older than `PT24H`.
 13. Registered compensation can close an unmerged PR or revert the landed change, revoke observer
    access, and prune the preview Realm; the verifier proves absence of WorkOrder-owned resources.
 

--- a/platform-contracts/paths/standard-http-service/v3/path.yaml
+++ b/platform-contracts/paths/standard-http-service/v3/path.yaml
@@ -59,9 +59,12 @@ workflow:
   - id: verify-runtime
     action: verification.run-http-probes/v1
     needs: [issue-http-probe-credential]
+  - id: store-http-probe-result
+    action: evidence.store-http-probe-result/v1
+    needs: [verify-runtime]
   - id: revoke-observer-access
     action: delivery.revoke-observer-access/v1
-    needs: [verify-runtime]
+    needs: [store-http-probe-result]
 policies:
   - delivery.platform-observer-access/v1
   - global.no-main-push/v1
@@ -132,6 +135,7 @@ evidence:
     - compensation.result/v1
     - supply-chain.attestation/v1
     - gitops.revision-status/v1
+    - http.probe-commit-receipt/v1
     - http.probe-result/v1
     - kubernetes.delivery-observation/v1
     - kubernetes.inherited-authority/v1

--- a/platform-contracts/probe-profiles/http-preview-service/v1/profile.yaml
+++ b/platform-contracts/probe-profiles/http-preview-service/v1/profile.yaml
@@ -90,6 +90,8 @@ evidence:
   canonicalization: rfc8785-json-canonicalization/v1
   digestAlgorithm: sha256
   signatureAlgorithm: Ed25519
+  signaturePayloadProfile: domain-separated-evidence-digest/v1
+  signatureDomain: darkfactory.http-probe-result/v1
   verifierProfileFrom: adapter.httpVerification.verifierProfile
   signingKeyFrom: adapter.httpVerification.signingKey
   workerEvidenceAccepted: false

--- a/platform-contracts/schemas/v1/http-evidence-commit-receipt.schema.json
+++ b/platform-contracts/schemas/v1/http-evidence-commit-receipt.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:darkfactory:platform-contract:http-evidence-commit-receipt:v1",
+  "title": "HttpEvidenceCommitReceipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "evidenceType", "workOrderId", "runId", "storeProfileDigest", "bucketArn", "objectKey", "versionId", "checksumSha256", "evidenceSha256", "committedAt", "canonicalization", "digestPayloadExcludes", "receiptSha256"],
+  "properties": {
+    "schemaVersion": {"const": "verification/http-evidence-commit-receipt/v1"},
+    "evidenceType": {"const": "http.probe-commit-receipt/v1"},
+    "workOrderId": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]{7,52}$"},
+    "runId": {"type": "string", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"},
+    "storeProfileDigest": {"$ref": "#/$defs/digest"},
+    "bucketArn": {"type": "string", "pattern": "^arn:aws:s3:::[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$"},
+    "objectKey": {"type": "string", "pattern": "^http-probe-result/v1/[a-z0-9][a-z0-9-]{7,52}/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\\.json$"},
+    "versionId": {"type": "string", "minLength": 1, "maxLength": 1024},
+    "checksumSha256": {"$ref": "#/$defs/digest"},
+    "evidenceSha256": {"$ref": "#/$defs/digest"},
+    "committedAt": {"type": "string", "format": "date-time"},
+    "canonicalization": {"const": "rfc8785-json-canonicalization/v1"},
+    "digestPayloadExcludes": {"const": ["receiptSha256"]},
+    "receiptSha256": {"$ref": "#/$defs/digest"}
+  },
+  "$defs": {
+    "digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+  }
+}

--- a/platform-contracts/schemas/v1/http-probe-profile.schema.json
+++ b/platform-contracts/schemas/v1/http-probe-profile.schema.json
@@ -131,7 +131,7 @@
     "evidence": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["subjectSchema", "resultSchema", "evidenceType", "canonicalization", "digestAlgorithm", "signatureAlgorithm", "verifierProfileFrom", "signingKeyFrom", "workerEvidenceAccepted", "rawResponseStored"],
+      "required": ["subjectSchema", "resultSchema", "evidenceType", "canonicalization", "digestAlgorithm", "signatureAlgorithm", "signaturePayloadProfile", "signatureDomain", "verifierProfileFrom", "signingKeyFrom", "workerEvidenceAccepted", "rawResponseStored"],
       "properties": {
         "subjectSchema": {"const": "urn:darkfactory:platform-contract:http-probe-subject:v1"},
         "resultSchema": {"const": "urn:darkfactory:platform-contract:http-probe-result:v1"},
@@ -139,6 +139,8 @@
         "canonicalization": {"const": "rfc8785-json-canonicalization/v1"},
         "digestAlgorithm": {"const": "sha256"},
         "signatureAlgorithm": {"const": "Ed25519"},
+        "signaturePayloadProfile": {"const": "domain-separated-evidence-digest/v1"},
+        "signatureDomain": {"const": "darkfactory.http-probe-result/v1"},
         "verifierProfileFrom": {"const": "adapter.httpVerification.verifierProfile"},
         "signingKeyFrom": {"const": "adapter.httpVerification.signingKey"},
         "workerEvidenceAccepted": {"const": false},

--- a/platform-contracts/schemas/v1/http-probe-result.schema.json
+++ b/platform-contracts/schemas/v1/http-probe-result.schema.json
@@ -242,11 +242,13 @@
     "signer": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["profileDigest", "signingKeyId", "algorithm", "signature"],
+      "required": ["profileDigest", "signingKeyId", "algorithm", "payloadProfile", "domain", "signature"],
       "properties": {
         "profileDigest": {"$ref": "#/$defs/digest"},
         "signingKeyId": {"type": "string", "minLength": 1, "maxLength": 253},
         "algorithm": {"const": "Ed25519"},
+        "payloadProfile": {"const": "domain-separated-evidence-digest/v1"},
+        "domain": {"const": "darkfactory.http-probe-result/v1"},
         "signature": {"type": "string", "pattern": "^[A-Za-z0-9_-]{43,4096}$"}
       }
     }

--- a/platform-contracts/schemas/v2/delivery-profile.schema.json
+++ b/platform-contracts/schemas/v2/delivery-profile.schema.json
@@ -205,7 +205,7 @@
     "runtimeVerification": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["action", "profile", "profileSchema", "subjectSchema", "resultSchema", "evidenceType", "deliveryObservationSchemaFrom", "credential", "network"],
+      "required": ["action", "profile", "profileSchema", "subjectSchema", "resultSchema", "evidenceType", "deliveryObservationSchemaFrom", "credential", "network", "evidenceCommit"],
       "properties": {
         "action": {"const": "verification.run-http-probes/v1"},
         "profile": {"const": "http-preview-service/v1"},
@@ -217,7 +217,7 @@
         "credential": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["authority", "serviceAccountFrom", "issueAction", "audienceFrom", "apiServerFrom", "caSha256From", "maxLifetime", "absoluteDeadline", "maxResponseBytes", "operations", "kindIds", "subjectIssuerProfileFrom"],
+          "required": ["authority", "serviceAccountFrom", "issueAction", "audienceFrom", "apiServerFrom", "caSha256From", "requestedLifetime", "maxActualLifetime", "minimumRemainingAtStart", "absoluteDeadline", "maxResponseBytes", "operations", "kindIds", "subjectIssuerProfileFrom"],
           "properties": {
             "authority": {"const": "platform-control-plane"},
             "serviceAccountFrom": {"const": "observerAccess.serviceAccount.nameTemplate"},
@@ -225,7 +225,9 @@
             "audienceFrom": {"const": "adapter.destination.tokenAudience"},
             "apiServerFrom": {"const": "adapter.destination.apiServer"},
             "caSha256From": {"const": "adapter.destination.caSha256"},
-            "maxLifetime": {"const": "PT5M"},
+            "requestedLifetime": {"const": "PT10M"},
+            "maxActualLifetime": {"const": "PT10M"},
+            "minimumRemainingAtStart": {"const": "PT4M5S"},
             "absoluteDeadline": {"const": "PT4M"},
             "maxResponseBytes": {"const": 1048576},
             "operations": {"const": ["deployments.list", "endpointslices.list", "namespace.get", "networkpolicies.list", "pods.list", "replicasets.list", "services.list"]},
@@ -251,6 +253,24 @@
             "observedPolicySnapshotFrom": {"const": "evidence.kubernetes.delivery-observation.finalCollectionSnapshots.networking-v1-networkpolicies"},
             "requiredAssertion": {"const": "http-verifier-ingress-only"},
             "callerNetworkTargetAccepted": {"const": false}
+          }
+        },
+        "evidenceCommit": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["action", "storeProfileFrom", "storeProfileDigestFrom", "objectKeyTemplate", "writePrecondition", "readBack", "identicalReplay", "sameKeyConflict", "receiptSchema", "receiptEvidenceType", "cleanupOnFailure"],
+          "properties": {
+            "action": {"const": "evidence.store-http-probe-result/v1"},
+            "storeProfileFrom": {"const": "adapter.httpVerification.evidenceStoreProfile"},
+            "storeProfileDigestFrom": {"const": "executionEnvelope.httpEvidenceStoreProfileDigest"},
+            "objectKeyTemplate": {"const": "http-probe-result/v1/{workOrderId}/{runId}.json"},
+            "writePrecondition": {"const": "if-none-match-star-policy-enforced"},
+            "readBack": {"const": "exact-canonical-bytes-and-evidence-digest"},
+            "identicalReplay": {"const": "idempotent-committed"},
+            "sameKeyConflict": {"const": "park-and-escalate"},
+            "receiptSchema": {"const": "urn:darkfactory:platform-contract:http-evidence-commit-receipt:v1"},
+            "receiptEvidenceType": {"const": "http.probe-commit-receipt/v1"},
+            "cleanupOnFailure": {"const": "always-attempt-without-completion"}
           }
         }
       }

--- a/scripts/http_probe_contract_validation.py
+++ b/scripts/http_probe_contract_validation.py
@@ -26,6 +26,7 @@ ROOT = Path(__file__).resolve().parents[1]
 PROFILE_PATH = (
     ROOT / "platform-contracts/probe-profiles/http-preview-service/v1/profile.yaml"
 )
+RESULT_SIGNATURE_DOMAIN = b"darkfactory.http-probe-result/v1"
 STATE_PRECEDENCE = ("probe-error", "fail", "inconclusive", "pass")
 
 
@@ -89,6 +90,22 @@ def _sign(
     )
 
 
+def _result_signature_payload(value: dict[str, Any]) -> bytes:
+    try:
+        digest = bytes.fromhex(value["evidenceSha256"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise HttpProbeContractError("HTTP result digest is not signable") from error
+    if len(digest) != 32:
+        raise HttpProbeContractError("HTTP result digest is not SHA-256")
+    return RESULT_SIGNATURE_DOMAIN + b"\0" + digest
+
+
+def _sign_result(value: dict[str, Any], private_key: Ed25519PrivateKey) -> None:
+    value["verifier"]["signature"] = _encode_signature(
+        private_key.sign(_result_signature_payload(value))
+    )
+
+
 def _verify_signature(
     value: dict[str, Any],
     signer: dict[str, Any],
@@ -108,12 +125,59 @@ def _verify_signature(
         raise HttpProbeContractError("cryptographic signature verification failed") from error
 
 
+def _verify_result_signature(
+    value: dict[str, Any],
+    public_key: Ed25519PublicKey,
+    expected_profile: str,
+    expected_key_id: str,
+) -> None:
+    signer = value["verifier"]
+    if (
+        signer["profileDigest"] != expected_profile
+        or signer["signingKeyId"] != expected_key_id
+        or signer["algorithm"] != "Ed25519"
+        or signer["payloadProfile"] != "domain-separated-evidence-digest/v1"
+        or signer["domain"] != RESULT_SIGNATURE_DOMAIN.decode("ascii")
+    ):
+        raise HttpProbeContractError("result signer is not the pinned trust profile")
+    try:
+        public_key.verify(
+            _decode_signature(signer["signature"]),
+            _result_signature_payload(value),
+        )
+    except (InvalidSignature, ValueError) as error:
+        raise HttpProbeContractError("HTTP result signature verification failed") from error
+
+
 def _parse(value: str) -> datetime:
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
 def _timestamp(value: datetime) -> str:
     return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _validate_commit_receipt(
+    receipt: dict[str, Any], result: dict[str, Any]
+) -> None:
+    expected_key = (
+        f"http-probe-result/v1/{result['workOrderId']}/{result['runId']}.json"
+    )
+    if (
+        receipt["workOrderId"] != result["workOrderId"]
+        or receipt["runId"] != result["runId"]
+        or receipt["objectKey"] != expected_key
+        or receipt["evidenceSha256"] != result["evidenceSha256"]
+        or receipt["checksumSha256"] != _digest(_canonical_bytes(result))
+    ):
+        raise HttpProbeContractError("HTTP commit receipt does not join stored result")
+    if receipt["receiptSha256"] != _digest(
+        _without(receipt, ("receiptSha256",))
+    ):
+        raise HttpProbeContractError("HTTP commit receipt digest is false")
+    committed_at = _parse(receipt["committedAt"])
+    if not _parse(result["completedAt"]) <= committed_at <= _parse(result["expiresAt"]):
+        raise HttpProbeContractError("HTTP commit receipt time is outside result validity")
 
 
 def _json_type(value: Any) -> str:
@@ -516,18 +580,15 @@ def _build_example(
             "profileDigest": _digest("http-verifier-profile"),
             "signingKeyId": "kms:http-verifier-v1",
             "algorithm": "Ed25519",
+            "payloadProfile": "domain-separated-evidence-digest/v1",
+            "domain": RESULT_SIGNATURE_DOMAIN.decode("ascii"),
             "signature": "0" * 86,
         },
     }
     result["evidenceSha256"] = _digest(
         _without(result, ("evidenceSha256", "verifier.signature"))
     )
-    _sign(
-        result,
-        verifier_private_key,
-        ("evidenceSha256", "verifier.signature"),
-        ("verifier", "signature"),
-    )
+    _sign_result(result, verifier_private_key)
     trusted = {
         "executionEnvelope": {
             "digest": subject["executionEnvelopeDigest"],
@@ -829,13 +890,11 @@ def _validate_semantics(
         raise HttpProbeContractError("cross-WorkOrder result")
     if result["runId"] != subject["runId"]:
         raise HttpProbeContractError("cross-run result")
-    _verify_signature(
+    _verify_result_signature(
         result,
-        result["verifier"],
         trusted["verifier"]["publicKey"],
         trusted["verifier"]["profileDigest"],
         trusted["verifier"]["signingKeyId"],
-        ("evidenceSha256", "verifier.signature"),
     )
 
     descriptors = [
@@ -1050,12 +1109,7 @@ def _redigest_result(
     result["evidenceSha256"] = _digest(
         _without(result, ("evidenceSha256", "verifier.signature"))
     )
-    _sign(
-        result,
-        private_key,
-        ("evidenceSha256", "verifier.signature"),
-        ("verifier", "signature"),
-    )
+    _sign_result(result, private_key)
 
 
 def _make_target_error_result(
@@ -1111,12 +1165,68 @@ def validate_http_probe_contracts(
     result_validator = Draft202012Validator(
         schemas[result_schema], registry=registry, format_checker=FormatChecker()
     )
+    receipt_schema = (
+        "urn:darkfactory:platform-contract:http-evidence-commit-receipt:v1"
+    )
+    receipt_validator = Draft202012Validator(
+        schemas[receipt_schema], registry=registry, format_checker=FormatChecker()
+    )
     subject, result, trusted = _build_example(index)
     subject_private_key = trusted["subjectIssuer"]["privateKey"]
     verifier_private_key = trusted["verifier"]["privateKey"]
     subject_validator.validate(subject)
     result_validator.validate(result)
     _validate_semantics(subject, result, index, trusted)
+    receipt = {
+        "schemaVersion": "verification/http-evidence-commit-receipt/v1",
+        "evidenceType": "http.probe-commit-receipt/v1",
+        "workOrderId": result["workOrderId"],
+        "runId": result["runId"],
+        "storeProfileDigest": _digest("http-evidence-store-profile"),
+        "bucketArn": "arn:aws:s3:::darkfactory-http-evidence-dev",
+        "objectKey": (
+            f"http-probe-result/v1/{result['workOrderId']}/{result['runId']}.json"
+        ),
+        "versionId": "s3-version-1",
+        "checksumSha256": _digest(_canonical_bytes(result)),
+        "evidenceSha256": result["evidenceSha256"],
+        "committedAt": result["completedAt"],
+        "canonicalization": "rfc8785-json-canonicalization/v1",
+        "digestPayloadExcludes": ["receiptSha256"],
+        "receiptSha256": "0" * 64,
+    }
+    receipt["receiptSha256"] = _digest(_without(receipt, ("receiptSha256",)))
+    receipt_validator.validate(receipt)
+    _validate_commit_receipt(receipt, result)
+
+    receipt_mutations = []
+    for name, field, value in (
+        (
+            "foreign object key",
+            "objectKey",
+            f"http-probe-result/v1/otherwork1/{result['runId']}.json",
+        ),
+        ("foreign evidence digest", "evidenceSha256", _digest("foreign-evidence")),
+        ("false stored checksum", "checksumSha256", _digest("foreign-bytes")),
+    ):
+        mutation = copy.deepcopy(receipt)
+        mutation[field] = value
+        mutation["receiptSha256"] = _digest(
+            _without(mutation, ("receiptSha256",))
+        )
+        receipt_mutations.append((name, mutation))
+    false_receipt_digest = copy.deepcopy(receipt)
+    false_receipt_digest["receiptSha256"] = _digest("false-receipt")
+    receipt_mutations.append(("false receipt digest", false_receipt_digest))
+    for name, mutation in receipt_mutations:
+        receipt_validator.validate(mutation)
+        try:
+            _validate_commit_receipt(mutation, result)
+        except HttpProbeContractError:
+            continue
+        raise HttpProbeContractError(
+            f"invalid HTTP commit receipt unexpectedly passed: {name}"
+        )
 
     profile_schema = "urn:darkfactory:platform-contract:http-probe-profile:v1"
     profile_validator = Draft202012Validator(
@@ -1567,6 +1677,25 @@ def validate_http_probe_contracts(
     unsigned_result["verifier"]["signature"] = "A" * 86
     semantic_mutations.append(
         ("fabricated verifier signature", unsigned_result["subject"], unsigned_result)
+    )
+
+    direct_canonical_signature = copy.deepcopy(result)
+    direct_canonical_signature["verifier"]["signature"] = _encode_signature(
+        verifier_private_key.sign(
+            _canonical_bytes(
+                _without(
+                    direct_canonical_signature,
+                    ("evidenceSha256", "verifier.signature"),
+                )
+            )
+        )
+    )
+    semantic_mutations.append(
+        (
+            "direct canonical result signature",
+            direct_canonical_signature["subject"],
+            direct_canonical_signature,
+        )
     )
 
     cross_run = copy.deepcopy(result)

--- a/scripts/validate-platform-contracts.py
+++ b/scripts/validate-platform-contracts.py
@@ -797,6 +797,7 @@ def validate_semantics(
                     runtime["profileSchema"],
                     runtime["subjectSchema"],
                     runtime["resultSchema"],
+                    runtime["evidenceCommit"]["receiptSchema"],
                 }
                 unknown_runtime_schemas = referenced_runtime_schemas - set(schemas)
                 if unknown_runtime_schemas:

--- a/scripts/validate-platform-contracts.py
+++ b/scripts/validate-platform-contracts.py
@@ -811,6 +811,9 @@ def validate_semantics(
                     "provision-observer-access": "delivery.provision-observer-access/v1",
                     "register-observer-access-compensation": "execution.register-compensation/v1",
                     "revoke-observer-access": "delivery.revoke-observer-access/v1",
+                    "store-http-probe-result": (
+                        "evidence.store-http-probe-result/v1"
+                    ),
                     "store-observation-evidence": "evidence.store-delivery-observation/v1",
                     "issue-http-probe-credential": (
                         "verification.issue-http-probe-credential/v1"
@@ -832,7 +835,8 @@ def validate_semantics(
                     "store-observation-evidence": ["observe-gitops"],
                     "issue-http-probe-credential": ["store-observation-evidence"],
                     "verify-runtime": ["issue-http-probe-credential"],
-                    "revoke-observer-access": ["verify-runtime"],
+                    "store-http-probe-result": ["verify-runtime"],
+                    "revoke-observer-access": ["store-http-probe-result"],
                 }
                 for step_id, needs in observer_chain.items():
                     if step_needs.get(step_id) != needs:
@@ -936,6 +940,17 @@ def validate_semantics(
                     )
                 if runtime["evidenceType"] != runtime_profile["evidence"]["evidenceType"]:
                     raise ContractError(f"{path_id}: HTTP evidence type binding differs")
+                commit = runtime.get("evidenceCommit")
+                if commit is None:
+                    raise ContractError(f"{path_id}: HTTP evidence commit profile is absent")
+                require_registered(commit["action"], registries["actions"], path_id)
+                require_registered(
+                    commit["receiptEvidenceType"], registries["evidenceTypes"], path_id
+                )
+                if commit["receiptEvidenceType"] not in path["evidence"]["requiredTypes"]:
+                    raise ContractError(
+                        f"{path_id}: HTTP evidence commit receipt is not required"
+                    )
         condition_ids = [condition["id"] for condition in path["conditionsOfDone"]]
         if len(condition_ids) != len(set(condition_ids)):
             raise ContractError(f"{path_id}: duplicate Condition of Done id")


### PR DESCRIPTION
## Summary
- add the create-only HTTP result store action and close the workflow edge before observer revoke
- publish an exact HTTP evidence commit receipt schema and require it in the evidence manifest
- domain-separate result signatures over the canonical evidence digest
- sync the runtime credential to Kubernetes exact 600-second TokenRequest floor while retaining the four-minute run budget
- add positive/adversarial receipt and signature qualification

## Verification
- `python3 scripts/validate-platform-contracts.py`
- 41 indexed artifacts validated with exact individual and bundle digests

The v3 path and profiles remain draft/readiness-ineligible.